### PR TITLE
Update container mechanics tests

### DIFF
--- a/test/functional-portable/cli/noncloud/cli_test.go
+++ b/test/functional-portable/cli/noncloud/cli_test.go
@@ -878,7 +878,7 @@ func Test_RadiusCoreEnv(t *testing.T) {
 		err = cli.GroupCreate(ctx, "test-group")
 		require.NoError(t, err)
 
-		_, err = cli.EnvironmentCreatePreview(ctx, "env-test-update", "test-group")
+		_, err = cli.EnvironmentCreatePreview(ctx, "env-test-update", "test-group", "")
 		require.NoError(t, err)
 
 		output, err := cli.EnvironmentListPreview(ctx, "test-group")

--- a/test/functional-portable/corerp/noncloud/mechanics/mechanics_test.go
+++ b/test/functional-portable/corerp/noncloud/mechanics/mechanics_test.go
@@ -179,7 +179,7 @@ func Test_RedeployWithUpdatedResourceUpdatesResource(t *testing.T) {
 			PostStepVerify: func(ctx context.Context, t *testing.T, test rp.RPTest) {
 				labelset := kubernetes.MakeSelectorLabels(name, "mechanicsd")
 
-				deployments, err := test.Options.K8sClient.AppsV1().Deployments(appNamespace).List(context.Background(), metav1.ListOptions{
+				deployments, err := test.Options.K8sClient.AppsV1().Deployments(appNamespace).List(ctx, metav1.ListOptions{
 					LabelSelector: labels.SelectorFromSet(labelset).String(),
 				})
 

--- a/test/functional-portable/corerp/noncloud/mechanics/mechanics_test.go
+++ b/test/functional-portable/corerp/noncloud/mechanics/mechanics_test.go
@@ -38,16 +38,15 @@ func Test_NestedModules(t *testing.T) {
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: "corerp-mechanics-nestedmodules-outerapp-app",
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: "corerp-mechanics-nestedmodules-innerapp-app",
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 				},
 			},
@@ -55,26 +54,29 @@ func Test_NestedModules(t *testing.T) {
 		},
 	})
 
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, name)
+	test.PreSetup = preSetup
+	test.Steps[0].Executor = step.NewDeployExecutor(template, fmt.Sprintf("environment=%s", previewEnvID))
+
 	test.Test(t)
 }
 
 func Test_RedeployWithAnotherResource(t *testing.T) {
 	name := "corerp-mechanics-redeploy-with-another-resource"
-	appNamespace := "default-corerp-mechanics-redeploy-with-another-resource"
+	appNamespace := name
 	templateFmt := "testdata/corerp-mechanics-redeploy-withanotherresource.step%d.bicep"
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(fmt.Sprintf(templateFmt, 1), testutil.GetMagpieImage()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: name,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: "mechanicsa",
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  name,
 					},
 				},
@@ -88,21 +90,20 @@ func Test_RedeployWithAnotherResource(t *testing.T) {
 			},
 		},
 		{
-			Executor: step.NewDeployExecutor(fmt.Sprintf(templateFmt, 2), testutil.GetMagpieImage()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: name,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: "mechanicsb",
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  name,
 					},
 					{
 						Name: "mechanicsc",
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  name,
 					},
 				},
@@ -118,26 +119,30 @@ func Test_RedeployWithAnotherResource(t *testing.T) {
 		},
 	})
 
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, appNamespace)
+	test.PreSetup = preSetup
+	test.Steps[0].Executor = step.NewDeployExecutor(fmt.Sprintf(templateFmt, 1), testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
+	test.Steps[1].Executor = step.NewDeployExecutor(fmt.Sprintf(templateFmt, 2), testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
+
 	test.Test(t)
 }
 
 func Test_RedeployWithUpdatedResourceUpdatesResource(t *testing.T) {
 	name := "corerp-mechanics-redeploy-withupdatedresource"
-	appNamespace := "default-corerp-mechanics-redeploy-withupdatedresource"
+	appNamespace := name
 	templateFmt := "testdata/corerp-mechanics-redeploy-withupdatedresource.step%d.bicep"
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(fmt.Sprintf(templateFmt, 1), testutil.GetMagpieImage()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: name,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: "mechanicsd",
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  name,
 					},
 				},
@@ -151,16 +156,15 @@ func Test_RedeployWithUpdatedResourceUpdatesResource(t *testing.T) {
 			},
 		},
 		{
-			Executor: step.NewDeployExecutor(fmt.Sprintf(templateFmt, 2), testutil.GetMagpieImage()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: name,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: "mechanicsd",
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  name,
 					},
 				},
@@ -182,32 +186,44 @@ func Test_RedeployWithUpdatedResourceUpdatesResource(t *testing.T) {
 				require.NoError(t, err, "failed to list deployments")
 				require.Len(t, deployments.Items, 1, "expected 1 deployment")
 				deployment := deployments.Items[0]
-				envVar := deployment.Spec.Template.Spec.Containers[0].Env[0]
-				require.Equal(t, "TEST", envVar.Name, "expected env var to be updated")
-				require.Equal(t, "updated", envVar.Value, "expected env var to be updated")
+
+				var found bool
+				for _, envVar := range deployment.Spec.Template.Spec.Containers[0].Env {
+					if envVar.Name == "TEST" {
+						found = true
+						require.Equal(t, "updated", envVar.Value, "expected env var TEST to be updated")
+						break
+					}
+				}
+				require.True(t, found, "expected env var TEST to be present on the redeployed container")
 			},
 		},
 	})
+
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, appNamespace)
+	test.PreSetup = preSetup
+	test.Steps[0].Executor = step.NewDeployExecutor(fmt.Sprintf(templateFmt, 1), testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
+	test.Steps[1].Executor = step.NewDeployExecutor(fmt.Sprintf(templateFmt, 2), testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
+
 	test.Test(t)
 }
 
 func Test_RedeployWithTwoSeparateResourcesKeepsResource(t *testing.T) {
 	name := "corerp-mechanics-redeploy-withtwoseparateresource"
-	appNamespace := "default-corerp-mechanics-redeploy-withtwoseparateresource"
+	appNamespace := name
 	templateFmt := "testdata/corerp-mechanics-redeploy-withtwoseparateresource.step%d.bicep"
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(fmt.Sprintf(templateFmt, 1), testutil.GetMagpieImage()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: name,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: "mechanicse",
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  name,
 					},
 				},
@@ -221,21 +237,20 @@ func Test_RedeployWithTwoSeparateResourcesKeepsResource(t *testing.T) {
 			},
 		},
 		{
-			Executor: step.NewDeployExecutor(fmt.Sprintf(templateFmt, 2), testutil.GetMagpieImage()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: name,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: "mechanicse",
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  name,
 					},
 					{
 						Name: "mechanicsf",
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  name,
 					},
 				},
@@ -250,6 +265,11 @@ func Test_RedeployWithTwoSeparateResourcesKeepsResource(t *testing.T) {
 			},
 		},
 	})
+
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, appNamespace)
+	test.PreSetup = preSetup
+	test.Steps[0].Executor = step.NewDeployExecutor(fmt.Sprintf(templateFmt, 1), testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
+	test.Steps[1].Executor = step.NewDeployExecutor(fmt.Sprintf(templateFmt, 2), testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
 
 	test.Test(t)
 }
@@ -298,33 +318,18 @@ func Test_InvalidResourceIDs(t *testing.T) {
 	name := "corerp-mechanics-invalid-resourceids"
 	template := "testdata/corerp-mechanics-invalid-resourceids.bicep"
 
-	// We've avoiding including resource IDs here because they can change depending on how the run is
-	// configured.
+	// The container references an invalid application resource ID ("not_an_id"). The deployment is
+	// expected to fail because the application ID cannot be parsed as a valid resource id. As with
+	// the original Applications.Core version of this test, the failed container resource is left
+	// behind (it cannot be cascade-deleted because it has no valid owning application), so resource
+	// and object validation are skipped.
 	validate := step.ValidateAllDetails("DeploymentFailed", []step.DeploymentErrorDetail{
 		{
 			Code: "ResourceDeploymentFailure",
 			Details: []step.DeploymentErrorDetail{
 				{
-					Code:            "BadRequest",
-					MessageContains: "has invalid Applications.Core/applications resource type.",
-				},
-			},
-		},
-		{
-			Code: "ResourceDeploymentFailure",
-			Details: []step.DeploymentErrorDetail{
-				{
-					Code:            "BadRequest",
-					MessageContains: "application ID \"not_an_id\" for the resource",
-				},
-			},
-		},
-		{
-			Code: "ResourceDeploymentFailure",
-			Details: []step.DeploymentErrorDetail{
-				{
-					Code:            "Internal",
-					MessageContains: "'global' is not a valid resource id",
+					Code:            "RecipeDeploymentFailed",
+					MessageContains: "is not a valid resource id",
 				},
 			},
 		},
@@ -332,18 +337,14 @@ func Test_InvalidResourceIDs(t *testing.T) {
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
-			Executor: step.NewDeployErrorExecutor(template, validate, testutil.GetMagpieImage(), testutil.GetBicepRecipeRegistry(), testutil.GetBicepRecipeVersion()),
-			RPResources: &validation.RPResourceSet{
-				Resources: []validation.RPResource{
-					{
-						Name: name,
-						Type: validation.ApplicationsResource,
-					},
-				},
-			},
-			K8sObjects: &validation.K8sObjectSet{},
+			SkipKubernetesOutputResourceValidation: true,
+			SkipObjectValidation:                   true,
 		},
 	})
+
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, name)
+	test.PreSetup = preSetup
+	test.Steps[0].Executor = step.NewDeployErrorExecutor(template, validate, testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
 
 	test.Test(t)
 }

--- a/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-invalid-resourceids.bicep
+++ b/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-invalid-resourceids.bicep
@@ -1,74 +1,23 @@
 extension radius
 
-@description('Specifies the location for resources.')
-param location string = 'global'
-
-@description('Specifies the environment for resources.')
-param environment string = 'test'
-
 @description('Specifies the image to be deployed.')
 param magpieimage string
 
-param registry string
-param version string
+@description('Specifies the environment for resources.')
+param environment string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
-  name: 'corerp-mechanics-invalid-resourceids'
-  location: location
-  properties: {
-    environment: environment
-  }
-}
-
-resource env 'Applications.Core/environments@2023-10-01-preview' = {
-  name: 'invalid-env'
-  properties: {
-    compute: {
-      kind: 'kubernetes'
-      resourceId: 'self'
-      namespace: 'invalid-env'
-    }
-    recipes: { 
-      'Applications.Dapr/pubSubBrokers': {
-        default: {
-          templateKind: 'bicep'
-          templatePath: '${registry}/test/testrecipes/test-bicep-recipes/dapr-pubsub-broker:${version}'
-        }
-      }
-    }
-  }
-}
-
-resource extender 'Applications.Core/extenders@2023-10-01-preview' = {
-  name: 'invalid-extndr'
-  properties: {
-    application: app.location
-    environment: env.id
-    resourceProvisioning: 'manual'
-  }
-}
-
-resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
-  name: 'invalid-gtwy'
-  location: location
+// A container that references an invalid application resource ID. The deployment is
+// expected to fail because the application ID cannot be parsed as a valid resource ID.
+resource container 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'invalid-ctnr'
+  location: 'global'
   properties: {
     application: 'not_an_id'
-    routes: [
-      {
-        destination: ''
-        path: ''
+    environment: environment
+    containers: {
+      invalidctnr: {
+        image: magpieimage
       }
-    ]
-  }
-}
-
-resource container 'Applications.Core/containers@2023-10-01-preview' = {
-  name: 'invalid-ctnr'
-  location: location
-  properties: {
-    application: '/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/default/providers/applications.core/environments/env'
-    container: {
-      image: magpieimage
     }
   }
 }

--- a/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-nestedmodules.bicep
+++ b/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-nestedmodules.bicep
@@ -4,7 +4,7 @@ extension radius
 param location string = 'global'
 
 @description('Specifies the environment for the resource.')
-param environment string = 'test'
+param environment string
 
 module outerApp 'modules/corerp-mechanics-nestedmodules-outerapp.bicep' = {
   name: 'corerp-mechanics-nestedmodules-outerapp'

--- a/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-redeploy-withanotherresource.step1.bicep
+++ b/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-redeploy-withanotherresource.step1.bicep
@@ -4,12 +4,12 @@ extension radius
 param location string = 'global'
 
 @description('Specifies the environment for resources.')
-param environment string = 'test'
+param environment string
 
 @description('Specifies the image to be deployed.')
 param magpieimage string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'corerp-mechanics-redeploy-with-another-resource'
   location: location
   properties: {
@@ -17,13 +17,16 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource mechanicsa 'Applications.Core/containers@2023-10-01-preview' = {
+resource mechanicsa 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'mechanicsa'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
+    environment: environment
+    containers: {
+      mechanicsa: {
+        image: magpieimage
+      }
     }
   }
 }

--- a/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-redeploy-withanotherresource.step2.bicep
+++ b/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-redeploy-withanotherresource.step2.bicep
@@ -4,12 +4,12 @@ extension radius
 param location string = 'global'
 
 @description('Specifies the environment for resources.')
-param environment string = 'test'
+param environment string
 
 @description('Specifies the image to be deployed.')
 param magpieimage string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'corerp-mechanics-redeploy-with-another-resource'
   location: location
   properties: {
@@ -17,24 +17,30 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource mechanicsb 'Applications.Core/containers@2023-10-01-preview' = {
+resource mechanicsb 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'mechanicsb'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
+    environment: environment
+    containers: {
+      mechanicsb: {
+        image: magpieimage
+      }
     }
   }
 }
 
-resource mechanicsc 'Applications.Core/containers@2023-10-01-preview' = {
+resource mechanicsc 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'mechanicsc'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
+    environment: environment
+    containers: {
+      mechanicsc: {
+        image: magpieimage
+      }
     }
   }
 }

--- a/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-redeploy-withtwoseparateresource.step1.bicep
+++ b/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-redeploy-withtwoseparateresource.step1.bicep
@@ -4,12 +4,12 @@ extension radius
 param location string = 'global'
 
 @description('Specifies the environment for resources.')
-param environment string = 'test'
+param environment string
 
 @description('Specifies the image to be deployed.')
 param magpieimage string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'corerp-mechanics-redeploy-withtwoseparateresource'
   location: location
   properties: {
@@ -17,13 +17,16 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource mechanicse 'Applications.Core/containers@2023-10-01-preview' = {
+resource mechanicse 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'mechanicse'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
+    environment: environment
+    containers: {
+      mechanicse: {
+        image: magpieimage
+      }
     }
   }
 }

--- a/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-redeploy-withtwoseparateresource.step2.bicep
+++ b/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-redeploy-withtwoseparateresource.step2.bicep
@@ -4,12 +4,12 @@ extension radius
 param location string = 'global'
 
 @description('Specifies the environment for resources.')
-param environment string = 'test'
+param environment string
 
 @description('Specifies the image to be deployed.')
 param magpieimage string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'corerp-mechanics-redeploy-withtwoseparateresource'
   location: location
   properties: {
@@ -17,13 +17,16 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource mechanicsf 'Applications.Core/containers@2023-10-01-preview' = {
+resource mechanicsf 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'mechanicsf'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
+    environment: environment
+    containers: {
+      mechanicsf: {
+        image: magpieimage
+      }
     }
   }
 }

--- a/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-redeploy-withupdatedresource.step1.bicep
+++ b/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-redeploy-withupdatedresource.step1.bicep
@@ -4,12 +4,12 @@ extension radius
 param location string = 'global'
 
 @description('Specifies the environment for resources.')
-param environment string = 'test'
+param environment string
 
 @description('Specifies the image to be deployed.')
 param magpieimage string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'corerp-mechanics-redeploy-withupdatedresource'
   location: location
   properties: {
@@ -17,13 +17,16 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource mechanicsd 'Applications.Core/containers@2023-10-01-preview' = {
+resource mechanicsd 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'mechanicsd'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
+    environment: environment
+    containers: {
+      mechanicsd: {
+        image: magpieimage
+      }
     }
   }
 }

--- a/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-redeploy-withupdatedresource.step2.bicep
+++ b/test/functional-portable/corerp/noncloud/mechanics/testdata/corerp-mechanics-redeploy-withupdatedresource.step2.bicep
@@ -4,12 +4,12 @@ extension radius
 param location string = 'global'
 
 @description('Specifies the environment for resources.')
-param environment string = 'test'
+param environment string
 
 @description('Specifies the image to be deployed.')
 param magpieimage string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'corerp-mechanics-redeploy-withupdatedresource'
   location: location
   properties: {
@@ -17,16 +17,19 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource mechanicsd 'Applications.Core/containers@2023-10-01-preview' = {
+resource mechanicsd 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'mechanicsd'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
-      env: {
-        TEST: {
-          value: 'updated'
+    environment: environment
+    containers: {
+      mechanicsd: {
+        image: magpieimage
+        env: {
+          TEST: {
+            value: 'updated'
+          }
         }
       }
     }

--- a/test/functional-portable/corerp/noncloud/mechanics/testdata/modules/corerp-mechanics-nestedmodules-innerapp.bicep
+++ b/test/functional-portable/corerp/noncloud/mechanics/testdata/modules/corerp-mechanics-nestedmodules-innerapp.bicep
@@ -3,7 +3,7 @@ extension radius
 param location string
 param environment string
 
-resource innerApp 'Applications.Core/applications@2023-10-01-preview' = {
+resource innerApp 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'corerp-mechanics-nestedmodules-innerapp-app'
   location: location
   properties: {

--- a/test/functional-portable/corerp/noncloud/mechanics/testdata/modules/corerp-mechanics-nestedmodules-outerapp.bicep
+++ b/test/functional-portable/corerp/noncloud/mechanics/testdata/modules/corerp-mechanics-nestedmodules-outerapp.bicep
@@ -3,7 +3,7 @@ extension radius
 param location string
 param environment string
 
-resource outerApp 'Applications.Core/applications@2023-10-01-preview' = {
+resource outerApp 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'corerp-mechanics-nestedmodules-outerapp-app'
   location: location
   properties: {

--- a/test/functional-portable/corerp/noncloud/resources/container_versioning_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/container_versioning_test.go
@@ -21,34 +21,47 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/radius-project/radius/pkg/kubernetes"
 	"github.com/radius-project/radius/test/rp"
 	"github.com/radius-project/radius/test/step"
 	"github.com/radius-project/radius/test/testutil"
 	"github.com/radius-project/radius/test/validation"
 	"github.com/stretchr/testify/require"
 
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
+// Test_ContainerVersioning verifies that redeploying a container with an updated definition
+// versions the container's runtime configuration. Version 1 consumes a Radius.Security/secrets
+// resource via a secretKeyRef environment variable; version 2 removes that environment variable.
+// The test asserts the secret-backed env var is present after v1 and absent after v2.
 func Test_ContainerVersioning(t *testing.T) {
 	containerV1 := "testdata/containers/corerp-resources-friendly-container-version-1.bicep"
 	containerV2 := "testdata/containers/corerp-resources-friendly-container-version-2.bicep"
 
 	name := "corerp-resources-container-versioning"
-	appNamespace := "default-corerp-resources-container-versioning"
+	appNamespace := name
+	containerName := "friendly-ctnr"
+	secretName := "friendly-secret"
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(containerV1, testutil.GetMagpieImage()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: name,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
-						Name: "friendly-ctnr",
-						Type: validation.ContainersResource,
+						Name: containerName,
+						Type: validation.ComputeContainersResource,
+						App:  name,
+					},
+					{
+						Name: secretName,
+						Type: validation.SecuritySecretsResource,
 						App:  name,
 					},
 				},
@@ -56,31 +69,42 @@ func Test_ContainerVersioning(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "friendly-ctnr"),
+						validation.NewK8sPodForResource(name, containerName),
 					},
 				},
 			},
 			SkipResourceDeletion: true,
 			PostStepVerify: func(ctx context.Context, t *testing.T, test rp.RPTest) {
-				label := fmt.Sprintf("radapp.io/application=%s", name)
-				secrets, err := test.Options.K8sClient.CoreV1().Secrets(appNamespace).List(ctx, metav1.ListOptions{
-					LabelSelector: label,
-				})
-				require.NoError(t, err)
-				require.Len(t, secrets.Items, 1)
+				deployment := getContainerDeployment(ctx, t, test, appNamespace, name, containerName)
+
+				var found bool
+				for _, envVar := range deployment.Spec.Template.Spec.Containers[0].Env {
+					if envVar.Name == "DB_PASSWORD" {
+						found = true
+						require.NotNil(t, envVar.ValueFrom, "expected DB_PASSWORD to be sourced from a secret")
+						require.NotNil(t, envVar.ValueFrom.SecretKeyRef, "expected DB_PASSWORD to use a secretKeyRef")
+						require.Equal(t, secretName, envVar.ValueFrom.SecretKeyRef.Name, "expected DB_PASSWORD to reference the friendly-secret")
+						break
+					}
+				}
+				require.True(t, found, "expected secret-backed env var DB_PASSWORD on version 1 of the container")
 			},
 		},
 		{
-			Executor: step.NewDeployExecutor(containerV2, testutil.GetMagpieImage()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: name,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
-						Name: "friendly-ctnr",
-						Type: validation.ContainersResource,
+						Name: containerName,
+						Type: validation.ComputeContainersResource,
+						App:  name,
+					},
+					{
+						Name: secretName,
+						Type: validation.SecuritySecretsResource,
 						App:  name,
 					},
 				},
@@ -88,20 +112,38 @@ func Test_ContainerVersioning(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "friendly-ctnr"),
+						validation.NewK8sPodForResource(name, containerName),
 					},
 				},
 			},
 			PostStepVerify: func(ctx context.Context, t *testing.T, test rp.RPTest) {
-				label := fmt.Sprintf("radapp.io/application=%s", name)
-				secrets, err := test.Options.K8sClient.CoreV1().Secrets(appNamespace).List(ctx, metav1.ListOptions{
-					LabelSelector: label,
-				})
-				require.NoError(t, err)
-				require.Len(t, secrets.Items, 0)
+				deployment := getContainerDeployment(ctx, t, test, appNamespace, name, containerName)
+
+				for _, envVar := range deployment.Spec.Template.Spec.Containers[0].Env {
+					require.NotEqual(t, "DB_PASSWORD", envVar.Name, "expected secret-backed env var DB_PASSWORD to be removed on version 2 of the container")
+				}
 			},
 		},
 	})
 
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, appNamespace)
+	test.PreSetup = preSetup
+	test.Steps[0].Executor = step.NewDeployExecutor(containerV1, testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
+	test.Steps[1].Executor = step.NewDeployExecutor(containerV2, testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
+
 	test.Test(t)
+}
+
+// getContainerDeployment returns the single Kubernetes Deployment for the given Radius container
+// resource, failing the test if it is not found.
+func getContainerDeployment(ctx context.Context, t *testing.T, test rp.RPTest, namespace, appName, resourceName string) appsv1.Deployment {
+	labelset := kubernetes.MakeSelectorLabels(appName, resourceName)
+
+	deployments, err := test.Options.K8sClient.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labelset).String(),
+	})
+	require.NoError(t, err, "failed to list deployments")
+	require.Len(t, deployments.Items, 1, "expected exactly 1 deployment for container %s", resourceName)
+
+	return deployments.Items[0]
 }

--- a/test/functional-portable/corerp/noncloud/resources/testdata/containers/corerp-resources-friendly-container-version-1.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/containers/corerp-resources-friendly-container-version-1.bicep
@@ -3,7 +3,7 @@ extension radius
 param magpieimage string
 param environment string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'corerp-resources-container-versioning'
   location: 'global'
   properties: {
@@ -11,61 +11,40 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource webapp 'Applications.Core/containers@2023-10-01-preview' = {
+resource webapp 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'friendly-ctnr'
   location: 'global'
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
-      env: {
-        DBCONNECTION: {
-          value: redis.listSecrets().connectionString
+    environment: environment
+    containers: {
+      friendlyctnr: {
+        image: magpieimage
+        env: {
+          DB_PASSWORD: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: friendlysecret.name
+                key: 'DB_PASSWORD'
+              }
+            }
+          }
         }
-      }
-      readinessProbe: {
-        kind: 'httpGet'
-        containerPort: 3000
-        path: '/healthz'
-      }
-    }
-    connections: {
-      redis: {
-        source: redis.id
       }
     }
   }
 }
 
-resource redisContainer 'Applications.Core/containers@2023-10-01-preview' = {
-  name: 'friendly-rds-ctnr'
-  location: 'global'
-  properties: {
-    application: app.id
-    container: {
-      image: 'ghcr.io/radius-project/mirror/redis:6.2'
-      ports: {
-        redis: {
-          containerPort: 6379
-        }
-      }
-    }
-    connections: {}
-  }
-}
-
-resource redis 'Applications.Datastores/redisCaches@2023-10-01-preview' = {
-  name: 'friendly-rds-rds'
+resource friendlysecret 'Radius.Security/secrets@2025-08-01-preview' = {
+  name: 'friendly-secret'
   location: 'global'
   properties: {
     environment: environment
     application: app.id
-    resourceProvisioning: 'manual'
-    host: 'friendly-rds-ctnr'
-    port: 6379
-    secrets: {
-      connectionString: 'friendly-rds-ctnr:6379'
-      password: ''
+    data: {
+      DB_PASSWORD: {
+        value: 'password'
+      }
     }
   }
 }

--- a/test/functional-portable/corerp/noncloud/resources/testdata/containers/corerp-resources-friendly-container-version-2.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/containers/corerp-resources-friendly-container-version-2.bicep
@@ -3,7 +3,7 @@ extension radius
 param magpieimage string
 param environment string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'corerp-resources-container-versioning'
   location: 'global'
   properties: {
@@ -11,20 +11,17 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource webapp 'Applications.Core/containers@2023-10-01-preview' = {
+resource webapp 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'friendly-ctnr'
   location: 'global'
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
-      env: {}
-      readinessProbe: {
-        kind: 'httpGet'
-        containerPort: 3000
-        path: '/healthz'
+    environment: environment
+    containers: {
+      friendlyctnr: {
+        image: magpieimage
+        env: {}
       }
     }
-    connections: {}
   }
 }

--- a/test/radcli/cli.go
+++ b/test/radcli/cli.go
@@ -495,12 +495,16 @@ func (cli *CLI) RecipePackShow(ctx context.Context, recipepackName, groupName st
 
 // EnvironmentCreatePreview runs the "env create" command for the specified environment name and returns the output as a string, returning
 // an error if the command fails.
-func (cli *CLI) EnvironmentCreatePreview(ctx context.Context, environmentName, groupName string) (string, error) {
+func (cli *CLI) EnvironmentCreatePreview(ctx context.Context, environmentName, groupName, kubernetesNamespace string) (string, error) {
 	args := []string{
 		"env",
 		"create",
 		environmentName,
 		"--preview",
+	}
+
+	if kubernetesNamespace != "" {
+		args = append(args, "--kubernetes-namespace", kubernetesNamespace)
 	}
 
 	if groupName != "" {

--- a/test/rp/rptest.go
+++ b/test/rp/rptest.go
@@ -232,16 +232,15 @@ func NewRPTest(t *testing.T, name string, steps []TestStep, initialResources ...
 // and configures its Kubernetes namespace for recipe-driven resource deployment.
 // It returns the PreSetup function and the environment resource ID.
 //
-// The preview environment is created via `rad env create <name> --preview`, which automatically
-// registers a default recipe pack (including container recipes). The environment is then updated
-// to set the Kubernetes namespace where recipes will deploy resources.
+// The preview environment is created via `rad env create <name> --preview --kubernetes-namespace <ns>`,
+// which automatically registers a default recipe pack (including container recipes) and sets the
+// Kubernetes namespace where recipes will deploy resources.
 //
 // The environment name is derived from the test name with "-env" suffix to avoid collisions.
 // The kubernetesNamespace parameter specifies where recipes should deploy K8s resources —
 // this typically matches the test's expected pod namespace (often the test name).
 //
-// t.Cleanup is registered immediately after env creation (before update) to prevent
-// resource leaks if the update step fails.
+// t.Cleanup is registered immediately after env creation to prevent resource leaks.
 func NewPreviewEnvPreSetup(testName string, workspaceScope string, kubernetesNamespace string) (preSetup func(ctx context.Context, t *testing.T, test RPTest), envID string) {
 	envName := testName + "-env"
 	envID = fmt.Sprintf("%s/providers/Radius.Core/environments/%s", workspaceScope, envName)
@@ -249,22 +248,21 @@ func NewPreviewEnvPreSetup(testName string, workspaceScope string, kubernetesNam
 	preSetup = func(ctx context.Context, t *testing.T, test RPTest) {
 		cli := radcli.NewCLI(t, test.Options.ConfigFilePath)
 
-		// Create the preview environment. The --preview flag also creates a default recipe pack
-		// with container and other resource recipes registered.
-		_, err := cli.EnvironmentCreatePreview(ctx, envName, "")
+		// Create the preview environment with the test-specific Kubernetes namespace so recipes
+		// know where to deploy resources. Passing the namespace at create time (rather than via a
+		// later update) avoids colliding on the default namespace, which the RP rejects when two
+		// environments in the same scope share a namespace. The --preview flag also creates a
+		// default recipe pack with container and other resource recipes registered.
+		_, err := cli.EnvironmentCreatePreview(ctx, envName, "", kubernetesNamespace)
 		require.NoError(t, err, "failed to create preview environment")
 
-		// Register cleanup immediately after create, before update, to prevent leaks on update failure.
+		// Register cleanup immediately after create to prevent leaks.
 		t.Cleanup(func() {
 			_, err := cli.EnvironmentDeletePreview(ctx, envName, "")
 			if err != nil {
 				t.Logf("failed to delete preview environment %s: %v", envName, err)
 			}
 		})
-
-		// Set the Kubernetes namespace so recipes know where to deploy resources.
-		_, err = cli.EnvironmentUpdatePreview(ctx, envName, "", "", kubernetesNamespace)
-		require.NoError(t, err, "failed to set kubernetes namespace on preview environment")
 	}
 
 	return preSetup, envID

--- a/test/validation/shared.go
+++ b/test/validation/shared.go
@@ -49,6 +49,9 @@ const (
 	// Radius.Compute resource types (new provider).
 	ComputeContainersResource = "radius.compute/containers"
 
+	// Radius.Security resource types (new provider).
+	SecuritySecretsResource = "radius.security/secrets"
+
 	RabbitMQQueuesResource          = "applications.messaging/rabbitMQQueues"
 	DaprPubSubBrokersResource       = "applications.dapr/pubSubBrokers"
 	DaprSecretStoresResource        = "applications.dapr/secretStores"


### PR DESCRIPTION
# Description

This pull request migrates container mechanics functional tests and Bicep templates in the corerp noncloud test suite from the legacy Applications.Core/* resource types to the new recipe-driven types (Radius.Core/Compute/Security types.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (#11489 ).

Fixes: Part of #11489 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
