### PR TITLE
ci(purge-old-images): use GitHub App instead of PAT

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -151,8 +151,7 @@ jobs:
           git status --porcelain -unormal -- *.md
 
       # Generate a short-lived GitHub App installation token scoped to the docs
-      # repository. This replaces the long-lived GH_RAD_CI_BOT_PAT: tokens expire
-      # after one hour, are least-privilege (contents + pull-requests on docs only),
+      # repository. Tokens expire after one hour, are least-privilege (contents + pull-requests on docs only),
       # and let repo-files-sync create GPG-verified commits via the GitHub API.
       #
       # Requires the App's credentials to be configured on radius-project/radius:

--- a/.github/workflows/purge-old-images.yaml
+++ b/.github/workflows/purge-old-images.yaml
@@ -22,11 +22,29 @@ jobs:
     timeout-minutes: 45
     permissions: {}
     steps:
+      # Generate a short-lived GitHub App installation token scoped to the
+      # radius-project organization with packages:write. App tokens expire after one hour and are
+      # least-privilege (packages only), reducing the blast radius if leaked.
+      #
+      # Requires the App's credentials to be configured on radius-project/radius:
+      #   - secrets.RADIUS_PURGE_BOT_CLIENT_ID
+      #   - secrets.RADIUS_PURGE_BOT_PRIVATE_KEY
+      # and the App installed on the radius-project org with the "Packages:
+      # Read and write" repository permission.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RADIUS_PURGE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RADIUS_PURGE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-packages: write
+
       - name: Delete 'dev' containers older than a week
         uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
         with:
-          account: radius-project
-          token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          account: ${{ github.repository_owner }}
+          token: ${{ steps.app-token.outputs.token }}
           image-names: dev/*
           image-tags: pr-*
           cut-off: 1w


### PR DESCRIPTION
# Description

Replaces the long-lived `GH_RAD_CI_BOT_PAT` personal access token with short-lived GitHub App installation tokens in two CI workflows.

The `purge-old-images.yaml` workflow now mints an org-scoped GitHub App token (via `actions/create-github-app-token`) with only the `packages: write` permission, instead of using `GH_RAD_CI_BOT_PAT`. The `publish-docs.yaml` comment is updated to drop the now-stale reference to the PAT it already replaced.

App tokens expire after one hour and are least-privilege, reducing the blast radius if a token is leaked.

### Required setup

A maintainer must configure a GitHub App on the `radius-project` org before this workflow can run:

- **App permission:** Repository → `Packages` = Read and write (no other permissions).
- **Installation:** installed on the `radius-project` org (all repositories), so it can manage org-owned GHCR packages.
- **Secrets** on `radius-project/radius`:
  - `RADIUS_PURGE_BOT_CLIENT_ID`
  - `RADIUS_PURGE_BOT_PRIVATE_KEY`

### Changed files

- `.github/workflows/purge-old-images.yaml` — adds a "Generate GitHub App token" step and switches the purge step to the App token; uses `${{ github.repository_owner }}` for `account`/`owner`.
- `.github/workflows/publish-docs.yaml` — removes the outdated `GH_RAD_CI_BOT_PAT` reference from a comment.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
