### PR TITLE
ci(purge-old-images): resolve dev container image names

### DIFF
--- a/.github/workflows/purge-old-images.yaml
+++ b/.github/workflows/purge-old-images.yaml
@@ -40,12 +40,43 @@ jobs:
           owner: ${{ github.repository_owner }}
           permission-packages: write
 
+      # snok/container-retention-policy classifies a GitHub App installation
+      # token (ghs_ prefix) the same as the temporal GITHUB_TOKEN, which cannot
+      # call the list-packages endpoint. As a result it rejects wildcard
+      # image-names such as 'dev/*'. To keep using an App token, resolve the
+      # concrete dev/* package names up front via the GitHub API (which the App
+      # token is allowed to call) and pass them to the action as an explicit
+      # list. image-tags wildcards (pr-*) are not affected by this restriction.
+      - name: Resolve dev/* container image names
+        id: image-names
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const org = core.getInput('owner')
+            const packages = await github.paginate(
+              github.rest.packages.listPackagesForOrganization,
+              { package_type: 'container', org, per_page: 100 }
+            )
+            const names = packages
+              .map((pkg) => pkg.name)
+              .filter((name) => name.startsWith('dev/'))
+            if (names.length === 0) {
+              core.info('No dev/* container packages found; nothing to purge.')
+            } else {
+              core.info(`Resolved ${names.length} dev/* package names.`)
+            }
+            core.setOutput('names', names.join(' '))
+        env:
+          INPUT_OWNER: ${{ github.repository_owner }}
+
       - name: Delete 'dev' containers older than a week
+        if: steps.image-names.outputs.names != ''
         uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
         with:
           account: ${{ github.repository_owner }}
           token: ${{ steps.app-token.outputs.token }}
-          image-names: dev/*
+          image-names: ${{ steps.image-names.outputs.names }}
           image-tags: pr-*
           cut-off: 1w
 


### PR DESCRIPTION
# Description

This pull request updates the `.github/workflows/purge-old-images.yaml` workflow to address a limitation with the `snok/container-retention-policy` action when using a GitHub App token. The workflow now resolves the actual list of `dev/*` container image names before passing them to the retention policy action, ensuring compatibility and preventing failures.

**Workflow improvements:**

* Added a new step (`Resolve dev/* container image names`) that uses the GitHub API to retrieve and list all `dev/*` container packages, outputting their names for use in the next step.
* Updated the container deletion step to use the resolved list of image names instead of a wildcard, and to only run if such images exist.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [ ] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [ ] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ ] Not applicable
