### PR TITLE
Add --preview flag for 'rad app graph' and 'rad app status' 

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -34,11 +34,13 @@ import (
 	app_delete "github.com/radius-project/radius/pkg/cli/cmd/app/delete"
 	app_delete_preview "github.com/radius-project/radius/pkg/cli/cmd/app/delete/preview"
 	app_graph "github.com/radius-project/radius/pkg/cli/cmd/app/graph"
+	app_graph_preview "github.com/radius-project/radius/pkg/cli/cmd/app/graph/preview"
 	app_list "github.com/radius-project/radius/pkg/cli/cmd/app/list"
 	app_list_preview "github.com/radius-project/radius/pkg/cli/cmd/app/list/preview"
 	app_show "github.com/radius-project/radius/pkg/cli/cmd/app/show"
 	app_show_preview "github.com/radius-project/radius/pkg/cli/cmd/app/show/preview"
 	app_status "github.com/radius-project/radius/pkg/cli/cmd/app/status"
+	app_status_preview "github.com/radius-project/radius/pkg/cli/cmd/app/status/preview"
 	bicep_generate_kubernetes_manifest "github.com/radius-project/radius/pkg/cli/cmd/bicep/generatekubernetesmanifest"
 	bicep_publish "github.com/radius-project/radius/pkg/cli/cmd/bicep/publish"
 	bicep_publishextension "github.com/radius-project/radius/pkg/cli/cmd/bicep/publishextension"
@@ -421,9 +423,13 @@ func initSubCommands() {
 	applicationCmd.AddCommand(appShowCmd)
 
 	appStatusCmd, _ := app_status.NewCommand(framework)
+	previewAppStatusCmd, _ := app_status_preview.NewCommand(framework)
+	wirePreviewSubcommand(appStatusCmd, previewAppStatusCmd)
 	applicationCmd.AddCommand(appStatusCmd)
 
 	appGraphCmd, _ := app_graph.NewCommand(framework)
+	previewAppGraphCmd, _ := app_graph_preview.NewCommand(framework)
+	wirePreviewSubcommand(appGraphCmd, previewAppGraphCmd)
 	applicationCmd.AddCommand(appGraphCmd)
 
 	envSwitchCmd, _ := env_switch.NewCommand(framework)

--- a/cmd/rad/cmd/root_test.go
+++ b/cmd/rad/cmd/root_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,5 +69,51 @@ func Test_prettyPrintJSON(t *testing.T) {
 		require.Contains(t, result, "nested")
 		require.Contains(t, result, "inner")
 		require.Contains(t, result, "array")
+	})
+}
+
+func Test_wirePreviewSubcommand(t *testing.T) {
+	t.Run("routes to legacy runner when --preview is not set", func(t *testing.T) {
+		legacyCalled := false
+		previewCalled := false
+
+		legacyCmd := &cobra.Command{
+			Use:  "test",
+			RunE: func(cmd *cobra.Command, args []string) error { legacyCalled = true; return nil },
+		}
+		previewCmd := &cobra.Command{
+			Use:  "test",
+			RunE: func(cmd *cobra.Command, args []string) error { previewCalled = true; return nil },
+		}
+
+		wirePreviewSubcommand(legacyCmd, previewCmd)
+
+		legacyCmd.SetArgs([]string{})
+		err := legacyCmd.Execute()
+		require.NoError(t, err)
+		require.True(t, legacyCalled, "legacy runner should have been called")
+		require.False(t, previewCalled, "preview runner should not have been called")
+	})
+
+	t.Run("routes to preview runner when --preview is set", func(t *testing.T) {
+		legacyCalled := false
+		previewCalled := false
+
+		legacyCmd := &cobra.Command{
+			Use:  "test",
+			RunE: func(cmd *cobra.Command, args []string) error { legacyCalled = true; return nil },
+		}
+		previewCmd := &cobra.Command{
+			Use:  "test",
+			RunE: func(cmd *cobra.Command, args []string) error { previewCalled = true; return nil },
+		}
+
+		wirePreviewSubcommand(legacyCmd, previewCmd)
+
+		legacyCmd.SetArgs([]string{"--preview"})
+		err := legacyCmd.Execute()
+		require.NoError(t, err)
+		require.False(t, legacyCalled, "legacy runner should not have been called")
+		require.True(t, previewCalled, "preview runner should have been called")
 	})
 }

--- a/pkg/cli/cmd/app/delete/preview/delete.go
+++ b/pkg/cli/cmd/app/delete/preview/delete.go
@@ -36,6 +36,7 @@ import (
 	"github.com/radius-project/radius/pkg/cli/prompt"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
 )
 
 const (
@@ -186,7 +187,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	// Build the fully qualified Radius.Core application ID for ownership matching
-	applicationID := r.Workspace.Scope + "/providers/Radius.Core/applications/" + r.ApplicationName
+	applicationID := r.Workspace.Scope + "/providers/" + datamodel.ApplicationResourceType_v20250801preview + "/" + r.ApplicationName
 
 	resourcesList, err := listResourcesOwnedByApplication(ctx, managementClient, applicationID)
 	if err != nil && !clients.Is404Error(err) {

--- a/pkg/cli/cmd/app/graph/compute.go
+++ b/pkg/cli/cmd/app/graph/compute.go
@@ -21,7 +21,8 @@ import (
 	"github.com/radius-project/radius/pkg/ucp/resources"
 )
 
-func providerFromID(id string) string {
+// ProviderFromID extracts the provider from a resource ID string.
+func ProviderFromID(id string) string {
 	parsed, err := resources.ParseResource(id)
 	if err != nil {
 		return ""

--- a/pkg/cli/cmd/app/graph/compute_test.go
+++ b/pkg/cli/cmd/app/graph/compute_test.go
@@ -22,13 +22,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_providerFromID(t *testing.T) {
+func Test_ProviderFromID(t *testing.T) {
 	t.Run("parse valid resource ID", func(t *testing.T) {
-		require.Equal(t, "aws", providerFromID(awsMemoryDBResourceID))
-		require.Equal(t, "azure", providerFromID(azureRedisCacheResourceID))
+		require.Equal(t, "aws", ProviderFromID(awsMemoryDBResourceID))
+		require.Equal(t, "azure", ProviderFromID(azureRedisCacheResourceID))
 	})
 
 	t.Run("parse invalid resource ID", func(t *testing.T) {
-		require.Equal(t, "", providerFromID("\ndkdkfkdfs\t"))
+		require.Equal(t, "", ProviderFromID("\ndkdkfkdfs\t"))
 	})
 }

--- a/pkg/cli/cmd/app/graph/display.go
+++ b/pkg/cli/cmd/app/graph/display.go
@@ -105,14 +105,20 @@ func display(applicationResources []*v20231001preview.ApplicationGraphResource, 
 
 func makeHyperlink(resource *v20231001preview.ApplicationGraphOutputResource) string {
 	// Just azure for now.
-	provider := providerFromID(*resource.ID)
+	return MakeResourceHyperlink(*resource.ID, *resource.Name)
+}
+
+// MakeResourceHyperlink builds a terminal hyperlink for an Azure resource.
+// Returns an empty string for non-Azure resources.
+func MakeResourceHyperlink(resourceID, resourceName string) string {
+	provider := ProviderFromID(resourceID)
 	if provider != "azure" {
 		return ""
 	}
-	// https://portal.azure.com/#@{tenantId}/resource{resourceId}
-	url := fmt.Sprintf("https://portal.azure.com/#@%s/resource%s", "72f988bf-86f1-41af-91ab-2d7cd011db47", *resource.ID)
 
-	// This is the magic incantation for a console hyperlink.
-	// \x1b]8;;h { URL } \x07 { link text } \x1b]8;;\x07
-	return fmt.Sprintf("\x1b]8;;%s\x07%s\x1b]8;;\x07", url, *resource.Name)
+	url := fmt.Sprintf("https://portal.azure.com/#@%s/resource%s", "72f988bf-86f1-41af-91ab-2d7cd011db47", resourceID)
+
+	// Terminal hyperlink escape sequence.
+	// \x1b]8;;{URL}\x07{link text}\x1b]8;;\x07
+	return fmt.Sprintf("\x1b]8;;%s\x07%s\x1b]8;;\x07", url, resourceName)
 }

--- a/pkg/cli/cmd/app/graph/preview/graph.go
+++ b/pkg/cli/cmd/app/graph/preview/graph.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preview
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/radius-project/radius/pkg/cli"
+	"github.com/radius-project/radius/pkg/cli/clients"
+	"github.com/radius-project/radius/pkg/cli/clierrors"
+	"github.com/radius-project/radius/pkg/cli/cmd"
+	"github.com/radius-project/radius/pkg/cli/cmd/app/graph"
+	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
+	"github.com/radius-project/radius/pkg/cli/framework"
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/cli/workspaces"
+	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	"github.com/radius-project/radius/pkg/ucp/resources"
+)
+
+// NewCommand creates an instance of the command and runner for the `rad app graph --preview` command.
+func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
+	runner := NewRunner(factory)
+	cmd := &cobra.Command{
+		Use:   "graph",
+		Short: "Shows the application graph (preview)",
+		Long:  `Shows the application graph for a Radius.Core application using the preview API surface.`,
+		Args:  cobra.MaximumNArgs(1),
+		Example: `
+# Show graph for specified application
+rad app graph my-application --preview`,
+		RunE: framework.RunCommand(runner),
+	}
+
+	commonflags.AddWorkspaceFlag(cmd)
+	commonflags.AddResourceGroupFlag(cmd)
+	commonflags.AddApplicationNameFlag(cmd)
+	commonflags.AddOutputFlag(cmd)
+
+	return cmd, runner
+}
+
+// Runner is the runner implementation for the preview `rad app graph` command.
+type Runner struct {
+	ConfigHolder            *framework.ConfigHolder
+	Output                  output.Interface
+	Workspace               *workspaces.Workspace
+	RadiusCoreClientFactory *corerpv20250801.ClientFactory
+
+	ApplicationName string
+	Format          string
+}
+
+// NewRunner creates a new instance of the preview graph runner.
+func NewRunner(factory framework.Factory) *Runner {
+	return &Runner{
+		ConfigHolder: factory.GetConfigHolder(),
+		Output:       factory.GetOutput(),
+	}
+}
+
+// Validate runs validation for the preview graph command.
+func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
+	workspace, err := cli.RequireWorkspace(cmd, r.ConfigHolder.Config)
+	if err != nil {
+		return err
+	}
+	r.Workspace = workspace
+
+	r.Workspace.Scope, err = cli.RequireScope(cmd, *r.Workspace)
+	if err != nil {
+		return err
+	}
+
+	r.ApplicationName, err = cli.RequireApplicationArgs(cmd, args, *workspace)
+	if err != nil {
+		return err
+	}
+
+	r.Format, err = cli.RequireOutput(cmd)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run runs the preview `rad app graph` command.
+func (r *Runner) Run(ctx context.Context) error {
+	if r.RadiusCoreClientFactory == nil {
+		factory, err := cmd.InitializeRadiusCoreClientFactory(ctx, r.Workspace, r.Workspace.Scope)
+		if err != nil {
+			return err
+		}
+		r.RadiusCoreClientFactory = factory
+	}
+
+	appClient := r.RadiusCoreClientFactory.NewApplicationsClient()
+
+	// Fetch the application graph — GetGraph returns 404 if the application does not exist.
+	graphResponse, err := appClient.GetGraph(ctx, r.ApplicationName, map[string]any{}, &corerpv20250801.ApplicationsClientGetGraphOptions{})
+	if clients.Is404Error(err) {
+		return clierrors.Message("Application %q does not exist or has been deleted.", r.ApplicationName)
+	} else if err != nil {
+		return err
+	}
+
+	switch r.Format {
+	case output.FormatJson:
+		return r.Output.WriteFormatted(r.Format, graphResponse.ApplicationGraphResponse, output.FormatterOptions{})
+	default:
+		d := display(graphResponse.Resources, r.ApplicationName)
+		r.Output.LogInfo(d)
+		return nil
+	}
+}
+
+// display builds the formatted output for the application graph as text.
+// This is a v20250801preview-specific version of the display function.
+func display(applicationResources []*corerpv20250801.ApplicationGraphResource, applicationName string) string {
+	containerType := "Applications.Core/containers"
+	sort.Slice(applicationResources, func(i, j int) bool {
+		if strings.EqualFold(*applicationResources[i].Type, containerType) !=
+			strings.EqualFold(*applicationResources[j].Type, containerType) {
+			return strings.EqualFold(*applicationResources[i].Type, containerType)
+		}
+		if *applicationResources[i].Type != *applicationResources[j].Type {
+			return *applicationResources[i].Type < *applicationResources[j].Type
+		}
+		if *applicationResources[i].Name != *applicationResources[j].Name {
+			return *applicationResources[i].Name < *applicationResources[j].Name
+		}
+		return *applicationResources[i].ID < *applicationResources[j].ID
+	})
+
+	out := &strings.Builder{}
+	out.WriteString(fmt.Sprintf("Displaying application: %s\n\n", applicationName))
+
+	if len(applicationResources) == 0 {
+		out.WriteString("(empty)")
+		out.WriteString("\n\n")
+		return out.String()
+	}
+
+	for _, resource := range applicationResources {
+		out.WriteString(fmt.Sprintf("Name: %s (%s)\n", *resource.Name, *resource.Type))
+
+		if len(resource.Connections) == 0 {
+			out.WriteString("Connections: (none)\n")
+		} else {
+			out.WriteString("Connections:\n")
+			for _, connection := range resource.Connections {
+				connectionID, err := resources.Parse(*connection.ID)
+				if err != nil {
+					out.WriteString(fmt.Sprintf("Error: %s\n", err.Error()))
+					continue
+				}
+				connectionName := connectionID.Name()
+				connectionType := connectionID.Type()
+
+				if *connection.Direction == corerpv20250801.DirectionOutbound {
+					out.WriteString(fmt.Sprintf("  %s -> %s (%s)\n", *resource.Name, connectionName, connectionType))
+				} else {
+					out.WriteString(fmt.Sprintf("  %s (%s) -> %s\n", connectionName, connectionType, *resource.Name))
+				}
+			}
+		}
+
+		if len(resource.OutputResources) == 0 {
+			out.WriteString("Resources: (none)\n")
+		} else {
+			out.WriteString("Resources:\n")
+			for _, outputResource := range resource.OutputResources {
+				link := makeHyperlink(outputResource)
+				if link == "" {
+					out.WriteString(fmt.Sprintf("  %s (%s)\n", *outputResource.Name, *outputResource.Type))
+				} else {
+					out.WriteString(fmt.Sprintf("  %s (%s)\n", link, *outputResource.Type))
+				}
+			}
+		}
+
+		out.WriteString("\n")
+	}
+
+	return out.String()
+}
+
+func makeHyperlink(resource *corerpv20250801.ApplicationGraphOutputResource) string {
+	return graph.MakeResourceHyperlink(*resource.ID, *resource.Name)
+}

--- a/pkg/cli/cmd/app/graph/preview/graph_test.go
+++ b/pkg/cli/cmd/app/graph/preview/graph_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preview
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/stretchr/testify/require"
+
+	"github.com/radius-project/radius/pkg/cli/clierrors"
+	"github.com/radius-project/radius/pkg/cli/framework"
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/cli/test_client_factory"
+	"github.com/radius-project/radius/pkg/cli/workspaces"
+	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	"github.com/radius-project/radius/pkg/corerp/api/v20250801preview/fake"
+	"github.com/radius-project/radius/test/radcli"
+)
+
+func Test_CommandValidation(t *testing.T) {
+	radcli.SharedCommandValidation(t, NewCommand)
+}
+
+func Test_Validate(t *testing.T) {
+	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
+
+	testcases := []radcli.ValidateInput{
+		{
+			Name:          "Graph command with flag",
+			Input:         []string{"-a", "test-app"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				Config: configWithWorkspace,
+			},
+		},
+		{
+			Name:          "Graph command with positional arg",
+			Input:         []string{"test-app"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				Config: configWithWorkspace,
+			},
+		},
+		{
+			Name:          "Graph command with fallback workspace",
+			Input:         []string{"--application", "test-app", "--group", "test-group"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				Config: radcli.LoadEmptyConfig(t),
+			},
+		},
+		{
+			Name:          "Graph command with incorrect args",
+			Input:         []string{"foo", "bar"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				Config: configWithWorkspace,
+			},
+		},
+	}
+
+	radcli.SharedValidateValidation(t, NewCommand, testcases)
+}
+
+func Test_Run(t *testing.T) {
+	workspace := &workspaces.Workspace{
+		Name:  "test-workspace",
+		Scope: "/planes/radius/local/resourceGroups/test-group",
+	}
+
+	t.Run("Success: empty graph (table)", func(t *testing.T) {
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(workspace.Scope, nil, nil, test_client_factory.WithApplicationsServerNoError)
+		require.NoError(t, err)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			RadiusCoreClientFactory: factory,
+			Workspace:               workspace,
+			ApplicationName:         "test-app",
+			Format:                  "table",
+			Output:                  outputSink,
+		}
+
+		err = runner.Run(context.Background())
+		require.NoError(t, err)
+		require.Len(t, outputSink.Writes, 1)
+
+		logOutput, ok := outputSink.Writes[0].(output.LogOutput)
+		require.True(t, ok)
+		require.Contains(t, logOutput.Format, "Displaying application: test-app")
+		require.Contains(t, logOutput.Format, "(empty)")
+	})
+
+	t.Run("Success: graph with resources (table)", func(t *testing.T) {
+		graphServer := func() fake.ApplicationsServer {
+			srv := test_client_factory.WithApplicationsServerNoError()
+			srv.GetGraph = func(
+				ctx context.Context,
+				applicationName string,
+				body any,
+				options *corerpv20250801.ApplicationsClientGetGraphOptions,
+			) (resp azfake.Responder[corerpv20250801.ApplicationsClientGetGraphResponse], errResp azfake.ErrorResponder) {
+				containerID := "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/containers/web"
+				containerName := "web"
+				containerType := "Applications.Core/containers"
+
+				resp.SetResponse(http.StatusOK, corerpv20250801.ApplicationsClientGetGraphResponse{
+					ApplicationGraphResponse: corerpv20250801.ApplicationGraphResponse{
+						Resources: []*corerpv20250801.ApplicationGraphResource{
+							{
+								ID:              &containerID,
+								Name:            &containerName,
+								Type:            &containerType,
+								Connections:     []*corerpv20250801.ApplicationGraphConnection{},
+								OutputResources: []*corerpv20250801.ApplicationGraphOutputResource{},
+							},
+						},
+					},
+				}, nil)
+				return
+			}
+			return srv
+		}
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(workspace.Scope, nil, nil, graphServer)
+		require.NoError(t, err)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			RadiusCoreClientFactory: factory,
+			Workspace:               workspace,
+			ApplicationName:         "test-app",
+			Format:                  "table",
+			Output:                  outputSink,
+		}
+
+		err = runner.Run(context.Background())
+		require.NoError(t, err)
+		require.Len(t, outputSink.Writes, 1)
+
+		logOutput, ok := outputSink.Writes[0].(output.LogOutput)
+		require.True(t, ok)
+		require.Contains(t, logOutput.Format, "Name: web (Applications.Core/containers)")
+	})
+
+	t.Run("Success: graph (JSON)", func(t *testing.T) {
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(workspace.Scope, nil, nil, test_client_factory.WithApplicationsServerNoError)
+		require.NoError(t, err)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			RadiusCoreClientFactory: factory,
+			Workspace:               workspace,
+			ApplicationName:         "test-app",
+			Format:                  "json",
+			Output:                  outputSink,
+		}
+
+		err = runner.Run(context.Background())
+		require.NoError(t, err)
+		require.Len(t, outputSink.Writes, 1)
+
+		formatted, ok := outputSink.Writes[0].(output.FormattedOutput)
+		require.True(t, ok)
+		require.Equal(t, "json", formatted.Format)
+	})
+
+	t.Run("Error: application not found (404)", func(t *testing.T) {
+		notFoundServer := func() fake.ApplicationsServer {
+			return fake.ApplicationsServer{
+				GetGraph: func(
+					ctx context.Context,
+					applicationName string,
+					body any,
+					options *corerpv20250801.ApplicationsClientGetGraphOptions,
+				) (resp azfake.Responder[corerpv20250801.ApplicationsClientGetGraphResponse], errResp azfake.ErrorResponder) {
+					errResp.SetResponseError(http.StatusNotFound, "NotFound")
+					return
+				},
+			}
+		}
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(workspace.Scope, nil, nil, notFoundServer)
+		require.NoError(t, err)
+
+		runner := &Runner{
+			RadiusCoreClientFactory: factory,
+			Workspace:               workspace,
+			ApplicationName:         "test-app",
+			Format:                  "table",
+			Output:                  &output.MockOutput{},
+		}
+
+		err = runner.Run(context.Background())
+		require.Error(t, err)
+		require.Equal(t, clierrors.Message("Application %q does not exist or has been deleted.", "test-app"), err)
+	})
+
+	t.Run("Error: GetGraph failure is propagated", func(t *testing.T) {
+		graphErrorServer := func() fake.ApplicationsServer {
+			srv := test_client_factory.WithApplicationsServerNoError()
+			srv.GetGraph = func(
+				ctx context.Context,
+				applicationName string,
+				body any,
+				options *corerpv20250801.ApplicationsClientGetGraphOptions,
+			) (resp azfake.Responder[corerpv20250801.ApplicationsClientGetGraphResponse], errResp azfake.ErrorResponder) {
+				errResp.SetResponseError(http.StatusInternalServerError, "InternalServerError")
+				return
+			}
+			return srv
+		}
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(workspace.Scope, nil, nil, graphErrorServer)
+		require.NoError(t, err)
+
+		runner := &Runner{
+			RadiusCoreClientFactory: factory,
+			Workspace:               workspace,
+			ApplicationName:         "test-app",
+			Format:                  "table",
+			Output:                  &output.MockOutput{},
+		}
+
+		err = runner.Run(context.Background())
+		require.Error(t, err)
+	})
+}

--- a/pkg/cli/cmd/app/status/objectformats.go
+++ b/pkg/cli/cmd/app/status/objectformats.go
@@ -18,8 +18,8 @@ package status
 
 import "github.com/radius-project/radius/pkg/cli/output"
 
-// statusFormat sets up the columns and headings for a table to display application names and resource counts.
-func statusFormat() output.FormatterOptions {
+// StatusFormat sets up the columns and headings for a table to display application names and resource counts.
+func StatusFormat() output.FormatterOptions {
 	return output.FormatterOptions{
 		Columns: []output.Column{
 			{
@@ -34,9 +34,9 @@ func statusFormat() output.FormatterOptions {
 	}
 }
 
-// gatewayFormat returns a FormatterOptions object which contains a list of columns to be used for
+// GatewayFormat returns a FormatterOptions object which contains a list of columns to be used for
 // formatting the output of a list of application gateways.
-func gatewayFormat() output.FormatterOptions {
+func GatewayFormat() output.FormatterOptions {
 	return output.FormatterOptions{
 		Columns: []output.Column{
 			{

--- a/pkg/cli/cmd/app/status/objectformats_test.go
+++ b/pkg/cli/cmd/app/status/objectformats_test.go
@@ -32,7 +32,7 @@ func Test_GetApplicationStatusTableFormat(t *testing.T) {
 	}
 
 	buffer := &bytes.Buffer{}
-	err := output.Write(output.FormatTable, obj, buffer, statusFormat())
+	err := output.Write(output.FormatTable, obj, buffer, StatusFormat())
 	require.NoError(t, err)
 
 	expected := "APPLICATION  RESOURCES\ntest         3\n"
@@ -46,7 +46,7 @@ func Test_GetApplicationGatewaysTableFormat(t *testing.T) {
 	}
 
 	buffer := &bytes.Buffer{}
-	err := output.Write(output.FormatTable, obj, buffer, gatewayFormat())
+	err := output.Write(output.FormatTable, obj, buffer, GatewayFormat())
 	require.NoError(t, err)
 
 	expected := "GATEWAY   ENDPOINT\ntest      test-endpoint\n"

--- a/pkg/cli/cmd/app/status/preview/status.go
+++ b/pkg/cli/cmd/app/status/preview/status.go
@@ -14,38 +14,43 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package status
+package preview
 
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+
 	"github.com/radius-project/radius/pkg/cli"
 	"github.com/radius-project/radius/pkg/cli/clients"
 	"github.com/radius-project/radius/pkg/cli/clierrors"
+	"github.com/radius-project/radius/pkg/cli/cmd"
+	"github.com/radius-project/radius/pkg/cli/cmd/app/status"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
 	"github.com/radius-project/radius/pkg/ucp/resources"
-	"github.com/spf13/cobra"
 )
 
-// NewCommand creates an instance of the `rad app status` command and runner.
+// NewCommand creates an instance of the command and runner for the `rad app status --preview` command.
 func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
 
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Show Radius Application status",
-		Long:  `Show Radius Application status, such as public endpoints and resource count.`,
+		Short: "Show Radius Application status (preview)",
+		Long:  `Show Radius.Core application status using the preview API surface, including resource count and public endpoints.`,
 		Args:  cobra.MaximumNArgs(1),
 		Example: `
 # Show status of specified application
-rad app status my-app
+rad app status my-app --preview
 
 # Show status of specified application in a specified resource group
-rad app status my-app --group my-group
+rad app status my-app --group my-group --preview
 `,
 		RunE: framework.RunCommand(runner),
 	}
@@ -58,31 +63,28 @@ rad app status my-app --group my-group
 	return cmd, runner
 }
 
-// Runner is the Runner implementation for the `rad app status` command.
+// Runner is the runner implementation for the preview `rad app status` command.
 type Runner struct {
-	ConfigHolder      *framework.ConfigHolder
-	ConnectionFactory connections.Factory
-	Workspace         *workspaces.Workspace
-	Output            output.Interface
+	ConfigHolder            *framework.ConfigHolder
+	ConnectionFactory       connections.Factory
+	Output                  output.Interface
+	Workspace               *workspaces.Workspace
+	RadiusCoreClientFactory *corerpv20250801.ClientFactory
 
 	ApplicationName string
 	Format          string
 }
 
-// NewRunner creates an instance of the runner for the `rad app status` command.
+// NewRunner creates a new instance of the preview status runner.
 func NewRunner(factory framework.Factory) *Runner {
 	return &Runner{
-		ConnectionFactory: factory.GetConnectionFactory(),
 		ConfigHolder:      factory.GetConfigHolder(),
+		ConnectionFactory: factory.GetConnectionFactory(),
 		Output:            factory.GetOutput(),
 	}
 }
 
-// Validate runs validation for the `rad app status` command.
-//
-
-// Runner.Validate checks the workspace, scope, application name and output format from the command line arguments and
-// request object, and returns an error if any of these are invalid.
+// Validate runs validation for the preview status command.
 func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	workspace, err := cli.RequireWorkspace(cmd, r.ConfigHolder.Config)
 	if err != nil {
@@ -90,47 +92,52 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
-	// Allow '--group' to override scope
-	scope, err := cli.RequireScope(cmd, *r.Workspace)
+	r.Workspace.Scope, err = cli.RequireScope(cmd, *r.Workspace)
 	if err != nil {
 		return err
 	}
-	r.Workspace.Scope = scope
 
 	r.ApplicationName, err = cli.RequireApplicationArgs(cmd, args, *workspace)
 	if err != nil {
 		return err
 	}
 
-	format, err := cli.RequireOutput(cmd)
+	r.Format, err = cli.RequireOutput(cmd)
 	if err != nil {
 		return err
 	}
-
-	r.Format = format
 
 	return nil
 }
 
-// Run runs the `rad app status` command.
-//
-
-// Run() retrieves the application status and its associated gateways from the given workspace and returns it in the specified format.
-// It returns an error if the application is not found or if there is an error while retrieving the application status.
+// Run runs the preview `rad app status` command.
 func (r *Runner) Run(ctx context.Context) error {
-	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, *r.Workspace)
-	if err != nil {
-		return err
+	if r.RadiusCoreClientFactory == nil {
+		factory, err := cmd.InitializeRadiusCoreClientFactory(ctx, r.Workspace, r.Workspace.Scope)
+		if err != nil {
+			return err
+		}
+		r.RadiusCoreClientFactory = factory
 	}
 
-	application, err := client.GetApplication(ctx, r.ApplicationName)
+	appClient := r.RadiusCoreClientFactory.NewApplicationsClient()
+
+	// Fetch the application resource.
+	application, err := appClient.Get(ctx, r.ApplicationName, &corerpv20250801.ApplicationsClientGetOptions{})
 	if clients.Is404Error(err) {
 		return clierrors.Message("The application %q was not found or has been deleted.", r.ApplicationName)
 	} else if err != nil {
 		return err
 	}
 
-	resourceList, err := client.ListResourcesInApplication(ctx, r.ApplicationName)
+	// Enumerate resources owned by this application using the management client.
+	managementClient, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, *r.Workspace)
+	if err != nil {
+		return err
+	}
+
+	applicationID := r.Workspace.Scope + "/providers/" + datamodel.ApplicationResourceType_v20250801preview + "/" + r.ApplicationName
+	resourceList, err := managementClient.ListResourcesInApplication(ctx, applicationID)
 	if err != nil {
 		return err
 	}
@@ -140,6 +147,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		ResourceCount: len(resourceList),
 	}
 
+	// Gather public endpoints from gateway resources.
 	diagnosticsClient, err := r.ConnectionFactory.CreateDiagnosticsClient(ctx, *r.Workspace)
 	if err != nil {
 		return err
@@ -166,16 +174,14 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 	}
 
-	err = r.Output.WriteFormatted(r.Format, applicationStatus, StatusFormat())
+	err = r.Output.WriteFormatted(r.Format, applicationStatus, status.StatusFormat())
 	if err != nil {
 		return err
 	}
 
 	if r.Format == output.FormatTable && len(applicationStatus.Gateways) > 0 {
-		// Print newline for readability
 		r.Output.LogInfo("")
-
-		err = r.Output.WriteFormatted(r.Format, applicationStatus.Gateways, GatewayFormat())
+		err = r.Output.WriteFormatted(r.Format, applicationStatus.Gateways, status.GatewayFormat())
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/cmd/app/status/preview/status_test.go
+++ b/pkg/cli/cmd/app/status/preview/status_test.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preview
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/radius-project/radius/pkg/cli/clients"
+	generated "github.com/radius-project/radius/pkg/cli/clients_new/generated"
+	"github.com/radius-project/radius/pkg/cli/cmd/app/status"
+	"github.com/radius-project/radius/pkg/cli/connections"
+	"github.com/radius-project/radius/pkg/cli/framework"
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/cli/test_client_factory"
+	"github.com/radius-project/radius/pkg/cli/workspaces"
+	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	"github.com/radius-project/radius/pkg/corerp/api/v20250801preview/fake"
+	"github.com/radius-project/radius/pkg/ucp/resources"
+	"github.com/radius-project/radius/test/radcli"
+)
+
+func Test_CommandValidation(t *testing.T) {
+	radcli.SharedCommandValidation(t, NewCommand)
+}
+
+func Test_Validate(t *testing.T) {
+	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
+
+	testcases := []radcli.ValidateInput{
+		{
+			Name:          "Status command with flag",
+			Input:         []string{"-a", "test-app"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				Config: configWithWorkspace,
+			},
+		},
+		{
+			Name:          "Status command with positional arg",
+			Input:         []string{"test-app"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				Config: configWithWorkspace,
+			},
+		},
+		{
+			Name:          "Status command with fallback workspace",
+			Input:         []string{"--application", "test-app", "--group", "test-group"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				Config: radcli.LoadEmptyConfig(t),
+			},
+		},
+		{
+			Name:          "Status command with incorrect args",
+			Input:         []string{"foo", "bar"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				Config: configWithWorkspace,
+			},
+		},
+	}
+
+	radcli.SharedValidateValidation(t, NewCommand, testcases)
+}
+
+func mustParse(t *testing.T, s string) resources.ID {
+	t.Helper()
+	id, err := resources.ParseResource(s)
+	require.NoError(t, err)
+	return id
+}
+
+func Test_Run(t *testing.T) {
+	workspace := &workspaces.Workspace{
+		Name:  "test-workspace",
+		Scope: "/planes/radius/local/resourceGroups/test-group",
+	}
+
+	t.Run("Success: application with no resources", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(workspace.Scope, nil, nil, test_client_factory.WithApplicationsServerNoError)
+		require.NoError(t, err)
+
+		appID := workspace.Scope + "/providers/Radius.Core/applications/test-app"
+
+		mockMgmt := clients.NewMockApplicationsManagementClient(ctrl)
+		mockMgmt.EXPECT().
+			ListResourcesInApplication(gomock.Any(), appID).
+			Return([]generated.GenericResource{}, nil).
+			Times(1)
+
+		mockDiag := clients.NewMockDiagnosticsClient(ctrl)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			RadiusCoreClientFactory: factory,
+			ConnectionFactory: &connections.MockFactory{
+				ApplicationsManagementClient: mockMgmt,
+				DiagnosticsClient:            mockDiag,
+			},
+			Workspace:       workspace,
+			ApplicationName: "test-app",
+			Format:          "table",
+			Output:          outputSink,
+		}
+
+		err = runner.Run(context.Background())
+		require.NoError(t, err)
+		require.Len(t, outputSink.Writes, 1)
+
+		formatted, ok := outputSink.Writes[0].(output.FormattedOutput)
+		require.True(t, ok)
+		require.Equal(t, status.StatusFormat(), formatted.Options)
+
+		appStatus, ok := formatted.Obj.(clients.ApplicationStatus)
+		require.True(t, ok)
+		require.Equal(t, "test-app", appStatus.Name)
+		require.Equal(t, 0, appStatus.ResourceCount)
+	})
+
+	t.Run("Success: application with resources and gateways", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(workspace.Scope, nil, nil, test_client_factory.WithApplicationsServerNoError)
+		require.NoError(t, err)
+
+		appID := workspace.Scope + "/providers/Radius.Core/applications/test-app"
+		containerID := "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/containers/web"
+		containerName := "web"
+		containerType := "Applications.Core/containers"
+		gatewayID := "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/gateways/gw"
+		gatewayName := "gw"
+		gatewayType := "Applications.Core/gateways"
+
+		mockMgmt := clients.NewMockApplicationsManagementClient(ctrl)
+		mockMgmt.EXPECT().
+			ListResourcesInApplication(gomock.Any(), appID).
+			Return([]generated.GenericResource{
+				{ID: &containerID, Name: &containerName, Type: &containerType},
+				{ID: &gatewayID, Name: &gatewayName, Type: &gatewayType},
+			}, nil).
+			Times(1)
+
+		containerParsedID := mustParse(t, containerID)
+		gatewayParsedID := mustParse(t, gatewayID)
+		endpoint := "http://gw.example.com"
+
+		mockDiag := clients.NewMockDiagnosticsClient(ctrl)
+		mockDiag.EXPECT().
+			GetPublicEndpoint(gomock.Any(), clients.EndpointOptions{ResourceID: containerParsedID}).
+			Return(nil, nil).
+			Times(1)
+		mockDiag.EXPECT().
+			GetPublicEndpoint(gomock.Any(), clients.EndpointOptions{ResourceID: gatewayParsedID}).
+			Return(&endpoint, nil).
+			Times(1)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			RadiusCoreClientFactory: factory,
+			ConnectionFactory: &connections.MockFactory{
+				ApplicationsManagementClient: mockMgmt,
+				DiagnosticsClient:            mockDiag,
+			},
+			Workspace:       workspace,
+			ApplicationName: "test-app",
+			Format:          "table",
+			Output:          outputSink,
+		}
+
+		err = runner.Run(context.Background())
+		require.NoError(t, err)
+
+		// Should have: status table, blank line, gateway table
+		require.Len(t, outputSink.Writes, 3)
+
+		// Verify status
+		formatted, ok := outputSink.Writes[0].(output.FormattedOutput)
+		require.True(t, ok)
+		appStatus, ok := formatted.Obj.(clients.ApplicationStatus)
+		require.True(t, ok)
+		require.Equal(t, 2, appStatus.ResourceCount)
+		require.Len(t, appStatus.Gateways, 1)
+		require.Equal(t, "gw", appStatus.Gateways[0].Name)
+		require.Equal(t, "http://gw.example.com", appStatus.Gateways[0].Endpoint)
+
+		// Verify gateway table format
+		gwFormatted, ok := outputSink.Writes[2].(output.FormattedOutput)
+		require.True(t, ok)
+		require.Equal(t, status.GatewayFormat(), gwFormatted.Options)
+	})
+
+	t.Run("Error: application not found (404)", func(t *testing.T) {
+		notFoundServer := func() fake.ApplicationsServer {
+			return fake.ApplicationsServer{
+				Get: func(
+					ctx context.Context,
+					applicationName string,
+					options *corerpv20250801.ApplicationsClientGetOptions,
+				) (resp azfake.Responder[corerpv20250801.ApplicationsClientGetResponse], errResp azfake.ErrorResponder) {
+					errResp.SetResponseError(http.StatusNotFound, "NotFound")
+					return
+				},
+			}
+		}
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(workspace.Scope, nil, nil, notFoundServer)
+		require.NoError(t, err)
+
+		runner := &Runner{
+			RadiusCoreClientFactory: factory,
+			Workspace:               workspace,
+			ApplicationName:         "test-app",
+			Format:                  "table",
+			Output:                  &output.MockOutput{},
+		}
+
+		err = runner.Run(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "was not found or has been deleted")
+	})
+
+	t.Run("Success: JSON output format", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(workspace.Scope, nil, nil, test_client_factory.WithApplicationsServerNoError)
+		require.NoError(t, err)
+
+		appID := workspace.Scope + "/providers/Radius.Core/applications/test-app"
+
+		mockMgmt := clients.NewMockApplicationsManagementClient(ctrl)
+		mockMgmt.EXPECT().
+			ListResourcesInApplication(gomock.Any(), appID).
+			Return([]generated.GenericResource{}, nil).
+			Times(1)
+
+		mockDiag := clients.NewMockDiagnosticsClient(ctrl)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			RadiusCoreClientFactory: factory,
+			ConnectionFactory: &connections.MockFactory{
+				ApplicationsManagementClient: mockMgmt,
+				DiagnosticsClient:            mockDiag,
+			},
+			Workspace:       workspace,
+			ApplicationName: "test-app",
+			Format:          "json",
+			Output:          outputSink,
+		}
+
+		err = runner.Run(context.Background())
+		require.NoError(t, err)
+		require.Len(t, outputSink.Writes, 1)
+
+		formatted, ok := outputSink.Writes[0].(output.FormattedOutput)
+		require.True(t, ok)
+		require.Equal(t, "json", formatted.Format)
+	})
+
+	t.Run("Error: resource list failure is propagated", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(workspace.Scope, nil, nil, test_client_factory.WithApplicationsServerNoError)
+		require.NoError(t, err)
+
+		appID := workspace.Scope + "/providers/Radius.Core/applications/test-app"
+
+		mockMgmt := clients.NewMockApplicationsManagementClient(ctrl)
+		mockMgmt.EXPECT().
+			ListResourcesInApplication(gomock.Any(), appID).
+			Return(nil, fmt.Errorf("simulated error")).
+			Times(1)
+
+		runner := &Runner{
+			RadiusCoreClientFactory: factory,
+			ConnectionFactory:       &connections.MockFactory{ApplicationsManagementClient: mockMgmt},
+			Workspace:               workspace,
+			ApplicationName:         "test-app",
+			Format:                  "table",
+			Output:                  &output.MockOutput{},
+		}
+
+		err = runner.Run(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "simulated error")
+	})
+}

--- a/pkg/cli/cmd/app/status/status_test.go
+++ b/pkg/cli/cmd/app/status/status_test.go
@@ -169,7 +169,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     applicationStatus,
-				Options: statusFormat(),
+				Options: StatusFormat(),
 			},
 			output.LogOutput{
 				Format: "",
@@ -177,7 +177,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     applicationStatus.Gateways,
-				Options: gatewayFormat(),
+				Options: GatewayFormat(),
 			},
 		}
 

--- a/pkg/cli/test_client_factory/radius_core.go
+++ b/pkg/cli/test_client_factory/radius_core.go
@@ -178,6 +178,7 @@ func WithEnvironmentServerNoError() corerpfake.EnvironmentsServer {
 	}
 }
 
+// WithApplicationsServerNoError returns an ApplicationsServer with default success behavior.
 func WithApplicationsServerNoError() corerpfake.ApplicationsServer {
 	return corerpfake.ApplicationsServer{
 		Get: func(
@@ -218,6 +219,19 @@ func WithApplicationsServerNoError() corerpfake.ApplicationsServer {
 				},
 				nil,
 			)
+			return
+		},
+		GetGraph: func(
+			ctx context.Context,
+			applicationName string,
+			body any,
+			options *v20250801preview.ApplicationsClientGetGraphOptions,
+		) (resp azfake.Responder[v20250801preview.ApplicationsClientGetGraphResponse], errResp azfake.ErrorResponder) {
+			resp.SetResponse(http.StatusOK, v20250801preview.ApplicationsClientGetGraphResponse{
+				ApplicationGraphResponse: v20250801preview.ApplicationGraphResponse{
+					Resources: []*v20250801preview.ApplicationGraphResource{},
+				},
+			}, nil)
 			return
 		},
 	}


### PR DESCRIPTION
This pr adds --preview flag support to rad app graph and rad app status commands. When --preview is passed, these commands operate againstRadius.Core/applications resources via the v20250801preview API surface, instead of the default Applications.Core/applications.
This completes the rad app preview command set, following the prior PR that added rad app show/list/delete --preview.

Notes:
 - rad app graph --preview — Calls the v20250801preview GetGraph custom action directly. Renders the application graph in table (text) or JSON format. Returns a friendly 404 error if the application does not exist. Includes a v20250801preview-specific display() function for graph rendering.
 - rad app status --preview — Fetches the Radius.Core/applications resource via the new client, enumerates owned child resources usingownership-based filtering (properties.application), and gathers public endpoints via the diagnostics client. Outputs status table andgateway table.
 - Exported helpers — StatusFormat(), GatewayFormat(), ProviderFromID(), and MakeResourceHyperlink() are now exported from existingpackages so preview subpackages can reuse them without duplication.
 - Test client factory — NewRadiusCoreTestClientFactory gains a variadic applicationsServer parameter (backwards compatible).WithApplicationsServerNoError() now includes GetGraph support.
 - wirePreviewSubcommand tests — Added unit tests verifying the --preview routing dispatches correctly.

## Type of change

- This pull request adds or changes features of Radius and has an approved issue (#11675).

Fixes: #11675

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
