### PR TITLE
docs: Contributing guide — building and the rad CLI

### DIFF
--- a/docs/contributing/contributing-code/contributing-code-building/README.md
+++ b/docs/contributing/contributing-code/contributing-code-building/README.md
@@ -1,67 +1,95 @@
 # Building the code
 
-Radius uses a Makefile to build the repository and automate most common repository tasks.
+## Purpose
 
-You can run `make` (no additional arguments) to see the list of targets and their descriptions.
+This is the authoritative guide for building Radius from source. It covers building the binaries (including the `rad` CLI), building the container images for the control-plane services, and regenerating checked-in generated code. Radius uses a [GNU Make](https://www.gnu.org/software/make/) `Makefile` (split into includes under [build/](../../../../build/)) to automate these tasks. If you are making your first contribution, the [first-commit walkthrough](../contributing-code-first-commit/first-commit-02-building/index.md) links here for the canonical steps.
 
-## Building the repository
+## Prerequisites
 
-You can build the repository with `make build`. This will build all of the packages and executables. The first time you run `make build` it may take a few minutes because it will download and build dependencies. Subsequent builds will be faster because they can use cached output.
+- The repository cloned locally. See [Creating your own fork](../contributing-code-forks/index.md).
+- The tools listed in the [prerequisites guide](../contributing-code-prerequisites/README.md) — at minimum Go (the version pinned in [go.mod](../../../../go.mod)) and GNU Make.
+- For building container images: a working Docker daemon and a registry you can push to.
+- For `make generate`: the extra code-generation tools listed under [Code generation](../contributing-code-prerequisites/README.md#code-generation).
 
-The following command will build, run unit tests, and run linters. This command is handy for verifying that your local changes are working correctly.
+Run `make` (or `make help`) with no arguments at any time to print every target and its description.
+
+## Steps
+
+### Build the repository
+
+Build all packages and binaries with:
+
+```sh
+make build
+```
+
+This runs `build-packages`, `build-binaries`, and `build-bicep`. The first run may take a few minutes because it downloads and builds dependencies; later builds reuse cached output. Binaries are written to `./dist/<GOOS>_<GOARCH>/release/`.
+
+To build a single binary instead of everything — useful when iterating on the CLI — use its `build-<name>` target. For example, to build only the `rad` CLI:
+
+```sh
+make build-rad
+```
+
+To build with debug symbols (`-gcflags "all=-N -l"`), set `DEBUG=1`:
+
+```sh
+DEBUG=1 make build-rad
+```
+
+### Build, test, lint, and check formatting
+
+This combined command builds the code, runs unit tests, runs the Go linters, and checks JSON/TS/JS/MJS formatting. Run it to verify your local changes before opening a pull request:
 
 ```sh
 make build test lint format-check
 ```
 
-You should also run `make format-write` if you have errors in the `format-check` command that you ran above or have added new or changed existing TS, JS, MJS, and/or JSON files.
+If `format-check` reports issues, or if you added or changed any `.ts`, `.js`, `.mjs`, or `.json` files, reformat them with:
 
 ```sh
 make format-write
 ```
 
-- See further information about tests [here](../contributing-code-tests/).
-- See further information about linking [here](../contributing-code-writing/).
+See the [tests guide](../contributing-code-tests/) for the full test matrix and the [writing code guide](../contributing-code-writing/) for linting details.
 
-## Building containers
+### Build the container images
 
-You can build containers for the Radius services using `make docker-build`, and push them with `make docker-push`.
+Build the control-plane service images with `make docker-build`, and push them with `make docker-push`. By default the registry is your OS username and the tag is `latest`; override them with environment variables:
 
-By default we will assume your Docker registry is your OS username, and assume you want to build the `latest` tag. You can override this with environment variables.
+- `DOCKER_REGISTRY` — destination registry.
+- `DOCKER_TAG_VERSION` — image tag.
 
-- `DOCKER_REGISTRY` - set destination registry
-- `DOCKER_TAG_VERSION` - set image tag
-
-These commands assume you are already logged-in to the registry you are using. If you get errors related to authentication, double-check that you are logged-in.
-
-Here's an example command that will build and push images to a specified registry:
+These commands assume you are already logged in to the target registry (`docker login`, `az acr login`, etc.). For example, to build and push to a specific registry:
 
 ```sh
 DOCKER_REGISTRY=ghcr.io/my-registry make docker-build docker-push
 ```
 
-If you work with Radius frequently, you may want to define a shell variable as part of your profile to set your registry.
+If you work with Radius frequently, set `DOCKER_REGISTRY` in your shell profile. The [radius-build-images](../../../../.github/skills/radius-build-images/SKILL.md) skill wraps this workflow, including single-image and multi-architecture builds.
 
-## Generating code
+### Generate code
 
-If you are updating API schemas, or updating Go APIs that have mocks, you will need to update the generated code as part of your commit. It is our policy that we **check in** generated code. This minimizes the number of people that have to install the generators and wait for them to run. We validate as part of our PR process that the generated files are up to date.
+When you change API schemas or Go APIs that have mocks, regenerate the checked-in generated code as part of your commit. Radius **checks in** generated code so that not every contributor has to install the generators. The PR process validates that the generated files are up to date.
 
-If you need to do this, first see the [prerequisites](../contributing-code-prerequisites/) for code generation.
-
-Once you have installed the prerequisites, run the following command and then **commit** the changes as part of your commit.
+After installing the [code-generation prerequisites](../contributing-code-prerequisites/README.md#code-generation), run:
 
 ```sh
 make generate
 ```
 
-This may take a few minutes as there are several steps.
+This runs several generators in sequence and may take a few minutes. **Commit** the resulting changes alongside your code change. For details on the TypeSpec → Swagger → Go pipeline, see the [schema changes guide](../contributing-code-schema-changes/README.md).
 
-If you encounter problems please [open an issue](https://github.com/radius-project/radius/issues/new/choose) so we can help. We're trying to make these instructions as streamlined as possible for contributors, your help in identifying problems with the tools and instructions is very much appreciated!
+## Verification
 
-## Troubleshooting and getting help
+- `make build` completes without errors and produces binaries under `./dist/<GOOS>_<GOARCH>/release/` (for example `rad`, `applications-rp`, `ucpd`, `dynamic-rp`, `controller`).
+- `make build test lint format-check` passes end to end.
+- After `make docker-build`, the images appear in `docker images`.
+- After `make generate`, `git status` shows only the generated changes you expect, and no generated files remain stale.
 
-You might encounter error messages while running various `make` commands due to missing dependencies. Review the [prerequisites](./../contributing-code-prerequisites/) page for installation instructions.
+## Troubleshooting
 
-If you get stuck working with the repository, please ask for help in our [forum](https://discordapp.com/channels/1113519723347456110/1115302284356767814). We're always interested in ways to improve the tooling, so please feel free to report problems and suggest improvements.
-
-If you need to report an issue with the Makefile, we may ask you for a dump of the variables. You can see the state of all of the variables our Makefile defines with `make dump`. The output will be quite large so you might want to redirect this to a file.
+- **A `make` command fails on a missing dependency.** Review the [prerequisites guide](../contributing-code-prerequisites/README.md) and install the missing tool.
+- **Docker push fails with an authentication error.** Confirm you are logged in to the registry named in `DOCKER_REGISTRY`.
+- **You need to report a build problem.** Dump every Makefile variable with `make dump` (the output is large, so redirect it to a file) and include it in your report.
+- **Still stuck.** Ask in the [Radius Discord forum](https://discordapp.com/channels/1113519723347456110/1115302284356767814), or [open an issue](https://github.com/radius-project/radius/issues/new/choose) so we can improve the tooling and these instructions.

--- a/docs/contributing/contributing-code/contributing-code-cli/README.md
+++ b/docs/contributing/contributing-code/contributing-code-cli/README.md
@@ -1,108 +1,95 @@
-# Build the Radius CLI
+# Develop the Radius CLI
 
-For a lot of your development tasks you will need to build `rad` from source instead of using a binary.
+## Purpose
 
-This is the best way to test changes, and to make sure you have the latest bits (other people's changes).
+This is the authoritative guide for developing the Radius CLI (`rad`). It covers running `rad` from source, installing a local build, debugging it in VS Code, and the error-handling conventions for CLI code. The CLI entry point is [cmd/rad/main.go](../../../../cmd/rad/main.go); commands live under [cmd/rad/cmd/](../../../../cmd/rad/cmd/) and their implementations under [pkg/cli/](../../../../pkg/cli/). For most CLI work you build `rad` from source instead of using a released binary, so you can test your changes and pick up other contributors' changes. The [first-commit CLI steps](../contributing-code-first-commit/first-commit-03-working-on-cli/index.md) link here for the canonical workflow.
 
-## Making code changes to the CLI
+## Prerequisites
 
-If you're working on the CLI then you will need to test out your changes. This section describes ways you might want to use a custom build of the CLI.
+- The repository cloned locally and a working build. See [Building the code](../contributing-code-building/README.md).
+- Go installed (the version pinned in [go.mod](../../../../go.mod)).
+- For debugging: [VS Code](https://code.visualstudio.com/) with the Go extension. The repo ships launch configurations in [.vscode/launch.json](../../../../.vscode/launch.json).
 
-## Debugging in VS Code
+## Steps
 
-We provide a debug target `Launch rad CLI` as part of our repo's VS Code configuration. Select `Launch rad CLI` from the drop-down press the Debug button to launch.
+### Run rad from source
 
-If you need to pass command line arguments into the CLI for testing then you can do this by editing `./vscode/launch.json`. Find the `Launch rad CLI` target and edit the `args` property.
+The fastest way to test a CLI change is `go run`, which builds and runs in one step:
 
-> ⚠️ VS Code debugging does not support interactive user-input. If you need to debug a command that prompts for confirmation, you can bypass it by passing `--yes` at the command line. This tip does not apply to `rad init` which is always interactive.
+```sh
+go run ./cmd/rad/main.go
+```
 
-## Installing a local build
+Pass arguments after the path, for example `go run ./cmd/rad/main.go env list`. This must be run from inside the repository so Go can resolve modules.
 
-You can use the Makefile to install a local build of Radius. By default this will install to `/usr/local/bin/rad`. You may also need to specify `sudo` depending on the destination and its permissions.
+If you prefer a built binary, run `make build-rad` (see [Building the code](../contributing-code-building/README.md)) and run the binary it writes to `./dist/<GOOS>_<GOARCH>/release/rad`.
+
+### Create a wrapper script (optional)
+
+If you frequently run a local build of `rad`, wrap `go run` in a script so it behaves like the real command. Create a file named `dev-rad` on your `PATH`:
+
+```sh
+#!/bin/sh
+set -eu
+go run /path/to/radius/cmd/rad/main.go "$@"
+```
+
+Replace `/path/to/radius` with your repository root, then `chmod +x dev-rad`. Because it uses `go run`, the wrapper only works when your shell's working directory is inside the repository.
+
+### Install a local build
+
+Use the Makefile to install a local build. By default it installs to `/usr/local/bin/rad`, which may require `sudo` depending on the destination's permissions:
 
 ```sh
 sudo make install
 ```
 
-If you need to install to a different location, you can override via the `RAD_LOCATION` environment variable. Make sure the path you choose ends includes `rad` as the filename and is on your `PATH` so it can be executed easily.
+Override the destination with `RAD_LOCATION`. The path must end in `rad` and should be on your `PATH`:
 
 ```sh
 RAD_LOCATION=/my/custom/location/rad sudo make install
 ```
 
-## Creating a wrapper script
+### Debug rad in VS Code
 
-If you frequently need to work with a local build of `rad` you can create a script that will wrap `go run`.
+The repo's [.vscode/launch.json](../../../../.vscode/launch.json) defines the **"Debug rad CLI (prompt for args)"** configuration, which launches [cmd/rad/main.go](../../../../cmd/rad/main.go) and prompts you for the command-line arguments to run.
 
-> ⚠️ This tip only works when your current working directory is inside the repository. If your shell is outside the repository, then Go won't know how to resolve modules and the build will fail.
+1. Set a breakpoint — click the gutter to the left of the line numbers. For example, break at the start of the `Run` method in [pkg/cli/cmd/version/version.go](../../../../pkg/cli/cmd/version/version.go) to debug `rad version`.
+2. Open the **Run and Debug** pane and select **"Debug rad CLI (prompt for args)"** from the drop-down.
+3. Click the green triangle to start. The project builds first (this can take a moment).
+4. When prompted, enter the arguments to debug (for example `version`, or `env list`) and confirm. Execution stops at your breakpoint.
 
-Create the following script and place it on your path with a name like `dev-rad`.
+> ⚠️ VS Code debugging does not support interactive user input. To debug a command that prompts for confirmation, pass `--yes` in the arguments to bypass the prompt. This does not apply to `rad init`, which is always interactive.
+>
+> 📝 On **macOS**, the first debug session with a new Go version may take 1–2 minutes and prompt for your password — this is expected.
 
-```sh
-#!/bin/sh
-set -eu
-go run ~/github.com/radius-project/radius/cmd/rad/main.go $@
-```
+### Write code for the CLI
 
-Replace `~/github.com/radius-project/radius` with the path to your repository root.
+Classify errors as *expected* or *unexpected*:
 
-Run `chmod +x dev-rad` to mark it executable
-
-Now use it as-if it were `rad`
-
-```txt
-➜ dev-rad env
-Radius CLI
-
-Usage:
-  rad [command]
-
-Available Commands:
-  deploy      Deploy a Radius Application
-  env         Manage environments
-  expose      Expose local port
-  help        Help about any command
-
-Flags:
-      --config string   config file (default is $HOME/.rad/config.yaml)
-  -h, --help            help for rad
-
-Use "rad [command] --help" for more information about a command.
-```
-
-### Using your $PATH variable to resolve the debug version of `rad` before the release version (MacOS/Linux)
-
-You can update your `$PATH` environment variable to resolve to a custom build of `rad` by updating your shell profile. For ZSH users this is your `~/.zshrc` file:
-
-```bash
-# add debug rad bits to $PATH resolution
-export PATH="$(pwd)/dist/linux_amd64/release:$PATH"
-```
-
-Make sure to set the appropriate path based on your OS and CPU type.
-
-## Writing code for the CLI
-
-### Error handling in the CLI
-
-In the `rad` CLI we try to classify errors into *expected* and *unexpected* errors. 
-
-- Expected: a known state we expect to encounter, that is not a bug in Radius. eg: application is not found.
-- Unexpected: an unknown state that could be a bug in Radius. eg: a partial HTTP response was sent by the server.
-
-*Expected* errors should be returned to the user as a normal error message. For these cases use the `clierrors.Message` and `clierrors.MessageWithCause` functions to create and return an error. When creating error messages for *expected* errors, write in complete sentences and end with a period. eg: `"The application could not be found."`
-
-We want *unexpected* errors to be shown to the user with full troubleshooting information. For these cases, return the error as-is. If it makes sense for the scenario it's useful to wrap the error with additional context as shown in the example below.
-
-**Example:**
+- **Expected** — a known state that is not a bug, such as "application not found". Return these as plain user-facing messages using `clierrors.Message` or `clierrors.MessageWithCause`. Write complete sentences ending with a period, for example `"The application could not be found."`.
+- **Unexpected** — an unknown state that could be a Radius bug, such as a partial HTTP response. Return these as-is so the user sees full troubleshooting information, optionally wrapping them with context.
 
 ```go
-// Good: classify expected errors and return them as basic user-facing messages.
+// Classify expected errors and return them as basic user-facing messages.
 result, err := findApplication(id)
 if errors.Is(err, NotFoundError{}) {
-   return clierrors.Message("The application %q could not be found.", applicationName)
+    return clierrors.Message("The application %q could not be found.", applicationName)
 } else if err != nil {
-  // optional: wrapping the error to add context.
-  return fmt.Errorf("error retrieving application: %w", err)
+    // optional: wrap the error to add context.
+    return fmt.Errorf("error retrieving application: %w", err)
 }
 ```
+
+## Verification
+
+- `go run ./cmd/rad/main.go version` prints version information that includes your local changes.
+- After `sudo make install`, running `rad version` from any directory resolves to your freshly installed build.
+- A breakpoint set in `cmd/rad/` is hit when you run **"Debug rad CLI (prompt for args)"**.
+
+## Troubleshooting
+
+- **`go run` fails to resolve modules.** Run it from inside the repository; Go needs the module context.
+- **The debugger never stops at your breakpoint.** Confirm you selected **"Debug rad CLI (prompt for args)"** and that the breakpoint is on an executable line in code the command actually reaches.
+- **A debugged command hangs waiting for input.** Add `--yes` to the prompted arguments (except for `rad init`).
+- **`make install` is denied.** The destination needs elevated permissions; prefix with `sudo` or point `RAD_LOCATION` at a writable directory on your `PATH`.

--- a/docs/contributing/contributing-code/contributing-code-control-plane/generating-and-installing-custom-build.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/generating-and-installing-custom-build.md
@@ -22,7 +22,7 @@ Note that installing a custom build could corrupt existing data or installation.
 
 2. Log into your container registry and make sure you have permission to push images.
 
-3. [Build Radius containers](../../contributing-code/contributing-code-building/README.md#building-containers) and push them to your registry.
+3. [Build Radius containers](../../contributing-code/contributing-code-building/README.md#build-the-container-images) and push them to your registry.
 
    ```console
    make docker-build docker-push

--- a/docs/contributing/contributing-code/contributing-code-first-commit/first-commit-02-building/index.md
+++ b/docs/contributing/contributing-code/contributing-code-first-commit/first-commit-02-building/index.md
@@ -1,67 +1,33 @@
 # Your first commit: Building
 
+This step of the walkthrough gets you a working build. For the full build reference — every `make` target, container builds, and code generation — see the authoritative [Building the code](../../contributing-code-building/README.md) guide.
+
 ## Fork the repository
 
-If you have not already done so, make a fork of the repository and clone it to your local machine. You can find the instructions [here](../../contributing-code-forks/index.md).
+If you have not already done so, [make a fork of the repository](../../contributing-code-forks/index.md) and clone it to your local machine.
 
-## Building the code
+## Build the code
 
-You can build the main outputs using `make`:
+From the root of the repository, build the main outputs with:
 
 ```sh
 make build
 ```
 
-You should see output similar to the following:
+The first build downloads and compiles dependencies, so it may take a few minutes; later builds are faster. When it finishes, the `rad` CLI binary is written under `./dist/<GOOS>_<GOARCH>/release/rad` (the exact path is printed in the build output, and depends on your OS and architecture).
 
-```txt
-➜ make build
-=> Building CLI from 'cmd/rad/main.go'
-=> Built CLI in './dist/darwin_amd64/release/rad'
-CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 \
-	go build \
-	-gcflags "" \
-	-ldflags "-s -w -X main.version=edge" \
-	-o ./dist/darwin_amd64/release/rad \
-	./cmd/rad/main.go;
-```
-
-Our makefile also has a built-in help command. Run `make` or `make help` to see the list of targets.
+Run `make` (or `make help`) at any time to see every target and its description.
 
 ## Test it out
 
-You should be able to run the binary that was just produced for the CLI. Copy the path from the previous output and run it at the command line.
+Run the binary that was just built — copy the path from the build output:
 
 ```sh
 ./dist/darwin_amd64/release/rad
 ```
 
-You should see the basic help text of the CLI. At the time of this writing it looks like:
+You should see the `rad` CLI help text listing its top-level commands. If you got this far, your build works.
 
-```txt
-Radius CLI
+## Next step
 
-Usage:
-  rad [command]
-
-Available Commands:
-  application Manage applications
-  bicep       Manage bicep compiler
-  component   Manage components
-  deploy      Deploy a Radius Application
-  deployment  Manage deployments
-  env         Manage environments
-  expose      Expose local port
-  help        Help about any command
-
-Flags:
-      --config string   config file (default is $HOME/.rad/config.yaml)
-  -h, --help            help for rad
-
-Use "rad [command] --help" for more information about a command.
-```
-
-If you got this far then you're able to build, and you should move to the next step.
-
-## Next step:
 - [Work on the CLI](../first-commit-03-working-on-cli/index.md)

--- a/docs/contributing/contributing-code/contributing-code-first-commit/first-commit-02-building/index.md
+++ b/docs/contributing/contributing-code/contributing-code-first-commit/first-commit-02-building/index.md
@@ -20,10 +20,10 @@ Run `make` (or `make help`) at any time to see every target and its description.
 
 ## Test it out
 
-Run the binary that was just built — copy the path from the build output:
+Run the binary that was just built — copy the path printed in the build output (it depends on your OS and architecture):
 
 ```sh
-./dist/darwin_amd64/release/rad
+./dist/<GOOS>_<GOARCH>/release/rad
 ```
 
 You should see the `rad` CLI help text listing its top-level commands. If you got this far, your build works.

--- a/docs/contributing/contributing-code/contributing-code-first-commit/first-commit-03-working-on-cli/index.md
+++ b/docs/contributing/contributing-code/contributing-code-first-commit/first-commit-03-working-on-cli/index.md
@@ -1,81 +1,45 @@
 # Your first commit: Working on the CLI
 
-## Making a change to the CLI
+This step walks you through a small change to the `rad` CLI so you learn how to test CLI changes locally. For the full CLI development reference — running from source, installing a local build, debugging, and CLI error-handling conventions — see the authoritative [Develop the Radius CLI](../../contributing-code-cli/README.md) guide.
 
-This step will walk you through making a cosmetic change to the `rad` CLI. This will ensure that you know some options for testing changes locally with the CLI.
+## Open the code
 
-### Opening the code
+Make sure you've cloned the repo and can open it in your editor. If you're using VS Code, run `code .` from the repository root.
 
-First, make sure you've clone the repo to your computer and can open it in your editor of choice.
+Open `cmd/rad/main.go` — the entry point of the `rad` CLI.
 
-If you're using VS Code, enter `code .` at the command line from the root directory of the repository will open everything you need.
-
-Open the file `cmd/rad/main.go`. This is the entry point of the `rad` CLI.
-
-> **VSCode tip** <br>
-Using VS Code you can hit `Command+P` (or `Ctrl+P`) and get a search bar for files that does fuzzy searching. For instance typing `main` would let you pick the file from a short list. With practice this can make navigation very fast.
+> **VS Code tip:** Press `Command+P` (or `Ctrl+P`) to fuzzy-search for files. Typing `main` lets you pick the file from a short list.
 
 You should see code like the following:
 
-<img width="600px" src="main-before-change.png" alt="editing main.go">
+![editing main.go](main-before-change.png)
 
-### Making an edit
+## Make an edit
 
-You can edit this code to show everyone that you were here. Place your cursor inside the `main()` function, and add the following on a blank line before `cmd.Execute()`
+Place your cursor inside the `main()` function and add the following on a blank line before `cmd.Execute()`:
 
 ```go
 fmt.Println("<yourname> was here")
 ```
 
-Replace `<yourname>` with your name.
+Replace `<yourname>` with your name, then save. VS Code auto-adds the `fmt` import for you, so it should look like:
 
-Save the file.
+![editing main.go after change](main-after-change.png)
 
-If you're using VS Code it will auto-add the import for `fmt` for you. Now it should look something like the following:
+## Run the CLI
 
-<img width="600px" src="main-after-change.png" alt="editing main.go">
-
-### Running the CLI
-
-You could repeat the commands from the previous step (`make` followed by `./dist/darwin_amd64/release/rad`) to test your changes.
-
-However, there is a faster way that you should learn. You can use `go run` to build and run in one step.
+You could rebuild with `make` and run the binary, but `go run` builds and runs in one step:
 
 ```sh
-go run cmd/rad/main.go
+go run ./cmd/rad/main.go
 ```
 
-You should see the basic help text of the CLI with your changes.
-
- At the time of this writing it looks like:
-
-```txt
-someone new was here
-Radius CLI
-
-Usage:
-  rad [command]
-
-Available Commands:
-  application Manage applications
-  bicep       Manage bicep compiler
-  component   Manage components
-  deploy      Deploy a Radius Application
-  deployment  Manage deployments
-  env         Manage environments
-  expose      Expose local port
-  help        Help about any command
-
-Flags:
-      --config string   config file (default is $HOME/.rad/config.yaml)
-  -h, --help            help for rad
-
-Use "rad [command] --help" for more information about a command.
-```
+You should see your message printed above the `rad` CLI help text.
 
 ## Next step
+
 - [Debug the CLI](../first-commit-04-debugging-cli/index.md)
 
-## Related Links
+## Related links
 
-- [Running the CLI from source](../../contributing-code-cli/running-rad-cli.md)
+- [Develop the Radius CLI](../../contributing-code-cli/README.md) — running, installing, and debugging `rad`.

--- a/docs/contributing/contributing-code/contributing-code-first-commit/first-commit-04-debugging-cli/index.md
+++ b/docs/contributing/contributing-code/contributing-code-first-commit/first-commit-04-debugging-cli/index.md
@@ -1,74 +1,34 @@
 # Your first commit: Debugging the CLI
 
-## Debugging your changes
+This step shows you how to debug the `rad` CLI in VS Code using the change you made in the previous step. For the full debugging reference, see the **Debug rad in VS Code** section of the authoritative [Develop the Radius CLI](../../contributing-code-cli/README.md#debug-rad-in-vs-code) guide. If you use another editor, you can skip this step.
 
-The following sections describe the debugging in Visual Studio Code (VS Code). If you are using another editor you can skip the following sections.
+> 📝 **Tip:** The first time you debug on **macOS** with a given version of Go, you'll be prompted for your password, and the prompt can take 1–2 minutes to appear. This is expected.
 
->📝 **Tip** The first time you debug on **macOS** with a given version of Go you will be prompted to enter your password. It is normal for this to take 1-2 minutes for the prompt to appear the first time.
+## Debug rad with the predefined configuration
 
-## Predefined debug configurations
+The repository's `.vscode/launch.json` provides the **"Debug rad CLI (prompt for args)"** configuration, which launches `cmd/rad/main.go` and asks you which command-line arguments to run.
 
-You can debug your changes right from VS Code. The repository has a `.vscode` directory which contains several launch configurations containing debugging configurations. We describe the configurations in the following sections.
+1. Set a breakpoint on the line you added in `main.go` — click in the *gutter* to the left of the line numbers.
 
-### Debugging rad CLI
+   ![Placing a breakpoint in main.go](img/main-with-breakpoint.png)
 
-This section describes the configuration named **"Debug rad CLI"**. This is a basic Go debugger configuration that is set up to launch the `rad` CLI. To try it out, set a breakpoint in `main.go`. Set the breakpoint by clicking in the *gutter* to the left of the line numbers in you editor. Place the breakpoint on the new line you added in `main.go`.
+2. Open the debug pane and select **"Debug rad CLI (prompt for args)"** from the drop-down.
 
-<img src="img/main-with-breakpoint.png" alt="Placing a breakpoint in main.go" width="600" height="auto">
+   ![Selecting the debug configuration](img/vscode-debug-config-selection-with-args.png)
 
-The debugger will stop the program prior to crossing over your breakpoint. Execute the following steps to launch the CLI in the debugger:
+3. Click the green triangle to start. The project builds first, which may take a moment.
 
-- Open the debug pane.
+   ![Starting the debug configuration](img/vscode-debug-start-version-with-args.png)
 
-  <img src="img/vscode-debug-pane.png" alt="VS Code debug pane" width="600" height="auto">
+4. When prompted, enter the arguments to run (for example `version`) and confirm.
 
-- Select the **"Debug rad CLI"** entry from the drop down list.
+   ![Entering the rad command to debug](img/vscode-debug-prompt-cmd.png)
 
-  <img src="img/vscode-debug-config-selection.png" alt="VS Code debug configuration selection" width="600" height="auto">
+Execution stops at your breakpoint, where you can step through the code:
 
-- Click the icon with the green triangle to launch the debugging session.
+![Hitting a breakpoint in main.go](img/main-breakpoint-hit.png)
 
-  <img src="img/vscode-debug-start.png" alt="VS Code start selected debug configuration" width="600" height="auto">
-
-Before the debugging will start the project is build in the background. This might take some time. After the build is completed the program will start and the breakpoint should be hit.
-
-<img src="img/main-breakpoint-hit.png" alt="Hitting a breakpoint in main.go" width="600" height="auto">
-
-You can play around with the various debugger features, like stepping into code. When you're done, hit the red square *stop* icon in the debugger tools to end the debugging session.
-
-> 📝 **Tip** - You can create definitions for any set of debug settings you want to keep handy.
-
-### Debug rad CLI - prompt for args
-
-This section describes the configuration named **"Debug rad CLI (prompt for args)"**. In contrast to the previous generic one this one uses the specific `rad CLI` commands to kick of the debugger.  
-
-Let us test this setup by checking debugging the `rad version` command. The file is located at `cmd/rad/cmd/version.go`. Set a breakpoint at the beginning of the function `writeVersionString`:
-
-<img src="img/version-with-breakpoint.png" alt="Placing a breakpoint in version.go" width="600" height="auto">
-
-The debugger will stop the program prior to crossing over your breakpoint. Execute the following steps to launch the CLI command in the debugger:
-
-- Open the debug pane.
-
-  <img src="img/vscode-debug-pane.png" alt="VS Code debug pane" width="600" height="auto">
-
-- Select the **"Debug rad CLI (prompt for args)"** entry from the drop down list.
-
-  <img src="img/vscode-debug-config-selection-with-args.png" alt="VS Code debug configuration selection with arguments" width="600" height="auto">
-
-- Click the icon with the green triangle to launch the debugging session.
-
-  <img src="img/vscode-debug-start-version-with-args.png" alt="VS Code start selected debug configuration with arguments" width="600" height="auto">
-
-- The system will open up the command palette. Enter the command you want to debug i.e. `version` and confirm.  
-
-  <img src="img/vscode-debug-prompt-cmd.png" alt="VS Code debug command prompt" width="600" height="auto">
-
-Before the debugging will start the project is build in the background. This might take some time. After the build is completed the program will start and the breakpoint should be hit.
-
-<img src="img/version-breakpoint-hit.png" alt="Hitting a breakpoint in version.go" width="600" height="auto">
-
-You can play around with the various debugger features, like stepping into code. When you're done, hit the red square *stop* icon in the debugger tools to end the debugging session.
+When you're done, hit the red square *stop* icon to end the session.
 
 ## Next step
 


### PR DESCRIPTION
## Summary

This is **PR 3 (Building + CLI)** of the [Agent Ex — Phase 3 (Contributing docs) plan](https://github.com/radius-project/radius/blob/brooke-hamilton/agentex-phase3/specs/002-agent-ex/agent-ex-phase-3-plan.md) — see the **PR 3** task under §6 of that plan. The goal is to make the "build the code" and "develop the CLI" guides the one place each topic is documented, and to stop the step-by-step tutorial from repeating (and drifting from) that content.

## Merge target

⚠️ This PR targets the `brooke-hamilton/agentex-phase3` **plan branch, not `main`**. It is one of seven stacked PRs for this phase; approving and merging it lands the change on the plan branch only — **it does not merge anything to `main`**. The whole phase rolls up to `main` in a single follow-up PR after all of this phase's PRs land.

## Files changed

All six files are edits — nothing is added or deleted.

- **`docs/contributing/contributing-code/contributing-code-building/README.md`** — rewritten into the repo's standard doc format (Purpose → Prerequisites → Steps → Verification → Troubleshooting) and made the authoritative build guide. Every `make` command in it was checked against the Makefiles in `build/`.
- **`docs/contributing/contributing-code/contributing-code-cli/README.md`** — rewritten into the same standard format and made the authoritative CLI-development guide, now including the VS Code debugging walkthrough.
- **`docs/contributing/contributing-code/contributing-code-first-commit/first-commit-02-building/index.md`** — shortened so it walks a newcomer through one build, then links to the building guide instead of repeating it. Also removed an out-of-date CLI help-text sample.
- **`docs/contributing/contributing-code/contributing-code-first-commit/first-commit-03-working-on-cli/index.md`** — shortened to link to the CLI guide, and fixed a broken link that pointed at a page (`running-rad-cli.md`) that does not exist.
- **`docs/contributing/contributing-code/contributing-code-first-commit/first-commit-04-debugging-cli/index.md`** — shortened to link to the CLI guide's debugging section. Updated it to match the one VS Code debug configuration that actually exists today.
- **`docs/contributing/contributing-code/contributing-code-control-plane/generating-and-installing-custom-build.md`** — one-line link fix: updated a link anchor that pointed at a heading I renamed in the building guide.

## Other things worth knowing for review

- The broken `running-rad-cli.md` link now points to `contributing-code-cli/README.md`, which already contains that content — so no new page was needed.
- I corrected a couple of stale code references found while verifying: the only rad debug config in `.vscode/launch.json` is "Debug rad CLI (prompt for args)" (the docs named configs that no longer exist), and the version command lives at `pkg/cli/cmd/version/version.go`.
- The first-commit screenshots are unchanged; I only converted their `<img>` tags to Markdown image syntax so the docs pass the Markdown linter.
- I did not touch any of the planning documents for this work.