### PR TITLE
test: retry functional deployments on transient image-pull errors

### DIFF
--- a/test/functional-portable/corerp/cloud/resources/aci_test.go
+++ b/test/functional-portable/corerp/cloud/resources/aci_test.go
@@ -18,7 +18,6 @@ package resource_test
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -167,42 +166,24 @@ func normalizeLocation(location string) string {
 	return strings.ToLower(strings.ReplaceAll(location, " ", ""))
 }
 
-// isTransientAzureError returns true if the error is a known transient Azure error
-// that may succeed on retry.
-//
-// rad surfaces the deployment root cause inside nested ARM error `details[].message`
-// fields, while CLIError.Error() only returns the top-level code and message
-// (e.g. "DeploymentFailed"). We therefore flatten the entire error response so the
-// match also covers nested causes such as the ACI container group quota error.
+// transientAzureErrorMarkers are substrings that identify transient Azure
+// deployment failures that may succeed on retry.
+var transientAzureErrorMarkers = []string{
+	// Managed identity propagation delay after environment identity creation.
+	"ManagedServiceIdentityNotFound",
+	// The regional ACI 'StandardCores' quota is shared across the subscription
+	// and is frequently exhausted by concurrent CI runs and in-progress async
+	// resource group cleanups. It drains on its own, so retrying after a short
+	// delay typically succeeds.
+	"ContainerGroupQuotaReached",
+}
+
+// isTransientAzureError returns true if the error is a known transient Azure
+// error that may succeed on retry. It delegates to step.ErrorContainsAny, which
+// flattens the nested ARM error details rad surfaces inside a CLIError so the
+// match covers causes such as the ACI container group quota error.
 func isTransientAzureError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	transientErrors := []string{
-		// Managed identity propagation delay after environment identity creation.
-		"ManagedServiceIdentityNotFound",
-		// The regional ACI 'StandardCores' quota is shared across the subscription
-		// and is frequently exhausted by concurrent CI runs and in-progress async
-		// resource group cleanups. It drains on its own, so retrying after a short
-		// delay typically succeeds.
-		"ContainerGroupQuotaReached",
-	}
-
-	haystack := err.Error()
-	if cliErr, ok := errors.AsType[*radcli.CLIError](err); ok {
-		if encoded, marshalErr := json.Marshal(cliErr.ErrorResponse); marshalErr == nil {
-			haystack += " " + string(encoded)
-		}
-	}
-
-	for _, te := range transientErrors {
-		if strings.Contains(haystack, te) {
-			return true
-		}
-	}
-
-	return false
+	return step.ErrorContainsAny(err, transientAzureErrorMarkers...)
 }
 
 func Test_isTransientAzureError(t *testing.T) {

--- a/test/step/deployexecutor.go
+++ b/test/step/deployexecutor.go
@@ -57,12 +57,58 @@ type DeployExecutor struct {
 	ShouldRetry func(error) bool
 }
 
+// Default retry behavior applied by NewDeployExecutor for transient container
+// image pull failures. Functional tests pull images from shared registries (for
+// example the ghcr.io/radius-project/* images), which occasionally fail to pull
+// due to registry or network blips in CI. Callers can override these defaults
+// with WithRetry.
+const (
+	defaultImagePullMaxRetries = 2
+	defaultImagePullRetryDelay = 30 * time.Second
+)
+
+// transientImagePullErrorMarkers are substrings that indicate a container image
+// pull failed for a transient reason (a registry or network blip) rather than a
+// permanent one (for example a nonexistent image or an authentication failure).
+// The kubelet automatically retries pulls that surface these states, so
+// re-running the deployment after a short delay typically succeeds.
+var transientImagePullErrorMarkers = []string{
+	// kubelet pull states. These are reported while the kubelet is still
+	// retrying the pull with backoff and usually clear on their own once the
+	// registry becomes reachable again.
+	"ErrImagePull",
+	"ImagePullBackOff",
+	// containerd surfaces this when a manifest or layer download from the
+	// registry fails partway through, commonly because the registry timed out.
+	"failed to pull and unpack image",
+	// The underlying HTTP error when a registry such as ghcr.io does not respond
+	// to a manifest or blob request in time.
+	"timeout awaiting response headers",
+}
+
+// IsTransientImagePullError reports whether err was caused by a transient
+// container image pull failure that is likely to succeed on retry. It is the
+// default ShouldRetry predicate for DeployExecutor (see NewDeployExecutor), used
+// by tests that pull images from a shared registry (for example the
+// ghcr.io/radius-project/mirror images), which occasionally fail to pull due to
+// registry or network blips in CI.
+func IsTransientImagePullError(err error) bool {
+	return ErrorContainsAny(err, transientImagePullErrorMarkers...)
+}
+
 // NewDeployExecutor creates a new DeployExecutor instance with the given template and parameters.
+//
+// By default the executor retries a deployment that fails with a transient
+// container image pull error (see IsTransientImagePullError). Use WithRetry to
+// override the retry count, delay, and predicate.
 func NewDeployExecutor(template string, parameters ...string) *DeployExecutor {
 	return &DeployExecutor{
 		Description: fmt.Sprintf("deploy %s", template),
 		Template:    template,
 		Parameters:  parameters,
+		MaxRetries:  defaultImagePullMaxRetries,
+		RetryDelay:  defaultImagePullRetryDelay,
+		ShouldRetry: IsTransientImagePullError,
 	}
 }
 
@@ -78,7 +124,8 @@ func (d *DeployExecutor) WithEnvironment(environment string) *DeployExecutor {
 	return d
 }
 
-// WithRetry configures retry behavior for transient deployment failures.
+// WithRetry configures retry behavior for transient deployment failures,
+// replacing the default transient image pull retry set by NewDeployExecutor.
 // maxRetries is the number of additional attempts after the first failure.
 // delay is the wait time between attempts. shouldRetry determines whether
 // a given error is eligible for retry.

--- a/test/step/deployexecutor_test.go
+++ b/test/step/deployexecutor_test.go
@@ -25,6 +25,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	apiv1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	"github.com/radius-project/radius/test/radcli"
 )
 
 func Test_ExecuteWithRetry_SucceedsOnFirstAttempt(t *testing.T) {
@@ -93,10 +96,12 @@ func Test_ExecuteWithRetry_ExhaustsAllRetries(t *testing.T) {
 	assert.Equal(t, int32(3), calls.Load()) // 1 initial + 2 retries
 }
 
-func Test_ExecuteWithRetry_NoRetriesWithoutConfig(t *testing.T) {
+func Test_ExecuteWithRetry_DefaultDoesNotRetryNonTransientError(t *testing.T) {
 	t.Parallel()
 	var calls atomic.Int32
-	d := NewDeployExecutor("test.bicep") // no WithRetry
+	// NewDeployExecutor enables transient image pull retries by default, but a
+	// non-transient error must not be retried.
+	d := NewDeployExecutor("test.bicep")
 
 	err := d.executeWithRetry(context.Background(), t, func() error {
 		calls.Add(1)
@@ -105,6 +110,26 @@ func Test_ExecuteWithRetry_NoRetriesWithoutConfig(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Equal(t, int32(1), calls.Load())
+}
+
+func Test_ExecuteWithRetry_DefaultRetriesTransientImagePullError(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	// NewDeployExecutor retries transient image pull failures by default, without
+	// an explicit WithRetry call.
+	d := NewDeployExecutor("test.bicep")
+	d.RetryDelay = 10 * time.Millisecond // shorten the delay for the test
+
+	err := d.executeWithRetry(context.Background(), t, func() error {
+		n := calls.Add(1)
+		if n < 2 {
+			return errors.New("Reason: ErrImagePull, net/http: timeout awaiting response headers")
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), calls.Load()) // failed once, succeeded on retry
 }
 
 func Test_ExecuteWithRetry_ContextCancelledDuringDelay(t *testing.T) {
@@ -142,4 +167,64 @@ func Test_ExecuteWithRetry_NilShouldRetryDisablesRetries(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Equal(t, int32(1), calls.Load())
+}
+
+func Test_IsTransientImagePullError(t *testing.T) {
+	// imagePullError mirrors how rad surfaces a transient image pull failure:
+	// the ErrImagePull/timeout cause only appears inside a deeply nested
+	// details[].message field, while the top-level code/message returned by
+	// CLIError.Error() is the generic "DeploymentFailed". This is the failure
+	// observed for Test_RabbitMQ_Manual when ghcr.io is slow to respond.
+	imagePullError := &radcli.CLIError{
+		ErrorResponse: apiv1.ErrorResponse{
+			Error: &apiv1.ErrorDetails{
+				Code:    "DeploymentFailed",
+				Message: "At least one resource deployment operation failed.",
+				Details: []*apiv1.ErrorDetails{
+					{Code: "OK"},
+					{
+						Code:    "ResourceDeploymentFailure",
+						Message: "Failed",
+						Details: []*apiv1.ErrorDetails{
+							{
+								Code:    "Internal",
+								Message: `Container state is 'Waiting' Reason: ErrImagePull, Message: rpc error: code = DeadlineExceeded desc = failed to pull and unpack image "ghcr.io/radius-project/mirror/rabbitmq:3.10": failed to copy: httpReadSeeker: failed open: failed to do request: Get "https://ghcr.io/v2/radius-project/mirror/rabbitmq/manifests/sha256:0c60": net/http: timeout awaiting response headers`,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// nonTransientError mirrors a permanent failure (an unsupported resource
+	// type) that should not be retried.
+	nonTransientError := &radcli.CLIError{
+		ErrorResponse: apiv1.ErrorResponse{
+			Error: &apiv1.ErrorDetails{
+				Code:    "DeploymentFailed",
+				Message: "the resource type is not supported",
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{name: "nil error", err: nil, expected: false},
+		{name: "nested ErrImagePull timeout", err: imagePullError, expected: true},
+		{name: "plain ImagePullBackOff string", err: errors.New("pod is stuck in ImagePullBackOff"), expected: true},
+		{name: "registry response header timeout", err: errors.New("failed to do request: net/http: timeout awaiting response headers"), expected: true},
+		{name: "containerd pull-and-unpack failure", err: errors.New(`failed to pull and unpack image "ghcr.io/radius-project/mirror/rabbitmq:3.10"`), expected: true},
+		{name: "non-transient CLIError", err: nonTransientError, expected: false},
+		{name: "unrelated error", err: errors.New("connection refused"), expected: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, IsTransientImagePullError(tc.err))
+		})
+	}
 }

--- a/test/step/retry.go
+++ b/test/step/retry.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package step
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/radius-project/radius/test/radcli"
+)
+
+// ErrorContainsAny reports whether err - including the nested ARM error details
+// that rad surfaces inside a CLIError - contains any of the given substrings.
+//
+// rad returns the deployment root cause inside nested ARM error
+// details[].message fields, while CLIError.Error() only exposes the top-level
+// code and message (for example "DeploymentFailed"). ErrorContainsAny therefore
+// flattens the full ARM error response before matching so callers can detect
+// deeply nested causes. It is the shared building block for transient-error
+// retry predicates such as IsTransientImagePullError.
+func ErrorContainsAny(err error, substrings ...string) bool {
+	if err == nil {
+		return false
+	}
+
+	haystack := err.Error()
+	if cliErr, ok := errors.AsType[*radcli.CLIError](err); ok {
+		if encoded, marshalErr := json.Marshal(cliErr.ErrorResponse); marshalErr == nil {
+			haystack += " " + string(encoded)
+		}
+	}
+
+	for _, s := range substrings {
+		if strings.Contains(haystack, s) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/test/step/retry_test.go
+++ b/test/step/retry_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package step
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	apiv1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	"github.com/radius-project/radius/test/radcli"
+)
+
+func Test_ErrorContainsAny(t *testing.T) {
+	// nestedCLIError verifies that ErrorContainsAny matches a substring that only
+	// appears inside the nested ARM error details, not the top-level message.
+	nestedCLIError := &radcli.CLIError{
+		ErrorResponse: apiv1.ErrorResponse{
+			Error: &apiv1.ErrorDetails{
+				Code:    "DeploymentFailed",
+				Message: "At least one resource deployment operation failed.",
+				Details: []*apiv1.ErrorDetails{
+					{Code: "Internal", Message: "the marker is buried here"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		err        error
+		substrings []string
+		expected   bool
+	}{
+		{name: "nil error", err: nil, substrings: []string{"x"}, expected: false},
+		{name: "no substrings", err: errors.New("boom"), substrings: nil, expected: false},
+		{name: "matches one of several", err: errors.New("boom"), substrings: []string{"nope", "boom"}, expected: true},
+		{name: "no match", err: errors.New("boom"), substrings: []string{"nope"}, expected: false},
+		{name: "matches nested ARM detail", err: nestedCLIError, substrings: []string{"buried here"}, expected: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, ErrorContainsAny(tc.err, tc.substrings...))
+		})
+	}
+}


### PR DESCRIPTION
# Description

## Problem this solves

Radius functional tests deploy real workloads whose containers pull images from
shared registries — `ghcr.io/radius-project/magpiego` and the
`ghcr.io/radius-project/mirror/*` mirror images (RabbitMQ, Redis, Mongo, etc.).
In CI these pulls intermittently time out (`ErrImagePull` / `ImagePullBackOff`
with `net/http: timeout awaiting response headers`), which fails the Radius
deployment and the test even though the code under test is correct.

These transient registry/network blips surface as red scheduled runs and flaky
PR checks. For example, a scheduled non-cloud run failed `Test_RabbitMQ_Manual`
solely because the node could not pull `ghcr.io/radius-project/mirror/rabbitmq:3.10`
in time — not because of any regression.

## What this change does

- Adds a generic, reusable matcher `step.ErrorContainsAny(err, substrings...)`
  that flattens the nested ARM error details rad surfaces inside a `CLIError`
  (the root cause lives in `details[].message`, not the top-level message)
  before substring matching.
- Adds `step.IsTransientImagePullError`, built on that matcher, which recognizes
  transient image-pull failures (`ErrImagePull`, `ImagePullBackOff`,
  `failed to pull and unpack image`, `timeout awaiting response headers`).
- Makes `NewDeployExecutor` retry on transient image-pull failures **by default**
  (2 retries, 30s delay); `WithRetry` still overrides per test. This is safe
  because `DeployExecutor.Execute` always asserts the deploy succeeds, so the
  constructor is only ever used for success-expected deploys and the predicate
  only fires on transient pull errors.
- Unifies the previously duplicated `isTransientAzureError` (ACI test) and the
  image-pull predicate onto the same `ErrorContainsAny` building block, keeping
  `retry.go` purely generic and the specific markers next to the code that uses
  them.

## Value proposition

- Removes a recurring source of false-negative CI failures and flaky PR checks
  caused by registry/network blips rather than real regressions.
- Centralizes transient-error detection in one tested, reusable helper instead
  of copy-pasted matching logic, so new transient categories are easy to add.
- No product code changes and no per-test edits: every existing deploy step
  inherits the resilience automatically, and tests that need different behavior
  opt out with `WithRetry`.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
