### PR TITLE
fix(test): make Test_TerraformRecipe_AzureResourceGroup safe under concurrent CI

### DIFF
--- a/.github/workflows/purge-azure-test-resources.yaml
+++ b/.github/workflows/purge-azure-test-resources.yaml
@@ -63,7 +63,7 @@ jobs:
           current_time=$(date +%s)
           hours_ago=$((current_time - ${{ env.VALID_RESOURCE_WINDOW }}))
           while IFS=$'\t' read -r name creation_time; do
-            if [[ ! "$name" =~ ^"samplestest-" ]] && [[ ! "$name" =~ ^"radtest-" ]]; then
+            if [[ ! "$name" =~ ^"samplestest-" ]] && [[ ! "$name" =~ ^"radtest-" ]] && [[ ! "$name" =~ ^"tfrg" ]]; then
               continue
             fi
 

--- a/test/functional-portable/corerp/cloud/resources/recipe_terraform_test.go
+++ b/test/functional-portable/corerp/cloud/resources/recipe_terraform_test.go
@@ -25,6 +25,7 @@ package resource_test
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -52,7 +53,7 @@ func Test_TerraformRecipe_AzureResourceGroup(t *testing.T) {
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, testutil.GetTerraformRecipeModuleServerURL(), "appName="+appName),
+			Executor: step.NewDeployExecutor(template, testutil.GetTerraformRecipeModuleServerURL(), "appName="+appName, "uniqueSeed="+os.Getenv("UNIQUE_ID")),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{

--- a/test/functional-portable/corerp/cloud/resources/testdata/corerp-resources-terraform-azurerg.bicep
+++ b/test/functional-portable/corerp/cloud/resources/testdata/corerp-resources-terraform-azurerg.bicep
@@ -8,6 +8,9 @@ param moduleServer string
 @description('Name of the Radius Application.')
 param appName string
 
+@description('Per-run seed used to ensure the Azure resource group name does not collide across concurrent CI runs that share a test subscription.')
+param uniqueSeed string = ''
+
 resource env 'Applications.Core/environments@2023-10-01-preview' = {
   name: 'corerp-resources-terraform-azrg-env'
   properties: {
@@ -27,7 +30,7 @@ resource env 'Applications.Core/environments@2023-10-01-preview' = {
           templateKind: 'terraform'
           templatePath: '${moduleServer}/azure-rg.zip'
           parameters: {
-            name: 'tfrg${uniqueString(resourceGroup().id)}'
+            name: 'tfrg${uniqueString(resourceGroup().id, uniqueSeed)}'
             location: location
           }
         }


### PR DESCRIPTION
## Why

`Test_TerraformRecipe_AzureResourceGroup` started flaking on cloud PRs (most recently the dependabot PR #12037) with:

```
Error: A resource with the ID "/subscriptions/.../resourceGroups/tfrgt2fpfmmhcn44c" already exists.
To be managed via Terraform this resource needs to be imported into the State.
```

Root cause is not a leaked RG — it is a deterministic name collision between concurrent CI runs.

The terraform recipe deployed by the test names its Azure resource group:

```bicep
name: 'tfrg${uniqueString(resourceGroup().id)}'
```

`resourceGroup()` here is the Radius RG, which is hard-coded to `kind-radius` in every functional test cluster. So `uniqueString(resourceGroup().id)` resolves to the same value (`t2fpfmmhcn44c`) on every PR, every run, in every CI invocation against the shared test subscription. The Azure RG name is therefore globally constant.

That is fine when only one cloud job runs at a time. It breaks the moment two cloud jobs overlap (or one starts inside the ARM eventual-consistency window of another's destroy) because the `azurerm` provider's `RequiresImport` preflight `GET` sees a still-tearing-down ghost RG and refuses to create.

Verified from the failing run's `applications-rp` log on PR #12037 — the failing terraform create at 18:07:45 immediately followed a successful destroy from the `fix/recipe-tag-version` cloud job that completed at 18:07:01 in the same subscription.

## What this PR changes

1. **`testdata/corerp-resources-terraform-azurerg.bicep`** — add a new `uniqueSeed` bicep param and mix it into the recipe parameter:

   ```bicep
   name: 'tfrg${uniqueString(resourceGroup().id, uniqueSeed)}'
   ```

2. **`recipe_terraform_test.go`** — pass the workflow-provided `UNIQUE_ID` env var as `uniqueSeed`:

   ```go
   step.NewDeployExecutor(template, ..., "appName="+appName, "uniqueSeed="+os.Getenv("UNIQUE_ID"))
   ```

   `UNIQUE_ID` is already exposed on the cloud-test job by `.github/workflows/functional-test-cloud.yaml`, so every CI invocation now gets a distinct Azure RG name. Local runs (no `UNIQUE_ID` set) fall back to empty seed and behave exactly as today.

3. **`.github/workflows/purge-azure-test-resources.yaml`** — extend the sweeper allowlist to include the `tfrg` prefix so any RG that does leak (e.g. recipe destroy killed mid-apply) is reaped by the scheduled purge job instead of accumulating in the test subscription.

## Test plan

- `gofmt -d`, `go build`, `go vet` of the test package are clean locally.
- The fix targets a cloud E2E that can only be exercised in CI; the corerp-cloud job on this PR is the real validation.
- After this PR merges I will rebase dependabot PR #12037 onto `main` so its corerp-cloud run picks up the fix and demonstrates the failure is gone.

## Risk

Low. Bicep param defaults to empty string so the behavior change is opt-in via the test executor. The only callers that pass a non-empty seed are CI runs that should already have been getting distinct names. Worst case the seed is empty and we are back to today's deterministic name.
