### PR TITLE
ci(purge-old-images): optimize image deletion by selecting only tagged images

### DIFF
--- a/.github/workflows/purge-old-images.yaml
+++ b/.github/workflows/purge-old-images.yaml
@@ -40,6 +40,11 @@ jobs:
           token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
           image-names: dev/*
           image-tags: pr-*
+          # Only delete the pr-* tagged image indexes. GHCR cascade-removes their
+          # untagged child manifests automatically, so we avoid issuing thousands
+          # of redundant deletes for already-removed children (which otherwise log
+          # as "404 Package not found" errors).
+          tag-selection: tagged
           cut-off: 1w
 
   create_issue_on_failure:


### PR DESCRIPTION
# Description

This pull request makes a targeted improvement to the workflow for purging old images in `.github/workflows/purge-old-images.yaml`. The change ensures that only the PR-tagged image indexes are deleted, which prevents redundant deletion attempts and reduces error logs.

Workflow optimization:

* Added the `tag-selection: tagged` option to limit deletions to only `pr-*` tagged image indexes, preventing unnecessary deletion attempts of already-removed child manifests and reducing "404 Package not found" errors.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [ ] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [ ] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ ] Not applicable
