### PR TITLE
ci: env var and token handling improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -479,7 +479,7 @@ jobs:
             --verify-tag \
             --prerelease
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Create GitHub Official Release
         if: ${{ !contains(env.REL_VERSION, 'rc') }}
@@ -490,7 +490,7 @@ jobs:
             --notes-file docs/release-notes/v${{ env.REL_VERSION }}.md \
             --verify-tag
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          GH_TOKEN: ${{ github.token }}
 
   # Comprehensive build summary that checks all critical build jobs.
   # Use this as the required status check in PR branch protection rules.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -132,14 +132,14 @@ jobs:
       - name: Copy cli binaries to release (unix-like)
         if: matrix.target_os != 'windows' && needs.changes.outputs.only_changed != 'true'
         run: |
-          mkdir ${{ env.RELEASE_PATH }}
-          cp ./dist/${{ matrix.target_os}}_${{ matrix.target_arch}}/release/rad ${{ env.RELEASE_PATH }}/rad_${{ matrix.target_os}}_${{ matrix.target_arch}}
+          mkdir "${RELEASE_PATH}"
+          cp "./dist/${GOOS}_${GOARCH}/release/rad" "${RELEASE_PATH}/rad_${GOOS}_${GOARCH}"
 
       - name: Copy cli binaries to release (windows)
         if: matrix.target_os == 'windows' && needs.changes.outputs.only_changed != 'true'
         run: |
-          mkdir ${{ env.RELEASE_PATH }}
-          cp ./dist/${{ matrix.target_os}}_${{ matrix.target_arch}}/release/rad.exe ${{ env.RELEASE_PATH }}/rad_${{ matrix.target_os}}_${{ matrix.target_arch}}.exe
+          mkdir "${RELEASE_PATH}"
+          cp "./dist/${GOOS}_${GOARCH}/release/rad.exe" "${RELEASE_PATH}/rad_${GOOS}_${GOARCH}.exe"
 
       - name: Upload CLI binary
         if: needs.changes.outputs.only_changed != 'true'
@@ -164,14 +164,14 @@ jobs:
       - name: Push latest rad cli binary to GHCR (unix-like)
         if: github.ref == 'refs/heads/main' && matrix.target_os != 'windows' && needs.changes.outputs.only_changed != 'true'
         run: |
-          cp ./dist/${{ matrix.target_os}}_${{ matrix.target_arch}}/release/rad ./rad
-          oras push ${{ env.CONTAINER_REGISTRY }}/rad/${{ matrix.target_os }}-${{ matrix.target_arch }}:latest ./rad --annotation "org.opencontainers.image.source=${{ env.IMAGE_SRC }}"
+          cp "./dist/${GOOS}_${GOARCH}/release/rad" ./rad
+          oras push "${CONTAINER_REGISTRY}/rad/${GOOS}-${GOARCH}:latest" ./rad --annotation "org.opencontainers.image.source=${IMAGE_SRC}"
 
       - name: Copy cli binaries to release (windows)
         if: github.ref == 'refs/heads/main' && matrix.target_os == 'windows' && needs.changes.outputs.only_changed != 'true'
         run: |
-          cp ./dist/${{ matrix.target_os}}_${{ matrix.target_arch}}/release/rad.exe ./rad.exe
-          oras push ${{ env.CONTAINER_REGISTRY }}/rad/${{ matrix.target_os }}-${{ matrix.target_arch }}:latest ./rad.exe --annotation "org.opencontainers.image.source=${{ env.IMAGE_SRC }}"
+          cp "./dist/${GOOS}_${GOARCH}/release/rad.exe" ./rad.exe
+          oras push "${CONTAINER_REGISTRY}/rad/${GOOS}-${GOARCH}:latest" ./rad.exe --annotation "org.opencontainers.image.source=${IMAGE_SRC}"
 
       - name: Skip
         if: needs.changes.outputs.only_changed == 'true'
@@ -341,17 +341,20 @@ jobs:
 
       - name: Run Helm linter
         run: |
-          helm lint ${{ env.HELM_CHARTS_DIR }}
+          helm lint "${HELM_CHARTS_DIR}"
 
       - name: Package Helm chart
         run: |
-          mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
-          helm package ${{ env.HELM_CHARTS_DIR }} --version ${{ env.CHART_VERSION }} --app-version ${{ env.REL_VERSION }} --destination ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+          mkdir -p "${ARTIFACT_DIR}/${HELM_PACKAGE_DIR}"
+          helm package "${HELM_CHARTS_DIR}" --version "${CHART_VERSION}" --app-version "${REL_VERSION}" --destination "${ARTIFACT_DIR}/${HELM_PACKAGE_DIR}"
 
       - name: Push helm chart to GHCR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_ACTOR: ${{ github.actor }}
         run: |
-          echo ${{ github.token }} | helm registry login -u ${{ github.actor }} --password-stdin ${{ env.OCI_REGISTRY }}
-          helm push ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}/radius-${{ env.CHART_VERSION }}.tgz oci://${{ env.OCI_REGISTRY }}/${{ env.OCI_REPOSITORY }}
+          echo "${GH_TOKEN}" | helm registry login -u "${GH_ACTOR}" --password-stdin "${OCI_REGISTRY}"
+          helm push "${ARTIFACT_DIR}/${HELM_PACKAGE_DIR}/radius-${CHART_VERSION}.tgz" "oci://${OCI_REGISTRY}/${OCI_REPOSITORY}"
 
   build-and-push-bicep-types:
     name: Dispatch Bicep Types publish
@@ -432,8 +435,9 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ steps.get-token.outputs.token }}
+          RUN_ID: ${{ steps.monitor-remote-workflow.outputs.run_id }}
         run: |
-          gh run view "${{ steps.monitor-remote-workflow.outputs.run_id }}" --repo azure-octo/radius-publisher --log-failed || true
+          gh run view "${RUN_ID}" --repo azure-octo/radius-publisher --log-failed || true
 
   publish-release:
     name: Publish GitHub Release
@@ -466,15 +470,15 @@ jobs:
 
       - name: generate checksum files
         run: |
-          cd ${{ env.RELEASE_PATH }} && for i in *; do sha256sum -b $i > "$i.sha256"; done && cd -
-          ls -l ${{ env.RELEASE_PATH }}
+          cd "${RELEASE_PATH}" && for i in *; do sha256sum -b "$i" > "$i.sha256"; done && cd -
+          ls -l "${RELEASE_PATH}"
 
       - name: Create GitHub RC Release (pre-release and auto-generate release notes)
         if: ${{ contains(env.REL_VERSION, 'rc') }}
         run: |
-          gh release create v${{ env.REL_VERSION }} \
-            ${{ env.RELEASE_PATH }}/* \
-            --title "Radius v${{ env.REL_VERSION }}" \
+          gh release create "v${REL_VERSION}" \
+            "${RELEASE_PATH}"/* \
+            --title "Radius v${REL_VERSION}" \
             --generate-notes \
             --verify-tag \
             --prerelease
@@ -484,10 +488,10 @@ jobs:
       - name: Create GitHub Official Release
         if: ${{ !contains(env.REL_VERSION, 'rc') }}
         run: |
-          gh release create v${{ env.REL_VERSION }} \
-            ${{ env.RELEASE_PATH }}/* \
-            --title "Radius v${{ env.REL_VERSION }}" \
-            --notes-file docs/release-notes/v${{ env.REL_VERSION }}.md \
+          gh release create "v${REL_VERSION}" \
+            "${RELEASE_PATH}"/* \
+            --title "Radius v${REL_VERSION}" \
+            --notes-file "docs/release-notes/v${REL_VERSION}.md" \
             --verify-tag
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/c9k-failure-report.yml
+++ b/.github/workflows/c9k-failure-report.yml
@@ -32,4 +32,4 @@ jobs:
           auto-issue-classes: "CodeChange,BrokenTestRun,DepMajorBump,DepGroupUpdate"
           auto-close-flaky: "true"
           assign-copilot: "true"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}

--- a/.github/workflows/devcontainer-feature-test.yaml
+++ b/.github/workflows/devcontainer-feature-test.yaml
@@ -37,8 +37,10 @@ jobs:
         run: npm install -g @devcontainers/cli
 
       - name: Generating tests for Radius CLI (default) against '${{ matrix.baseImage }}'
-        run: devcontainer features test --skip-scenarios -f radcli -i ${{ matrix.baseImage }} .
+        run: devcontainer features test --skip-scenarios -f radcli -i "${BASE_IMAGE}" .
         working-directory: ./deploy/devcontainer-feature
+        env:
+          BASE_IMAGE: ${{ matrix.baseImage }}
 
   test-scenarios:
     runs-on: ubuntu-24.04

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -1116,11 +1116,13 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     if: failure() && github.event_name == 'schedule' && github.repository == vars.RADIUS_REPOSITORY
+    permissions:
+      issues: write # Required to create an issue when the scheduled run fails
     steps:
       - name: Create failure issue for failing scheduled run
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          github-token: ${{ github.token }}
           script: |
             github.rest.issues.create({
               ...context.repo,

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -603,7 +603,15 @@ jobs:
       CHECKOUT_REPO: ${{ needs.setup.outputs.CHECKOUT_REPO }}
       CHECKOUT_REF: ${{ needs.setup.outputs.CHECKOUT_REF }}
       PR_NUMBER: ${{ needs.setup.outputs.PR_NUMBER }}
-      AZURE_TEST_RESOURCE_GROUP: radtest-${{ needs.setup.outputs.UNIQUE_ID }}-${{ matrix.name }}
+      # Include run_attempt so each re-run uses a distinct resource group.
+      # UNIQUE_ID is generated in the separate `setup` job, which is NOT
+      # re-executed by "Re-run failed jobs", so it stays constant across
+      # attempts. The delete step uses `az group delete --no-wait`, so a
+      # re-run would otherwise try to recreate the same resource group while
+      # the previous attempt's deletion is still in progress, failing with
+      # "ResourceGroupBeingDeleted". The radtest- prefix is preserved so the
+      # purge workflow still cleans up any orphaned groups.
+      AZURE_TEST_RESOURCE_GROUP: radtest-${{ needs.setup.outputs.UNIQUE_ID }}-${{ matrix.name }}-${{ github.run_attempt }}
       RAD_CLI_ARTIFACT_NAME: ${{ needs.setup.outputs.RAD_CLI_ARTIFACT_NAME }}
       BICEP_RECIPE_TAG_VERSION: ${{ needs.setup.outputs.REL_VERSION }}
       DE_IMAGE: ${{ needs.setup.outputs.DE_IMAGE }}

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -198,42 +198,54 @@ jobs:
       BASE_SHA: ${{ steps.gen-id.outputs.BASE_SHA }}
     steps:
       - name: Log Event Information
+        env:
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
         run: |
-          echo "Event Name: ${{ github.event_name }}"
-          echo "Actor: ${{ github.actor }}"
-          echo "Author Association: ${{ github.event.pull_request.author_association }}"
-          echo "PR Head Repo: ${{ github.event.pull_request.head.repo.full_name }}"
-          echo "PR Base Repo: ${{ github.event.pull_request.base.repo.full_name }}"
-          echo "Is Fork: ${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}"
+          echo "Event Name: ${GITHUB_EVENT_NAME}"
+          echo "Actor: ${GITHUB_ACTOR}"
+          echo "Author Association: ${PR_AUTHOR_ASSOCIATION}"
+          echo "PR Head Repo: ${PR_HEAD_REPO}"
+          echo "PR Base Repo: ${PR_BASE_REPO}"
+          echo "Is Fork: ${IS_FORK}"
 
       - name: Set up checkout target (scheduled)
         if: github.event_name == 'schedule'
         run: |
-          echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
+          echo "CHECKOUT_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
           echo "CHECKOUT_REF=refs/heads/main" >> $GITHUB_ENV
 
       - name: Set up checkout target (repository_dispatch)
         if: github.event_name == 'repository_dispatch'
         run: |
-          echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
+          echo "CHECKOUT_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
           echo "CHECKOUT_REF=refs/heads/main" >> $GITHUB_ENV
 
       - name: Set up checkout target (pull_request_target)
         if: github.event_name == 'pull_request_target'
+        env:
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           {
-            echo "CHECKOUT_REPO=${{ github.event.pull_request.head.repo.full_name }}"
-            echo "CHECKOUT_REF=${{ github.event.pull_request.head.sha }}"
-            echo "PR_NUMBER=${{ github.event.pull_request.number }}"
-            echo "BASE_SHA=${{ github.event.pull_request.base.sha }}"
+            echo "CHECKOUT_REPO=${PR_HEAD_REPO}"
+            echo "CHECKOUT_REF=${PR_HEAD_SHA}"
+            echo "PR_NUMBER=${PR_NUMBER}"
+            echo "BASE_SHA=${PR_BASE_SHA}"
           } >> "${GITHUB_ENV}"
 
       - name: Set up checkout target (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_BRANCH: ${{ github.event.inputs.branch }}
         run: |
           {
-            echo "CHECKOUT_REPO=${{ github.repository }}"
-            echo "CHECKOUT_REF=refs/heads/${{ github.event.inputs.branch }}"
+            echo "CHECKOUT_REPO=${GITHUB_REPOSITORY}"
+            echo "CHECKOUT_REF=refs/heads/${INPUT_BRANCH}"
           } >> "${GITHUB_ENV}"
 
       - name: Checkout
@@ -268,13 +280,13 @@ jobs:
           {
             echo "REL_VERSION=pr-${UNIQUE_ID}"
             echo "UNIQUE_ID=${UNIQUE_ID}"
-            echo "CHECKOUT_REPO=${{ env.CHECKOUT_REPO }}"
-            echo "CHECKOUT_REF=${{ env.CHECKOUT_REF }}"
+            echo "CHECKOUT_REPO=${CHECKOUT_REPO}"
+            echo "CHECKOUT_REF=${CHECKOUT_REF}"
             echo "RAD_CLI_ARTIFACT_NAME=rad_cli_linux_amd64"
-            echo "PR_NUMBER=${{ env.PR_NUMBER }}"
-            echo "DE_IMAGE=${{ env.DE_IMAGE }}"
-            echo "DE_TAG=${{ env.DE_TAG }}"
-            echo "BASE_SHA=${{ env.BASE_SHA }}"
+            echo "PR_NUMBER=${PR_NUMBER}"
+            echo "DE_IMAGE=${DE_IMAGE}"
+            echo "DE_TAG=${DE_TAG}"
+            echo "BASE_SHA=${BASE_SHA}"
           } >> "${GITHUB_OUTPUT}"
 
   changes:
@@ -457,8 +469,10 @@ jobs:
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
 
       - name: Generate Bicep extensibility types from OpenAPI specs
+        env:
+          BICEP_TYPES_VERSION: ${{ env.REL_VERSION == 'edge' && 'latest' || env.REL_VERSION }}
         run: |
-          make generate-bicep-types VERSION=${{ env.REL_VERSION == 'edge' && 'latest' || env.REL_VERSION }}
+          make generate-bicep-types VERSION="${BICEP_TYPES_VERSION}"
 
       - name: Setup and verify bicep CLI
         run: |
@@ -475,21 +489,23 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
 
       - name: Publish Radius test bicep types
+        env:
+          BICEP_TYPES_VERSION: ${{ env.REL_VERSION == 'edge' && 'latest' || env.REL_VERSION }}
         run: |
-          bicep publish-extension ./hack/bicep-types-radius/generated/index.json --target br:${{ env.TEST_BICEP_TYPES_REGISTRY }}/test/radius:${{ env.REL_VERSION == 'edge' && 'latest' || env.REL_VERSION }} --force
+          bicep publish-extension ./hack/bicep-types-radius/generated/index.json --target "br:${TEST_BICEP_TYPES_REGISTRY}/test/radius:${BICEP_TYPES_VERSION}" --force
 
       - name: Generate test bicepconfig.json
         run: |
-          if [[ "${{ env.REL_VERSION }}" == "edge" ]]; then
+          if [[ "${REL_VERSION}" == "edge" ]]; then
             RADIUS_VERSION="latest"
           else
-            RADIUS_VERSION="${{ env.REL_VERSION }}"
+            RADIUS_VERSION="${REL_VERSION}"
           fi
           cat <<EOF > ./test/bicepconfig.json
           {
             "extensions": {
-              "radius": "br:${{ env.TEST_BICEP_TYPES_REGISTRY }}/test/radius:$RADIUS_VERSION",
-              "aws": "br:${{ env.BICEP_TYPES_REGISTRY }}/aws:latest"
+              "radius": "br:${TEST_BICEP_TYPES_REGISTRY}/test/radius:$RADIUS_VERSION",
+              "aws": "br:${BICEP_TYPES_REGISTRY}/aws:latest"
             }
           }
           EOF
@@ -650,7 +666,7 @@ jobs:
       - name: Copy rad CLI to bin
         run: |
           mkdir -p ./bin
-          cp "${{ runner.temp }}/rad-cli-artifact/rad" ./bin/rad
+          cp "${RUNNER_TEMP}/rad-cli-artifact/rad" ./bin/rad
           chmod +x ./bin/rad
           # Verify it is the expected binary
           file ./bin/rad | grep -q "ELF" || { echo "Downloaded rad binary is not a valid ELF executable"; exit 1; }
@@ -678,13 +694,14 @@ jobs:
         run: |
           current_time=$(date +%s)
           az group create \
-            --location ${{ env.AZURE_LOCATION }} \
-            --name $RESOURCE_GROUP \
-            --subscription ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }} \
+            --location "${AZURE_LOCATION}" \
+            --name "${RESOURCE_GROUP}" \
+            --subscription "${AZURE_SUBSCRIPTIONID_TESTS}" \
             --tags creationTime=$current_time
-          while [ $(az group exists --name $RESOURCE_GROUP) = false ]; do sleep 2; done
+          while [ $(az group exists --name "${RESOURCE_GROUP}") = false ]; do sleep 2; done
         env:
           RESOURCE_GROUP: ${{ env.AZURE_TEST_RESOURCE_GROUP }}
+          AZURE_SUBSCRIPTIONID_TESTS: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
 
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
@@ -701,14 +718,17 @@ jobs:
 
       # create kind cluster with OIDC provider.
       - name: Create KinD cluster
+        env:
+          FUNCTEST_AZURE_OIDC_JSON: ${{ secrets.FUNCTEST_AZURE_OIDC_JSON }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          curl -sSLo "kind" "https://github.com/kubernetes-sigs/kind/releases/download/${{ env.KIND_VER }}/kind-linux-amd64"
+          curl -sSLo "kind" "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VER}/kind-linux-amd64"
           chmod +x ./kind
 
           # Parse and validate Azure workload identity values from secret JSON.
-          OIDC_JSON='${{ secrets.FUNCTEST_AZURE_OIDC_JSON }}'
+          OIDC_JSON="${FUNCTEST_AZURE_OIDC_JSON}"
           if ! echo "${OIDC_JSON}" | jq -e . >/dev/null; then
             echo "FUNCTEST_AZURE_OIDC_JSON is not valid JSON."
             echo "Expected keys: AZURE_OIDC_ISSUER, AZURE_OIDC_ISSUER_PUBLIC_KEY, AZURE_OIDC_ISSUER_PRIVATE_KEY"
@@ -719,7 +739,7 @@ jobs:
           AZURE_OIDC_ISSUER_PUBLIC_KEY="$(echo "${OIDC_JSON}" | jq -er '.AZURE_OIDC_ISSUER_PUBLIC_KEY')"
           AZURE_OIDC_ISSUER_PRIVATE_KEY="$(echo "${OIDC_JSON}" | jq -er '.AZURE_OIDC_ISSUER_PRIVATE_KEY')"
 
-          AUTHKEY=$(printf '%s' "${{ github.actor }}:${{ github.token }}" | base64)
+          AUTHKEY=$(printf '%s' "${GITHUB_ACTOR}:${GITHUB_TOKEN}" | base64)
           echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"${AUTHKEY}\"}}}" > "./ghcr_secret.json"
 
           # Create KinD cluster with OIDC Issuer keys
@@ -756,12 +776,14 @@ jobs:
       - name: Install Azure Keyvault CSI driver chart
         run: |
           helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
-          helm install csi csi-secrets-store-provider-azure/csi-secrets-store-provider-azure --version ${{ env.AZURE_KEYVAULT_CSI_DRIVER_VER }}
+          helm install csi csi-secrets-store-provider-azure/csi-secrets-store-provider-azure --version "${AZURE_KEYVAULT_CSI_DRIVER_VER}"
 
       - name: Install azure workload identity webhook chart
+        env:
+          AZURE_SP_TESTS_TENANTID: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
         run: |
           helm repo add azure-workload-identity https://azure.github.io/azure-workload-identity/charts
-          helm install workload-identity-webhook azure-workload-identity/workload-identity-webhook --namespace radius-default --create-namespace --version ${{ env.AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER }} --set azureTenantID=${{ secrets.AZURE_SP_TESTS_TENANTID }}
+          helm install workload-identity-webhook azure-workload-identity/workload-identity-webhook --namespace radius-default --create-namespace --version "${AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER}" --set "azureTenantID=${AZURE_SP_TESTS_TENANTID}"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -779,7 +801,7 @@ jobs:
 
       - name: Install gotestsum (test reporting tool)
         run: |
-          go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VER }}
+          go install "gotest.tools/gotestsum@v${GOTESTSUM_VER}"
 
       - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         if: failure() && env.PR_NUMBER != ''
@@ -792,19 +814,25 @@ jobs:
           message: |
             :x: Test tool installation for ${{ matrix.name }} failed. Please check [the logs](${{ env.ACTION_LINK }}) for more details
       - name: Install Radius
+        env:
+          AZURE_SUBSCRIPTIONID_TESTS: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
+          AZURE_SP_TESTS_APPID: ${{ secrets.AZURE_SP_TESTS_APPID }}
+          AZURE_SP_TESTS_TENANTID: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
+          FUNCTEST_AWS_ACCOUNT_ID: ${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}
+          FUNC_TEST_RAD_IRSA_ROLE: ${{ secrets.FUNC_TEST_RAD_IRSA_ROLE }}
         run: |
           export PATH=$GITHUB_WORKSPACE/bin:$PATH
           which rad || { echo "cannot find rad"; exit 1; }
 
           echo "*** Installing Radius to Kubernetes ***"
           rad install kubernetes \
-            --chart ${{ env.RADIUS_CHART_LOCATION }} \
-            --set rp.image=${{ env.CONTAINER_REGISTRY }}/applications-rp,rp.tag=${{ env.REL_VERSION }} \
-            --set dynamicrp.image=${{ env.CONTAINER_REGISTRY }}/dynamic-rp,dynamicrp.tag=${{ env.REL_VERSION }} \
-            --set controller.image=${{ env.CONTAINER_REGISTRY }}/controller,controller.tag=${{ env.REL_VERSION }} \
-            --set ucp.image=${{ env.CONTAINER_REGISTRY }}/ucpd,ucp.tag=${{ env.REL_VERSION }} \
-            --set de.image=${{ env.DE_IMAGE }},de.tag=${{ env.DE_TAG }} \
-            --set bicep.image=${{ env.CONTAINER_REGISTRY }}/bicep,bicep.tag=${{ env.REL_VERSION }} \
+            --chart "${RADIUS_CHART_LOCATION}" \
+            --set "rp.image=${CONTAINER_REGISTRY}/applications-rp,rp.tag=${REL_VERSION}" \
+            --set "dynamicrp.image=${CONTAINER_REGISTRY}/dynamic-rp,dynamicrp.tag=${REL_VERSION}" \
+            --set "controller.image=${CONTAINER_REGISTRY}/controller,controller.tag=${REL_VERSION}" \
+            --set "ucp.image=${CONTAINER_REGISTRY}/ucpd,ucp.tag=${REL_VERSION}" \
+            --set "de.image=${DE_IMAGE},de.tag=${DE_TAG}" \
+            --set "bicep.image=${CONTAINER_REGISTRY}/bicep,bicep.tag=${REL_VERSION}" \
             --set global.azureWorkloadIdentity.enabled=true \
             --set global.aws.irsa.enabled=true
 
@@ -862,17 +890,17 @@ jobs:
           rad env switch kind-radius
 
           echo "*** Configuring Azure provider ***"
-          rad env update kind-radius --azure-subscription-id ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }} \
-            --azure-resource-group ${{ env.AZURE_TEST_RESOURCE_GROUP }}
+          rad env update kind-radius --azure-subscription-id "${AZURE_SUBSCRIPTIONID_TESTS}" \
+            --azure-resource-group "${AZURE_TEST_RESOURCE_GROUP}"
           rad credential register azure wi \
-            --client-id ${{ secrets.AZURE_SP_TESTS_APPID }} \
-            --tenant-id ${{ secrets.AZURE_SP_TESTS_TENANTID }}
+            --client-id "${AZURE_SP_TESTS_APPID}" \
+            --tenant-id "${AZURE_SP_TESTS_TENANTID}"
 
           echo "*** Configuring AWS provider ***"
-          rad env update kind-radius --aws-region ${{ env.AWS_REGION }} --aws-account-id ${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}
+          rad env update kind-radius --aws-region "${AWS_REGION}" --aws-account-id "${FUNCTEST_AWS_ACCOUNT_ID}"
 
           rad credential register aws irsa \
-            --iam-role ${{ secrets.FUNC_TEST_RAD_IRSA_ROLE }}
+            --iam-role "${FUNC_TEST_RAD_IRSA_ROLE}"
 
       - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         if: failure() && env.PR_NUMBER != ''
@@ -890,16 +918,16 @@ jobs:
           make publish-test-terraform-recipes
       - name: Generate test bicepconfig.json
         run: |
-          if [[ "${{ env.REL_VERSION }}" == "edge" ]]; then
+          if [[ "${REL_VERSION}" == "edge" ]]; then
             RADIUS_VERSION="latest"
           else
-            RADIUS_VERSION="${{ env.REL_VERSION }}"
+            RADIUS_VERSION="${REL_VERSION}"
           fi
           cat <<EOF > ./test/bicepconfig.json
           {
             "extensions": {
-              "radius": "br:${{ env.TEST_BICEP_TYPES_REGISTRY }}/test/radius:$RADIUS_VERSION",
-              "aws": "br:${{ env.BICEP_TYPES_REGISTRY }}/aws:latest"
+              "radius": "br:${TEST_BICEP_TYPES_REGISTRY}/test/radius:$RADIUS_VERSION",
+              "aws": "br:${BICEP_TYPES_REGISTRY}/aws:latest"
             },
             "cloud": {
               "credentialPrecedence": ["AzureCLI", "Environment"]
@@ -930,7 +958,7 @@ jobs:
           # AZURE_MSSQL_RESOURCE_ID
           # AZURE_MSSQL_USERNAME
           # AZURE_MSSQL_PASSWORD
-          PREPROVISIONED_JSON='${{ secrets.FUNCTEST_PREPROVISIONED_RESOURCE_JSON }}'
+          PREPROVISIONED_JSON="${FUNCTEST_PREPROVISIONED_RESOURCE_JSON}"
           if ! echo "${PREPROVISIONED_JSON}" | jq -e . >/dev/null; then
             echo "FUNCTEST_PREPROVISIONED_RESOURCE_JSON is not valid JSON."
             echo "Expected keys: AZURE_COSMOS_MONGODB_ACCOUNT_ID, AZURE_MSSQL_RESOURCE_ID, AZURE_MSSQL_USERNAME, AZURE_MSSQL_PASSWORD"
@@ -942,7 +970,7 @@ jobs:
           export AZURE_MSSQL_USERNAME="$(echo "${PREPROVISIONED_JSON}" | jq -er '.AZURE_MSSQL_USERNAME')"
           export AZURE_MSSQL_PASSWORD="$(echo "${PREPROVISIONED_JSON}" | jq -er '.AZURE_MSSQL_PASSWORD')"
 
-          make test-functional-${{ matrix.name }}
+          make "test-functional-${MATRIX_NAME}"
         env:
           DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           TEST_TIMEOUT: ${{ env.FUNCTIONALTEST_TIMEOUT }}
@@ -958,6 +986,8 @@ jobs:
           BICEP_RECIPE_TAG_VERSION: ${{ env.BICEP_RECIPE_TAG_VERSION }}
           GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
           GOTESTSUM_OPTS: --junitfile ./dist/functional_test/results.xml
+          MATRIX_NAME: ${{ matrix.name }}
+          FUNCTEST_PREPROVISIONED_RESOURCE_JSON: ${{ secrets.FUNCTEST_PREPROVISIONED_RESOURCE_JSON }}
 
       - name: Process Functional Test Results
         uses: ./.github/actions/process-test-results
@@ -970,9 +1000,11 @@ jobs:
 
       - name: Collect Pod details
         if: always()
+        env:
+          MATRIX_NAME: ${{ matrix.name }}
         run: |
-          POD_STATE_LOG_FILENAME='${{ env.RADIUS_CONTAINER_LOG_BASE }}/${{ matrix.name }}-tests-pod-states.log'
-          mkdir -p $(dirname $POD_STATE_LOG_FILENAME)
+          POD_STATE_LOG_FILENAME="${RADIUS_CONTAINER_LOG_BASE}/${MATRIX_NAME}-tests-pod-states.log"
+          mkdir -p "$(dirname "${POD_STATE_LOG_FILENAME}")"
           {
             echo "kubectl get pods -A"
             kubectl get pods -A
@@ -1046,11 +1078,13 @@ jobs:
 
       - name: Delete azure resource group - ${{ env.AZURE_TEST_RESOURCE_GROUP }}
         if: always()
+        env:
+          AZURE_SUBSCRIPTIONID_TESTS: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
         run: |
           # if deletion fails, purge workflow will purge the resource group and its resources later.
           az group delete \
-            --subscription ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }} \
-            --name ${{ env.AZURE_TEST_RESOURCE_GROUP }} \
+            --subscription "${AZURE_SUBSCRIPTIONID_TESTS}" \
+            --name "${AZURE_TEST_RESOURCE_GROUP}" \
             --yes \
             --verbose \
             --no-wait
@@ -1078,9 +1112,11 @@ jobs:
 
       - name: Get tests job status
         id: get_test_status
+        env:
+          GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
         run: |
           # from: https://github.com/orgs/community/discussions/26526#discussioncomment-3252209
-          ALL_JOBS_STATUS=$(curl -X GET -s -u "admin:${{ steps.get_installation_token.outputs.token }}" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq ".jobs[] | {job_status: .conclusion}")
+          ALL_JOBS_STATUS=$(curl -X GET -s -u "admin:${GH_TOKEN}" "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" | jq ".jobs[] | {job_status: .conclusion}")
           echo "All jobs status: $ALL_JOBS_STATUS"
           TEST_STATUS="success"
           for job_status in $(echo "$ALL_JOBS_STATUS" | jq -r '.[]'); do

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -149,8 +149,8 @@ jobs:
           # Set output variables to be used in the other jobs
           {
             echo "REL_VERSION=pr-${UNIQUE_ID}"
-            echo "DE_IMAGE=${{ env.DE_IMAGE }}"
-            echo "DE_TAG=${{ env.DE_TAG }}"
+            echo "DE_IMAGE=${DE_IMAGE}"
+            echo "DE_TAG=${DE_TAG}"
           } >> "${GITHUB_OUTPUT}"
 
   tests:
@@ -194,25 +194,29 @@ jobs:
         if: github.event_name == 'schedule' || github.event_name == 'repository_dispatch'
         run: |
           {
-            echo "CHECKOUT_REPO=${{ github.repository }}"
+            echo "CHECKOUT_REPO=${GITHUB_REPOSITORY}"
             echo "CHECKOUT_REF=refs/heads/main"
           } >> "${GITHUB_ENV}"
 
       - name: Set up checkout target (pull_request)
         if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           {
-            echo "CHECKOUT_REPO=${{ github.repository }}"
-            echo "CHECKOUT_REF=${{ github.ref }}"
-            echo "PR_NUMBER=${{ github.event.pull_request.number }}"
+            echo "CHECKOUT_REPO=${GITHUB_REPOSITORY}"
+            echo "CHECKOUT_REF=${GITHUB_REF}"
+            echo "PR_NUMBER=${PR_NUMBER}"
           } >> "${GITHUB_ENV}"
 
       - name: Set up checkout target (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_BRANCH: ${{ github.event.inputs.branch }}
         run: |
           {
-            echo "CHECKOUT_REPO=${{ github.repository }}"
-            echo "CHECKOUT_REF=refs/heads/${{ github.event.inputs.branch }}"
+            echo "CHECKOUT_REPO=${GITHUB_REPOSITORY}"
+            echo "CHECKOUT_REF=refs/heads/${INPUT_BRANCH}"
           } >> "${GITHUB_ENV}"
 
       - name: Checkout
@@ -238,7 +242,7 @@ jobs:
 
       - name: Install gotestsum (test reporting tool)
         run: |
-          go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VER }}
+          go install "gotest.tools/gotestsum@v${GOTESTSUM_VER}"
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -255,8 +259,10 @@ jobs:
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
 
       - name: Generate Bicep extensibility types from OpenAPI specs
+        env:
+          BICEP_TYPES_VERSION: ${{ env.REL_VERSION == 'edge' && 'latest' || env.REL_VERSION }}
         run: |
-          make generate-bicep-types VERSION=${{ env.REL_VERSION == 'edge' && 'latest' || env.REL_VERSION }}
+          make generate-bicep-types VERSION="${BICEP_TYPES_VERSION}"
 
       - name: Upload Radius Bicep types artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -276,27 +282,29 @@ jobs:
 
       - name: Setup and verify bicep CLI
         run: |
-          curl -Lo bicep "https://github.com/Azure/bicep/releases/download/${{ env.BICEP_VER }}/bicep-linux-x64"
+          curl -Lo bicep "https://github.com/Azure/bicep/releases/download/${BICEP_VER}/bicep-linux-x64"
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
 
       - name: Publish bicep types
+        env:
+          BICEP_TYPES_VERSION: ${{ env.REL_VERSION == 'edge' && 'latest' || env.REL_VERSION }}
         run: |
-          bicep publish-extension ./hack/bicep-types-radius/generated/index.json --target br:${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}/radius:${{ env.REL_VERSION == 'edge' && 'latest' || env.REL_VERSION }} --force
+          bicep publish-extension ./hack/bicep-types-radius/generated/index.json --target "br:${LOCAL_REGISTRY_SERVER}:${LOCAL_REGISTRY_PORT}/radius:${BICEP_TYPES_VERSION}" --force
 
       - name: Generate test bicepconfig.json
         run: |
-          if [[ "${{ env.REL_VERSION }}" == "edge" ]]; then
+          if [[ "${REL_VERSION}" == "edge" ]]; then
             RADIUS_VERSION="latest"
           else
-            RADIUS_VERSION="${{ env.REL_VERSION }}"
+            RADIUS_VERSION="${REL_VERSION}"
           fi
           cat <<EOF > ./test/bicepconfig.json
           {
             "extensions": {
-              "radius": "br:${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}/radius:$RADIUS_VERSION",
-              "aws": "br:${{ env.BICEP_TYPES_REGISTRY }}/aws:latest"
+              "radius": "br:${LOCAL_REGISTRY_SERVER}:${LOCAL_REGISTRY_PORT}/radius:$RADIUS_VERSION",
+              "aws": "br:${BICEP_TYPES_REGISTRY}/aws:latest"
             }
           }
           EOF
@@ -353,17 +361,17 @@ jobs:
           fi
 
           RAD_COMMAND="rad install kubernetes \
-                 --chart ${{ env.RADIUS_CHART_LOCATION }} \
-                 --set rp.image=${{ env.LOCAL_REGISTRY_NAME }}:${{ env.LOCAL_REGISTRY_PORT }}/applications-rp,rp.tag=${{ env.REL_VERSION }} \
-                 --set dynamicrp.image=${{ env.LOCAL_REGISTRY_NAME }}:${{ env.LOCAL_REGISTRY_PORT }}/dynamic-rp,dynamicrp.tag=${{ env.REL_VERSION }} \
-                 --set controller.image=${{ env.LOCAL_REGISTRY_NAME }}:${{ env.LOCAL_REGISTRY_PORT }}/controller,controller.tag=${{ env.REL_VERSION }} \
-                 --set ucp.image=${{ env.LOCAL_REGISTRY_NAME }}:${{ env.LOCAL_REGISTRY_PORT }}/ucpd,ucp.tag=${{ env.REL_VERSION }} \
-                 --set bicep.image=${{ env.LOCAL_REGISTRY_NAME }}:${{ env.LOCAL_REGISTRY_PORT }}/bicep,bicep.tag=${{ env.REL_VERSION }} \
-                 --set preupgrade.image=${{ env.LOCAL_REGISTRY_NAME }}:${{ env.LOCAL_REGISTRY_PORT }}/pre-upgrade,preupgrade.tag=${{ env.REL_VERSION }} \
-                 --set de.image=${{ env.DE_IMAGE }},de.tag=${{ env.DE_TAG }}"
+                 --chart ${RADIUS_CHART_LOCATION} \
+                 --set rp.image=${LOCAL_REGISTRY_NAME}:${LOCAL_REGISTRY_PORT}/applications-rp,rp.tag=${REL_VERSION} \
+                 --set dynamicrp.image=${LOCAL_REGISTRY_NAME}:${LOCAL_REGISTRY_PORT}/dynamic-rp,dynamicrp.tag=${REL_VERSION} \
+                 --set controller.image=${LOCAL_REGISTRY_NAME}:${LOCAL_REGISTRY_PORT}/controller,controller.tag=${REL_VERSION} \
+                 --set ucp.image=${LOCAL_REGISTRY_NAME}:${LOCAL_REGISTRY_PORT}/ucpd,ucp.tag=${REL_VERSION} \
+                 --set bicep.image=${LOCAL_REGISTRY_NAME}:${LOCAL_REGISTRY_PORT}/bicep,bicep.tag=${REL_VERSION} \
+                 --set preupgrade.image=${LOCAL_REGISTRY_NAME}:${LOCAL_REGISTRY_PORT}/pre-upgrade,preupgrade.tag=${REL_VERSION} \
+                 --set de.image=${DE_IMAGE},de.tag=${DE_TAG}"
 
-          if [ "${{ env.USE_CERT_FILE }}" = "true" ]; then
-            RAD_COMMAND="$RAD_COMMAND --set-file global.rootCA.cert=$TEMP_CERT_DIR/certs/${{ env.LOCAL_REGISTRY_SERVER }}/client.crt"
+          if [ "${USE_CERT_FILE}" = "true" ]; then
+            RAD_COMMAND="$RAD_COMMAND --set-file global.rootCA.cert=$TEMP_CERT_DIR/certs/${LOCAL_REGISTRY_SERVER}/client.crt"
           fi
 
           echo "*** Installing Radius to Kubernetes ***"
@@ -454,36 +462,40 @@ jobs:
       - name: Install Dapr CLI and control plane
         if: matrix.name == 'daprrp-noncloud'
         run: |
-          wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}
-          dapr init -k --wait --timeout 600 --runtime-version ${{ env.DAPR_RUNTIME_VER }} --dashboard-version ${{ env.DAPR_DASHBOARD_VER }}
+          wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s "${DAPR_CLI_VER}"
+          dapr init -k --wait --timeout 600 --runtime-version "${DAPR_RUNTIME_VER}" --dashboard-version "${DAPR_DASHBOARD_VER}"
 
       - name: Publish Terraform test recipes
         run: |
           make publish-test-terraform-recipes
 
       - name: Publish bicep types
+        env:
+          BICEP_TYPES_VERSION: ${{ env.REL_VERSION == 'edge' && 'latest' || env.REL_VERSION }}
         run: |
-          bicep publish-extension ./hack/bicep-types-radius/generated/index.json --target br:${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}/radius:${{ env.REL_VERSION == 'edge' && 'latest' || env.REL_VERSION }} --force
+          bicep publish-extension ./hack/bicep-types-radius/generated/index.json --target "br:${LOCAL_REGISTRY_SERVER}:${LOCAL_REGISTRY_PORT}/radius:${BICEP_TYPES_VERSION}" --force
 
       - name: Publish UDT types
+        env:
+          BICEP_TYPES_VERSION: ${{ env.REL_VERSION == 'edge' && 'latest' || env.REL_VERSION }}
         run: |
           export PATH=$GITHUB_WORKSPACE/bin:$PATH
           which rad || { echo "cannot find rad"; exit 1; }
-          rad bicep publish-extension -f ./test/functional-portable/dynamicrp/noncloud/resources/testdata/testresourcetypes.yaml --target br:${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}/testresources:${{ env.REL_VERSION == 'edge' && 'latest' || env.REL_VERSION }} --force
+          rad bicep publish-extension -f ./test/functional-portable/dynamicrp/noncloud/resources/testdata/testresourcetypes.yaml --target "br:${LOCAL_REGISTRY_SERVER}:${LOCAL_REGISTRY_PORT}/testresources:${BICEP_TYPES_VERSION}" --force
 
       - name: Generate test bicepconfig.json
         run: |
-          if [[ "${{ env.REL_VERSION }}" == "edge" ]]; then
+          if [[ "${REL_VERSION}" == "edge" ]]; then
             RADIUS_VERSION="latest"
           else
-            RADIUS_VERSION="${{ env.REL_VERSION }}"
+            RADIUS_VERSION="${REL_VERSION}"
           fi
           cat <<EOF > ./test/bicepconfig.json
           {
             "extensions": {
-              "radius": "br:${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}/radius:$RADIUS_VERSION",
-              "aws": "br:${{ env.BICEP_TYPES_REGISTRY }}/aws:latest",
-              "testresources": "br:${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}/testresources:$RADIUS_VERSION"
+              "radius": "br:${LOCAL_REGISTRY_SERVER}:${LOCAL_REGISTRY_PORT}/radius:$RADIUS_VERSION",
+              "aws": "br:${BICEP_TYPES_REGISTRY}/aws:latest",
+              "testresources": "br:${LOCAL_REGISTRY_SERVER}:${LOCAL_REGISTRY_PORT}/testresources:$RADIUS_VERSION"
             }
           }
           EOF
@@ -512,7 +524,7 @@ jobs:
 
           which rad || { echo "cannot find rad"; exit 1; }
 
-          make test-functional-${{ matrix.name }}
+          make "test-functional-${MATRIX_NAME}"
         env:
           DOCKER_REGISTRY: ${{ env.LOCAL_REGISTRY_NAME }}:${{ env.LOCAL_REGISTRY_PORT }}
           TEST_TIMEOUT: ${{ env.FUNCTIONALTEST_TIMEOUT }}
@@ -524,6 +536,7 @@ jobs:
           GOTESTSUM_OPTS: --junitfile ./dist/functional_test/results.xml
           RADIUS_TEST_FAST_CLEANUP: true
           GIT_HTTP_PASSWORD: ${{ env.GIT_HTTP_PASSWORD }}
+          MATRIX_NAME: ${{ matrix.name }}
 
       - name: Process Functional Test Results
         uses: ./.github/actions/process-test-results
@@ -537,19 +550,21 @@ jobs:
       - name: Collect detailed Radius logs and events
         id: radius-logs-events
         if: always()
+        env:
+          MATRIX_NAME: ${{ matrix.name }}
         run: |
           # Create Radius logs directory
-          mkdir -p func-nc/radius-logs-events/${{ matrix.name }}
+          mkdir -p "func-nc/radius-logs-events/${MATRIX_NAME}"
 
           # Get pod logs and save to file
           namespace="radius-system"
           pod_names=($(kubectl get pods -n $namespace -o jsonpath='{.items[*].metadata.name}'))
           for pod_name in "${pod_names[@]}"; do
-            kubectl logs $pod_name -n $namespace > func-nc/radius-logs-events/${{ matrix.name }}/${pod_name}.txt 2>&1 || echo "Failed to get logs for pod: $pod_name" > func-nc/radius-logs-events/${{ matrix.name }}/${pod_name}.txt
+            kubectl logs $pod_name -n $namespace > "func-nc/radius-logs-events/${MATRIX_NAME}/${pod_name}.txt" 2>&1 || echo "Failed to get logs for pod: $pod_name" > "func-nc/radius-logs-events/${MATRIX_NAME}/${pod_name}.txt"
           done
-          echo "Pod logs saved to func-nc/radius-logs-events/${{ matrix.name }}/"
+          echo "Pod logs saved to func-nc/radius-logs-events/${MATRIX_NAME}/"
           # Get kubernetes events and save to file
-          kubectl get events -n $namespace > func-nc/radius-logs-events/${{ matrix.name }}/events.txt
+          kubectl get events -n $namespace > "func-nc/radius-logs-events/${MATRIX_NAME}/events.txt"
 
       - name: Upload Pod logs for failed tests
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -562,9 +577,11 @@ jobs:
 
       - name: Collect Pod details
         if: always()
+        env:
+          MATRIX_NAME: ${{ matrix.name }}
         run: |
-          POD_STATE_LOG_FILENAME='${{ env.RADIUS_CONTAINER_LOG_BASE }}/${{ matrix.name }}-tests-pod-states.log'
-          mkdir -p $(dirname $POD_STATE_LOG_FILENAME)
+          POD_STATE_LOG_FILENAME="${RADIUS_CONTAINER_LOG_BASE}/${MATRIX_NAME}-tests-pod-states.log"
+          mkdir -p "$(dirname "$POD_STATE_LOG_FILENAME")"
           {
             echo "kubectl get pods -A"
             kubectl get pods -A

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -95,12 +95,12 @@ jobs:
 
       - name: Run Helm linter
         run: |
-          helm lint ${{ env.HELM_CHARTS_DIR }}
+          helm lint "${HELM_CHARTS_DIR}"
 
       - name: Run Helm unit tests
         run: |
           helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.0.2 || true
-          cd ${{ env.HELM_CHARTS_DIR }} && helm unittest .
+          cd "${HELM_CHARTS_DIR}" && helm unittest .
 
       - name: Run TypeSpec format check
         run: make tsp-format-check

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -186,21 +186,24 @@ jobs:
       - name: Create azure resource group - ${{ steps.gen-id.outputs.AZURE_TEST_RESOURCE_GROUP }}
         env:
           AZURE_TEST_RESOURCE_GROUP: ${{ steps.gen-id.outputs.AZURE_TEST_RESOURCE_GROUP }}
+          AZURE_SUBSCRIPTIONID_TESTS: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
         run: |
           current_time=$(date +%s)
           az group create \
-            --location ${{ env.AZURE_LOCATION }} \
+            --location "${AZURE_LOCATION}" \
             --name "${AZURE_TEST_RESOURCE_GROUP}" \
-            --subscription ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }} \
+            --subscription "${AZURE_SUBSCRIPTIONID_TESTS}" \
             --tags creationTime=$current_time
           while [ "$(az group exists --name "${AZURE_TEST_RESOURCE_GROUP}")" = false ]; do sleep 2; done
 
       - name: Get kubeconf credential for AKS cluster
+        env:
+          AZURE_SUBSCRIPTIONID_TESTS: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
         run: |
           az aks get-credentials \
-            --subscription ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }} \
-            --resource-group ${{ env.AKS_RESOURCE_GROUP }} \
-            --name ${{ env.AKS_CLUSTER_NAME }} --admin
+            --subscription "${AZURE_SUBSCRIPTIONID_TESTS}" \
+            --resource-group "${AKS_RESOURCE_GROUP}" \
+            --name "${AKS_CLUSTER_NAME}" --admin
 
       - name: Restore skip-delete-resources-list
         if: always()
@@ -265,7 +268,7 @@ jobs:
 
       - name: Install gotestsum (test reporting tool)
         run: |
-          go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VER }}
+          go install "gotest.tools/gotestsum@v${GOTESTSUM_VER}"
 
       - name: Manage Radius control plane installation
         run: |
@@ -281,6 +284,12 @@ jobs:
       - name: Configure Radius test workspace
         env:
           AZURE_TEST_RESOURCE_GROUP: ${{ steps.gen-id.outputs.AZURE_TEST_RESOURCE_GROUP }}
+          AZURE_SUBSCRIPTIONID_TESTS: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
+          AZURE_SP_TESTS_APPID: ${{ secrets.AZURE_SP_TESTS_APPID }}
+          AZURE_SP_TESTS_TENANTID: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
+          FUNCTEST_AWS_ACCOUNT_ID: ${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}
+          FUNCTEST_AWS_ACCESS_KEY_ID: ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }}
+          FUNCTEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.FUNCTEST_AWS_SECRET_ACCESS_KEY }}
         run: |
           set -x
 
@@ -289,24 +298,24 @@ jobs:
 
           echo "*** Create workspace, group and environment for test ***"
           rad workspace create kubernetes --force
-          rad group create ${{ env.RADIUS_TEST_ENVIRONMENT_NAME }}
-          rad group switch ${{ env.RADIUS_TEST_ENVIRONMENT_NAME }}
+          rad group create "${RADIUS_TEST_ENVIRONMENT_NAME}"
+          rad group switch "${RADIUS_TEST_ENVIRONMENT_NAME}"
 
           # The functional test is designed to use default namespace. So you must create the environment for default namespace.
-          rad env create ${{ env.RADIUS_TEST_ENVIRONMENT_NAME }} --namespace default
-          rad env switch ${{ env.RADIUS_TEST_ENVIRONMENT_NAME }}
+          rad env create "${RADIUS_TEST_ENVIRONMENT_NAME}" --namespace default
+          rad env switch "${RADIUS_TEST_ENVIRONMENT_NAME}"
 
           echo "*** Configuring Azure provider ***"
-          rad env update ${{ env.RADIUS_TEST_ENVIRONMENT_NAME }} --azure-subscription-id ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }} \
+          rad env update "${RADIUS_TEST_ENVIRONMENT_NAME}" --azure-subscription-id "${AZURE_SUBSCRIPTIONID_TESTS}" \
             --azure-resource-group "${AZURE_TEST_RESOURCE_GROUP}"
           rad credential register azure wi \
-            --client-id ${{ secrets.AZURE_SP_TESTS_APPID }} \
-            --tenant-id ${{ secrets.AZURE_SP_TESTS_TENANTID }}
+            --client-id "${AZURE_SP_TESTS_APPID}" \
+            --tenant-id "${AZURE_SP_TESTS_TENANTID}"
 
           echo "*** Configuring AWS provider ***"
-          rad env update ${{ env.RADIUS_TEST_ENVIRONMENT_NAME }} --aws-region ${{ env.AWS_REGION }} --aws-account-id ${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}
+          rad env update "${RADIUS_TEST_ENVIRONMENT_NAME}" --aws-region "${AWS_REGION}" --aws-account-id "${FUNCTEST_AWS_ACCOUNT_ID}"
           rad credential register aws access-key \
-            --access-key-id ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }} --secret-access-key ${{ secrets.FUNCTEST_AWS_SECRET_ACCESS_KEY }}
+            --access-key-id "${FUNCTEST_AWS_ACCESS_KEY_ID}" --secret-access-key "${FUNCTEST_AWS_SECRET_ACCESS_KEY}"
 
       - name: Log radius installation status (failure)
         if: failure()
@@ -342,7 +351,7 @@ jobs:
       - name: Get OIDC Issuer from AKS cluster
         id: get-oidc-issuer
         run: |
-          echo "FUNCTEST_OIDC_ISSUER=$(az aks show -n ${{ env.AKS_CLUSTER_NAME }} -g ${{ env.AKS_RESOURCE_GROUP }} --query "oidcIssuerProfile.issuerUrl" -otsv)" >> $GITHUB_OUTPUT
+          echo "FUNCTEST_OIDC_ISSUER=$(az aks show -n "${AKS_CLUSTER_NAME}" -g "${AKS_RESOURCE_GROUP}" --query "oidcIssuerProfile.issuerUrl" -otsv)" >> "$GITHUB_OUTPUT"
 
       - name: Re-login to Azure before functional tests
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
@@ -390,6 +399,7 @@ jobs:
           BICEP_RECIPE_TAG_VERSION: ${{ steps.gen-id.outputs.UNIQUE_ID }}
           GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
           GIT_HTTP_PASSWORD: ${{ env.GIT_HTTP_PASSWORD }}
+          FUNCTEST_PREPROVISIONED_RESOURCE_JSON: ${{ secrets.FUNCTEST_PREPROVISIONED_RESOURCE_JSON }}
         working-directory: ${{ steps.checkout-release-codebase.outputs.release-dir }}
         run: |
           set -euo pipefail
@@ -404,7 +414,7 @@ jobs:
           # AZURE_MSSQL_RESOURCE_ID
           # AZURE_MSSQL_USERNAME
           # AZURE_MSSQL_PASSWORD
-          PREPROVISIONED_JSON='${{ secrets.FUNCTEST_PREPROVISIONED_RESOURCE_JSON }}'
+          PREPROVISIONED_JSON="${FUNCTEST_PREPROVISIONED_RESOURCE_JSON}"
           if ! echo "${PREPROVISIONED_JSON}" | jq -e . >/dev/null; then
             echo "FUNCTEST_PREPROVISIONED_RESOURCE_JSON is not valid JSON."
             echo "Expected keys: AZURE_COSMOS_MONGODB_ACCOUNT_ID, AZURE_MSSQL_RESOURCE_ID, AZURE_MSSQL_USERNAME, AZURE_MSSQL_PASSWORD"
@@ -421,7 +431,7 @@ jobs:
       - name: Collect Pod details
         if: always()
         run: |
-          POD_STATE_LOG_FILENAME='${{ env.RADIUS_CONTAINER_LOG_BASE }}/all-tests-pod-states.log'
+          POD_STATE_LOG_FILENAME="${RADIUS_CONTAINER_LOG_BASE}/all-tests-pod-states.log"
           mkdir -p $(dirname $POD_STATE_LOG_FILENAME)
           {
             echo "kubectl get pods -A"
@@ -459,10 +469,11 @@ jobs:
         if: always()
         env:
           AZURE_TEST_RESOURCE_GROUP: ${{ steps.gen-id.outputs.AZURE_TEST_RESOURCE_GROUP }}
+          AZURE_SUBSCRIPTIONID_TESTS: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
         run: |
           # if deletion fails, purge workflow will purge the resource group and its resources later.
           az group delete \
-            --subscription ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }} \
+            --subscription "${AZURE_SUBSCRIPTIONID_TESTS}" \
             --name "${AZURE_TEST_RESOURCE_GROUP}" \
             --yes --verbose --no-wait
 

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -351,7 +351,8 @@ jobs:
       - name: Get OIDC Issuer from AKS cluster
         id: get-oidc-issuer
         run: |
-          echo "FUNCTEST_OIDC_ISSUER=$(az aks show -n "${AKS_CLUSTER_NAME}" -g "${AKS_RESOURCE_GROUP}" --query "oidcIssuerProfile.issuerUrl" -otsv)" >> "$GITHUB_OUTPUT"
+          oidc_issuer="$(az aks show -n "${AKS_CLUSTER_NAME}" -g "${AKS_RESOURCE_GROUP}" --query 'oidcIssuerProfile.issuerUrl' -o tsv)"
+          echo "FUNCTEST_OIDC_ISSUER=${oidc_issuer}" >> "${GITHUB_OUTPUT}"
 
       - name: Re-login to Azure before functional tests
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -492,11 +492,13 @@ jobs:
     needs: [tests]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      issues: write # Required to create an issue when the scheduled run fails
     steps:
       - name: Create failure issue for failing long running test run
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          github-token: ${{ github.token }}
           script: |
             github.rest.issues.create({
               ...context.repo,

--- a/.github/workflows/nightly-rad-CLI-tests.yaml
+++ b/.github/workflows/nightly-rad-CLI-tests.yaml
@@ -51,11 +51,22 @@ jobs:
           persist-credentials: false
 
       - name: Test CLI download
-        run: make test-cli-download OS=${{ matrix.os }} ARCH=${{ matrix.arch }} FILE=${{ matrix.file }} EXT=${{ matrix.ext }}
+        env:
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_ARCH: ${{ matrix.arch }}
+          MATRIX_FILE: ${{ matrix.file }}
+          MATRIX_EXT: ${{ matrix.ext }}
+        run: make test-cli-download OS="${MATRIX_OS}" ARCH="${MATRIX_ARCH}" FILE="${MATRIX_FILE}" EXT="${MATRIX_EXT}"
 
       - name: Create GitHub issue on failure
         if: ${{ failure() }}
         run: |
-          gh issue create --title "CLI nightly test failed - ${{ matrix.os }}-${{ matrix.arch }}" --body "Test failed on ${{ github.repository }} for ${{ matrix.os }}-${{ matrix.arch }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --label "test-failure" --repo ${{ github.repository }}
+          gh issue create \
+            --title "CLI nightly test failed - ${MATRIX_OS}-${MATRIX_ARCH}" \
+            --body "Test failed on ${GITHUB_REPOSITORY} for ${MATRIX_OS}-${MATRIX_ARCH}. See [workflow logs](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) for more details." \
+            --label "test-failure" \
+            --repo "${GITHUB_REPOSITORY}"
         env:
           GH_TOKEN: ${{ github.token }}
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/nightly-rad-CLI-tests.yaml
+++ b/.github/workflows/nightly-rad-CLI-tests.yaml
@@ -43,6 +43,7 @@ jobs:
             ext: .exe
     permissions:
       contents: read
+      issues: write # Required to create an issue when the nightly run fails
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -57,4 +58,4 @@ jobs:
         run: |
           gh issue create --title "CLI nightly test failed - ${{ matrix.os }}-${{ matrix.arch }}" --body "Test failed on ${{ github.repository }} for ${{ matrix.os }}-${{ matrix.arch }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --label "test-failure" --repo ${{ github.repository }}
         env:
-          GH_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish-de-image.yaml
+++ b/.github/workflows/publish-de-image.yaml
@@ -105,5 +105,6 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ steps.get-token.outputs.token }}
+          RUN_ID: ${{ steps.monitor-remote-workflow.outputs.run_id }}
         run: |
-          gh run view "${{ steps.monitor-remote-workflow.outputs.run_id }}" --repo azure-octo/radius-publisher --log-failed || true
+          gh run view "${RUN_ID}" --repo azure-octo/radius-publisher --log-failed || true

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -65,10 +65,10 @@ jobs:
 
       - name: Generate docs release branch name
         run: |
-          if [[ ${{ env.REL_CHANNEL }} != "edge" ]]; then
-            echo DOCS_BRANCH="v${{ env.REL_CHANNEL }}" >> $GITHUB_ENV
+          if [[ "${REL_CHANNEL}" != "edge" ]]; then
+            echo "DOCS_BRANCH=v${REL_CHANNEL}" >> "$GITHUB_ENV"
           else
-            echo DOCS_BRANCH="edge" >> $GITHUB_ENV
+            echo "DOCS_BRANCH=edge" >> "$GITHUB_ENV"
           fi
 
       - name: Checkout docs repository

--- a/.github/workflows/purge-aws-test-resources.yaml
+++ b/.github/workflows/purge-aws-test-resources.yaml
@@ -39,6 +39,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      issues: write # Required to create an issue when the scheduled run fails
     steps:
       - name: Checkout the repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -60,7 +61,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         if: failure()
         with:
-          github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          github-token: ${{ github.token }}
           script: |
             github.rest.issues.create({
               ...context.repo,

--- a/.github/workflows/purge-aws-test-resources.yaml
+++ b/.github/workflows/purge-aws-test-resources.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Delete old AWS resources
         run: |
-          ./.github/scripts/delete-aws-resources.sh ${{ env.AWS_RESOURCE_TYPES }}
+          ./.github/scripts/delete-aws-resources.sh "${AWS_RESOURCE_TYPES}"
 
       - name: Create issue for failing purge aws test resources run
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/purge-azure-test-resources.yaml
+++ b/.github/workflows/purge-azure-test-resources.yaml
@@ -126,12 +126,13 @@ jobs:
     needs: [purge_azure_resources, purge_bicep_types]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    permissions: {}
+    permissions:
+      issues: write # Required to create an issue when the scheduled run fails
     if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          github-token: ${{ github.token }}
           script: |
             github.rest.issues.create({
               ...context.repo,

--- a/.github/workflows/purge-azure-test-resources.yaml
+++ b/.github/workflows/purge-azure-test-resources.yaml
@@ -51,17 +51,19 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
 
       - name: Find old test resource groups
+        env:
+          AZURE_SUBSCRIPTIONID_TESTS: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
         run: |
           echo "## Test resource group list" >> $GITHUB_STEP_SUMMARY
 
           # Create the file to store the resource group list
-          touch ${{ env.AZURE_RG_DELETE_LIST_FILE}}
+          touch "${AZURE_RG_DELETE_LIST_FILE}"
 
-          az account set -s ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
+          az account set -s "${AZURE_SUBSCRIPTIONID_TESTS}"
           resource_groups=$(az group list --query "[].{Name:name, creationTime:tags.creationTime}" -o tsv)
 
           current_time=$(date +%s)
-          hours_ago=$((current_time - ${{ env.VALID_RESOURCE_WINDOW }}))
+          hours_ago=$((current_time - VALID_RESOURCE_WINDOW))
           while IFS=$'\t' read -r name creation_time; do
             if [[ ! "$name" =~ ^"samplestest-" ]] && [[ ! "$name" =~ ^"radtest-" ]] && [[ ! "$name" =~ ^"tfrg" ]]; then
               continue
@@ -69,14 +71,14 @@ jobs:
 
             if [ "$creation_time" = "None" ]; then
               echo " * :wastebasket: $name - old resource"  >> $GITHUB_STEP_SUMMARY
-              echo $name >> ${{ env.AZURE_RG_DELETE_LIST_FILE}}
+              echo "$name" >> "${AZURE_RG_DELETE_LIST_FILE}"
               continue
             fi
 
             # Check if the resource group was created more than 6 hours ago
             if [ "$creation_time" -lt "$hours_ago" ]; then
               echo " * :wastebasket: $name - creationTime: $creation_time"  >> $GITHUB_STEP_SUMMARY
-              echo $name >> ${{ env.AZURE_RG_DELETE_LIST_FILE}}
+              echo "$name" >> "${AZURE_RG_DELETE_LIST_FILE}"
             else
               echo " * :white_check_mark: $name - creationTime: $creation_time"  >> $GITHUB_STEP_SUMMARY
             fi
@@ -85,7 +87,7 @@ jobs:
       - name: Delete Azure resource groups
         run: |
           echo "## Deleting resource group list" >> $GITHUB_STEP_SUMMARY
-          cat ${{ env.AZURE_RG_DELETE_LIST_FILE}} | while read line
+          cat "${AZURE_RG_DELETE_LIST_FILE}" | while read line
           do
               echo " * $line" >> $GITHUB_STEP_SUMMARY
               az group delete --resource-group $line --yes --verbose --no-wait

--- a/.github/workflows/purge-old-images.yaml
+++ b/.github/workflows/purge-old-images.yaml
@@ -37,11 +37,12 @@ jobs:
     needs: [purge_ghcr_dev]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    permissions: {}
+    permissions:
+      issues: write # Required to create an issue when the scheduled run fails
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          github-token: ${{ github.token }}
           script: |
             github.rest.issues.create({
               ...context.repo,

--- a/.github/workflows/radius-bot.yaml
+++ b/.github/workflows/radius-bot.yaml
@@ -17,6 +17,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      issues: write # Required to assign the commenter to the issue via the /assign command
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -31,7 +32,7 @@ jobs:
         env:
           TEAM_SLUG: approvers-radius
         with:
-          github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          github-token: ${{ github.token }}
           script: |
             const script = require('./.github/scripts/radius-bot.js')
             await script({github, context})

--- a/.github/workflows/release-verification.yaml
+++ b/.github/workflows/release-verification.yaml
@@ -42,9 +42,13 @@ jobs:
           persist-credentials: false
 
       - name: Ensure inputs.version is valid semver
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          python ./.github/scripts/validate_semver.py ${{ inputs.version }}
+          python ./.github/scripts/validate_semver.py "${INPUT_VERSION}"
 
       - name: Run release verification
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          ./.github/scripts/release-verification.sh ${{ inputs.version }}
+          ./.github/scripts/release-verification.sh "${INPUT_VERSION}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,8 +61,10 @@ jobs:
 
       - name: Determine desired release version
         id: get-version
+        env:
+          SUPPORTED_VERSIONS: ${{ steps.get-supported-versions.outputs.result }}
         run: |
-          ./.github/scripts/release-get-version.sh ${{ steps.get-supported-versions.outputs.result }} "."
+          ./.github/scripts/release-get-version.sh "${SUPPORTED_VERSIONS}" "."
 
       - name: Find the previous tag
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -111,8 +113,10 @@ jobs:
 
       - name: Find release note
         shell: bash
+        env:
+          RELEASE_VERSION: ${{ steps.get-version.outputs.release-version }}
         run: |
-          if [ -f ./docs/release-notes/${{ steps.get-version.outputs.release-version }}.md ]; then
+          if [ -f "./docs/release-notes/${RELEASE_VERSION}.md" ]; then
             echo "RELNOTE_FOUND=true" >> "${GITHUB_ENV}"
           fi
 
@@ -200,8 +204,10 @@ jobs:
 
       - name: Determine desired release version
         id: get-version
+        env:
+          SUPPORTED_VERSIONS: ${{ steps.get-supported-versions.outputs.result }}
         run: |
-          ./radius/.github/scripts/release-get-version.sh ${{ steps.get-supported-versions.outputs.result }} radius
+          ./radius/.github/scripts/release-get-version.sh "${SUPPORTED_VERSIONS}" radius
 
       - name: Check if release branch exists
         id: release-branch-exists
@@ -230,35 +236,51 @@ jobs:
 
       - name: Generate release summary
         if: steps.release-branch-exists.outputs.result == 'false'
+        env:
+          SUPPORTED_VERSIONS: ${{ steps.get-supported-versions.outputs.result }}
+          RELEASE_VERSION: ${{ steps.get-version.outputs.release-version }}
+          RELEASE_BRANCH_NAME: ${{ steps.get-version.outputs.release-branch-name }}
         run: |
           {
             echo "## Release"
             echo "* Release driver: ${GITHUB_ACTOR}"
-            echo "* Supported versions: ${{ steps.get-supported-versions.outputs.result }}"
-            echo "* Desired release tag: ${{ steps.get-version.outputs.release-version }}"
-            echo "* Desired release branch: ${{ steps.get-version.outputs.release-branch-name }}"
+            echo "* Supported versions: ${SUPPORTED_VERSIONS}"
+            echo "* Desired release tag: ${RELEASE_VERSION}"
+            echo "* Desired release branch: ${RELEASE_BRANCH_NAME}"
             echo "* Release date: $(date)"
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Release radius-project/radius version ${{ steps.get-version.outputs.release-version }}
         if: success() && steps.release-branch-exists.outputs.result == 'false'
+        env:
+          RELEASE_VERSION: ${{ steps.get-version.outputs.release-version }}
+          RELEASE_BRANCH_NAME: ${{ steps.get-version.outputs.release-branch-name }}
         run: |
-          ./radius/.github/scripts/release-create-tag-and-branch.sh radius ${{ steps.get-version.outputs.release-version }} ${{ steps.get-version.outputs.release-branch-name }}
+          ./radius/.github/scripts/release-create-tag-and-branch.sh radius "${RELEASE_VERSION}" "${RELEASE_BRANCH_NAME}"
 
       - name: Release radius-project/recipes version ${{ steps.get-version.outputs.release-version }}
         if: success() && steps.release-branch-exists.outputs.result == 'false'
+        env:
+          RELEASE_VERSION: ${{ steps.get-version.outputs.release-version }}
+          RELEASE_BRANCH_NAME: ${{ steps.get-version.outputs.release-branch-name }}
         run: |
-          ./radius/.github/scripts/release-create-tag-and-branch.sh recipes ${{ steps.get-version.outputs.release-version }} ${{ steps.get-version.outputs.release-branch-name }}
+          ./radius/.github/scripts/release-create-tag-and-branch.sh recipes "${RELEASE_VERSION}" "${RELEASE_BRANCH_NAME}"
 
       - name: Release radius-project/dashboard version ${{ steps.get-version.outputs.release-version }}
         if: success() && steps.release-branch-exists.outputs.result == 'false'
+        env:
+          RELEASE_VERSION: ${{ steps.get-version.outputs.release-version }}
+          RELEASE_BRANCH_NAME: ${{ steps.get-version.outputs.release-branch-name }}
         run: |
-          ./radius/.github/scripts/release-create-tag-and-branch.sh dashboard ${{ steps.get-version.outputs.release-version }} ${{ steps.get-version.outputs.release-branch-name }}
+          ./radius/.github/scripts/release-create-tag-and-branch.sh dashboard "${RELEASE_VERSION}" "${RELEASE_BRANCH_NAME}"
 
       - name: Release radius-project/bicep-types-aws version ${{ steps.get-version.outputs.release-version }}
         if: success() && steps.release-branch-exists.outputs.result == 'false'
+        env:
+          RELEASE_VERSION: ${{ steps.get-version.outputs.release-version }}
+          RELEASE_BRANCH_NAME: ${{ steps.get-version.outputs.release-branch-name }}
         run: |
-          ./radius/.github/scripts/release-create-tag-and-branch.sh bicep-types-aws ${{ steps.get-version.outputs.release-version }} ${{ steps.get-version.outputs.release-branch-name }}
+          ./radius/.github/scripts/release-create-tag-and-branch.sh bicep-types-aws "${RELEASE_VERSION}" "${RELEASE_BRANCH_NAME}"
 
       - name: Get App Token for radius-publisher
         if: success() && steps.release-branch-exists.outputs.result == 'false'
@@ -318,5 +340,6 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ steps.get-de-token.outputs.token }}
+          RUN_ID: ${{ steps.monitor-de-workflow.outputs.run_id }}
         run: |
-          gh run view "${{ steps.monitor-de-workflow.outputs.run_id }}" --repo azure-octo/radius-publisher --log-failed || true
+          gh run view "${RUN_ID}" --repo azure-octo/radius-publisher --log-failed || true

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -69,7 +69,7 @@ jobs:
         run: |
           {
             echo "## :x: Spellcheck Failed"
-            echo "There are spelling errors in your PR. Visit [the workflow output](${{ env.ACTION_LINK }}) to see what words are failing."
+            echo "There are spelling errors in your PR. Visit [the workflow output](${ACTION_LINK}) to see what words are failing."
             echo "### Adding new words"
             echo "You can add new custom words to [.cspellignore](https://github.com/radius-project/radius/blob/main/.cspellignore)."
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,7 +14,7 @@ on:
       - release/*
   # This workflow can run on forks for testing.
   # Uncomment the line below and push to your fork's main branch: (git push <remote fork> HEAD:main)
-  # workflow_dispatch: 
+  # workflow_dispatch:
 
 permissions: {}
 
@@ -68,7 +68,7 @@ jobs:
           GOTEST_OPTS: -race -coverprofile ./dist/unit_test/ut_coverage.out
         run: |
           mkdir -p ./dist/unit_test
-          go install gotest.tools/gotestsum@v${{ env.GOTESTSUMVERSION }}
+          go install "gotest.tools/gotestsum@v${GOTESTSUMVERSION}"
           make test
 
       - name: Run make test-validate-cli (CLI integration tests)

--- a/.github/workflows/validate-bicep.yaml
+++ b/.github/workflows/validate-bicep.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Setup and verify bicep CLI
         run: |
           # Download bicep CLI
-          curl -Lo bicep "https://github.com/Azure/bicep/releases/download/${{ env.BICEP_VER }}/bicep-linux-x64"
+          curl -Lo bicep "https://github.com/Azure/bicep/releases/download/${BICEP_VER}/bicep-linux-x64"
           chmod +x ./bicep
 
           # Install in both locations for maximum compatibility
@@ -110,10 +110,9 @@ jobs:
       - name: Modify bicepconfig.json
         run: |
           # Update bicepconfig.json with paths for extensions
-          WORKDIR="${{ github.workspace }}"
           jq \
-            --arg rad "$WORKDIR/tmp-radius-bicep-extension/radius.tgz" \
-            --arg test "$WORKDIR/tmp-testresources-bicep-extension/testresources.tgz" \
+            --arg rad "$GITHUB_WORKSPACE/tmp-radius-bicep-extension/radius.tgz" \
+            --arg test "$GITHUB_WORKSPACE/tmp-testresources-bicep-extension/testresources.tgz" \
             '.extensions.radius = $rad | .extensions.testresources = $test' \
             bicepconfig.json > tmp.json && mv tmp.json bicepconfig.json
 


### PR DESCRIPTION
# Description

CI-only maintenance changes to the GitHub Actions workflows. No Radius runtime functionality is affected. Two logical changes are included:

1. **Adopt the built-in `github.token`** — replaces `secrets.GH_RAD_CI_BOT_PAT` (and a stray `secrets.GITHUB_TOKEN`) with the automatically provided `github.token` across nine workflows, reducing reliance on a long-lived bot PAT.

2. **Improve environment variable usage in inline shell scripts** — converts GitHub Actions `${{ ... }}` expressions used inside bash `run:` blocks to native shell variable syntax (`"${VAR}"`). Values that are not already environment variables (`secrets`, `matrix`, `inputs`, `steps.*.outputs`) are mapped through step-level `env:` blocks so they are visible to the shell and no longer interpolated directly into the script body, hardening the workflows against shell script injection. YAML fields (`if:`, `with:`, `name:`, etc.), `actions/github-script` blocks, `with:` client payloads, and Markdown comment bodies are intentionally left unchanged.

### Affected workflows

`build.yaml`, `c9k-failure-report.yml`, `devcontainer-feature-test.yaml`, `functional-test-cloud.yaml`, `functional-test-noncloud.yaml`, `lint.yaml`, `long-running-azure.yaml`, `nightly-rad-CLI-tests.yaml`, `publish-de-image.yaml`, `publish-docs.yaml`, `purge-aws-test-resources.yaml`, `purge-azure-test-resources.yaml`, `purge-old-images.yaml`, `radius-bot.yaml`, `release-verification.yaml`, `release.yaml`, `spellcheck.yaml`, `unit-tests.yaml`, `validate-bicep.yaml`

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
