### PR TITLE
add an optional code-reference property to all resources

### DIFF
--- a/hack/bicep-types-radius/generated/applications/applications.core/2023-10-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/applications/applications.core/2023-10-01-preview/types.json
@@ -922,7 +922,7 @@
           "$ref": "#/0"
         },
         "flags": 2,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -1821,7 +1821,7 @@
           "$ref": "#/0"
         },
         "flags": 0,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -2768,7 +2768,7 @@
           "$ref": "#/0"
         },
         "flags": 2,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -2958,7 +2958,7 @@
           "$ref": "#/0"
         },
         "flags": 0,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -3179,7 +3179,7 @@
           "$ref": "#/0"
         },
         "flags": 2,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -3477,7 +3477,7 @@
           "$ref": "#/0"
         },
         "flags": 0,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -3708,7 +3708,7 @@
           "$ref": "#/0"
         },
         "flags": 0,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -4116,7 +4116,7 @@
           "$ref": "#/0"
         },
         "flags": 0,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {

--- a/hack/bicep-types-radius/generated/applications/applications.core/2023-10-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/applications/applications.core/2023-10-01-preview/types.json
@@ -917,6 +917,13 @@
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 2,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+      },
       "status": {
         "type": {
           "$ref": "#/31"
@@ -1808,6 +1815,13 @@
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
+      },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
       },
       "status": {
         "type": {
@@ -2749,6 +2763,13 @@
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 2,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+      },
       "status": {
         "type": {
           "$ref": "#/31"
@@ -2931,6 +2952,13 @@
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
+      },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
       },
       "status": {
         "type": {
@@ -3145,6 +3173,13 @@
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
+      },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 2,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
       },
       "status": {
         "type": {
@@ -3437,6 +3472,13 @@
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+      },
       "status": {
         "type": {
           "$ref": "#/31"
@@ -3660,6 +3702,13 @@
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
+      },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
       },
       "status": {
         "type": {
@@ -4061,6 +4110,13 @@
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
+      },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
       },
       "status": {
         "type": {

--- a/hack/bicep-types-radius/generated/applications/applications.dapr/2023-10-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/applications/applications.dapr/2023-10-01-preview/types.json
@@ -97,6 +97,13 @@
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+      },
       "status": {
         "type": {
           "$ref": "#/14"
@@ -819,6 +826,13 @@
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+      },
       "status": {
         "type": {
           "$ref": "#/14"
@@ -1091,6 +1105,13 @@
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+      },
       "status": {
         "type": {
           "$ref": "#/14"
@@ -1342,6 +1363,13 @@
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
+      },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
       },
       "status": {
         "type": {

--- a/hack/bicep-types-radius/generated/applications/applications.dapr/2023-10-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/applications/applications.dapr/2023-10-01-preview/types.json
@@ -102,7 +102,7 @@
           "$ref": "#/0"
         },
         "flags": 0,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -831,7 +831,7 @@
           "$ref": "#/0"
         },
         "flags": 0,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -1110,7 +1110,7 @@
           "$ref": "#/0"
         },
         "flags": 0,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -1369,7 +1369,7 @@
           "$ref": "#/0"
         },
         "flags": 0,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {

--- a/hack/bicep-types-radius/generated/applications/applications.datastores/2023-10-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/applications/applications.datastores/2023-10-01-preview/types.json
@@ -63,6 +63,13 @@
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 2,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+      },
       "status": {
         "type": {
           "$ref": "#/13"
@@ -573,6 +580,13 @@
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+      },
       "status": {
         "type": {
           "$ref": "#/13"
@@ -951,6 +965,13 @@
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 2,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+      },
       "status": {
         "type": {
           "$ref": "#/13"
@@ -1181,6 +1202,13 @@
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
+      },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
       },
       "status": {
         "type": {
@@ -1453,6 +1481,13 @@
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 2,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+      },
       "status": {
         "type": {
           "$ref": "#/13"
@@ -1676,6 +1711,13 @@
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
+      },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
       },
       "status": {
         "type": {

--- a/hack/bicep-types-radius/generated/applications/applications.datastores/2023-10-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/applications/applications.datastores/2023-10-01-preview/types.json
@@ -68,7 +68,7 @@
           "$ref": "#/0"
         },
         "flags": 2,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -585,7 +585,7 @@
           "$ref": "#/0"
         },
         "flags": 0,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -970,7 +970,7 @@
           "$ref": "#/0"
         },
         "flags": 2,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -1208,7 +1208,7 @@
           "$ref": "#/0"
         },
         "flags": 0,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -1486,7 +1486,7 @@
           "$ref": "#/0"
         },
         "flags": 2,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -1717,7 +1717,7 @@
           "$ref": "#/0"
         },
         "flags": 0,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {

--- a/hack/bicep-types-radius/generated/applications/applications.messaging/2023-10-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/applications/applications.messaging/2023-10-01-preview/types.json
@@ -63,6 +63,13 @@
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 2,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+      },
       "status": {
         "type": {
           "$ref": "#/13"
@@ -586,6 +593,13 @@
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
+      },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
       },
       "status": {
         "type": {

--- a/hack/bicep-types-radius/generated/applications/applications.messaging/2023-10-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/applications/applications.messaging/2023-10-01-preview/types.json
@@ -68,7 +68,7 @@
           "$ref": "#/0"
         },
         "flags": 2,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {
@@ -599,7 +599,7 @@
           "$ref": "#/0"
         },
         "flags": 0,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
       },
       "status": {
         "type": {

--- a/hack/bicep-types-radius/generated/radius/radius.core/2025-08-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/radius/radius.core/2025-08-01-preview/types.json
@@ -49,13 +49,6 @@
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
-      "codeReference": {
-        "type": {
-          "$ref": "#/0"
-        },
-        "flags": 2,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
-      },
       "environment": {
         "type": {
           "$ref": "#/0"
@@ -418,13 +411,6 @@
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
-      },
-      "codeReference": {
-        "type": {
-          "$ref": "#/0"
-        },
-        "flags": 0,
-        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
       },
       "environment": {
         "type": {

--- a/hack/bicep-types-radius/generated/radius/radius.core/2025-08-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/radius/radius.core/2025-08-01-preview/types.json
@@ -49,6 +49,13 @@
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 2,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+      },
       "environment": {
         "type": {
           "$ref": "#/0"
@@ -411,6 +418,13 @@
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
+      },
+      "codeReference": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
       },
       "environment": {
         "type": {

--- a/pkg/corerp/api/v20231001preview/container_conversion.go
+++ b/pkg/corerp/api/v20231001preview/container_conversion.go
@@ -28,6 +28,10 @@ import (
 
 // ConvertTo converts from the versioned Container resource to version-agnostic datamodel.
 func (src *ContainerResource) ConvertTo() (v1.DataModelInterface, error) {
+	if err := rpv1.ValidateCodeReference(to.String(src.Properties.CodeReference)); err != nil {
+		return nil, v1.NewClientErrInvalidRequest(err.Error())
+	}
+
 	// Note: SystemData conversion isn't required since this property comes ARM and datastore.
 
 	connections := make(map[string]datamodel.ConnectionProperties)

--- a/pkg/corerp/api/v20231001preview/container_conversion.go
+++ b/pkg/corerp/api/v20231001preview/container_conversion.go
@@ -123,7 +123,8 @@ func (src *ContainerResource) ConvertTo() (v1.DataModelInterface, error) {
 		},
 		Properties: datamodel.ContainerProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Application: to.String(src.Properties.Application),
+				Application:   to.String(src.Properties.Application),
+				CodeReference: to.String(src.Properties.CodeReference),
 			},
 			Connections: connections,
 			Container: datamodel.Container{
@@ -334,6 +335,9 @@ func (dst *ContainerResource) ConvertFrom(src v1.DataModelInterface) error {
 		Resources:            fromResourceReferencesDataModel(c.Properties.Resources),
 		ResourceProvisioning: fromContainerResourceProvisioningDataModel(c.Properties.ResourceProvisioning),
 		RestartPolicy:        fromRestartPolicyDataModel(c.Properties.RestartPolicy),
+	}
+	if c.Properties.CodeReference != "" {
+		dst.Properties.CodeReference = to.Ptr(c.Properties.CodeReference)
 	}
 
 	return nil

--- a/pkg/corerp/api/v20231001preview/extender_conversion.go
+++ b/pkg/corerp/api/v20231001preview/extender_conversion.go
@@ -45,8 +45,9 @@ func (src *ExtenderResource) ConvertTo() (v1.DataModelInterface, error) {
 		},
 		Properties: datamodel.ExtenderProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Environment: to.String(src.Properties.Environment),
-				Application: to.String(src.Properties.Application),
+				Environment:   to.String(src.Properties.Environment),
+				Application:   to.String(src.Properties.Application),
+				CodeReference: to.String(src.Properties.CodeReference),
 			},
 			AdditionalProperties: src.Properties.AdditionalProperties,
 			Secrets:              src.Properties.Secrets,
@@ -87,6 +88,9 @@ func (dst *ExtenderResource) ConvertFrom(src v1.DataModelInterface) error {
 		Recipe:               fromRecipeDataModel(extender.Properties.ResourceRecipe),
 		ResourceProvisioning: fromResourceProvisioningDataModel(extender.Properties.ResourceProvisioning),
 		// Secrets are omitted.
+	}
+	if extender.Properties.CodeReference != "" {
+		dst.Properties.CodeReference = to.Ptr(extender.Properties.CodeReference)
 	}
 
 	return nil

--- a/pkg/corerp/api/v20231001preview/extender_conversion.go
+++ b/pkg/corerp/api/v20231001preview/extender_conversion.go
@@ -29,6 +29,10 @@ import (
 // ConvertTo converts from the versioned Extender resource to version-agnostic datamodel and returns it, or an error if the
 // conversion fails.
 func (src *ExtenderResource) ConvertTo() (v1.DataModelInterface, error) {
+	if err := rpv1.ValidateCodeReference(to.String(src.Properties.CodeReference)); err != nil {
+		return nil, v1.NewClientErrInvalidRequest(err.Error())
+	}
+
 	converted := &datamodel.Extender{
 		BaseResource: v1.BaseResource{
 			TrackedResource: v1.TrackedResource{

--- a/pkg/corerp/api/v20231001preview/gateway_conversion.go
+++ b/pkg/corerp/api/v20231001preview/gateway_conversion.go
@@ -86,7 +86,8 @@ func (src *GatewayResource) ConvertTo() (v1.DataModelInterface, error) {
 		},
 		Properties: datamodel.GatewayProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Application: to.String(src.Properties.Application),
+				Application:   to.String(src.Properties.Application),
+				CodeReference: to.String(src.Properties.CodeReference),
 			},
 			Hostname: hostname,
 			TLS:      tls,
@@ -157,6 +158,9 @@ func (dst *GatewayResource) ConvertFrom(src v1.DataModelInterface) error {
 		Routes:            routes,
 		TLS:               tls,
 		URL:               new(g.Properties.URL),
+	}
+	if g.Properties.CodeReference != "" {
+		dst.Properties.CodeReference = to.Ptr(g.Properties.CodeReference)
 	}
 
 	return nil

--- a/pkg/corerp/api/v20231001preview/gateway_conversion.go
+++ b/pkg/corerp/api/v20231001preview/gateway_conversion.go
@@ -25,6 +25,10 @@ import (
 
 // ConvertTo converts from the versioned Gateway resource to version-agnostic datamodel.
 func (src *GatewayResource) ConvertTo() (v1.DataModelInterface, error) {
+	if err := rpv1.ValidateCodeReference(to.String(src.Properties.CodeReference)); err != nil {
+		return nil, v1.NewClientErrInvalidRequest(err.Error())
+	}
+
 	tls := &datamodel.GatewayPropertiesTLS{}
 	if src.Properties.TLS == nil {
 		tls = nil

--- a/pkg/corerp/api/v20231001preview/secretstore_conversion.go
+++ b/pkg/corerp/api/v20231001preview/secretstore_conversion.go
@@ -41,7 +41,8 @@ func (src *SecretStoreResource) ConvertTo() (v1.DataModelInterface, error) {
 		},
 		Properties: &datamodel.SecretStoreProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Application: to.String(src.Properties.Application),
+				Application:   to.String(src.Properties.Application),
+				CodeReference: to.String(src.Properties.CodeReference),
 			},
 			Resource: to.String(src.Properties.Resource),
 			Type:     toSecretStoreDataTypeDataModel(src.Properties.Type),
@@ -73,6 +74,9 @@ func (dst *SecretStoreResource) ConvertFrom(src v1.DataModelInterface) error {
 		Type:              fromSecretStoreDataTypeDataModel(ss.Properties.Type),
 		Resource:          new(ss.Properties.Resource),
 		Data:              fromSecretStoreDataPropertiesDataModel(ss.Properties.Data),
+	}
+	if ss.Properties.CodeReference != "" {
+		dst.Properties.CodeReference = to.Ptr(ss.Properties.CodeReference)
 	}
 
 	return nil

--- a/pkg/corerp/api/v20231001preview/secretstore_conversion.go
+++ b/pkg/corerp/api/v20231001preview/secretstore_conversion.go
@@ -25,6 +25,10 @@ import (
 
 // ConvertTo converts from the versioned SecretStoreResource resource to version-agnostic datamodel.
 func (src *SecretStoreResource) ConvertTo() (v1.DataModelInterface, error) {
+	if err := rpv1.ValidateCodeReference(to.String(src.Properties.CodeReference)); err != nil {
+		return nil, v1.NewClientErrInvalidRequest(err.Error())
+	}
+
 	converted := &datamodel.SecretStore{
 		BaseResource: v1.BaseResource{
 			TrackedResource: v1.TrackedResource{

--- a/pkg/corerp/api/v20231001preview/testdata/volume-az-kv-datamodel.json
+++ b/pkg/corerp/api/v20231001preview/testdata/volume-az-kv-datamodel.json
@@ -24,6 +24,7 @@
       ]
     },
     "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
+    "codeReference": "src/testresources/resource.ts#L10",
     "kind": "azure.com.keyvault",
     "azureKeyVault": {
       "resource": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.KeyVault/vaults/vault0",

--- a/pkg/corerp/api/v20231001preview/testdata/volume-az-kv.json
+++ b/pkg/corerp/api/v20231001preview/testdata/volume-az-kv.json
@@ -24,6 +24,7 @@
     },
     "provisioningState": "Succeeded",
     "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
+    "codeReference": "src/testresources/resource.ts#L10",
     "resource": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.KeyVault/vaults/vault0",
     "kind": "azure.com.keyvault",
     "secrets": {

--- a/pkg/corerp/api/v20231001preview/volume_conversion.go
+++ b/pkg/corerp/api/v20231001preview/volume_conversion.go
@@ -41,7 +41,8 @@ func (src *VolumeResource) ConvertTo() (v1.DataModelInterface, error) {
 		},
 		Properties: datamodel.VolumeResourceProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Application: to.String(src.Properties.GetVolumeProperties().Application),
+				Application:   to.String(src.Properties.GetVolumeProperties().Application),
+				CodeReference: to.String(src.Properties.GetVolumeProperties().CodeReference),
 			},
 			Kind: to.String(src.Properties.GetVolumeProperties().Kind),
 		},
@@ -101,6 +102,9 @@ func (dst *VolumeResource) ConvertFrom(src v1.DataModelInterface) error {
 			Application:       new(resource.Properties.Application),
 			Resource:          new(azProp.Resource),
 			ProvisioningState: fromProvisioningStateDataModel(resource.InternalMetadata.AsyncProvisioningState),
+		}
+		if resource.Properties.CodeReference != "" {
+			p.CodeReference = to.Ptr(resource.Properties.CodeReference)
 		}
 		if azProp.Certificates != nil {
 			p.Certificates = map[string]*CertificateObjectProperties{}

--- a/pkg/corerp/api/v20231001preview/volume_conversion.go
+++ b/pkg/corerp/api/v20231001preview/volume_conversion.go
@@ -25,6 +25,10 @@ import (
 
 // ConvertTo converts from the versioned Volume resource to version-agnostic datamodel.
 func (src *VolumeResource) ConvertTo() (v1.DataModelInterface, error) {
+	if err := rpv1.ValidateCodeReference(to.String(src.Properties.GetVolumeProperties().CodeReference)); err != nil {
+		return nil, v1.NewClientErrInvalidRequest(err.Error())
+	}
+
 	converted := &datamodel.VolumeResource{
 		BaseResource: v1.BaseResource{
 			TrackedResource: v1.TrackedResource{

--- a/pkg/corerp/api/v20231001preview/zz_generated_models.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_models.go
@@ -54,6 +54,10 @@ type ApplicationGraphResource struct {
 	// REQUIRED; The resource type.
 	Type *string
 
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
+
 	// Stable hash over the authorable properties of this resource and its sorted dependsOn list. Used by tooling to classify
 	// resources as added, removed, modified, or unchanged across graphs. Format:
 	// 'sha256:{hex}'.
@@ -192,6 +196,10 @@ type AzureKeyVaultVolumeProperties struct {
 	// The KeyVault certificates that this volume exposes
 	Certificates map[string]*CertificateObjectProperties
 
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
+
 	// Fully qualified resource ID for the environment that the application is linked to
 	Environment *string
 
@@ -212,6 +220,7 @@ type AzureKeyVaultVolumeProperties struct {
 func (a *AzureKeyVaultVolumeProperties) GetVolumeProperties() *VolumeProperties {
 	return &VolumeProperties{
 		Application:       a.Application,
+		CodeReference:     a.CodeReference,
 		Environment:       a.Environment,
 		Kind:              a.Kind,
 		ProvisioningState: a.ProvisioningState,
@@ -360,6 +369,10 @@ type ContainerProperties struct {
 
 	// REQUIRED; Definition of a container.
 	Container *Container
+
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
 
 	// Specifies a connection to another resource.
 	Connections map[string]*ConnectionProperties
@@ -671,6 +684,10 @@ type ExtenderProperties struct {
 	// Fully qualified resource ID for the application that the portable resource is consumed by (if applicable)
 	Application *string
 
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
+
 	// The recipe used to automatically deploy underlying infrastructure for the extender portable resource
 	Recipe *Recipe
 
@@ -765,6 +782,10 @@ type GatewayProperties struct {
 
 	// REQUIRED; Routes attached to this Gateway
 	Routes []*GatewayRoute
+
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
 
 	// Fully qualified resource ID for the environment that the application is linked to
 	Environment *string
@@ -1365,6 +1386,10 @@ type SecretStoreProperties struct {
 	// Fully qualified resource ID for the application
 	Application *string
 
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
+
 	// Fully qualified resource ID for the environment that the application is linked to
 	Environment *string
 
@@ -1585,6 +1610,10 @@ type VolumeProperties struct {
 
 	// REQUIRED; Discriminator property for VolumeProperties.
 	Kind *string
+
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
 
 	// Fully qualified resource ID for the environment that the application is linked to
 	Environment *string

--- a/pkg/corerp/api/v20231001preview/zz_generated_models.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_models.go
@@ -55,7 +55,6 @@ type ApplicationGraphResource struct {
 	Type *string
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// Stable hash over the authorable properties of this resource and its sorted dependsOn list. Used by tooling to classify
@@ -197,7 +196,6 @@ type AzureKeyVaultVolumeProperties struct {
 	Certificates map[string]*CertificateObjectProperties
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// Fully qualified resource ID for the environment that the application is linked to
@@ -371,7 +369,6 @@ type ContainerProperties struct {
 	Container *Container
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// Specifies a connection to another resource.
@@ -685,7 +682,6 @@ type ExtenderProperties struct {
 	Application *string
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// The recipe used to automatically deploy underlying infrastructure for the extender portable resource
@@ -784,7 +780,6 @@ type GatewayProperties struct {
 	Routes []*GatewayRoute
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// Fully qualified resource ID for the environment that the application is linked to
@@ -1387,7 +1382,6 @@ type SecretStoreProperties struct {
 	Application *string
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// Fully qualified resource ID for the environment that the application is linked to
@@ -1612,7 +1606,6 @@ type VolumeProperties struct {
 	Kind *string
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// Fully qualified resource ID for the environment that the application is linked to

--- a/pkg/corerp/api/v20231001preview/zz_generated_models_serde.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_models_serde.go
@@ -107,6 +107,7 @@ func (a *ApplicationGraphOutputResource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ApplicationGraphResource.
 func (a ApplicationGraphResource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
+	populate(objectMap, "codeReference", a.CodeReference)
 	populate(objectMap, "connections", a.Connections)
 	populate(objectMap, "diffHash", a.DiffHash)
 	populate(objectMap, "id", a.ID)
@@ -126,6 +127,9 @@ func (a *ApplicationGraphResource) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &a.CodeReference)
+			delete(rawMsg, key)
 		case "connections":
 			err = unpopulate(val, "Connections", &a.Connections)
 			delete(rawMsg, key)
@@ -448,6 +452,7 @@ func (a AzureKeyVaultVolumeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "application", a.Application)
 	populate(objectMap, "certificates", a.Certificates)
+	populate(objectMap, "codeReference", a.CodeReference)
 	populate(objectMap, "environment", a.Environment)
 	populate(objectMap, "keys", a.Keys)
 	objectMap["kind"] = "azure.com.keyvault"
@@ -472,6 +477,9 @@ func (a *AzureKeyVaultVolumeProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "certificates":
 			err = unpopulate(val, "Certificates", &a.Certificates)
+			delete(rawMsg, key)
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &a.CodeReference)
 			delete(rawMsg, key)
 		case "environment":
 			err = unpopulate(val, "Environment", &a.Environment)
@@ -799,6 +807,7 @@ func (c *ContainerPortProperties) UnmarshalJSON(data []byte) error {
 func (c ContainerProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "application", c.Application)
+	populate(objectMap, "codeReference", c.CodeReference)
 	populate(objectMap, "connections", c.Connections)
 	populate(objectMap, "container", c.Container)
 	populate(objectMap, "environment", c.Environment)
@@ -824,6 +833,9 @@ func (c *ContainerProperties) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "application":
 			err = unpopulate(val, "Application", &c.Application)
+			delete(rawMsg, key)
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &c.CodeReference)
 			delete(rawMsg, key)
 		case "connections":
 			err = unpopulate(val, "Connections", &c.Connections)
@@ -1501,6 +1513,7 @@ func (e *ExecHealthProbeProperties) UnmarshalJSON(data []byte) error {
 func (e ExtenderProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "application", e.Application)
+	populate(objectMap, "codeReference", e.CodeReference)
 	populate(objectMap, "environment", e.Environment)
 	populate(objectMap, "provisioningState", e.ProvisioningState)
 	populate(objectMap, "recipe", e.Recipe)
@@ -1526,6 +1539,9 @@ func (e *ExtenderProperties) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "application":
 			err = unpopulate(val, "Application", &e.Application)
+			delete(rawMsg, key)
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &e.CodeReference)
 			delete(rawMsg, key)
 		case "environment":
 			err = unpopulate(val, "Environment", &e.Environment)
@@ -1750,6 +1766,7 @@ func (g *GatewayHostname) UnmarshalJSON(data []byte) error {
 func (g GatewayProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "application", g.Application)
+	populate(objectMap, "codeReference", g.CodeReference)
 	populate(objectMap, "environment", g.Environment)
 	populate(objectMap, "hostname", g.Hostname)
 	populate(objectMap, "internal", g.Internal)
@@ -1772,6 +1789,9 @@ func (g *GatewayProperties) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "application":
 			err = unpopulate(val, "Application", &g.Application)
+			delete(rawMsg, key)
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &g.CodeReference)
 			delete(rawMsg, key)
 		case "environment":
 			err = unpopulate(val, "Environment", &g.Environment)
@@ -3255,6 +3275,7 @@ func (s *SecretStoreListSecretsResult) UnmarshalJSON(data []byte) error {
 func (s SecretStoreProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "application", s.Application)
+	populate(objectMap, "codeReference", s.CodeReference)
 	populate(objectMap, "data", s.Data)
 	populate(objectMap, "environment", s.Environment)
 	populate(objectMap, "provisioningState", s.ProvisioningState)
@@ -3275,6 +3296,9 @@ func (s *SecretStoreProperties) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "application":
 			err = unpopulate(val, "Application", &s.Application)
+			delete(rawMsg, key)
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &s.CodeReference)
 			delete(rawMsg, key)
 		case "data":
 			err = unpopulate(val, "Data", &s.Data)
@@ -3739,6 +3763,7 @@ func (v *Volume) UnmarshalJSON(data []byte) error {
 func (v VolumeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "application", v.Application)
+	populate(objectMap, "codeReference", v.CodeReference)
 	populate(objectMap, "environment", v.Environment)
 	objectMap["kind"] = v.Kind
 	populate(objectMap, "provisioningState", v.ProvisioningState)
@@ -3757,6 +3782,9 @@ func (v *VolumeProperties) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "application":
 			err = unpopulate(val, "Application", &v.Application)
+			delete(rawMsg, key)
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &v.CodeReference)
 			delete(rawMsg, key)
 		case "environment":
 			err = unpopulate(val, "Environment", &v.Environment)

--- a/pkg/corerp/api/v20250801preview/application_conversion.go
+++ b/pkg/corerp/api/v20250801preview/application_conversion.go
@@ -41,8 +41,7 @@ func (src *ApplicationResource) ConvertTo() (v1.DataModelInterface, error) {
 		},
 		Properties: datamodel.ApplicationProperties_v20250801preview{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Environment:   to.String(src.Properties.Environment),
-				CodeReference: to.String(src.Properties.CodeReference),
+				Environment: to.String(src.Properties.Environment),
 			},
 		},
 	}
@@ -67,9 +66,6 @@ func (dst *ApplicationResource) ConvertFrom(src v1.DataModelInterface) error {
 		ProvisioningState: fromProvisioningStateDataModel(app.InternalMetadata.AsyncProvisioningState),
 		Environment:       new(app.Properties.Environment),
 		Status:            &ResourceStatus{},
-	}
-	if app.Properties.CodeReference != "" {
-		dst.Properties.CodeReference = to.Ptr(app.Properties.CodeReference)
 	}
 
 	return nil

--- a/pkg/corerp/api/v20250801preview/application_conversion.go
+++ b/pkg/corerp/api/v20250801preview/application_conversion.go
@@ -41,7 +41,8 @@ func (src *ApplicationResource) ConvertTo() (v1.DataModelInterface, error) {
 		},
 		Properties: datamodel.ApplicationProperties_v20250801preview{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Environment: to.String(src.Properties.Environment),
+				Environment:   to.String(src.Properties.Environment),
+				CodeReference: to.String(src.Properties.CodeReference),
 			},
 		},
 	}
@@ -66,6 +67,9 @@ func (dst *ApplicationResource) ConvertFrom(src v1.DataModelInterface) error {
 		ProvisioningState: fromProvisioningStateDataModel(app.InternalMetadata.AsyncProvisioningState),
 		Environment:       new(app.Properties.Environment),
 		Status:            &ResourceStatus{},
+	}
+	if app.Properties.CodeReference != "" {
+		dst.Properties.CodeReference = to.Ptr(app.Properties.CodeReference)
 	}
 
 	return nil

--- a/pkg/corerp/api/v20250801preview/zz_generated_models.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_models.go
@@ -49,7 +49,6 @@ type ApplicationGraphResource struct {
 	Type *string
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// Stable hash over the authorable properties of this resource and its sorted dependsOn list. Used by tooling to classify
@@ -68,10 +67,6 @@ type ApplicationGraphResponse struct {
 type ApplicationProperties struct {
 	// REQUIRED; Fully qualified resource ID for the environment that the application is linked to
 	Environment *string
-
-	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
-	CodeReference *string
 
 	// READ-ONLY; The status of the asynchronous operation.
 	ProvisioningState *ProvisioningState

--- a/pkg/corerp/api/v20250801preview/zz_generated_models.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_models.go
@@ -48,6 +48,10 @@ type ApplicationGraphResource struct {
 	// REQUIRED; The resource type.
 	Type *string
 
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
+
 	// Stable hash over the authorable properties of this resource and its sorted dependsOn list. Used by tooling to classify
 	// resources as added, removed, modified, or unchanged across graphs. Format:
 	// 'sha256:{hex}'.
@@ -64,6 +68,10 @@ type ApplicationGraphResponse struct {
 type ApplicationProperties struct {
 	// REQUIRED; Fully qualified resource ID for the environment that the application is linked to
 	Environment *string
+
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
 
 	// READ-ONLY; The status of the asynchronous operation.
 	ProvisioningState *ProvisioningState

--- a/pkg/corerp/api/v20250801preview/zz_generated_models_serde.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_models_serde.go
@@ -162,7 +162,6 @@ func (a *ApplicationGraphResponse) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ApplicationProperties.
 func (a ApplicationProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "codeReference", a.CodeReference)
 	populate(objectMap, "environment", a.Environment)
 	populate(objectMap, "provisioningState", a.ProvisioningState)
 	populate(objectMap, "status", a.Status)
@@ -178,9 +177,6 @@ func (a *ApplicationProperties) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "codeReference":
-			err = unpopulate(val, "CodeReference", &a.CodeReference)
-			delete(rawMsg, key)
 		case "environment":
 			err = unpopulate(val, "Environment", &a.Environment)
 			delete(rawMsg, key)

--- a/pkg/corerp/api/v20250801preview/zz_generated_models_serde.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_models_serde.go
@@ -80,6 +80,7 @@ func (a *ApplicationGraphOutputResource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ApplicationGraphResource.
 func (a ApplicationGraphResource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
+	populate(objectMap, "codeReference", a.CodeReference)
 	populate(objectMap, "connections", a.Connections)
 	populate(objectMap, "diffHash", a.DiffHash)
 	populate(objectMap, "id", a.ID)
@@ -99,6 +100,9 @@ func (a *ApplicationGraphResource) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &a.CodeReference)
+			delete(rawMsg, key)
 		case "connections":
 			err = unpopulate(val, "Connections", &a.Connections)
 			delete(rawMsg, key)
@@ -158,6 +162,7 @@ func (a *ApplicationGraphResponse) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ApplicationProperties.
 func (a ApplicationProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
+	populate(objectMap, "codeReference", a.CodeReference)
 	populate(objectMap, "environment", a.Environment)
 	populate(objectMap, "provisioningState", a.ProvisioningState)
 	populate(objectMap, "status", a.Status)
@@ -173,6 +178,9 @@ func (a *ApplicationProperties) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &a.CodeReference)
+			delete(rawMsg, key)
 		case "environment":
 			err = unpopulate(val, "Environment", &a.Environment)
 			delete(rawMsg, key)

--- a/pkg/corerp/frontend/controller/applications/graph_util.go
+++ b/pkg/corerp/frontend/controller/applications/graph_util.go
@@ -306,6 +306,13 @@ func computeGraph(applicationResources []generated.GenericResource, environmentR
 			applicationGraphResource.ProvisioningState = &state
 		}
 
+		// Propagate codeReference (e.g. a GitHub blob URL set by tooling like 'rad app graph').
+		if codeReference, ok := resource.Properties["codeReference"]; ok {
+			if cr, ok := codeReference.(string); ok && cr != "" {
+				applicationGraphResource.CodeReference = &cr
+			}
+		}
+
 		// Resolve Outbound connections based on 'connections'.
 		connections := resolveConnections(resource, connectionsPath, connectionsResolver(resources))
 		// Resolve Outbound connections based on 'routes'.

--- a/pkg/daprrp/api/v20231001preview/configurationstore_conversion.go
+++ b/pkg/daprrp/api/v20231001preview/configurationstore_conversion.go
@@ -31,6 +31,10 @@ import (
 // ConvertTo converts a versioned DaprConfigurationStoreResource to a version-agnostic DaprConfigurationStore. It returns an error
 // if the mode is not specified or if the required properties for the mode are not specified.
 func (src *DaprConfigurationStoreResource) ConvertTo() (v1.DataModelInterface, error) {
+	if err := rpv1.ValidateCodeReference(to.String(src.Properties.CodeReference)); err != nil {
+		return nil, v1.NewClientErrInvalidRequest(err.Error())
+	}
+
 	daprConfigurationStoreProperties := datamodel.DaprConfigurationStoreProperties{
 		BasicResourceProperties: rpv1.BasicResourceProperties{
 			Environment:   to.String(src.Properties.Environment),

--- a/pkg/daprrp/api/v20231001preview/configurationstore_conversion.go
+++ b/pkg/daprrp/api/v20231001preview/configurationstore_conversion.go
@@ -33,8 +33,9 @@ import (
 func (src *DaprConfigurationStoreResource) ConvertTo() (v1.DataModelInterface, error) {
 	daprConfigurationStoreProperties := datamodel.DaprConfigurationStoreProperties{
 		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Environment: to.String(src.Properties.Environment),
-			Application: to.String(src.Properties.Application),
+			Environment:   to.String(src.Properties.Environment),
+			Application:   to.String(src.Properties.Application),
+			CodeReference: to.String(src.Properties.CodeReference),
 		},
 	}
 
@@ -135,6 +136,9 @@ func (dst *DaprConfigurationStoreResource) ConvertFrom(src v1.DataModelInterface
 			Recipe:          fromRecipeStatus(daprConfigstore.Properties.Status.Recipe),
 		},
 		Auth: fromAuthDataModel(daprConfigstore.Properties.Auth),
+	}
+	if daprConfigstore.Properties.CodeReference != "" {
+		dst.Properties.CodeReference = to.Ptr(daprConfigstore.Properties.CodeReference)
 	}
 
 	if daprConfigstore.Properties.ResourceProvisioning == portableresources.ResourceProvisioningManual {

--- a/pkg/daprrp/api/v20231001preview/pubsubbroker_conversion.go
+++ b/pkg/daprrp/api/v20231001preview/pubsubbroker_conversion.go
@@ -33,8 +33,9 @@ import (
 func (src *DaprPubSubBrokerResource) ConvertTo() (v1.DataModelInterface, error) {
 	daprPubSubproperties := datamodel.DaprPubSubBrokerProperties{
 		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Environment: to.String(src.Properties.Environment),
-			Application: to.String(src.Properties.Application),
+			Environment:   to.String(src.Properties.Environment),
+			Application:   to.String(src.Properties.Application),
+			CodeReference: to.String(src.Properties.CodeReference),
 		},
 	}
 
@@ -133,6 +134,9 @@ func (dst *DaprPubSubBrokerResource) ConvertFrom(src v1.DataModelInterface) erro
 			Recipe:          fromRecipeStatus(daprPubSub.Properties.Status.Recipe),
 		},
 		Auth: fromAuthDataModel(daprPubSub.Properties.Auth),
+	}
+	if daprPubSub.Properties.CodeReference != "" {
+		dst.Properties.CodeReference = to.Ptr(daprPubSub.Properties.CodeReference)
 	}
 
 	if daprPubSub.Properties.ResourceProvisioning == portableresources.ResourceProvisioningManual {

--- a/pkg/daprrp/api/v20231001preview/pubsubbroker_conversion.go
+++ b/pkg/daprrp/api/v20231001preview/pubsubbroker_conversion.go
@@ -31,6 +31,10 @@ import (
 // ConvertTo converts a versioned DaprPubSubBrokerResource to a version-agnostic DaprPubSubBroker. It returns an error
 // if the mode is not specified or if the required properties for the mode are not specified.
 func (src *DaprPubSubBrokerResource) ConvertTo() (v1.DataModelInterface, error) {
+	if err := rpv1.ValidateCodeReference(to.String(src.Properties.CodeReference)); err != nil {
+		return nil, v1.NewClientErrInvalidRequest(err.Error())
+	}
+
 	daprPubSubproperties := datamodel.DaprPubSubBrokerProperties{
 		BasicResourceProperties: rpv1.BasicResourceProperties{
 			Environment:   to.String(src.Properties.Environment),

--- a/pkg/daprrp/api/v20231001preview/secretstore_conversion.go
+++ b/pkg/daprrp/api/v20231001preview/secretstore_conversion.go
@@ -31,6 +31,10 @@ import (
 // ConvertTo converts from the versioned DaprSecretStore resource to version-agnostic datamodel and returns an error if the
 // resourceProvisioning is set to manual and the required fields are not specified.
 func (src *DaprSecretStoreResource) ConvertTo() (v1.DataModelInterface, error) {
+	if err := rpv1.ValidateCodeReference(to.String(src.Properties.CodeReference)); err != nil {
+		return nil, v1.NewClientErrInvalidRequest(err.Error())
+	}
+
 	converted := &datamodel.DaprSecretStore{
 		BaseResource: v1.BaseResource{
 			TrackedResource: v1.TrackedResource{

--- a/pkg/daprrp/api/v20231001preview/secretstore_conversion.go
+++ b/pkg/daprrp/api/v20231001preview/secretstore_conversion.go
@@ -47,8 +47,9 @@ func (src *DaprSecretStoreResource) ConvertTo() (v1.DataModelInterface, error) {
 		},
 		Properties: datamodel.DaprSecretStoreProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Environment: to.String(src.Properties.Environment),
-				Application: to.String(src.Properties.Application),
+				Environment:   to.String(src.Properties.Environment),
+				Application:   to.String(src.Properties.Application),
+				CodeReference: to.String(src.Properties.CodeReference),
 			},
 		},
 	}
@@ -126,6 +127,9 @@ func (dst *DaprSecretStoreResource) ConvertFrom(src v1.DataModelInterface) error
 			OutputResources: toOutputResources(daprSecretStore.Properties.Status.OutputResources),
 			Recipe:          fromRecipeStatus(daprSecretStore.Properties.Status.Recipe),
 		},
+	}
+	if daprSecretStore.Properties.CodeReference != "" {
+		dst.Properties.CodeReference = to.Ptr(daprSecretStore.Properties.CodeReference)
 	}
 	if daprSecretStore.Properties.ResourceProvisioning == portableresources.ResourceProvisioningManual {
 		dst.Properties.Metadata = fromMetadataDataModel(daprSecretStore.Properties.Metadata)

--- a/pkg/daprrp/api/v20231001preview/statestore_conversion.go
+++ b/pkg/daprrp/api/v20231001preview/statestore_conversion.go
@@ -17,8 +17,9 @@ import (
 func (src *DaprStateStoreResource) ConvertTo() (v1.DataModelInterface, error) {
 	daprStateStoreProperties := datamodel.DaprStateStoreProperties{
 		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Environment: to.String(src.Properties.Environment),
-			Application: to.String(src.Properties.Application),
+			Environment:   to.String(src.Properties.Environment),
+			Application:   to.String(src.Properties.Application),
+			CodeReference: to.String(src.Properties.CodeReference),
 		},
 	}
 
@@ -117,6 +118,9 @@ func (dst *DaprStateStoreResource) ConvertFrom(src v1.DataModelInterface) error 
 		ResourceProvisioning: fromResourceProvisioningDataModel(daprStateStore.Properties.ResourceProvisioning),
 		Resources:            fromResourcesDataModel(daprStateStore.Properties.Resources),
 		Auth:                 fromAuthDataModel(daprStateStore.Properties.Auth),
+	}
+	if daprStateStore.Properties.CodeReference != "" {
+		dst.Properties.CodeReference = to.Ptr(daprStateStore.Properties.CodeReference)
 	}
 
 	if daprStateStore.Properties.ResourceProvisioning == portableresources.ResourceProvisioningManual {

--- a/pkg/daprrp/api/v20231001preview/statestore_conversion.go
+++ b/pkg/daprrp/api/v20231001preview/statestore_conversion.go
@@ -15,6 +15,10 @@ import (
 // ConvertTo converts from the versioned DaprStateStore resource to version-agnostic datamodel and returns an error
 // if the resourceProvisioning is set to manual and the required fields are not specified.
 func (src *DaprStateStoreResource) ConvertTo() (v1.DataModelInterface, error) {
+	if err := rpv1.ValidateCodeReference(to.String(src.Properties.CodeReference)); err != nil {
+		return nil, v1.NewClientErrInvalidRequest(err.Error())
+	}
+
 	daprStateStoreProperties := datamodel.DaprStateStoreProperties{
 		BasicResourceProperties: rpv1.BasicResourceProperties{
 			Environment:   to.String(src.Properties.Environment),

--- a/pkg/daprrp/api/v20231001preview/zz_generated_models.go
+++ b/pkg/daprrp/api/v20231001preview/zz_generated_models.go
@@ -60,6 +60,10 @@ type DaprConfigurationStoreProperties struct {
 	// The name of the Dapr component to be used as a secret store
 	Auth *DaprResourceAuth
 
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
+
 	// The metadata for Dapr resource which must match the values specified in Dapr component spec
 	Metadata map[string]*MetadataValue
 
@@ -150,6 +154,10 @@ type DaprPubSubBrokerProperties struct {
 
 	// The name of the Dapr component to be used as a secret store
 	Auth *DaprResourceAuth
+
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
 
 	// The metadata for Dapr resource which must match the values specified in Dapr component spec
 	Metadata map[string]*MetadataValue
@@ -245,6 +253,10 @@ type DaprSecretStoreProperties struct {
 	// Fully qualified resource ID for the application that the portable resource is consumed by (if applicable)
 	Application *string
 
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
+
 	// The metadata for Dapr resource which must match the values specified in Dapr component spec
 	Metadata map[string]*MetadataValue
 
@@ -332,6 +344,10 @@ type DaprStateStoreProperties struct {
 
 	// The name of the Dapr component to be used as a secret store
 	Auth *DaprResourceAuth
+
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
 
 	// The metadata for Dapr resource which must match the values specified in Dapr component spec
 	Metadata map[string]*MetadataValue

--- a/pkg/daprrp/api/v20231001preview/zz_generated_models.go
+++ b/pkg/daprrp/api/v20231001preview/zz_generated_models.go
@@ -61,7 +61,6 @@ type DaprConfigurationStoreProperties struct {
 	Auth *DaprResourceAuth
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// The metadata for Dapr resource which must match the values specified in Dapr component spec
@@ -156,7 +155,6 @@ type DaprPubSubBrokerProperties struct {
 	Auth *DaprResourceAuth
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// The metadata for Dapr resource which must match the values specified in Dapr component spec
@@ -254,7 +252,6 @@ type DaprSecretStoreProperties struct {
 	Application *string
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// The metadata for Dapr resource which must match the values specified in Dapr component spec
@@ -346,7 +343,6 @@ type DaprStateStoreProperties struct {
 	Auth *DaprResourceAuth
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// The metadata for Dapr resource which must match the values specified in Dapr component spec

--- a/pkg/daprrp/api/v20231001preview/zz_generated_models_serde.go
+++ b/pkg/daprrp/api/v20231001preview/zz_generated_models_serde.go
@@ -98,6 +98,7 @@ func (d DaprConfigurationStoreProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "application", d.Application)
 	populate(objectMap, "auth", d.Auth)
+	populate(objectMap, "codeReference", d.CodeReference)
 	populate(objectMap, "componentName", d.ComponentName)
 	populate(objectMap, "environment", d.Environment)
 	populate(objectMap, "metadata", d.Metadata)
@@ -125,6 +126,9 @@ func (d *DaprConfigurationStoreProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "auth":
 			err = unpopulate(val, "Auth", &d.Auth)
+			delete(rawMsg, key)
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &d.CodeReference)
 			delete(rawMsg, key)
 		case "componentName":
 			err = unpopulate(val, "ComponentName", &d.ComponentName)
@@ -294,6 +298,7 @@ func (d DaprPubSubBrokerProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "application", d.Application)
 	populate(objectMap, "auth", d.Auth)
+	populate(objectMap, "codeReference", d.CodeReference)
 	populate(objectMap, "componentName", d.ComponentName)
 	populate(objectMap, "environment", d.Environment)
 	populate(objectMap, "metadata", d.Metadata)
@@ -321,6 +326,9 @@ func (d *DaprPubSubBrokerProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "auth":
 			err = unpopulate(val, "Auth", &d.Auth)
+			delete(rawMsg, key)
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &d.CodeReference)
 			delete(rawMsg, key)
 		case "componentName":
 			err = unpopulate(val, "ComponentName", &d.ComponentName)
@@ -516,6 +524,7 @@ func (d *DaprResourceAuth) UnmarshalJSON(data []byte) error {
 func (d DaprSecretStoreProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "application", d.Application)
+	populate(objectMap, "codeReference", d.CodeReference)
 	populate(objectMap, "componentName", d.ComponentName)
 	populate(objectMap, "environment", d.Environment)
 	populate(objectMap, "metadata", d.Metadata)
@@ -539,6 +548,9 @@ func (d *DaprSecretStoreProperties) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "application":
 			err = unpopulate(val, "Application", &d.Application)
+			delete(rawMsg, key)
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &d.CodeReference)
 			delete(rawMsg, key)
 		case "componentName":
 			err = unpopulate(val, "ComponentName", &d.ComponentName)
@@ -705,6 +717,7 @@ func (d DaprStateStoreProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "application", d.Application)
 	populate(objectMap, "auth", d.Auth)
+	populate(objectMap, "codeReference", d.CodeReference)
 	populate(objectMap, "componentName", d.ComponentName)
 	populate(objectMap, "environment", d.Environment)
 	populate(objectMap, "metadata", d.Metadata)
@@ -732,6 +745,9 @@ func (d *DaprStateStoreProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "auth":
 			err = unpopulate(val, "Auth", &d.Auth)
+			delete(rawMsg, key)
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &d.CodeReference)
 			delete(rawMsg, key)
 		case "componentName":
 			err = unpopulate(val, "ComponentName", &d.ComponentName)

--- a/pkg/datastoresrp/api/v20231001preview/mongodatabase_conversion.go
+++ b/pkg/datastoresrp/api/v20231001preview/mongodatabase_conversion.go
@@ -27,6 +27,10 @@ import (
 // ConvertTo converts from the versioned Mongo database resource to version-agnostic datamodel and returns it,
 // returning an error if any of the inputs are invalid.
 func (src *MongoDatabaseResource) ConvertTo() (v1.DataModelInterface, error) {
+	if err := rpv1.ValidateCodeReference(to.String(src.Properties.CodeReference)); err != nil {
+		return nil, v1.NewClientErrInvalidRequest(err.Error())
+	}
+
 	converted := &datamodel.MongoDatabase{
 		BaseResource: v1.BaseResource{
 			TrackedResource: v1.TrackedResource{

--- a/pkg/datastoresrp/api/v20231001preview/mongodatabase_conversion.go
+++ b/pkg/datastoresrp/api/v20231001preview/mongodatabase_conversion.go
@@ -43,8 +43,9 @@ func (src *MongoDatabaseResource) ConvertTo() (v1.DataModelInterface, error) {
 		},
 		Properties: datamodel.MongoDatabaseProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Environment: to.String(src.Properties.Environment),
-				Application: to.String(src.Properties.Application),
+				Environment:   to.String(src.Properties.Environment),
+				Application:   to.String(src.Properties.Application),
+				CodeReference: to.String(src.Properties.CodeReference),
 			},
 		},
 	}
@@ -107,6 +108,9 @@ func (dst *MongoDatabaseResource) ConvertFrom(src v1.DataModelInterface) error {
 		Recipe:               fromRecipeDataModel(mongo.Properties.Recipe),
 		ResourceProvisioning: fromResourceProvisioningDataModel(mongo.Properties.ResourceProvisioning),
 		Username:             new(mongo.Properties.Username),
+	}
+	if mongo.Properties.CodeReference != "" {
+		dst.Properties.CodeReference = to.Ptr(mongo.Properties.CodeReference)
 	}
 
 	return nil

--- a/pkg/datastoresrp/api/v20231001preview/rediscache_conversion.go
+++ b/pkg/datastoresrp/api/v20231001preview/rediscache_conversion.go
@@ -27,6 +27,10 @@ import (
 // ConvertTo converts from the versioned Redis cache resource to version-agnostic datamodel
 // and returns an error if the inputs are invalid.
 func (src *RedisCacheResource) ConvertTo() (v1.DataModelInterface, error) {
+	if err := rpv1.ValidateCodeReference(to.String(src.Properties.CodeReference)); err != nil {
+		return nil, v1.NewClientErrInvalidRequest(err.Error())
+	}
+
 	converted := &datamodel.RedisCache{
 		BaseResource: v1.BaseResource{
 			InternalMetadata: v1.InternalMetadata{

--- a/pkg/datastoresrp/api/v20231001preview/rediscache_conversion.go
+++ b/pkg/datastoresrp/api/v20231001preview/rediscache_conversion.go
@@ -43,8 +43,9 @@ func (src *RedisCacheResource) ConvertTo() (v1.DataModelInterface, error) {
 		},
 		Properties: datamodel.RedisCacheProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Environment: to.String(src.Properties.Environment),
-				Application: to.String(src.Properties.Application),
+				Environment:   to.String(src.Properties.Environment),
+				Application:   to.String(src.Properties.Application),
+				CodeReference: to.String(src.Properties.CodeReference),
 			},
 		},
 	}
@@ -106,6 +107,9 @@ func (dst *RedisCacheResource) ConvertFrom(src v1.DataModelInterface) error {
 		ProvisioningState: fromProvisioningStateDataModel(redis.InternalMetadata.AsyncProvisioningState),
 		Environment:       new(redis.Properties.Environment),
 		Application:       new(redis.Properties.Application),
+	}
+	if redis.Properties.CodeReference != "" {
+		dst.Properties.CodeReference = to.Ptr(redis.Properties.CodeReference)
 	}
 
 	return nil

--- a/pkg/datastoresrp/api/v20231001preview/sqldatabase_conversion.go
+++ b/pkg/datastoresrp/api/v20231001preview/sqldatabase_conversion.go
@@ -27,6 +27,10 @@ import (
 // ConvertTo converts from the versioned SqlDatabase resource to version-agnostic datamodel
 // and returns an error if the inputs are invalid.
 func (src *SQLDatabaseResource) ConvertTo() (v1.DataModelInterface, error) {
+	if err := rpv1.ValidateCodeReference(to.String(src.Properties.CodeReference)); err != nil {
+		return nil, v1.NewClientErrInvalidRequest(err.Error())
+	}
+
 	converted := &datamodel.SqlDatabase{
 		BaseResource: v1.BaseResource{
 			TrackedResource: v1.TrackedResource{

--- a/pkg/datastoresrp/api/v20231001preview/sqldatabase_conversion.go
+++ b/pkg/datastoresrp/api/v20231001preview/sqldatabase_conversion.go
@@ -43,8 +43,9 @@ func (src *SQLDatabaseResource) ConvertTo() (v1.DataModelInterface, error) {
 		},
 		Properties: datamodel.SqlDatabaseProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Environment: to.String(src.Properties.Environment),
-				Application: to.String(src.Properties.Application),
+				Environment:   to.String(src.Properties.Environment),
+				Application:   to.String(src.Properties.Application),
+				CodeReference: to.String(src.Properties.CodeReference),
 			},
 		},
 	}
@@ -105,6 +106,9 @@ func (dst *SQLDatabaseResource) ConvertFrom(src v1.DataModelInterface) error {
 		Environment:       new(sql.Properties.Environment),
 		Application:       new(sql.Properties.Application),
 		Username:          new(sql.Properties.Username),
+	}
+	if sql.Properties.CodeReference != "" {
+		dst.Properties.CodeReference = to.Ptr(sql.Properties.CodeReference)
 	}
 	if sql.Properties.ResourceProvisioning == portableresources.ResourceProvisioningRecipe {
 		dst.Properties.Recipe = fromRecipeDataModel(sql.Properties.Recipe)

--- a/pkg/datastoresrp/api/v20231001preview/zz_generated_models.go
+++ b/pkg/datastoresrp/api/v20231001preview/zz_generated_models.go
@@ -155,7 +155,6 @@ type MongoDatabaseProperties struct {
 	Application *string
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// Database name of the target Mongo database
@@ -354,7 +353,6 @@ type RedisCacheProperties struct {
 	Application *string
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// The host name of the target Redis cache
@@ -502,7 +500,6 @@ type SQLDatabaseProperties struct {
 	Application *string
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// The name of the Sql database.

--- a/pkg/datastoresrp/api/v20231001preview/zz_generated_models.go
+++ b/pkg/datastoresrp/api/v20231001preview/zz_generated_models.go
@@ -154,6 +154,10 @@ type MongoDatabaseProperties struct {
 	// Fully qualified resource ID for the application that the portable resource is consumed by (if applicable)
 	Application *string
 
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
+
 	// Database name of the target Mongo database
 	Database *string
 
@@ -349,6 +353,10 @@ type RedisCacheProperties struct {
 	// Fully qualified resource ID for the application that the portable resource is consumed by (if applicable)
 	Application *string
 
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
+
 	// The host name of the target Redis cache
 	Host *string
 
@@ -492,6 +500,10 @@ type SQLDatabaseProperties struct {
 
 	// Fully qualified resource ID for the application that the portable resource is consumed by (if applicable)
 	Application *string
+
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
 
 	// The name of the Sql database.
 	Database *string

--- a/pkg/datastoresrp/api/v20231001preview/zz_generated_models_serde.go
+++ b/pkg/datastoresrp/api/v20231001preview/zz_generated_models_serde.go
@@ -342,6 +342,7 @@ func (m *MongoDatabaseListSecretsResult) UnmarshalJSON(data []byte) error {
 func (m MongoDatabaseProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "application", m.Application)
+	populate(objectMap, "codeReference", m.CodeReference)
 	populate(objectMap, "database", m.Database)
 	populate(objectMap, "environment", m.Environment)
 	populate(objectMap, "host", m.Host)
@@ -367,6 +368,9 @@ func (m *MongoDatabaseProperties) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "application":
 			err = unpopulate(val, "Application", &m.Application)
+			delete(rawMsg, key)
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &m.CodeReference)
 			delete(rawMsg, key)
 		case "database":
 			err = unpopulate(val, "Database", &m.Database)
@@ -818,6 +822,7 @@ func (r *RedisCacheListSecretsResult) UnmarshalJSON(data []byte) error {
 func (r RedisCacheProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "application", r.Application)
+	populate(objectMap, "codeReference", r.CodeReference)
 	populate(objectMap, "environment", r.Environment)
 	populate(objectMap, "host", r.Host)
 	populate(objectMap, "port", r.Port)
@@ -843,6 +848,9 @@ func (r *RedisCacheProperties) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "application":
 			err = unpopulate(val, "Application", &r.Application)
+			delete(rawMsg, key)
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &r.CodeReference)
 			delete(rawMsg, key)
 		case "environment":
 			err = unpopulate(val, "Environment", &r.Environment)
@@ -1181,6 +1189,7 @@ func (s *SQLDatabaseListSecretsResult) UnmarshalJSON(data []byte) error {
 func (s SQLDatabaseProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "application", s.Application)
+	populate(objectMap, "codeReference", s.CodeReference)
 	populate(objectMap, "database", s.Database)
 	populate(objectMap, "environment", s.Environment)
 	populate(objectMap, "port", s.Port)
@@ -1206,6 +1215,9 @@ func (s *SQLDatabaseProperties) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "application":
 			err = unpopulate(val, "Application", &s.Application)
+			delete(rawMsg, key)
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &s.CodeReference)
 			delete(rawMsg, key)
 		case "database":
 			err = unpopulate(val, "Database", &s.Database)

--- a/pkg/messagingrp/api/v20231001preview/rabbitmq_conversion.go
+++ b/pkg/messagingrp/api/v20231001preview/rabbitmq_conversion.go
@@ -27,6 +27,10 @@ import (
 // ConvertTo converts a versioned RabbitMQQueueResource to a version-agnostic datamodel.RabbitMQQueue
 // and returns it or an error if the inputs are invalid.
 func (src *RabbitMQQueueResource) ConvertTo() (v1.DataModelInterface, error) {
+	if err := rpv1.ValidateCodeReference(to.String(src.Properties.CodeReference)); err != nil {
+		return nil, v1.NewClientErrInvalidRequest(err.Error())
+	}
+
 	converted := &datamodel.RabbitMQQueue{
 		BaseResource: v1.BaseResource{
 			TrackedResource: v1.TrackedResource{

--- a/pkg/messagingrp/api/v20231001preview/rabbitmq_conversion.go
+++ b/pkg/messagingrp/api/v20231001preview/rabbitmq_conversion.go
@@ -43,8 +43,9 @@ func (src *RabbitMQQueueResource) ConvertTo() (v1.DataModelInterface, error) {
 		},
 		Properties: datamodel.RabbitMQQueueProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Environment: to.String(src.Properties.Environment),
-				Application: to.String(src.Properties.Application),
+				Environment:   to.String(src.Properties.Environment),
+				Application:   to.String(src.Properties.Application),
+				CodeReference: to.String(src.Properties.CodeReference),
 			},
 		},
 	}
@@ -109,6 +110,9 @@ func (dst *RabbitMQQueueResource) ConvertFrom(src v1.DataModelInterface) error {
 		Username:             new(rabbitmq.Properties.Username),
 		Resources:            fromResourcesDataModel(rabbitmq.Properties.Resources),
 		TLS:                  new(rabbitmq.Properties.TLS),
+	}
+	if rabbitmq.Properties.CodeReference != "" {
+		dst.Properties.CodeReference = to.Ptr(rabbitmq.Properties.CodeReference)
 	}
 	if rabbitmq.Properties.ResourceProvisioning == portableresources.ResourceProvisioningRecipe {
 		dst.Properties.Recipe = fromRecipeDataModel(rabbitmq.Properties.Recipe)

--- a/pkg/messagingrp/api/v20231001preview/zz_generated_models.go
+++ b/pkg/messagingrp/api/v20231001preview/zz_generated_models.go
@@ -218,6 +218,10 @@ type RabbitMQQueueProperties struct {
 	// Fully qualified resource ID for the application that the portable resource is consumed by (if applicable)
 	Application *string
 
+	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
+	// Set by tooling such as 'rad app graph' for visualizations.
+	CodeReference *string
+
 	// The hostname of the RabbitMQ instance
 	Host *string
 

--- a/pkg/messagingrp/api/v20231001preview/zz_generated_models.go
+++ b/pkg/messagingrp/api/v20231001preview/zz_generated_models.go
@@ -219,7 +219,6 @@ type RabbitMQQueueProperties struct {
 	Application *string
 
 	// Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).
-	// Set by tooling such as 'rad app graph' for visualizations.
 	CodeReference *string
 
 	// The hostname of the RabbitMQ instance

--- a/pkg/messagingrp/api/v20231001preview/zz_generated_models_serde.go
+++ b/pkg/messagingrp/api/v20231001preview/zz_generated_models_serde.go
@@ -490,6 +490,7 @@ func (r *RabbitMQListSecretsResult) UnmarshalJSON(data []byte) error {
 func (r RabbitMQQueueProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "application", r.Application)
+	populate(objectMap, "codeReference", r.CodeReference)
 	populate(objectMap, "environment", r.Environment)
 	populate(objectMap, "host", r.Host)
 	populate(objectMap, "port", r.Port)
@@ -517,6 +518,9 @@ func (r *RabbitMQQueueProperties) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "application":
 			err = unpopulate(val, "Application", &r.Application)
+			delete(rawMsg, key)
+		case "codeReference":
+			err = unpopulate(val, "CodeReference", &r.CodeReference)
 			delete(rawMsg, key)
 		case "environment":
 			err = unpopulate(val, "Environment", &r.Environment)

--- a/pkg/rp/v1/coderef.go
+++ b/pkg/rp/v1/coderef.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// maxCodeReferenceLength bounds the size of a CodeReference value to keep stored
+// data reasonable. The limit comfortably accommodates a deep GitHub blob URL
+// with a line anchor.
+const maxCodeReferenceLength = 2048
+
+// codeReferenceAnchorRE matches a single-line GitHub-style anchor of the form "L<line>"
+// where <line> is a positive integer (no leading zero).
+var codeReferenceAnchorRE = regexp.MustCompile(`^L[1-9][0-9]*$`)
+
+// ValidateCodeReference validates the format of a CodeReference value. An empty
+// string is treated as unset and is considered valid (the field is optional).
+//
+// Valid forms:
+//   - A repository-root-relative file path using forward slashes, e.g.
+//     "src/cache/redis.ts".
+//   - The same with an optional GitHub-style single-line anchor appended as a
+//     fragment, e.g. "src/cache/redis.ts#L10".
+//   - An absolute http:// or https:// URL, e.g.
+//     "https://github.com/radius-project/radius/blob/main/pkg/.../service.go#L31".
+//
+// The value must point to a file (not a directory) and must not contain path
+// traversal segments ("." or ".."). Backslashes are not permitted.
+func ValidateCodeReference(s string) error {
+	if s == "" {
+		return nil
+	}
+	if len(s) > maxCodeReferenceLength {
+		return fmt.Errorf("codeReference exceeds the maximum length of %d characters", maxCodeReferenceLength)
+	}
+	if strings.ContainsRune(s, '\\') {
+		return fmt.Errorf("codeReference must use forward slashes only")
+	}
+
+	pathPart, anchor, hasAnchor := strings.Cut(s, "#")
+	if hasAnchor && !codeReferenceAnchorRE.MatchString(anchor) {
+		return fmt.Errorf("codeReference anchor %q must have the form '#L<line>' where <line> is a positive integer", "#"+anchor)
+	}
+
+	if strings.HasPrefix(pathPart, "http://") || strings.HasPrefix(pathPart, "https://") {
+		return validateCodeReferenceURL(pathPart)
+	}
+
+	return validateCodeReferenceRelativePath(pathPart)
+}
+
+func validateCodeReferenceURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("codeReference URL is not parseable: %v", err)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("codeReference URL must include a host")
+	}
+	if u.Path == "" || u.Path == "/" || strings.HasSuffix(u.Path, "/") {
+		return fmt.Errorf("codeReference URL must point to a file, not a directory")
+	}
+	return nil
+}
+
+func validateCodeReferenceRelativePath(p string) error {
+	if p == "" {
+		return fmt.Errorf("codeReference must include a file path")
+	}
+	if strings.HasPrefix(p, "/") {
+		return fmt.Errorf("codeReference must be a repository-root-relative path and must not start with '/'")
+	}
+	if strings.HasSuffix(p, "/") {
+		return fmt.Errorf("codeReference must point to a file, not a directory")
+	}
+	for _, seg := range strings.Split(p, "/") {
+		if seg == "" {
+			return fmt.Errorf("codeReference must not contain empty path segments")
+		}
+		if seg == "." || seg == ".." {
+			return fmt.Errorf("codeReference must not contain '.' or '..' path segments")
+		}
+	}
+	return nil
+}

--- a/pkg/rp/v1/coderef_test.go
+++ b/pkg/rp/v1/coderef_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCodeReference(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantErr     bool
+		errContains string
+	}{
+		// Valid cases.
+		{name: "empty is valid (optional)", input: ""},
+		{name: "relative file path", input: "src/cache/redis.ts"},
+		{name: "single-segment file", input: "main.go"},
+		{name: "relative path with line anchor", input: "src/cache/redis.ts#L10"},
+		{name: "deep relative path", input: "a/b/c/d/e/file.ts#L1"},
+		{name: "https URL", input: "https://github.com/radius-project/radius/blob/main/pkg/armrpc/asyncoperation/worker/service.go"},
+		{name: "https URL with anchor", input: "https://github.com/radius-project/radius/blob/main/pkg/armrpc/asyncoperation/worker/service.go#L31"},
+		{name: "http URL", input: "http://example.com/foo/bar.go"},
+
+		// Path-shape failures.
+		{name: "absolute path rejected", input: "/etc/passwd", wantErr: true, errContains: "repository-root-relative"},
+		{name: "single dot segment rejected", input: "./foo.ts", wantErr: true, errContains: "'.' or '..'"},
+		{name: "double dot segment rejected", input: "../foo.ts", wantErr: true, errContains: "'.' or '..'"},
+		{name: "embedded double dot rejected", input: "src/../etc/passwd", wantErr: true, errContains: "'.' or '..'"},
+		{name: "trailing slash rejected (directory)", input: "src/cache/", wantErr: true, errContains: "file, not a directory"},
+		{name: "backslash rejected", input: "src\\cache\\redis.ts", wantErr: true, errContains: "forward slashes"},
+		{name: "empty segment rejected", input: "src//redis.ts", wantErr: true, errContains: "empty path segments"},
+
+		// Anchor failures.
+		{name: "missing line number rejected", input: "foo.ts#L", wantErr: true, errContains: "form '#L<line>'"},
+		{name: "non-numeric anchor rejected", input: "foo.ts#Label", wantErr: true, errContains: "form '#L<line>'"},
+		{name: "zero line rejected", input: "foo.ts#L0", wantErr: true, errContains: "form '#L<line>'"},
+		{name: "leading zero rejected", input: "foo.ts#L01", wantErr: true, errContains: "form '#L<line>'"},
+		{name: "unknown anchor form rejected", input: "foo.ts#section", wantErr: true, errContains: "form '#L<line>'"},
+
+		// URL failures.
+		{name: "URL without host rejected", input: "https:///foo/bar.go", wantErr: true, errContains: "host"},
+		{name: "URL ending in slash rejected", input: "https://github.com/radius-project/radius/", wantErr: true, errContains: "file, not a directory"},
+		{name: "URL bare host rejected", input: "https://github.com", wantErr: true, errContains: "file, not a directory"},
+
+		// Length.
+		{name: "overlong rejected", input: "a/" + strings.Repeat("x", 2048), wantErr: true, errContains: "maximum length"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateCodeReference(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.errContains != "" {
+					require.Contains(t, err.Error(), tc.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/rp/v1/types.go
+++ b/pkg/rp/v1/types.go
@@ -47,6 +47,11 @@ type BasicResourceProperties struct {
 	// Application represents the id of application resource.
 	Application string `json:"application,omitempty"`
 
+	// CodeReference is an optional URL that deep-links the resource to its source code
+	// (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). It is set by tooling
+	// such as 'rad app graph' for visualizations and is round-tripped through the API.
+	CodeReference string `json:"codeReference,omitempty"`
+
 	// Status represents the resource status.
 	Status ResourceStatus `json:"status"`
 }

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/openapi.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/openapi.json
@@ -2326,6 +2326,10 @@
         "diffHash": {
           "type": "string",
           "description": "Stable hash over the authorable properties of this resource and its sorted dependsOn list. Used by tooling to classify resources as added, removed, modified, or unchanged across graphs. Format: 'sha256:{hex}'."
+        },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
         }
       },
       "required": [
@@ -2837,6 +2841,10 @@
           "description": "The status of the asynchronous operation.",
           "readOnly": true
         },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
           "description": "Status of a resource.",
@@ -3264,6 +3272,10 @@
           "description": "The status of the asynchronous operation.",
           "readOnly": true
         },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
           "description": "Status of a resource.",
@@ -3389,6 +3401,10 @@
           "$ref": "#/definitions/ProvisioningState",
           "description": "The status of the asynchronous operation.",
           "readOnly": true
+        },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
@@ -4526,6 +4542,10 @@
           "description": "The status of the asynchronous operation.",
           "readOnly": true
         },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
           "description": "Status of a resource.",
@@ -4867,6 +4887,10 @@
           "$ref": "#/definitions/ProvisioningState",
           "description": "The status of the asynchronous operation.",
           "readOnly": true
+        },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/openapi.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/openapi.json
@@ -2329,7 +2329,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         }
       },
       "required": [
@@ -2843,7 +2843,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
@@ -3274,7 +3274,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
@@ -3404,7 +3404,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
@@ -4544,7 +4544,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
@@ -4890,7 +4890,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",

--- a/swagger/specification/applications/resource-manager/Applications.Dapr/preview/2023-10-01-preview/openapi.json
+++ b/swagger/specification/applications/resource-manager/Applications.Dapr/preview/2023-10-01-preview/openapi.json
@@ -1302,6 +1302,10 @@
           "description": "The status of the asynchronous operation.",
           "readOnly": true
         },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
           "description": "Status of a resource.",
@@ -1420,6 +1424,10 @@
           "$ref": "#/definitions/ProvisioningState",
           "description": "The status of the asynchronous operation.",
           "readOnly": true
+        },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
@@ -1550,6 +1558,10 @@
           "description": "The status of the asynchronous operation.",
           "readOnly": true
         },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
           "description": "Status of a resource.",
@@ -1657,6 +1669,10 @@
           "$ref": "#/definitions/ProvisioningState",
           "description": "The status of the asynchronous operation.",
           "readOnly": true
+        },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",

--- a/swagger/specification/applications/resource-manager/Applications.Dapr/preview/2023-10-01-preview/openapi.json
+++ b/swagger/specification/applications/resource-manager/Applications.Dapr/preview/2023-10-01-preview/openapi.json
@@ -1304,7 +1304,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
@@ -1427,7 +1427,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
@@ -1560,7 +1560,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
@@ -1672,7 +1672,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",

--- a/swagger/specification/applications/resource-manager/Applications.Datastores/preview/2023-10-01-preview/openapi.json
+++ b/swagger/specification/applications/resource-manager/Applications.Datastores/preview/2023-10-01-preview/openapi.json
@@ -1290,7 +1290,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
@@ -1560,7 +1560,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
@@ -1772,7 +1772,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",

--- a/swagger/specification/applications/resource-manager/Applications.Datastores/preview/2023-10-01-preview/openapi.json
+++ b/swagger/specification/applications/resource-manager/Applications.Datastores/preview/2023-10-01-preview/openapi.json
@@ -1288,6 +1288,10 @@
           "description": "The status of the asynchronous operation.",
           "readOnly": true
         },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
           "description": "Status of a resource.",
@@ -1554,6 +1558,10 @@
           "description": "The status of the asynchronous operation.",
           "readOnly": true
         },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
           "description": "Status of a resource.",
@@ -1761,6 +1769,10 @@
           "$ref": "#/definitions/ProvisioningState",
           "description": "The status of the asynchronous operation.",
           "readOnly": true
+        },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",

--- a/swagger/specification/applications/resource-manager/Applications.Messaging/preview/2023-10-01-preview/openapi.json
+++ b/swagger/specification/applications/resource-manager/Applications.Messaging/preview/2023-10-01-preview/openapi.json
@@ -680,7 +680,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         },
         "status": {
           "$ref": "#/definitions/ResourceStatus",

--- a/swagger/specification/applications/resource-manager/Applications.Messaging/preview/2023-10-01-preview/openapi.json
+++ b/swagger/specification/applications/resource-manager/Applications.Messaging/preview/2023-10-01-preview/openapi.json
@@ -678,6 +678,10 @@
           "description": "The status of the asynchronous operation.",
           "readOnly": true
         },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+        },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
           "description": "Status of a resource.",

--- a/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/openapi.json
+++ b/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/openapi.json
@@ -1337,6 +1337,10 @@
         "diffHash": {
           "type": "string",
           "description": "Stable hash over the authorable properties of this resource and its sorted dependsOn list. Used by tooling to classify resources as added, removed, modified, or unchanged across graphs. Format: 'sha256:{hex}'."
+        },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
         }
       },
       "required": [
@@ -1375,6 +1379,10 @@
           "$ref": "#/definitions/ProvisioningState",
           "description": "The status of the asynchronous operation.",
           "readOnly": true
+        },
+        "codeReference": {
+          "type": "string",
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
         },
         "environment": {
           "type": "string",

--- a/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/openapi.json
+++ b/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/openapi.json
@@ -1340,7 +1340,7 @@
         },
         "codeReference": {
           "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
+          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor)."
         }
       },
       "required": [
@@ -1379,10 +1379,6 @@
           "$ref": "#/definitions/ProvisioningState",
           "description": "The status of the asynchronous operation.",
           "readOnly": true
-        },
-        "codeReference": {
-          "type": "string",
-          "description": "Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations."
         },
         "environment": {
           "type": "string",

--- a/typespec/Applications.Core/applications.tsp
+++ b/typespec/Applications.Core/applications.tsp
@@ -116,7 +116,7 @@ model ApplicationGraphResource {
   @doc("Stable hash over the authorable properties of this resource and its sorted dependsOn list. Used by tooling to classify resources as added, removed, modified, or unchanged across graphs. Format: 'sha256:{hex}'.")
   diffHash?: string;
 
-  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations.")
+  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).")
   codeReference?: string;
 }
 

--- a/typespec/Applications.Core/applications.tsp
+++ b/typespec/Applications.Core/applications.tsp
@@ -6,7 +6,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
-    
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -115,6 +115,9 @@ model ApplicationGraphResource {
 
   @doc("Stable hash over the authorable properties of this resource and its sorted dependsOn list. Used by tooling to classify resources as added, removed, modified, or unchanged across graphs. Format: 'sha256:{hex}'.")
   diffHash?: string;
+
+  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations.")
+  codeReference?: string;
 }
 
 @doc("Describes an output resource that comprises an application graph resource.")

--- a/typespec/Radius.Core/applications.tsp
+++ b/typespec/Radius.Core/applications.tsp
@@ -6,7 +6,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
-    
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -51,6 +51,9 @@ model ApplicationProperties {
   @doc("The status of the asynchronous operation.")
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
+
+  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations.")
+  codeReference?: string;
 
   @doc("Fully qualified resource ID for the environment that the application is linked to")
   environment: string;
@@ -109,6 +112,9 @@ model ApplicationGraphResource {
 
   @doc("Stable hash over the authorable properties of this resource and its sorted dependsOn list. Used by tooling to classify resources as added, removed, modified, or unchanged across graphs. Format: 'sha256:{hex}'.")
   diffHash?: string;
+
+  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations.")
+  codeReference?: string;
 }
 
 @doc("Describes an output resource that comprises an application graph resource.")

--- a/typespec/Radius.Core/applications.tsp
+++ b/typespec/Radius.Core/applications.tsp
@@ -52,9 +52,6 @@ model ApplicationProperties {
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
 
-  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations.")
-  codeReference?: string;
-
   @doc("Fully qualified resource ID for the environment that the application is linked to")
   environment: string;
 
@@ -113,7 +110,7 @@ model ApplicationGraphResource {
   @doc("Stable hash over the authorable properties of this resource and its sorted dependsOn list. Used by tooling to classify resources as added, removed, modified, or unchanged across graphs. Format: 'sha256:{hex}'.")
   diffHash?: string;
 
-  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations.")
+  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).")
   codeReference?: string;
 }
 

--- a/typespec/radius/v1/resources.tsp
+++ b/typespec/radius/v1/resources.tsp
@@ -6,7 +6,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
-    
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,6 +40,9 @@ model EnvironmentScopedResource {
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
 
+  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations.")
+  codeReference?: string;
+
   @doc("Status of a resource.")
   @visibility(Lifecycle.Read)
   status?: ResourceStatus;
@@ -57,6 +60,9 @@ model ApplicationScopedResource {
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
 
+  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations.")
+  codeReference?: string;
+
   @doc("Status of a resource.")
   @visibility(Lifecycle.Read)
   status?: ResourceStatus;
@@ -73,6 +79,9 @@ model GlobalScopedResource {
   @doc("The status of the asynchronous operation.")
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
+
+  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations.")
+  codeReference?: string;
 
   @doc("Status of a resource.")
   @visibility(Lifecycle.Read)

--- a/typespec/radius/v1/resources.tsp
+++ b/typespec/radius/v1/resources.tsp
@@ -40,7 +40,7 @@ model EnvironmentScopedResource {
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
 
-  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations.")
+  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).")
   codeReference?: string;
 
   @doc("Status of a resource.")
@@ -60,7 +60,7 @@ model ApplicationScopedResource {
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
 
-  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations.")
+  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).")
   codeReference?: string;
 
   @doc("Status of a resource.")
@@ -80,7 +80,7 @@ model GlobalScopedResource {
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
 
-  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor). Set by tooling such as 'rad app graph' for visualizations.")
+  @doc("Optional URL that deep-links the resource to its source code (e.g. a GitHub blob URL, optionally with a '#Lnnn' line anchor).")
   codeReference?: string;
 
   @doc("Status of a resource.")


### PR DESCRIPTION
# Description

This pull request adds support for a new optional field, `codeReference`, across several resource types in the API. The `codeReference` field is intended to store a URL that deep-links a resource to its source code location (such as a GitHub blob URL, potentially with a line anchor), which can be used by tooling for visualization and traceability. The changes include updates to data models, serialization/deserialization logic, resource conversion methods, and test data.



## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
- This pull request is a design document and only includes files in the eng/design-notes directory.

<!-- Please update the following to link the associated issue. This is required for some kinds of changes (see above). -->
Fixes: [#12114](https://github.com/radius-project/radius/issues/12114)

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [x] Yes
    - [ ] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [x] Yes
    - [ ] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
