### PR TITLE
Migrating cli tests

### DIFF
--- a/cmd/rad/cmd/resourceExpose.go
+++ b/cmd/rad/cmd/resourceExpose.go
@@ -34,6 +34,9 @@ const (
 	LevenshteinCutoff = 2
 
 	ContainerType = "Applications.Core/containers"
+
+	// PreviewContainerType is the preview container resource type used with the --preview flag.
+	PreviewContainerType = "Radius.Compute/containers"
 )
 
 var resourceExposeCmd = &cobra.Command{
@@ -45,25 +48,45 @@ This command is useful for testing resources that accept network traffic but are
 Press CTRL+C to exit the command and terminate the tunnel.`,
 	Example: `# expose port 80 on the 'orders' resource of the 'icecream-store' application
 # on local port 5000
-rad resource expose --application icecream-store Applications.Core/containers orders --port 5000 --remote-port 80`,
+rad resource expose --application icecream-store Applications.Core/containers orders --port 5000 --remote-port 80
+
+# expose port 80 using the preview resource type 'Radius.Compute/containers'
+rad resource expose --application icecream-store Radius.Compute/containers orders --port 5000 --remote-port 80 --preview`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		workspace, err := cli.RequireWorkspace(cmd, ConfigFromContext(cmd.Context()))
-		if err != nil {
-			return err
-		}
+		return exposeResource(cmd, args, false)
+	},
+}
 
-		scope, err := cli.RequireScope(cmd, *workspace)
-		if err != nil {
-			return err
-		}
-		workspace.Scope = scope
+// resourceExposePreviewCmd holds the preview implementation of "rad resource expose".
+// It is wired to resourceExposeCmd via wirePreviewSubcommand so it is selected by the
+// --preview flag or the RADIUS_PREVIEW environment variable.
+var resourceExposePreviewCmd = &cobra.Command{
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return exposeResource(cmd, args, true)
+	},
+}
 
-		// This gets the application name from the args provided
-		application, err := cli.RequireApplication(cmd, *workspace)
-		if err != nil {
-			return err
-		}
+// exposeResource runs "rad resource expose" against either the legacy
+// (Applications.Core/containers) or preview (Radius.Compute/containers) API surface.
+func exposeResource(cmd *cobra.Command, args []string, preview bool) error {
+	workspace, err := cli.RequireWorkspace(cmd, ConfigFromContext(cmd.Context()))
+	if err != nil {
+		return err
+	}
 
+	scope, err := cli.RequireScope(cmd, *workspace)
+	if err != nil {
+		return err
+	}
+	workspace.Scope = scope
+
+	// This gets the application name from the args provided
+	application, err := cli.RequireApplication(cmd, *workspace)
+	if err != nil {
+		return err
+	}
+
+	if !preview {
 		// Check if the application provided exists or suggest a closest application in the scope
 		managementClient, err := connections.DefaultFactory.CreateApplicationsManagementClient(cmd.Context(), *workspace)
 		if err != nil {
@@ -95,69 +118,78 @@ rad resource expose --application icecream-store Applications.Core/containers or
 			}
 			fmt.Println(msg)
 		}
+	}
 
-		resourceType, resourceName, err := cli.RequireResource(cmd, args)
-		if err != nil {
-			return err
-		}
-		if !strings.EqualFold(resourceType, ContainerType) {
-			return fmt.Errorf("only %s is supported", ContainerType)
-		}
+	resourceType, resourceName, err := cli.RequireResource(cmd, args)
+	if err != nil {
+		return err
+	}
 
-		localPort, err := cmd.Flags().GetInt("port")
-		if err != nil {
-			return err
-		}
+	expectedType := ContainerType
+	if preview {
+		expectedType = PreviewContainerType
+	}
+	if !strings.EqualFold(resourceType, expectedType) {
+		return fmt.Errorf("only %s is supported", expectedType)
+	}
 
-		remotePort, err := cmd.Flags().GetInt("remote-port")
-		if err != nil {
-			return err
-		}
+	localPort, err := cmd.Flags().GetInt("port")
+	if err != nil {
+		return err
+	}
 
-		replica, err := cmd.Flags().GetString("replica")
-		if err != nil {
-			return err
-		}
+	remotePort, err := cmd.Flags().GetInt("remote-port")
+	if err != nil {
+		return err
+	}
 
-		if remotePort == -1 {
-			remotePort = localPort
-		}
+	replica, err := cmd.Flags().GetString("replica")
+	if err != nil {
+		return err
+	}
 
-		var client clients.DiagnosticsClient
+	if remotePort == -1 {
+		remotePort = localPort
+	}
+
+	var client clients.DiagnosticsClient
+	if preview {
+		client, err = connections.DefaultFactory.CreateDiagnosticsClientPreview(cmd.Context(), *workspace)
+	} else {
 		client, err = connections.DefaultFactory.CreateDiagnosticsClient(cmd.Context(), *workspace)
+	}
 
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return err
+	}
 
-		failed, stop, signals, err := client.Expose(cmd.Context(), clients.ExposeOptions{
-			Application: application,
-			Resource:    resourceName,
-			Port:        localPort,
-			RemotePort:  remotePort,
-			Replica:     replica})
+	failed, stop, signals, err := client.Expose(cmd.Context(), clients.ExposeOptions{
+		Application: application,
+		Resource:    resourceName,
+		Port:        localPort,
+		RemotePort:  remotePort,
+		Replica:     replica})
 
-		if err != nil {
-			return err
-		}
-		// We own stopping the signal created by Expose
-		defer signal.Stop(signals)
+	if err != nil {
+		return err
+	}
+	// We own stopping the signal created by Expose
+	defer signal.Stop(signals)
 
-		for {
-			select {
-			case <-signals:
-				// shutting down... wait for socket to close
-				close(stop)
-				continue
-			case err := <-failed:
-				if err != nil {
-					return fmt.Errorf("failed to port-forward: %w", err)
-				}
-
-				return nil
+	for {
+		select {
+		case <-signals:
+			// shutting down... wait for socket to close
+			close(stop)
+			continue
+		case err := <-failed:
+			if err != nil {
+				return fmt.Errorf("failed to port-forward: %w", err)
 			}
+
+			return nil
 		}
-	},
+	}
 }
 
 func init() {
@@ -171,5 +203,6 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+	wirePreviewSubcommand(resourceExposeCmd, resourceExposePreviewCmd)
 	resourceCmd.AddCommand(resourceExposeCmd)
 }

--- a/cmd/rad/cmd/resourceLogs.go
+++ b/cmd/rad/cmd/resourceLogs.go
@@ -34,7 +34,7 @@ import (
 var resourceLogsCmd = &cobra.Command{
 	Use:   "logs [resource]",
 	Short: "Read logs from a running containers resource",
-	Long: `Reads logs from a running resource. Currently only supports the resource type 'Applications.Core/containers'.
+	Long: `Reads logs from a running resource. Supports the resource type 'Applications.Core/containers', or 'Radius.Compute/containers' when the '--preview' flag is set.
 This command allows you to access logs of a deployed application and output those logs to the local console.
 
 'rad resource logs' will output all currently available logs for the resource and then exit.
@@ -52,78 +52,105 @@ rad resource logs Applications.Core/containers orders --application icecream-sto
 rad resource logs Applications.Core/containers orders --application icecream-store --follow
 
 # read logs from the 'daprd' sidecar container of the 'orders' resource of the 'icecream-store' application
-rad resource logs Applications.Core/containers orders --application icecream-store --container daprd`,
+rad resource logs Applications.Core/containers orders --application icecream-store --container daprd
+
+# read logs from the 'orders' resource using the preview resource type 'Radius.Compute/containers'
+rad resource logs Radius.Compute/containers orders --application icecream-store --preview`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		workspace, err := cli.RequireWorkspace(cmd, ConfigFromContext(cmd.Context()))
-		if err != nil {
-			return err
-		}
-
-		scope, err := cli.RequireScope(cmd, *workspace)
-		if err != nil {
-			return err
-		}
-		workspace.Scope = scope
-
-		application, err := cli.RequireApplication(cmd, *workspace)
-		if err != nil {
-			return err
-		}
-
-		resourceType, resourceName, err := cli.RequireResource(cmd, args)
-		if err != nil {
-			return err
-		}
-		if !strings.EqualFold(resourceType, ContainerType) {
-			return fmt.Errorf("only %s is supported", ContainerType)
-		}
-		follow, err := cmd.Flags().GetBool("follow")
-		if err != nil {
-			return err
-		}
-
-		container, err := cmd.Flags().GetString("container")
-		if err != nil {
-			return err
-		}
-
-		var client clients.DiagnosticsClient
-		client, err = connections.DefaultFactory.CreateDiagnosticsClient(cmd.Context(), *workspace)
-		if err != nil {
-			return err
-		}
-
-		streams, err := client.Logs(cmd.Context(), clients.LogsOptions{
-			Application: application,
-			Resource:    resourceName,
-			Follow:      follow,
-			Container:   container})
-		if err != nil {
-			return err
-		}
-
-		logErrors := make(chan error, len(streams))
-		for _, logInfo := range streams {
-
-			// We can keep reading this until cancellation occurs.
-			if follow {
-				// Sending to stderr so it doesn't interfere with parsing
-				fmt.Fprintf(os.Stderr, "Streaming logs from replica %s for Container %s. Press CTRL+C to exit...\n", logInfo.Name, resourceName)
-			}
-
-			// Kick off go routine to read the logs from each stream.
-			go captureLogs(logInfo, logErrors, follow)
-		}
-
-		for range streams {
-			err := <-logErrors
-			if err != nil {
-				// TODO format
-				fmt.Fprintln(os.Stderr, err)
-			}
-		}
-		return nil
+		return logsResource(cmd, args, false)
 	},
+}
+
+// resourceLogsPreviewCmd holds the preview implementation of "rad resource logs".
+// It is wired to resourceLogsCmd via wirePreviewSubcommand so it is selected by the
+// --preview flag or the RADIUS_PREVIEW environment variable.
+var resourceLogsPreviewCmd = &cobra.Command{
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return logsResource(cmd, args, true)
+	},
+}
+
+// logsResource runs "rad resource logs" against either the legacy
+// (Applications.Core/containers) or preview (Radius.Compute/containers) API surface.
+func logsResource(cmd *cobra.Command, args []string, preview bool) error {
+	workspace, err := cli.RequireWorkspace(cmd, ConfigFromContext(cmd.Context()))
+	if err != nil {
+		return err
+	}
+
+	scope, err := cli.RequireScope(cmd, *workspace)
+	if err != nil {
+		return err
+	}
+	workspace.Scope = scope
+
+	application, err := cli.RequireApplication(cmd, *workspace)
+	if err != nil {
+		return err
+	}
+
+	resourceType, resourceName, err := cli.RequireResource(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	expectedType := ContainerType
+	if preview {
+		expectedType = PreviewContainerType
+	}
+	if !strings.EqualFold(resourceType, expectedType) {
+		return fmt.Errorf("only %s is supported", expectedType)
+	}
+	follow, err := cmd.Flags().GetBool("follow")
+	if err != nil {
+		return err
+	}
+
+	container, err := cmd.Flags().GetString("container")
+	if err != nil {
+		return err
+	}
+
+	var client clients.DiagnosticsClient
+	if preview {
+		client, err = connections.DefaultFactory.CreateDiagnosticsClientPreview(cmd.Context(), *workspace)
+	} else {
+		client, err = connections.DefaultFactory.CreateDiagnosticsClient(cmd.Context(), *workspace)
+	}
+	if err != nil {
+		return err
+	}
+
+	streams, err := client.Logs(cmd.Context(), clients.LogsOptions{
+		Application: application,
+		Resource:    resourceName,
+		Follow:      follow,
+		Container:   container})
+	if err != nil {
+		return err
+	}
+
+	logErrors := make(chan error, len(streams))
+	for _, logInfo := range streams {
+
+		// We can keep reading this until cancellation occurs.
+		if follow {
+			// Sending to stderr so it doesn't interfere with parsing
+			fmt.Fprintf(os.Stderr, "Streaming logs from replica %s for Container %s. Press CTRL+C to exit...\n", logInfo.Name, resourceName)
+		}
+
+		// Kick off go routine to read the logs from each stream.
+		go captureLogs(logInfo, logErrors, follow)
+	}
+
+	for range streams {
+		err := <-logErrors
+		if err != nil {
+			// TODO format
+			fmt.Fprintln(os.Stderr, err)
+		}
+	}
+	return nil
 }
 
 func captureLogs(info clients.LogStream, logErrors chan<- error, follow bool) {
@@ -182,5 +209,6 @@ func init() {
 	resourceLogsCmd.Flags().BoolP("follow", "f", false, "specify that logs should be stream until the command is canceled")
 	resourceLogsCmd.Flags().String("replica", "", "specify the replica to collect logs from")
 	commonflags.AddResourceGroupFlag(resourceLogsCmd)
+	wirePreviewSubcommand(resourceLogsCmd, resourceLogsPreviewCmd)
 	resourceCmd.AddCommand(resourceLogsCmd)
 }

--- a/pkg/cli/connections/factory.go
+++ b/pkg/cli/connections/factory.go
@@ -41,6 +41,7 @@ var DefaultFactory = &impl{}
 type Factory interface {
 	CreateDeploymentClient(ctx context.Context, workspace workspaces.Workspace) (clients.DeploymentClient, error)
 	CreateDiagnosticsClient(ctx context.Context, workspace workspaces.Workspace) (clients.DiagnosticsClient, error)
+	CreateDiagnosticsClientPreview(ctx context.Context, workspace workspaces.Workspace) (clients.DiagnosticsClient, error)
 	CreateApplicationsManagementClient(ctx context.Context, workspace workspaces.Workspace) (clients.ApplicationsManagementClient, error)
 	CreateCredentialManagementClient(ctx context.Context, workspace workspaces.Workspace) (cli_credential.CredentialManagementClient, error)
 }
@@ -146,6 +147,44 @@ func (i *impl) CreateDiagnosticsClient(ctx context.Context, workspace workspaces
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported connection type: %+v", connection)
+	}
+}
+
+// CreateDiagnosticsClientPreview creates a DiagnosticsClient that operates against the preview
+// resource types (Radius.Compute/containers, Radius.Core/applications). The namespace of a
+// container is resolved via the management client (which discovers the correct API version per
+// resource type).
+func (i *impl) CreateDiagnosticsClientPreview(ctx context.Context, workspace workspaces.Workspace) (clients.DiagnosticsClient, error) {
+	connectionConfig, err := workspace.ConnectionConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	switch c := connectionConfig.(type) {
+	case *workspaces.KubernetesConnectionConfig:
+		k8sClient, config, err := kubernetes.NewClientset(c.Context)
+		if err != nil {
+			return nil, err
+		}
+		client, err := kubernetes.NewRuntimeClient(c.Context, kubernetes.Scheme)
+		if err != nil {
+			return nil, err
+		}
+
+		managementClient, err := i.CreateApplicationsManagementClient(ctx, workspace)
+		if err != nil {
+			return nil, err
+		}
+
+		return &deployment.ARMDiagnosticsClient{
+			K8sTypedClient:   k8sClient,
+			RestConfig:       config,
+			K8sRuntimeClient: client,
+			Preview:          true,
+			ManagementClient: managementClient,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported connection type: %+v", connectionConfig)
 	}
 }
 

--- a/pkg/cli/connections/mock_factory.go
+++ b/pkg/cli/connections/mock_factory.go
@@ -42,6 +42,12 @@ func (f *MockFactory) CreateDiagnosticsClient(ctx context.Context, workspace wor
 	return f.DiagnosticsClient, nil
 }
 
+// CreateDiagnosticsClientPreview function takes in a context and a workspace and returns a DiagnosticsClient (for the
+// preview resource types) without any errors.
+func (f *MockFactory) CreateDiagnosticsClientPreview(ctx context.Context, workspace workspaces.Workspace) (clients.DiagnosticsClient, error) {
+	return f.DiagnosticsClient, nil
+}
+
 // CreateApplicationsManagementClient function takes in a context and a workspace and returns an ApplicationsManagementClient
 // and an error if one occurs.
 func (f *MockFactory) CreateApplicationsManagementClient(ctx context.Context, workspace workspaces.Workspace) (clients.ApplicationsManagementClient, error) {

--- a/pkg/cli/deployment/diagnostics.go
+++ b/pkg/cli/deployment/diagnostics.go
@@ -25,6 +25,7 @@ import (
 	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
 	k8slabels "github.com/radius-project/radius/pkg/kubernetes"
 	"github.com/radius-project/radius/pkg/ucp/resources"
+	resourceskubernetes "github.com/radius-project/radius/pkg/ucp/resources/kubernetes"
 
 	"io"
 	"net/http"
@@ -49,7 +50,20 @@ type ARMDiagnosticsClient struct {
 	ContainerClient   generated.GenericResourcesClient
 	EnvironmentClient generated.GenericResourcesClient
 	GatewayClient     generated.GenericResourcesClient
+
+	// Preview indicates the client should operate against the preview resource types
+	// (Radius.Compute/containers, Radius.Core/applications) using the dynamic
+	// API-version resolution provided by ManagementClient.
+	Preview bool
+
+	// ManagementClient is used in preview mode to resolve a container resource using the
+	// API version registered for its resource type. It is only set when Preview is true.
+	ManagementClient clients.ApplicationsManagementClient
 }
+
+// previewContainerResourceType is the preview container resource type resolved via the
+// management client when Preview is enabled.
+const previewContainerResourceType = "Radius.Compute/containers"
 
 var _ clients.DiagnosticsClient = (*ARMDiagnosticsClient)(nil)
 
@@ -118,7 +132,7 @@ func (dc *ARMDiagnosticsClient) Expose(ctx context.Context, options clients.Expo
 func (dc *ARMDiagnosticsClient) Logs(ctx context.Context, options clients.LogsOptions) ([]clients.LogStream, error) {
 	namespace, err := dc.findNamespaceOfContainer(ctx, options.Resource)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	var replicas []corev1.Pod
@@ -150,6 +164,10 @@ func (dc *ARMDiagnosticsClient) Logs(ctx context.Context, options clients.LogsOp
 }
 
 func (dc *ARMDiagnosticsClient) findNamespaceOfContainer(ctx context.Context, resourceName string) (string, error) {
+	if dc.Preview {
+		return dc.findNamespaceOfContainerPreview(ctx, resourceName)
+	}
+
 	containerResponse, err := dc.ContainerClient.Get(ctx, resourceName, nil)
 	if err != nil {
 		return "", fmt.Errorf("could not find container %q:%w", resourceName, err)
@@ -208,17 +226,61 @@ func (dc *ARMDiagnosticsClient) findNamespaceOfContainer(ctx context.Context, re
 	return "", fmt.Errorf("could not find namespace for container %q", resourceName)
 }
 
-// Note: If an error is returned, any streams that were created before the error will also be returned.
+// findNamespaceOfContainerPreview resolves the Kubernetes namespace for a preview
+// Radius.Compute/containers resource. Unlike the legacy path, the preview
+// Radius.Core/applications resource does not expose status.compute.namespace, so the
+// namespace is derived from the container's output resources (the backing Deployment's
+// Kubernetes resource ID encodes the namespace).
+func (dc *ARMDiagnosticsClient) findNamespaceOfContainerPreview(ctx context.Context, resourceName string) (string, error) {
+	container, err := dc.ManagementClient.GetResource(ctx, previewContainerResourceType, resourceName)
+	if err != nil {
+		return "", fmt.Errorf("could not find container %q: %w", resourceName, err)
+	}
+
+	status, ok := container.Properties["status"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("could not find namespace for container %q", resourceName)
+	}
+
+	outputResources, ok := status["outputResources"].([]any)
+	if !ok {
+		return "", fmt.Errorf("could not find namespace for container %q", resourceName)
+	}
+
+	for _, raw := range outputResources {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		idValue, ok := entry["id"].(string)
+		if !ok {
+			continue
+		}
+
+		id, err := resources.Parse(idValue)
+		if err != nil {
+			continue
+		}
+
+		if namespace := id.FindScope(resourceskubernetes.ScopeNamespaces); namespace != "" {
+			return namespace, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find namespace for container %q", resourceName)
+}
+
 // Caller is responsible for closing streams even when there is an error.
 func createLogStreams(ctx context.Context, options clients.LogsOptions, dc *ARMDiagnosticsClient, replicas []corev1.Pod) ([]clients.LogStream, error) {
-	container := options.Container
 	follow := options.Follow
 
 	var streams []clients.LogStream
 	for _, replica := range replicas {
+		container := options.Container
 		if container == "" {
 			// We don't really expect this to fail, but let's do something reasonable if it does...
-			container = getAppContainerName(&replica)
+			container = defaultContainerName(dc, &replica)
 			if container == "" {
 				return streams, fmt.Errorf("failed to find the default container for resource '%s'. use '--container <name>' to specify the name", options.Resource)
 			}
@@ -325,6 +387,20 @@ func getAppContainerName(replica *corev1.Pod) string {
 	// The container name will be the resource name
 	resource := replica.Labels[k8slabels.LabelRadiusResource]
 	return resource
+}
+
+// defaultContainerName resolves the container to read logs from when none is specified.
+// For preview (Radius.Compute/containers) the pod's container is named after the container
+// map key rather than the resource, so the resource-name heuristic does not apply. When the
+// pod has exactly one container its name is used; otherwise the caller must pass --container.
+func defaultContainerName(dc *ARMDiagnosticsClient, replica *corev1.Pod) string {
+	if dc.Preview {
+		if len(replica.Spec.Containers) == 1 {
+			return replica.Spec.Containers[0].Name
+		}
+		return ""
+	}
+	return getAppContainerName(replica)
 }
 
 func streamLogs(ctx context.Context, client *k8s.Clientset, replica *corev1.Pod, container string, follow bool) (io.ReadCloser, error) {

--- a/pkg/cli/deployment/diagnostics_test.go
+++ b/pkg/cli/deployment/diagnostics_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/cli/clients"
+	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_findNamespaceOfContainerPreview(t *testing.T) {
+	const resourceName = "myapp-frontend"
+	deploymentID := "/planes/kubernetes/local/namespaces/my-namespace/providers/apps/Deployment/myapp-frontend"
+
+	containerWith := func(properties map[string]any) generated.GenericResource {
+		return generated.GenericResource{Properties: properties}
+	}
+
+	tests := []struct {
+		name      string
+		resource  generated.GenericResource
+		getErr    error
+		expected  string
+		expectErr bool
+	}{
+		{
+			name: "resolves namespace from output resource deployment id",
+			resource: containerWith(map[string]any{
+				"status": map[string]any{
+					"outputResources": []any{
+						map[string]any{"id": deploymentID},
+					},
+				},
+			}),
+			expected: "my-namespace",
+		},
+		{
+			name: "skips non-namespaced output resources and resolves the namespaced one",
+			resource: containerWith(map[string]any{
+				"status": map[string]any{
+					"outputResources": []any{
+						map[string]any{"id": "/planes/radius/local/resourceGroups/default/providers/Applications.Core/secretStores/secret"},
+						map[string]any{"id": deploymentID},
+					},
+				},
+			}),
+			expected: "my-namespace",
+		},
+		{
+			name:      "errors when GetResource fails",
+			getErr:    errors.New("not found"),
+			expectErr: true,
+		},
+		{
+			name:      "errors when status is missing",
+			resource:  containerWith(map[string]any{}),
+			expectErr: true,
+		},
+		{
+			name: "errors when outputResources is missing",
+			resource: containerWith(map[string]any{
+				"status": map[string]any{},
+			}),
+			expectErr: true,
+		},
+		{
+			name: "errors when no output resource encodes a namespace",
+			resource: containerWith(map[string]any{
+				"status": map[string]any{
+					"outputResources": []any{
+						map[string]any{"id": "/planes/radius/local/resourceGroups/default/providers/Applications.Core/secretStores/secret"},
+					},
+				},
+			}),
+			expectErr: true,
+		},
+		{
+			name: "errors when output resource id is malformed",
+			resource: containerWith(map[string]any{
+				"status": map[string]any{
+					"outputResources": []any{
+						map[string]any{"id": "not-a-valid-resource-id"},
+					},
+				},
+			}),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			managementClient := clients.NewMockApplicationsManagementClient(ctrl)
+			managementClient.EXPECT().
+				GetResource(gomock.Any(), previewContainerResourceType, resourceName).
+				Return(tt.resource, tt.getErr)
+
+			dc := &ARMDiagnosticsClient{Preview: true, ManagementClient: managementClient}
+			namespace, err := dc.findNamespaceOfContainerPreview(context.Background(), resourceName)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				require.Empty(t, namespace)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, namespace)
+		})
+	}
+}
+
+func Test_defaultContainerName(t *testing.T) {
+	podWithContainers := func(names ...string) *corev1.Pod {
+		pod := &corev1.Pod{}
+		for _, name := range names {
+			pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: name})
+		}
+		return pod
+	}
+
+	t.Run("preview pod with a single container uses that container name", func(t *testing.T) {
+		dc := &ARMDiagnosticsClient{Preview: true}
+		require.Equal(t, "main", defaultContainerName(dc, podWithContainers("main")))
+	})
+
+	t.Run("preview pod with multiple containers returns empty so caller requires --container", func(t *testing.T) {
+		dc := &ARMDiagnosticsClient{Preview: true}
+		require.Equal(t, "", defaultContainerName(dc, podWithContainers("main", "sidecar")))
+	})
+
+	t.Run("preview pod with no containers returns empty", func(t *testing.T) {
+		dc := &ARMDiagnosticsClient{Preview: true}
+		require.Equal(t, "", defaultContainerName(dc, podWithContainers()))
+	})
+
+	t.Run("legacy pod uses the radius resource label as the container name", func(t *testing.T) {
+		dc := &ARMDiagnosticsClient{Preview: false}
+		pod := podWithContainers("anything")
+		pod.Labels = map[string]string{"radapp.io/resource": "frontend"}
+		require.Equal(t, "frontend", defaultContainerName(dc, pod))
+	})
+}

--- a/test/functional-portable/cli/noncloud/cli_test.go
+++ b/test/functional-portable/cli/noncloud/cli_test.go
@@ -35,13 +35,12 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/radius-project/radius/pkg/cli/bicep"
-	"github.com/radius-project/radius/pkg/cli/clients"
 	"github.com/radius-project/radius/pkg/cli/cmd/radinit"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
+	"github.com/radius-project/radius/pkg/cli/kubernetes"
 	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
-	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
 	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/radius-project/radius/pkg/version"
 
@@ -52,8 +51,6 @@ import (
 	"github.com/radius-project/radius/test/testutil"
 	"github.com/radius-project/radius/test/validation"
 	"github.com/stretchr/testify/require"
-
-	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
 )
 
 const (
@@ -162,16 +159,16 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test rp.RPTest) {
 	options := rp.NewRPTestOptions(t)
 	cli := radcli.NewCLI(t, options.ConfigFilePath)
 	appName := test.Name
-	containerName := "containerA"
+	containerName := "containera"
 	if strings.EqualFold(appName, "kubernetes-cli-json") {
-		containerName = "containerA-json"
+		containerName = "containera-json"
 	}
 
 	scope, err := resources.ParseScope(options.Workspace.Scope)
 	require.NoError(t, err)
 
 	t.Run("Validate rad application show", func(t *testing.T) {
-		actualOutput, err := cli.ApplicationShow(ctx, appName)
+		actualOutput, err := cli.ApplicationShow(ctx, appName, radcli.ShowOptions{Preview: true})
 		require.NoError(t, err)
 
 		lines := strings.Split(actualOutput, "\n")
@@ -185,27 +182,27 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test rp.RPTest) {
 
 		values := strings.Fields(lines[1])
 		require.Equal(t, appName, values[0], "First value should be %s", appName)
-		require.Equal(t, "Applications.Core/applications", values[1], "Second value should be Applications.Core/applications")
+		require.Equal(t, "Radius.Core/applications", values[1], "Second value should be Radius.Core/applications")
 		require.Equal(t, scope.Name(), values[2], "Third value should be %s", scope.Name())
 		require.Equal(t, "Succeeded", values[3], "Fourth value should be Succeeded")
 	})
 
 	t.Run("Validate rad resource list", func(t *testing.T) {
-		output, err := cli.ResourceList(ctx, appName)
+		output, err := cli.ResourceList(ctx, "Radius.Compute/containers", "")
 		require.NoError(t, err)
 
 		// Resource ordering can vary so we don't assert exact output.
 		if strings.EqualFold(appName, "kubernetes-cli") {
-			require.Regexp(t, `containerA`, output)
-			require.Regexp(t, `containerB`, output)
+			require.Regexp(t, `containera`, output)
+			require.Regexp(t, `containerb`, output)
 		} else {
-			require.Regexp(t, `containerA-json`, output)
-			require.Regexp(t, `containerB-json`, output)
+			require.Regexp(t, `containera-json`, output)
+			require.Regexp(t, `containerb-json`, output)
 		}
 	})
 
 	t.Run("Validate rad resource show", func(t *testing.T) {
-		actualOutput, err := cli.ResourceShow(ctx, "Applications.Core/containers", containerName)
+		actualOutput, err := cli.ResourceShow(ctx, "Radius.Compute/containers", containerName)
 		require.NoError(t, err)
 
 		lines := strings.Split(actualOutput, "\n")
@@ -219,13 +216,13 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test rp.RPTest) {
 
 		values := strings.Fields(lines[1])
 		require.Equal(t, containerName, values[0], "First value should be %s", containerName)
-		require.Equal(t, "Applications.Core/containers", values[1], "Second value should be Applications.Core/applications")
+		require.Equal(t, "Radius.Compute/containers", values[1], "Second value should be Radius.Compute/containers")
 		require.Equal(t, scope.Name(), values[2], "Third value should be %s", scope.Name())
 		require.Equal(t, "Succeeded", values[3], "Fourth value should be Succeeded")
 	})
 
-	t.Run("Validate rad resoure logs containers", func(t *testing.T) {
-		output, err := cli.ResourceLogs(ctx, appName, containerName)
+	t.Run("Validate rad resource logs containers", func(t *testing.T) {
+		output, err := cli.ResourceLogs(ctx, "Radius.Compute/containers", appName, containerName, true)
 		require.NoError(t, err)
 
 		// We don't want to be too fragile so we're not validating the logs in depth
@@ -241,7 +238,7 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test rp.RPTest) {
 
 		done := make(chan error)
 		go func() {
-			output, err := cli.ResourceExpose(child, appName, containerName, port, 3000)
+			output, err := cli.ResourceExpose(child, "Radius.Compute/containers", appName, containerName, port, 3000, true)
 			t.Logf("ResourceExpose - output: %s", output)
 			done <- err
 		}()
@@ -458,28 +455,27 @@ func Test_CLI(t *testing.T) {
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, testutil.GetMagpieImage()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: "kubernetes-cli",
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
-						Name: "containerA",
-						Type: validation.ContainersResource,
+						Name: "containera",
+						Type: validation.ComputeContainersResource,
 						App:  "kubernetes-cli",
 					},
 					{
-						Name: "containerB",
-						Type: validation.ContainersResource,
+						Name: "containerb",
+						Type: validation.ComputeContainersResource,
 						App:  "kubernetes-cli",
 					},
 				},
 			},
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
-					"default-kubernetes-cli": {
+					"kubernetes-cli": {
 						validation.NewK8sPodForResource(name, "containera"),
 						validation.NewK8sPodForResource(name, "containerb"),
 					},
@@ -488,6 +484,10 @@ func Test_CLI(t *testing.T) {
 			PostStepVerify: verifyCLIBasics,
 		},
 	})
+
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, name)
+	test.PreSetup = preSetup
+	test.Steps[0].Executor = step.NewDeployExecutor(template, testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
 
 	test.Test(t)
 }
@@ -498,28 +498,27 @@ func Test_CLI_JSON(t *testing.T) {
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, testutil.GetMagpieImage()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: "kubernetes-cli-json",
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
-						Name: "containerA-json",
-						Type: validation.ContainersResource,
+						Name: "containera-json",
+						Type: validation.ComputeContainersResource,
 						App:  "kubernetes-cli-json",
 					},
 					{
-						Name: "containerB-json",
-						Type: validation.ContainersResource,
+						Name: "containerb-json",
+						Type: validation.ComputeContainersResource,
 						App:  "kubernetes-cli-json",
 					},
 				},
 			},
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
-					"default-kubernetes-cli-json": {
+					"kubernetes-cli-json": {
 						validation.NewK8sPodForResource(name, "containera-json"),
 						validation.NewK8sPodForResource(name, "containerb-json"),
 					},
@@ -528,6 +527,10 @@ func Test_CLI_JSON(t *testing.T) {
 			PostStepVerify: verifyCLIBasics,
 		},
 	})
+
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, name)
+	test.PreSetup = preSetup
+	test.Steps[0].Executor = step.NewDeployExecutor(template, testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
 
 	test.Test(t)
 }
@@ -555,71 +558,89 @@ func Test_CLI_Delete(t *testing.T) {
 
 	cli := radcli.NewCLI(t, options.ConfigFilePath)
 
+	// Set up a preview environment with a Kubernetes namespace so the recipe-based
+	// Radius.Compute/containers resources have somewhere to deploy.
+	namespace := "kubernetes-cli-delete"
+	envName := namespace + "-env"
+	envID := fmt.Sprintf("%s/providers/Radius.Core/environments/%s", options.Workspace.Scope, envName)
+
+	require.NoError(t, kubernetes.EnsureNamespace(ctx, options.K8sClient, namespace), "failed to create namespace")
+	_, err = cli.EnvironmentCreatePreview(ctx, envName, "", namespace)
+	require.NoError(t, err, "failed to create preview environment")
+	t.Cleanup(func() {
+		_, err := cli.EnvironmentDeletePreview(ctx, envName, "")
+		if err != nil {
+			t.Logf("failed to delete preview environment %s: %v", envName, err)
+		}
+	})
+
+	envParam := fmt.Sprintf("environment=%s", envID)
+
 	t.Run("Validate rad app delete with non empty resources", func(t *testing.T) {
 		t.Logf("deploying %s from file %s", appName, templateWithResources)
 
-		err = cli.Deploy(ctx, templateFilePathWithResources, "", appName, testutil.GetMagpieImage())
+		err = cli.Deploy(ctx, templateFilePathWithResources, "", "", testutil.GetMagpieImage(), envParam)
 		require.NoErrorf(t, err, "failed to deploy %s", appName)
 
 		validation.ValidateObjectsRunning(ctx, t, options.K8sClient, options.DynamicClient, validation.K8sObjectSet{
 			Namespaces: map[string][]validation.K8sObject{
-				"default-kubernetes-cli-with-resources": {
+				namespace: {
 					validation.NewK8sPodForResource(appName, "containera-app-with-resources"),
 					validation.NewK8sPodForResource(appName, "containerb-app-with-resources"),
 				},
 			},
 		})
 
-		err = cli.ApplicationDelete(ctx, appName)
+		_, err = cli.ApplicationDeletePreview(ctx, appName, "")
 		require.NoErrorf(t, err, "failed to delete %s", appName)
 	})
 
 	t.Run("Validate rad app delete with empty resources", func(t *testing.T) {
 		t.Logf("deploying %s from file %s", appNameEmptyResources, templateEmptyResources)
 
-		err = cli.Deploy(ctx, templateFilePathEmptyResources, "", appNameEmptyResources)
+		err = cli.Deploy(ctx, templateFilePathEmptyResources, "", "", envParam)
 		require.NoErrorf(t, err, "failed to deploy %s", appNameEmptyResources)
 
-		err = cli.ApplicationDelete(ctx, appNameEmptyResources)
+		_, err = cli.ApplicationDeletePreview(ctx, appNameEmptyResources, "")
 		require.NoErrorf(t, err, "failed to delete %s", appNameEmptyResources)
 	})
 
 	t.Run("Validate rad app delete with non existent app", func(t *testing.T) {
-		err = cli.ApplicationDelete(ctx, appName)
+		_, err = cli.ApplicationDeletePreview(ctx, appName, "")
 		require.NoErrorf(t, err, "failed to delete %s", appName)
 	})
 
 	t.Run("Validate rad app delete with resources not associated with any application", func(t *testing.T) {
-		t.Logf("deploying from file %s", templateWithResources)
+		t.Logf("deploying from file %s", templateWithResourcesUnassociated)
 
-		err := cli.Deploy(ctx, templateFilePathWithResourcesUnassociated, "", appNameUnassociatedResources, testutil.GetMagpieImage())
+		err := cli.Deploy(ctx, templateFilePathWithResourcesUnassociated, "", "", testutil.GetMagpieImage(), envParam)
 		require.NoErrorf(t, err, "failed to deploy %s", appNameUnassociatedResources)
 
 		validation.ValidateObjectsRunning(ctx, t, options.K8sClient, options.DynamicClient, validation.K8sObjectSet{
 			Namespaces: map[string][]validation.K8sObject{
-				"default-kubernetes-cli-with-unassociated-resources": {
-					validation.NewK8sPodForResource(appNameUnassociatedResources, "containerX"),
-					validation.NewK8sPodForResource(appNameUnassociatedResources, "containerY"),
+				namespace: {
+					validation.NewK8sPodForResource(appNameUnassociatedResources, "containerx"),
+					validation.NewK8sPodForResource(appNameUnassociatedResources, "containery"),
 				},
 			},
 		})
 
 		//ignore response for tests
-		_, err = options.ManagementClient.DeleteResource(ctx, "Applications.Core/containers", "containerY", false)
-		require.NoErrorf(t, err, "failed to delete resource containerY")
+		_, err = options.ManagementClient.DeleteResource(ctx, "Radius.Compute/containers", "containery", false)
+		require.NoErrorf(t, err, "failed to delete resource containery")
 		err = DeleteAppWithoutDeletingResources(t, ctx, options, appNameUnassociatedResources)
 		require.NoErrorf(t, err, "failed to delete application %s", appNameUnassociatedResources)
 
 		t.Logf("deploying from file %s", templateEmptyResources)
-		err = cli.Deploy(ctx, templateFilePathEmptyResources, "", appNameEmptyResources)
+		err = cli.Deploy(ctx, templateFilePathEmptyResources, "", "", envParam)
 		require.NoErrorf(t, err, "failed to deploy %s", appNameEmptyResources)
 
-		err = cli.ApplicationDelete(ctx, appNameEmptyResources)
+		_, err = cli.ApplicationDeletePreview(ctx, appNameEmptyResources, "")
 		require.NoErrorf(t, err, "failed to delete %s", appNameEmptyResources)
 
 		//ignore response for tests
-		_, err = options.ManagementClient.DeleteResource(ctx, "Applications.Core/containers", "containerX", false)
-		require.NoErrorf(t, err, "failed to delete resource containerX")
+		_, err = options.ManagementClient.DeleteResource(ctx, "Radius.Compute/containers", "containerx", false)
+		require.NoErrorf(t, err, "failed to delete resource containerx")
 
 	})
 }
@@ -636,28 +657,27 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, "@"+parameterFilePath, testutil.GetMagpieTag()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: "kubernetes-cli-params",
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
-						Name: "containerC",
-						Type: validation.ContainersResource,
+						Name: "containerc",
+						Type: validation.ComputeContainersResource,
 						App:  "kubernetes-cli-params",
 					},
 					{
-						Name: "containerD",
-						Type: validation.ContainersResource,
+						Name: "containerd",
+						Type: validation.ComputeContainersResource,
 						App:  "kubernetes-cli-params",
 					},
 				},
 			},
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
-					"default-kubernetes-cli-params": {
+					"kubernetes-cli-params": {
 						validation.NewK8sPodForResource(name, "containerc"),
 						validation.NewK8sPodForResource(name, "containerd"),
 					},
@@ -665,6 +685,10 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 			},
 		},
 	})
+
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, name)
+	test.PreSetup = preSetup
+	test.Steps[0].Executor = step.NewDeployExecutor(template, "@"+parameterFilePath, testutil.GetMagpieTag(), fmt.Sprintf("environment=%s", previewEnvID))
 
 	test.Test(t)
 }
@@ -798,16 +822,12 @@ func GetAvailablePort() (int, error) {
 	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
-// DeleteAppWithoutDeletingResources creates a client to delete an application without deleting its resources and returns
-// an error if one occurs.
+// DeleteAppWithoutDeletingResources deletes only the application resource (non-cascading) so its
+// resources remain, returning an error if one occurs.
 func DeleteAppWithoutDeletingResources(t *testing.T, ctx context.Context, options rp.RPTestOptions, applicationName string) error {
-	client := options.ManagementClient
-	require.IsType(t, client, &clients.UCPApplicationsManagementClient{})
-	appManagementClient := client.(*clients.UCPApplicationsManagementClient)
-	appDeleteClient, err := v20231001preview.NewApplicationsClient(&aztoken.AnonymousCredential{}, appManagementClient.ClientOptions)
-	require.NoError(t, err)
-	// We don't care about the response for tests
-	_, err = appDeleteClient.Delete(ctx, appManagementClient.RootScope, applicationName, nil)
+	// Deleting the Radius.Core/applications resource directly removes only the application,
+	// leaving its associated resources in place (unlike "rad app delete --preview" which cascades).
+	_, err := options.ManagementClient.DeleteResource(ctx, "Radius.Core/applications", applicationName, false)
 	return err
 }
 

--- a/test/functional-portable/cli/noncloud/testdata/corerp-kubernetes-cli-app-empty-resources.bicep
+++ b/test/functional-portable/cli/noncloud/testdata/corerp-kubernetes-cli-app-empty-resources.bicep
@@ -4,9 +4,9 @@ extension radius
 param location string = 'global'
 
 @description('Specifies the environment for resources.')
-param environment string = 'test'
+param environment string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'kubernetes-cli-empty-resources'
   location: location
   properties: {

--- a/test/functional-portable/cli/noncloud/testdata/corerp-kubernetes-cli-parameters.bicep
+++ b/test/functional-portable/cli/noncloud/testdata/corerp-kubernetes-cli-parameters.bicep
@@ -4,7 +4,7 @@ extension radius
 param location string = 'global'
 
 @description('Specifies the environment for resources.')
-param environment string = 'test'
+param environment string
 
 @description('Specifies the tag of the image to be deployed.')
 param magpietag string = 'latest'
@@ -12,7 +12,7 @@ param magpietag string = 'latest'
 @description('Specifies the registry of the image to be deployed.')
 param registry string
 
-resource parametersApp 'Applications.Core/applications@2023-10-01-preview' = {
+resource parametersApp 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'kubernetes-cli-params'
   location: location
   properties: {
@@ -20,24 +20,30 @@ resource parametersApp 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource containerc 'Applications.Core/containers@2023-10-01-preview' = {
-  name: 'containerC'
+resource containerc 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'containerc'
   location: location
   properties: {
     application: parametersApp.id
-    container: {
-      image: '${registry}/magpiego:${magpietag}'
+    environment: environment
+    containers: {
+      main: {
+        image: '${registry}/magpiego:${magpietag}'
+      }
     }
   }
 }
 
-resource containerd 'Applications.Core/containers@2023-10-01-preview' = {
-  name: 'containerD'
+resource containerd 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'containerd'
   location: location
   properties: {
     application: parametersApp.id
-    container: {
-      image: '${registry}/magpiego:${magpietag}'
+    environment: environment
+    containers: {
+      main: {
+        image: '${registry}/magpiego:${magpietag}'
+      }
     }
   }
 }

--- a/test/functional-portable/cli/noncloud/testdata/corerp-kubernetes-cli-with-resources.bicep
+++ b/test/functional-portable/cli/noncloud/testdata/corerp-kubernetes-cli-with-resources.bicep
@@ -4,12 +4,12 @@ extension radius
 param location string = 'global'
 
 @description('Specifies the environment for resources.')
-param environment string = 'test'
+param environment string
 
 @description('Specifies the image to be deployed.')
 param magpieimage string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'kubernetes-cli-with-resources'
   location: location
   properties: {
@@ -17,24 +17,30 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource containera 'Applications.Core/containers@2023-10-01-preview' = {
+resource containera 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'containera-app-with-resources'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
+    environment: environment
+    containers: {
+      main: {
+        image: magpieimage
+      }
     }
   }
 }
 
-resource containerb 'Applications.Core/containers@2023-10-01-preview' = {
+resource containerb 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'containerb-app-with-resources'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
+    environment: environment
+    containers: {
+      main: {
+        image: magpieimage
+      }
     }
   }
 }

--- a/test/functional-portable/cli/noncloud/testdata/corerp-kubernetes-cli-with-unassociated-resources.bicep
+++ b/test/functional-portable/cli/noncloud/testdata/corerp-kubernetes-cli-with-unassociated-resources.bicep
@@ -4,12 +4,12 @@ extension radius
 param location string = 'global'
 
 @description('Specifies the environment for resources.')
-param environment string = 'test'
+param environment string
 
 @description('Specifies the image to be deployed.')
 param magpieimage string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'kubernetes-cli-with-unassociated-resources'
   location: location
   properties: {
@@ -17,24 +17,30 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource containerx 'Applications.Core/containers@2023-10-01-preview' = {
-  name: 'containerX'
+resource containerx 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'containerx'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
+    environment: environment
+    containers: {
+      main: {
+        image: magpieimage
+      }
     }
   }
 }
 
-resource containery 'Applications.Core/containers@2023-10-01-preview' = {
-  name: 'containerY'
+resource containery 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'containery'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
+    environment: environment
+    containers: {
+      main: {
+        image: magpieimage
+      }
     }
   }
 }

--- a/test/functional-portable/cli/noncloud/testdata/corerp-kubernetes-cli.bicep
+++ b/test/functional-portable/cli/noncloud/testdata/corerp-kubernetes-cli.bicep
@@ -4,12 +4,12 @@ extension radius
 param location string = 'global'
 
 @description('Specifies the environment for resources.')
-param environment string = 'test'
+param environment string
 
 @description('Specifies the image to be deployed.')
 param magpieimage string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'kubernetes-cli'
   location: location
   properties: {
@@ -17,24 +17,30 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource containera 'Applications.Core/containers@2023-10-01-preview' = {
-  name: 'containerA'
+resource containera 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'containera'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
+    environment: environment
+    containers: {
+      main: {
+        image: magpieimage
+      }
     }
   }
 }
 
-resource containerb 'Applications.Core/containers@2023-10-01-preview' = {
-  name: 'containerB'
+resource containerb 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'containerb'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
+    environment: environment
+    containers: {
+      main: {
+        image: magpieimage
+      }
     }
   }
 }

--- a/test/functional-portable/cli/noncloud/testdata/corerp-kubernetes-cli.json
+++ b/test/functional-portable/cli/noncloud/testdata/corerp-kubernetes-cli.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-  "languageVersion": "1.9-experimental",
+  "languageVersion": "2.0",
   "contentVersion": "1.0.0.0",
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.7.20.15963",
-      "templateHash": "4645026798404255599"
+      "version": "0.42.1.51946",
+      "templateHash": "6050584823325268153"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
     },
     "environment": {
       "type": "string",
-      "defaultValue": "test",
       "metadata": {
         "description": "Specifies the environment for resources."
       }
@@ -34,13 +33,13 @@
   "imports": {
     "radius": {
       "provider": "Radius",
-      "version": "1.0"
+      "version": "latest"
     }
   },
   "resources": {
     "app": {
       "import": "radius",
-      "type": "Applications.Core/applications@2023-10-01-preview",
+      "type": "Radius.Core/applications@2025-08-01-preview",
       "properties": {
         "name": "kubernetes-cli-json",
         "location": "[parameters('location')]",
@@ -51,14 +50,17 @@
     },
     "containera": {
       "import": "radius",
-      "type": "Applications.Core/containers@2023-10-01-preview",
+      "type": "Radius.Compute/containers@2025-08-01-preview",
       "properties": {
-        "name": "containerA-json",
+        "name": "containera-json",
         "location": "[parameters('location')]",
         "properties": {
           "application": "[reference('app').id]",
-          "container": {
-            "image": "[parameters('magpieimage')]"
+          "environment": "[parameters('environment')]",
+          "containers": {
+            "main": {
+              "image": "[parameters('magpieimage')]"
+            }
           }
         }
       },
@@ -66,14 +68,17 @@
     },
     "containerb": {
       "import": "radius",
-      "type": "Applications.Core/containers@2023-10-01-preview",
+      "type": "Radius.Compute/containers@2025-08-01-preview",
       "properties": {
-        "name": "containerB-json",
+        "name": "containerb-json",
         "location": "[parameters('location')]",
         "properties": {
           "application": "[reference('app').id]",
-          "container": {
-            "image": "[parameters('magpieimage')]"
+          "environment": "[parameters('environment')]",
+          "containers": {
+            "main": {
+              "image": "[parameters('magpieimage')]"
+            }
           }
         }
       },

--- a/test/functional-portable/corerp/noncloud/api_test.go
+++ b/test/functional-portable/corerp/noncloud/api_test.go
@@ -51,7 +51,7 @@ func Test_ResourceList(t *testing.T) {
 
 	resourceTypesList, err := options.ManagementClient.(*clients.UCPApplicationsManagementClient).ListAllResourceTypesNames(context.Background(), "local")
 	require.NoError(t, err)
-	resourceTypes := []string{"Applications.Core/applications", "Applications.Core/environments"}
+	resourceTypes := []string{"Applications.Core/applications", "Applications.Core/environments", "Radius.Core/applications", "Radius.Core/environments"}
 	resourceTypes = append(resourceTypes, resourceTypesList...)
 
 	listResources := func(t *testing.T, resourceType string) {

--- a/test/radcli/cli.go
+++ b/test/radcli/cli.go
@@ -149,6 +149,7 @@ type ShowOptions struct {
 	Workspace   string // The workspace name
 	Output      string // Output format (json, table, plain-text)
 	Application string // Application name (for resource show)
+	Preview     bool   // Use the preview API surface (--preview)
 }
 
 // DeleteOptions provides configuration for delete commands
@@ -193,6 +194,9 @@ func (cli *CLI) ApplicationShow(ctx context.Context, applicationName string, opt
 		}
 		if opt.Output != "" {
 			args = append(args, "--output", opt.Output)
+		}
+		if opt.Preview {
+			args = append(args, "--preview")
 		}
 	}
 
@@ -335,14 +339,17 @@ func (cli *CLI) ResourceShow(ctx context.Context, resourceType string, resourceN
 	return cli.RunCommand(ctx, args)
 }
 
-// ResourceList runs the "resource list containers" command with the given application name and returns the output as a
-// string, returning an error if the command fails.
-func (cli *CLI) ResourceList(ctx context.Context, applicationName string) (string, error) {
+// ResourceList runs the "resource list <resourceType>" command and returns the output as a string,
+// returning an error if the command fails. When applicationName is non-empty the results are scoped
+// to that application via the "-a" flag.
+func (cli *CLI) ResourceList(ctx context.Context, resourceType string, applicationName string) (string, error) {
 	args := []string{
 		"resource",
 		"list",
-		"Applications.Core/containers",
-		"-a", applicationName,
+		resourceType,
+	}
+	if applicationName != "" {
+		args = append(args, "-a", applicationName)
 	}
 	return cli.RunCommand(ctx, args)
 }
@@ -429,28 +436,36 @@ func (cli *CLI) GroupShow(ctx context.Context, groupName string) (string, error)
 	return cli.RunCommand(ctx, args)
 }
 
-// ResourceLogs runs the CLI command to get the logs of a resource in an application.
-func (cli *CLI) ResourceLogs(ctx context.Context, applicationName string, resourceName string) (string, error) {
+// ResourceLogs runs the CLI command to get the logs of a resource in an application. When preview is
+// true the "--preview" flag is added so the command operates against the preview resource types.
+func (cli *CLI) ResourceLogs(ctx context.Context, resourceType string, applicationName string, resourceName string, preview bool) (string, error) {
 	args := []string{
 		"resource",
 		"logs",
 		"-a", applicationName,
-		"Applications.Core/containers",
+		resourceType,
 		resourceName,
+	}
+	if preview {
+		args = append(args, "--preview")
 	}
 	return cli.RunCommand(ctx, args)
 }
 
-// ResourceExpose runs a command to expose a resource from an application on a given port.
-func (cli *CLI) ResourceExpose(ctx context.Context, applicationName string, resourceName string, localPort int, remotePort int) (string, error) {
+// ResourceExpose runs a command to expose a resource from an application on a given port. When preview
+// is true the "--preview" flag is added so the command operates against the preview resource types.
+func (cli *CLI) ResourceExpose(ctx context.Context, resourceType string, applicationName string, resourceName string, localPort int, remotePort int, preview bool) (string, error) {
 	args := []string{
 		"resource",
 		"expose",
 		"-a", applicationName,
-		"Applications.Core/containers",
+		resourceType,
 		resourceName,
 		"--port", fmt.Sprintf("%d", localPort),
 		"--remote-port", fmt.Sprintf("%d", remotePort),
+	}
+	if preview {
+		args = append(args, "--preview")
 	}
 	return cli.RunCommand(ctx, args)
 }


### PR DESCRIPTION
# Description
This pull request migrates CLI tests from the legacy Applications.Core/*  resource types to the new recipe-driven  Radius.Core/*  and  Radius.Compute/*  types. It also adds support for a new "preview" flag for the `rad resource expose` and `rad resource logs` commands, allowing users to interact with both the legacy (`Applications.Core/containers`) and preview (`Radius.Compute/containers`) resource types. The implementation refactors the CLI to select the appropriate backend based on the `--preview` flag or environment variable, updates diagnostics client logic, and ensures correct Kubernetes namespace resolution for preview resources.

Notes:
 Container resource  name:  values were lowercased (e.g.  containerA  →  containera ) because  Radius.Compute/containers  uses the   resource name verbatim as the Kubernetes Deployment name, which must  be RFC1123-compliant. 

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (#11489 ).

Fixes: part of #11489 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
