### PR TITLE
Register Radius.Compute/containerImages as a default resource type

### DIFF
--- a/deploy/manifest/built-in-providers/dev/containerImages.yaml
+++ b/deploy/manifest/built-in-providers/dev/containerImages.yaml
@@ -1,0 +1,98 @@
+namespace: Radius.Compute
+types:
+  containerImages:
+    description: |
+      The Radius.Compute/containerImages Resource Type builds a container image from source and pushes it to an OCI registry. Builds run inside the Radius control plane.
+
+      To use a containerImages resource in your application, add a containerImages resource to the application definition Bicep file, then reference the `containerImages.imageReference` property in the containers resource. For example:
+
+      ```bicep
+      extension radius
+
+      param environment string
+
+      resource myApp 'Radius.Core/applications@2025-08-01-preview' = {
+        name: 'myApp'
+        properties: {
+          environment: environment
+        }
+      }
+
+      resource myImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
+        name: 'myImage'
+        properties: {
+          environment: environment
+          application: myApp.id
+          tag:         'v1.2.3'
+          build: {
+            source: 'git::https://github.com/myorg/myapp.git//frontend?ref=v1.2.3'
+          }
+        }
+      }
+
+      resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'myContainer'
+        properties: {
+          environment: environment
+          application: myApp.id
+          containers: {
+            app: {
+              image: myImage.properties.imageReference
+              ports: {
+                web: {
+                  containerPort: 3000
+                }
+              }
+            }
+          }
+        }
+      }
+      ```
+
+      Multi-architecture builds (e.g. `platforms: ["linux/amd64", "linux/arm64"]`) require a Dockerfile that supports cross-compilation via `FROM --platform=$BUILDPLATFORM` and `TARGETARCH`. Dockerfiles that execute target-arch binaries during the build will fail with `exec format error`. There is no QEMU/binfmt fallback in this design.
+
+    apiVersions:
+      '2025-08-01-preview':
+        schema:
+          type: object
+          properties:
+            environment:
+              type: string
+              description: (Required) The Radius Environment ID. Typically set by the rad CLI. Typical value should be `environment`.
+            application:
+              type: string
+              description: (Required) The Radius Application ID. `myApplication.id` for example.
+            tag:
+              type: string
+              description: (Optional) Tag for the produced image. When unset, the recipe computes a content-addressable digest (`sha256-<hash>`) from the build inputs. For git sources, pin to a commit SHA or immutable tag (e.g. `?ref=<sha>`) so that the computed tag is genuinely content-addressable; with a moving ref like `?ref=main`, the computed tag does not change when the upstream branch advances.
+            build:
+              type: object
+              description: (Required) Build configuration for the container image.
+              properties:
+                source:
+                  type: string
+                  description: "(Required) Source location for the build. Either a git URL of the form `git::https://...` (BuildKit clones the repo inside the cluster) or a local filesystem path to a directory containing the build context. For git URLs, the subdirectory is selected via the go-getter `//<subdir>` segment and the ref via the `?ref=<branch-or-sha>` query parameter, in that order. Example, `git::https://github.com/myorg/myapp.git//frontend?ref=v1.2.3`."
+                dockerfile:
+                  type: string
+                  description: (Optional) Path to the Dockerfile relative to the build source. Defaults to `Dockerfile`.
+                platforms:
+                  type: array
+                  items:
+                    type: string
+                  description: |
+                    (Optional) Target platforms to build for (e.g. `["linux/amd64"]`, `["linux/amd64", "linux/arm64"]`). When omitted, defaults to `["linux/amd64", "linux/arm64"]`. Multi-platform builds use cross-compilation; the Dockerfile must use `FROM --platform=$BUILDPLATFORM` and `TARGETARCH`.
+                args:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: "(Optional) Map of `--build-arg` values passed to the build, e.g. `{ VERSION: 'v1.2.3' }`. Argument names must match `[A-Za-z_][A-Za-z0-9_]*`. Values must not contain shell metacharacters."
+              required:
+                - source
+            imageReference:
+              type: string
+              readOnly: true
+              description: (Read Only) The full image reference produced by the recipe in the form `<registry>/<resource-name>:<tag>`. Reference this from `Radius.Compute/containers` to consume the built image.
+          required:
+            - environment
+            - application
+            - build

--- a/deploy/manifest/built-in-providers/self-hosted/containerImages.yaml
+++ b/deploy/manifest/built-in-providers/self-hosted/containerImages.yaml
@@ -1,0 +1,98 @@
+namespace: Radius.Compute
+types:
+  containerImages:
+    description: |
+      The Radius.Compute/containerImages Resource Type builds a container image from source and pushes it to an OCI registry. Builds run inside the Radius control plane.
+
+      To use a containerImages resource in your application, add a containerImages resource to the application definition Bicep file, then reference the `containerImages.imageReference` property in the containers resource. For example:
+
+      ```bicep
+      extension radius
+
+      param environment string
+
+      resource myApp 'Radius.Core/applications@2025-08-01-preview' = {
+        name: 'myApp'
+        properties: {
+          environment: environment
+        }
+      }
+
+      resource myImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
+        name: 'myImage'
+        properties: {
+          environment: environment
+          application: myApp.id
+          tag:         'v1.2.3'
+          build: {
+            source: 'git::https://github.com/myorg/myapp.git//frontend?ref=v1.2.3'
+          }
+        }
+      }
+
+      resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'myContainer'
+        properties: {
+          environment: environment
+          application: myApp.id
+          containers: {
+            app: {
+              image: myImage.properties.imageReference
+              ports: {
+                web: {
+                  containerPort: 3000
+                }
+              }
+            }
+          }
+        }
+      }
+      ```
+
+      Multi-architecture builds (e.g. `platforms: ["linux/amd64", "linux/arm64"]`) require a Dockerfile that supports cross-compilation via `FROM --platform=$BUILDPLATFORM` and `TARGETARCH`. Dockerfiles that execute target-arch binaries during the build will fail with `exec format error`. There is no QEMU/binfmt fallback in this design.
+
+    apiVersions:
+      '2025-08-01-preview':
+        schema:
+          type: object
+          properties:
+            environment:
+              type: string
+              description: (Required) The Radius Environment ID. Typically set by the rad CLI. Typical value should be `environment`.
+            application:
+              type: string
+              description: (Required) The Radius Application ID. `myApplication.id` for example.
+            tag:
+              type: string
+              description: (Optional) Tag for the produced image. When unset, the recipe computes a content-addressable digest (`sha256-<hash>`) from the build inputs. For git sources, pin to a commit SHA or immutable tag (e.g. `?ref=<sha>`) so that the computed tag is genuinely content-addressable; with a moving ref like `?ref=main`, the computed tag does not change when the upstream branch advances.
+            build:
+              type: object
+              description: (Required) Build configuration for the container image.
+              properties:
+                source:
+                  type: string
+                  description: "(Required) Source location for the build. Either a git URL of the form `git::https://...` (BuildKit clones the repo inside the cluster) or a local filesystem path to a directory containing the build context. For git URLs, the subdirectory is selected via the go-getter `//<subdir>` segment and the ref via the `?ref=<branch-or-sha>` query parameter, in that order. Example, `git::https://github.com/myorg/myapp.git//frontend?ref=v1.2.3`."
+                dockerfile:
+                  type: string
+                  description: (Optional) Path to the Dockerfile relative to the build source. Defaults to `Dockerfile`.
+                platforms:
+                  type: array
+                  items:
+                    type: string
+                  description: |
+                    (Optional) Target platforms to build for (e.g. `["linux/amd64"]`, `["linux/amd64", "linux/arm64"]`). When omitted, defaults to `["linux/amd64", "linux/arm64"]`. Multi-platform builds use cross-compilation; the Dockerfile must use `FROM --platform=$BUILDPLATFORM` and `TARGETARCH`.
+                args:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: "(Optional) Map of `--build-arg` values passed to the build, e.g. `{ VERSION: 'v1.2.3' }`. Argument names must match `[A-Za-z_][A-Za-z0-9_]*`. Values must not contain shell metacharacters."
+              required:
+                - source
+            imageReference:
+              type: string
+              readOnly: true
+              description: (Read Only) The full image reference produced by the recipe in the form `<registry>/<resource-name>:<tag>`. Reference this from `Radius.Compute/containers` to consume the built image.
+          required:
+            - environment
+            - application
+            - build

--- a/deploy/manifest/defaults.yaml
+++ b/deploy/manifest/defaults.yaml
@@ -13,6 +13,7 @@
 #   3. Run: make update-resource-types
 #   4. Commit the updated files (defaults.yaml, go.mod, go.sum, and copied YAMLs).
 defaultRegistration:
+  - Radius.Compute/containerImages
   - Radius.Compute/containers
   - Radius.Compute/persistentVolumes
   - Radius.Compute/routes


### PR DESCRIPTION
# Description

Registers `Radius.Compute/containerImages` as a default resource type so it ships out of the box in `rad install kubernetes`.

This PR is independent of the BuildKit-sidecar PR (#11882). It only adds the type registration; the runtime that executes the recipe is added separately. With this PR alone, attempting to deploy a `Radius.Compute/containerImages` resource will fail at recipe execution time because the BuildKit sidecar isn't running. Once #11882 merges and operators opt in via `--set dynamicrp.buildkit.enabled=true`, end-to-end builds work.

## What changes

- **`deploy/manifest/defaults.yaml`** — adds `Radius.Compute/containerImages` to `defaultRegistration`.
- **`deploy/manifest/built-in-providers/dev/containerImages.yaml`** and **`deploy/manifest/built-in-providers/self-hosted/containerImages.yaml`** — schema copies, generated by `make sync-resource-types` from the resource-types-contrib version already pinned in `go.mod` (`1552489`). The schema landed upstream in [resource-types-contrib#151](https://github.com/radius-project/resource-types-contrib/pull/151).

The two built-in-providers files are mechanical copies; the schema source is the authoritative one in resource-types-contrib.

## Validation

- `make sync-resource-types` — 6/6 default types copied with no errors.
- `diff` between source and committed copies — byte-identical (both `dev/` and `self-hosted/`).
- `go test ./pkg/ucp/initializer/... ./pkg/ucp/integrationtests/resourceproviders/...` — pass.
- The `verify-resource-types` CI check will re-run sync and confirm zero drift.
- E2E validation against a chart with the BuildKit sidecar enabled is in [willdavsmith/radius-containerimagetype-demo](https://github.com/willdavsmith/radius-containerimagetype-demo) — all 4 cluster types (kind / k3d / AKS / EKS) pass.

## Coordination

- **Companion PR**: #11882 (chart-side BuildKit sidecar opt-in). Should land first or alongside this PR; otherwise the type is registered but no recipe is functional.
- **Schema source**: [resource-types-contrib#151](https://github.com/radius-project/resource-types-contrib/pull/151) (already merged, included in the pinned `go.mod` version).

## Why this is a separate PR

- Reviewers can sign off on the type registration on its own; the surface area is exactly what the manifest sync produces, with no chart/runtime changes.
- The `verify-resource-types` check makes drift impossible to merge accidentally.
- Keeps #11882's chart-only diff focused on the BuildKit sidecar.
