### PR TITLE
Add Contour HTTPProxy recipes to default recipe pack

### DIFF
--- a/pkg/cli/recipepack/recipepack.go
+++ b/pkg/cli/recipepack/recipepack.go
@@ -50,11 +50,11 @@ type ResourceGroupCreator func(ctx context.Context, planeName string, resourceGr
 // for all core resource types. This is the default recipe pack that gets injected into
 // environments that have no recipe packs configured.
 func NewDefaultRecipePackResource() corerpv20250801.RecipePackResource {
-	bicepKind := corerpv20250801.RecipeKindBicep
 	recipes := make(map[string]*corerpv20250801.RecipeDefinition)
 	for _, def := range GetCoreTypesRecipeInfo() {
+		recipeKind := corerpv20250801.RecipeKind(def.RecipeKind)
 		recipes[def.ResourceType] = &corerpv20250801.RecipeDefinition{
-			RecipeKind:     &bicepKind,
+			RecipeKind:     &recipeKind,
 			RecipeLocation: to.Ptr(def.RecipeLocation),
 		}
 	}
@@ -110,7 +110,9 @@ func GetOrCreateDefaultRecipePack(ctx context.Context, client *corerpv20250801.R
 type CoreTypesRecipeInfo struct {
 	// ResourceType is the full resource type (e.g., "Radius.Compute/containers").
 	ResourceType string
-	// RecipeLocation is the OCI registry location for the recipe.
+	// RecipeKind is the kind of recipe to run for the resource type.
+	RecipeKind string
+	// RecipeLocation is the location for the recipe.
 	RecipeLocation string
 }
 
@@ -119,28 +121,43 @@ type CoreTypesRecipeInfo struct {
 // The OCI tag is set to the current Radius version channel (e.g., "0.40" or "edge").
 func GetCoreTypesRecipeInfo() []CoreTypesRecipeInfo {
 	tag := version.Channel()
+	gitRef := tag
 	if version.IsEdgeChannel() {
 		tag = "latest"
+		gitRef = "main"
 	}
+	bicepKind := string(corerpv20250801.RecipeKindBicep)
+	terraformKind := string(corerpv20250801.RecipeKindTerraform)
+
 	return []CoreTypesRecipeInfo{
 		{
 			ResourceType:   "Radius.Compute/containers",
+			RecipeKind:     bicepKind,
 			RecipeLocation: "ghcr.io/radius-project/kube-recipes/containers:" + tag,
 		},
 		{
 			ResourceType:   "Radius.Compute/persistentVolumes",
+			RecipeKind:     bicepKind,
 			RecipeLocation: "ghcr.io/radius-project/kube-recipes/persistentvolumes:" + tag,
 		},
 		{
+			ResourceType:   "Radius.Compute/gateways",
+			RecipeKind:     terraformKind,
+			RecipeLocation: "git::https://github.com/radius-project/resource-types-contrib.git//Compute/gateways/recipes/kubernetes-contour-httpproxy/terraform?ref=" + gitRef,
+		},
+		{
 			ResourceType:   "Radius.Compute/routes",
-			RecipeLocation: "ghcr.io/radius-project/kube-recipes/routes:" + tag,
+			RecipeKind:     terraformKind,
+			RecipeLocation: "git::https://github.com/radius-project/resource-types-contrib.git//Compute/routes/recipes/kubernetes-contour-httpproxy/terraform?ref=" + gitRef,
 		},
 		{
 			ResourceType:   "Radius.Security/secrets",
+			RecipeKind:     bicepKind,
 			RecipeLocation: "ghcr.io/radius-project/kube-recipes/secrets:" + tag,
 		},
 		{
 			ResourceType:   "Radius.Data/mySqlDatabases",
+			RecipeKind:     bicepKind,
 			RecipeLocation: "ghcr.io/radius-project/kube-recipes/mysqldatabases:" + tag,
 		},
 	}

--- a/pkg/cli/recipepack/recipepack_test.go
+++ b/pkg/cli/recipepack/recipepack_test.go
@@ -29,12 +29,13 @@ func Test_GetDefaultRecipePackDefinition(t *testing.T) {
 	definitions := GetCoreTypesRecipeInfo()
 
 	// Verify we have the expected number of definitions
-	require.Len(t, definitions, 5)
+	require.Len(t, definitions, 6)
 
 	// Verify expected resource types
 	expectedResourceTypes := []string{
 		"Radius.Compute/containers",
 		"Radius.Compute/persistentVolumes",
+		"Radius.Compute/gateways",
 		"Radius.Compute/routes",
 		"Radius.Security/secrets",
 		"Radius.Data/mySqlDatabases",
@@ -42,19 +43,25 @@ func Test_GetDefaultRecipePackDefinition(t *testing.T) {
 	actualResourceTypes := make([]string, len(definitions))
 	for i, def := range definitions {
 		actualResourceTypes[i] = def.ResourceType
+		require.NotEmpty(t, def.RecipeKind, "RecipeKind should not be empty for %s", def.ResourceType)
 		require.NotEmpty(t, def.RecipeLocation, "RecipeLocation should not be empty for %s", def.ResourceType)
 	}
 	require.ElementsMatch(t, expectedResourceTypes, actualResourceTypes)
 }
 
-func Test_GetDefaultRecipePackDefinition_UsesLatestTagForEdgeChannel(t *testing.T) {
+func Test_GetDefaultRecipePackDefinition_UsesLatestRefForEdgeChannel(t *testing.T) {
 	// The test binary is built without ldflags, so channel defaults to "edge".
 	require.True(t, version.IsEdgeChannel(), "default should be on edge channel")
 
 	definitions := GetCoreTypesRecipeInfo()
 	for _, def := range definitions {
-		require.True(t, strings.HasSuffix(def.RecipeLocation, ":latest"),
-			"Expected :latest tag for edge channel, got %s", def.RecipeLocation)
+		if def.RecipeKind == string(corerpv20250801.RecipeKindTerraform) {
+			require.True(t, strings.HasSuffix(def.RecipeLocation, "?ref=main"),
+				"Expected ?ref=main for edge channel, got %s", def.RecipeLocation)
+		} else {
+			require.True(t, strings.HasSuffix(def.RecipeLocation, ":latest"),
+				"Expected :latest tag for edge channel, got %s", def.RecipeLocation)
+		}
 	}
 }
 
@@ -77,7 +84,7 @@ func Test_NewDefaultRecipePackResource(t *testing.T) {
 		recipe, exists := resource.Properties.Recipes[def.ResourceType]
 		require.True(t, exists, "Expected recipe for resource type %s to exist", def.ResourceType)
 		require.NotNil(t, recipe.RecipeKind)
-		require.Equal(t, corerpv20250801.RecipeKindBicep, *recipe.RecipeKind)
+		require.Equal(t, corerpv20250801.RecipeKind(def.RecipeKind), *recipe.RecipeKind)
 		require.NotNil(t, recipe.RecipeLocation)
 		require.Equal(t, def.RecipeLocation, *recipe.RecipeLocation)
 	}


### PR DESCRIPTION
## Summary

Adds Contour HTTPProxy behavior to the default Radius recipe pack while Radius continues installing Contour by default.

This changes the default recipe pack to:

- Add a `Radius.Compute/gateways` recipe entry for the Contour HTTPProxy gateway recipe.
- Replace the default `Radius.Compute/routes` Gateway API recipe with the Contour HTTPProxy route recipe.
- Allow default recipe pack entries to specify their own `recipeKind`, since the existing core defaults are Bicep recipes and the Contour HTTPProxy recipes are Terraform recipes.

## Scope

This does not change `rad install kubernetes`; Radius still special-cases and installs Contour by default. This only changes the default recipe-pack experience used by `rad init --preview`, `rad env create --preview`, and environment resources that receive the default recipe pack through `rad deploy`.

## Dependencies

Depends on the Contour HTTPProxy recipes from:

- https://github.com/radius-project/resource-types-contrib/pull/172

The default recipe locations point to `resource-types-contrib` Git sources:

- `Compute/gateways/recipes/kubernetes-contour-httpproxy/terraform`
- `Compute/routes/recipes/kubernetes-contour-httpproxy/terraform`

## Validation

Ran:

```bash
GOCACHE=/private/tmp/radius-go-build-cache go test ./pkg/cli/recipepack ./pkg/cli/cmd/env/create/preview ./pkg/cli/cmd/deploy
```

The recipe behavior was previously validated end to end in the demo repo:

- Contour HTTPProxy recipes: https://github.com/willdavsmith/radius-nginx-demo/actions/runs/26118318051
- Contour Gateway API recipes: https://github.com/willdavsmith/radius-nginx-demo/actions/runs/26118318008
- NGINX Gateway API recipes: https://github.com/willdavsmith/radius-nginx-demo/actions/runs/26118318007

## Related

- Design PR: https://github.com/radius-project/radius/pull/11995
- Issue: https://github.com/radius-project/radius/issues/11952
