### PR TITLE
Fix recipe pack OCI tags to use full semver version

### DIFF
--- a/pkg/cli/recipepack/recipepack.go
+++ b/pkg/cli/recipepack/recipepack.go
@@ -116,9 +116,10 @@ type CoreTypesRecipeInfo struct {
 
 // GetCoreTypesRecipeInfo returns recipe information for all core types.
 // Each definition represents a recipe for one core resource type.
-// The OCI tag is set to the current Radius version channel (e.g., "0.40" or "edge").
+// The OCI tag is set to the full semver release version (e.g., "0.58.0") to match the
+// tags used by the recipes publishing pipeline. For edge/dev builds, "latest" is used.
 func GetCoreTypesRecipeInfo() []CoreTypesRecipeInfo {
-	tag := version.Channel()
+	tag := version.Release()
 	if version.IsEdgeChannel() {
 		tag = "latest"
 	}


### PR DESCRIPTION
This pull request updates how the OCI tag is determined for core resource type recipes in the `GetCoreTypesRecipeInfo` function. Instead of using the version channel (like "0.40" or "edge"), it now uses the full semantic version (like "0.58.0") to align with tags from the kube-recipes publishing pipeline. For edge or development builds, "latest" is still used.

note: tests for this update will be included in pr: https://github.com/radius-project/radius/pull/12012

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (#12026 ).

Fixes: #12026 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
