### PR TITLE
feat(tests): enable fast cleanup for functional tests to improve teardown efficiency

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -994,6 +994,12 @@ jobs:
           BICEP_RECIPE_TAG_VERSION: ${{ env.BICEP_RECIPE_TAG_VERSION }}
           GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
           GOTESTSUM_OPTS: --junitfile ./dist/functional_test/results.xml
+          # Initiate resource deletion without blocking on completion (matches the
+          # non-cloud suite). Test assertions for deploy/create still run in full;
+          # only the synchronous teardown wait is skipped, and the per-run resource
+          # group is force-deleted afterward. This removes the slow Test_ACI teardown
+          # (~9 min) from the critical path without reducing validation scope.
+          RADIUS_TEST_FAST_CLEANUP: true
           MATRIX_NAME: ${{ matrix.name }}
           FUNCTEST_PREPROVISIONED_RESOURCE_JSON: ${{ secrets.FUNCTEST_PREPROVISIONED_RESOURCE_JSON }}
 


### PR DESCRIPTION
# Description

## Problem

The `Functional Tests (with Cloud Resources)` workflow is very time-consuming, and the cost is concentrated almost entirely in one place.

Measuring a representative run, the critical path is `build (5.5 min) → corerp-cloud (27.2 min)`, while the `ucp-cloud` leg (8.3 min) runs in parallel and is not the bottleneck.

Within the `corerp-cloud` leg, the `Run functional tests` step takes ~22 min and is bounded by a **single test**. From the JUnit results, `Test_ACI` runs for ~20 min (`time=1208s`), while every other test is ≤2 min and already finishes in parallel inside ACI's window. `Test_ACI` breaks down as **~11 min of deployment + ~9 min of synchronous resource teardown** at the end of the test.

Because one monolithic test dominates the wall-clock, sharding or raising `-parallel` cannot help (you cannot beat the slowest single test), and adding concurrency would also worsen the shared Azure ACI `StandardCores` quota contention.

## Solution

The test framework already supports a non-blocking cleanup mode (`RADIUS_TEST_FAST_CLEANUP=true`) that initiates resource deletion without blocking the test while it waits for teardown to complete. The non-cloud functional test workflow already enables it; the cloud workflow did not. This change enables it for the cloud suite as well by setting `RADIUS_TEST_FAST_CLEANUP: true` on the `Run functional tests` step in `.github/workflows/functional-test-cloud.yaml`.

This removes the ~9 min synchronous `Test_ACI` teardown from the critical path, cutting the `corerp-cloud` leg from ~27 min to ~18 min (~33% faster) with no added Azure concurrency.

## Why test scope is preserved

All deploy/create assertions still run in full (`ValidateRPResources`, `ValidateObjectsRunning`, and the ACI `PostStepVerify` resource-location checks). Only the synchronous wait for teardown is skipped — deletion is still initiated, and the per-run Azure resource group is force-deleted afterward (`az group delete`) as the backstop. This matches the established behavior of the non-cloud suite.

Related: #12044 (slow ACI gateway/app delete — the underlying product issue this works around in CI).

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
