### PR TITLE
ci(test): refresh functional test result check on passing re-run

### DIFF
--- a/.github/actions/process-test-results/action.yaml
+++ b/.github/actions/process-test-results/action.yaml
@@ -25,6 +25,13 @@ inputs:
   result_directory:
     description: Directory containing result XML files. These should be in jUnit format. See the description of the action.
     required: true
+  comment_mode:
+    description: |
+      When the EnricoMi action posts a pull request comment. Defaults to "always" to preserve
+      existing behavior. Use "failures" to comment only when tests fail, or "off" to disable
+      comments. See publish-unit-test-result-action docs for the full list of values.
+    required: false
+    default: always
 runs:
   using: composite
   steps:
@@ -75,6 +82,7 @@ runs:
       if: always()
       with:
         check_name: ${{ inputs.test_group_name }}
+        comment_mode: ${{ inputs.comment_mode }}
         files: |
           ${{ inputs.result_directory }}/processed/*.xml
 

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -1017,12 +1017,18 @@ jobs:
 
       - name: Process Functional Test Results
         uses: ./.github/actions/process-test-results
-        # In case of failure, upload functional_test_results to artifacts so that they are not erased by subsequent runs.
-        if: failure() && github.repository == vars.RADIUS_REPOSITORY
+        # Run on success and failure so a passing "Re-run failed jobs" refreshes the
+        # "Functional Tests - <name>" check published by EnricoMi. Gating this on
+        # failure() left that check stuck red after a green re-run, because the step
+        # was skipped and the previous attempt's failed check was never updated.
+        # comment_mode: failures keeps PR comments limited to actual failures, and
+        # the failure artifacts are still uploaded for post-mortem.
+        if: always() && github.repository == vars.RADIUS_REPOSITORY
         with:
           test_group_name: Functional Tests - ${{ matrix.name }}
           artifact_name: functional_test_results_${{ matrix.name }}
           result_directory: dist/functional_test/
+          comment_mode: failures
 
       - name: Collect Pod details
         if: always()
@@ -1128,7 +1134,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      checks: read
     env:
       CHECKOUT_REF: ${{ needs.setup.outputs.CHECKOUT_REF }}
     steps:
@@ -1140,28 +1145,30 @@ jobs:
           private-key: ${{ secrets.FUNCTIONAL_TEST_APP_PRIVATE_KEY }}
           permission-checks: write
 
-      - name: Get tests job status
+      - name: Aggregate functional test status
         id: get_test_status
-        env:
-          GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
         run: |
-          # from: https://github.com/orgs/community/discussions/26526#discussioncomment-3252209
-          ALL_JOBS_STATUS=$(curl -X GET -s -u "admin:${GH_TOKEN}" "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" | jq ".jobs[] | {job_status: .conclusion}")
-          echo "All jobs status: $ALL_JOBS_STATUS"
+          # Derive the overall status from the needs context instead of querying the
+          # Actions API. `tests` is a matrix job, so needs.tests.result already collapses
+          # all legs (success only if every leg passed). A docs-only run skips build+tests
+          # with setup successful, which yields success and matches the skip-tests job.
+          # failure takes precedence over cancelled.
+          echo "setup=${SETUP_RESULT} build=${BUILD_RESULT} tests=${TESTS_RESULT}"
           TEST_STATUS="success"
-          for job_status in $(echo "$ALL_JOBS_STATUS" | jq -r '.[]'); do
-            echo "Job Status: $job_status"
-            if [[ "$job_status" == "failure" ]]; then
-              echo "Found failed test. Setting test status to failure"
+          for result in "${SETUP_RESULT}" "${BUILD_RESULT}" "${TESTS_RESULT}"; do
+            if [[ "${result}" == "failure" ]]; then
               TEST_STATUS="failure"
               break
-            elif [[ "$job_status" == "cancelled" ]]; then
-              echo "Found cancelled test. Setting test status to cancelled"
+            elif [[ "${result}" == "cancelled" ]]; then
               TEST_STATUS="cancelled"
             fi
           done
-          echo "Test Status: $TEST_STATUS"
-          echo "test_status=$TEST_STATUS" >> $GITHUB_OUTPUT
+          echo "Functional Test Run status: ${TEST_STATUS}"
+          echo "test_status=${TEST_STATUS}" >> "${GITHUB_OUTPUT}"
+        env:
+          SETUP_RESULT: ${{ needs.setup.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          TESTS_RESULT: ${{ needs.tests.result }}
 
       - uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
         if: always()

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -1162,13 +1162,18 @@ jobs:
           echo "Releasing ACI quota by deleting:"
           echo "${aci_ids}"
           # nGroups (container scale sets) back the quota-holding container groups, so
-          # delete them first; then delete the remaining ACI resources (profiles).
+          # delete them first (in parallel) and wait, then delete the remaining ACI
+          # resources (profiles). Parallelizing keeps the synchronous teardown short
+          # while preserving the nGroups-before-profiles order (nGroups reference the
+          # profiles).
           for id in $(echo "${aci_ids}" | grep -i '/nGroups/' || true); do
-            az resource delete --subscription "${sub}" --ids "${id}" --api-version "${aci_api_version}" --verbose || true
+            az resource delete --subscription "${sub}" --ids "${id}" --api-version "${aci_api_version}" --verbose || true &
           done
+          wait
           for id in $(echo "${aci_ids}" | grep -iv '/nGroups/' || true); do
-            az resource delete --subscription "${sub}" --ids "${id}" --api-version "${aci_api_version}" --verbose || true
+            az resource delete --subscription "${sub}" --ids "${id}" --api-version "${aci_api_version}" --verbose || true &
           done
+          wait
 
       - name: Delete azure resource group - ${{ env.AZURE_TEST_RESOURCE_GROUP }}
         if: always()

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -1140,6 +1140,12 @@ jobs:
           set -uo pipefail
           sub="${AZURE_SUBSCRIPTIONID_TESTS}"
           rg="${AZURE_TEST_RESOURCE_GROUP}"
+          # Radius creates the ACI nGroups/containerGroupProfiles with this API version
+          # (pkg/sdk/v20241101preview). Delete with it explicitly: a plain delete lets
+          # ARM pick the provider's latest advertised version (e.g. 2026-06-01-preview),
+          # which the RP rejects ("api-version not supported"), leaving the nGroups -
+          # and therefore the whole resource group - undeletable.
+          aci_api_version="2024-11-01-preview"
           if ! az group show --subscription "${sub}" --name "${rg}" >/dev/null 2>&1; then
             echo "Resource group ${rg} not found; nothing to release."
             exit 0
@@ -1158,10 +1164,10 @@ jobs:
           # nGroups (container scale sets) back the quota-holding container groups, so
           # delete them first; then delete the remaining ACI resources (profiles).
           for id in $(echo "${aci_ids}" | grep -i '/nGroups/' || true); do
-            az resource delete --subscription "${sub}" --ids "${id}" --verbose || true
+            az resource delete --subscription "${sub}" --ids "${id}" --api-version "${aci_api_version}" --verbose || true
           done
           for id in $(echo "${aci_ids}" | grep -iv '/nGroups/' || true); do
-            az resource delete --subscription "${sub}" --ids "${id}" --verbose || true
+            az resource delete --subscription "${sub}" --ids "${id}" --api-version "${aci_api_version}" --verbose || true
           done
 
       - name: Delete azure resource group - ${{ env.AZURE_TEST_RESOURCE_GROUP }}

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -54,6 +54,17 @@ on:
 
 permissions: {}
 
+# Reduce self-contention on the shared Azure ACI 'StandardCores' quota (the
+# bottleneck behind Test_ACI's ContainerGroupQuotaReached flakes): serialize cloud
+# functional-test runs per pull request so a single PR pushing rapid commits does
+# not run several ACI-provisioning runs at once. Keyed by PR number because under
+# pull_request_target github.ref is the base ref, which would otherwise collapse
+# every PR into one group and cancel unrelated runs. cancel-in-progress is limited
+# to pull_request_target so the merge queue and scheduled runs are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
 env:
   GOPROXY: https://proxy.golang.org
   # yq version
@@ -613,6 +624,7 @@ jobs:
       contents: read # Required for listing the commits
       checks: write # Required for publishing test results
       packages: read # Required for pulling images from ghcr.io inside KinD
+      pull-requests: write # Required for posting a PR comment
     env:
       UNIQUE_ID: ${{ needs.setup.outputs.UNIQUE_ID }}
       REL_VERSION: ${{ needs.setup.outputs.REL_VERSION }}
@@ -1111,6 +1123,46 @@ jobs:
           append: true
           message: |
             :x: ${{ matrix.name }} functional test cancelled. Please check [the logs](${{ env.ACTION_LINK }}) for more details
+
+      - name: Release ACI quota before async resource group delete
+        if: always()
+        env:
+          AZURE_SUBSCRIPTIONID_TESTS: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
+        run: |
+          # The regional Azure Container Instances 'StandardCores' quota is shared
+          # across all concurrent cloud functional-test runs and is the bottleneck
+          # behind Test_ACI (deploys fail with ContainerGroupQuotaReached). The
+          # resource group is deleted with --no-wait below because the full delete is
+          # slow for gateways/VNets (see #12044), so its ACI resources would otherwise
+          # linger for minutes and keep holding quota that other runs need. Delete the
+          # ACI resources synchronously here to release the quota promptly. Best-effort:
+          # the resource group delete and the purge workflow still clean up the rest.
+          set -uo pipefail
+          sub="${AZURE_SUBSCRIPTIONID_TESTS}"
+          rg="${AZURE_TEST_RESOURCE_GROUP}"
+          if ! az group show --subscription "${sub}" --name "${rg}" >/dev/null 2>&1; then
+            echo "Resource group ${rg} not found; nothing to release."
+            exit 0
+          fi
+          aci_ids=$(az resource list \
+            --subscription "${sub}" \
+            --resource-group "${rg}" \
+            --query "[?starts_with(type, 'Microsoft.ContainerInstance/')].id" \
+            --output tsv 2>/dev/null || true)
+          if [ -z "${aci_ids}" ]; then
+            echo "No Azure Container Instances resources in ${rg}."
+            exit 0
+          fi
+          echo "Releasing ACI quota by deleting:"
+          echo "${aci_ids}"
+          # nGroups (container scale sets) back the quota-holding container groups, so
+          # delete them first; then delete the remaining ACI resources (profiles).
+          for id in $(echo "${aci_ids}" | grep -i '/nGroups/' || true); do
+            az resource delete --subscription "${sub}" --ids "${id}" --verbose || true
+          done
+          for id in $(echo "${aci_ids}" | grep -iv '/nGroups/' || true); do
+            az resource delete --subscription "${sub}" --ids "${id}" --verbose || true
+          done
 
       - name: Delete azure resource group - ${{ env.AZURE_TEST_RESOURCE_GROUP }}
         if: always()

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -163,6 +163,7 @@ jobs:
     permissions:
       contents: read # Required for listing the commits
       checks: write # Required for creating a check run
+      pull-requests: write # Required for posting a PR comment
     strategy:
       # Keep matrix legs independent. With fail-fast: true, a single failing
       # (often flaky) leg cancels all in-progress siblings. GitHub's

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -542,12 +542,18 @@ jobs:
 
       - name: Process Functional Test Results
         uses: ./.github/actions/process-test-results
-        # In case of failure, upload functional_test_results to artifacts so that they are not erased by subsequent runs.
-        if: failure() && github.repository == vars.RADIUS_REPOSITORY
+        # Run on success and failure so a passing "Re-run failed jobs" refreshes the
+        # "Functional Tests - <name>" check published by EnricoMi. Gating this on
+        # failure() left that check stuck red after a green re-run, because the step
+        # was skipped and the previous attempt's failed check was never updated.
+        # comment_mode: failures keeps PR comments limited to actual failures, and
+        # the failure artifacts are still uploaded for post-mortem.
+        if: always() && github.repository == vars.RADIUS_REPOSITORY
         with:
           test_group_name: Functional Tests - ${{ matrix.name }}
           artifact_name: functional_test_results_${{ matrix.name }}
           result_directory: dist/functional_test/
+          comment_mode: failures
 
       - name: Collect detailed Radius logs and events
         id: radius-logs-events

--- a/.github/workflows/purge-azure-test-resources.yaml
+++ b/.github/workflows/purge-azure-test-resources.yaml
@@ -39,7 +39,11 @@ jobs:
     name: Clean up unused Azure resources
     if: github.repository == 'radius-project/radius'
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    # Deleting ACI nGroups synchronously before each resource group (see the delete
+    # step) is slower than the previous fire-and-forget 'az group delete --no-wait',
+    # so allow more time to work through a backlog. The purge is idempotent and runs
+    # twice a day, so any groups not reached in one run are handled by the next.
+    timeout-minutes: 30
     permissions:
       id-token: write
     steps:
@@ -86,12 +90,47 @@ jobs:
 
       - name: Delete Azure resource groups
         run: |
-          echo "## Deleting resource group list" >> $GITHUB_STEP_SUMMARY
-          cat "${AZURE_RG_DELETE_LIST_FILE}" | while read line
-          do
-              echo " * $line" >> $GITHUB_STEP_SUMMARY
-              az group delete --resource-group $line --yes --verbose --no-wait
-          done
+          echo "## Deleting resource group list" >> "$GITHUB_STEP_SUMMARY"
+
+          # Azure Container Instances 'nGroups' (container scale sets) are delegated
+          # into the resource group's VNet subnet. A plain 'az group delete' deletes
+          # resources in parallel and cannot remove the subnet while the nGroups still
+          # reference it, so the whole resource group delete silently fails (--no-wait)
+          # and leaves an empty-looking group behind whose only resource is the nGroups.
+          # Delete the Container Instances resources first (nGroups before profiles) so
+          # the resource group delete can then succeed.
+          # Radius creates the ACI nGroups/containerGroupProfiles with this API version
+          # (pkg/sdk/v20241101preview). A plain delete lets ARM pick the provider's
+          # latest advertised version (e.g. 2026-06-01-preview), which the RP rejects
+          # ("api-version not supported"), leaving the nGroups - and therefore the
+          # whole resource group - undeletable. Delete them with the explicit version.
+          aci_api_version="2024-11-01-preview"
+          delete_rg() {
+            line="$1"
+            aci_ids=$(az resource list --resource-group "$line" \
+              --query "[?starts_with(type, 'Microsoft.ContainerInstance/')].id" \
+              --output tsv 2>/dev/null || true)
+            for id in $(echo "$aci_ids" | grep -i '/nGroups/' || true); do
+              echo "deleting $id"
+              az resource delete --ids "$id" --api-version "${aci_api_version}" || true
+            done
+            for id in $(echo "$aci_ids" | grep -iv '/nGroups/' || true); do
+              echo "deleting $id"
+              az resource delete --ids "$id" --api-version "${aci_api_version}" || true
+            done
+            az group delete --resource-group "$line" --yes --verbose --no-wait || true
+          }
+
+          # Delete resource groups in parallel (capped) so a large backlog still fits
+          # the job timeout.
+          max_parallel=10
+          while read -r line; do
+              [ -z "$line" ] && continue
+              echo " * $line" >> "$GITHUB_STEP_SUMMARY"
+              delete_rg "$line" &
+              while [ "$(jobs -r | wc -l)" -ge "${max_parallel}" ]; do wait -n; done
+          done < "${AZURE_RG_DELETE_LIST_FILE}"
+          wait
 
   purge_bicep_types:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
# Description

**Problem**

When a functional test leg fails and is retried with **Re-run failed jobs**, a passing re-run left the `Functional Tests - <leg>` check **stuck red** on the pull request. The step that publishes that check (via the EnricoMi `publish-unit-test-result-action`) was gated on `if: failure()`, so on a green re-run it was skipped and the failed check from the previous attempt was never refreshed. The PR kept showing a failed functional-test result even though every test passed — confusing reviewers and, where the check is required, forcing manual re-runs or overrides to merge.

**What changed**

- **Self-healing result check** — the `Process Functional Test Results` step now runs on `if: always()` (matching `unit-tests.yaml`) in both the cloud and non-cloud functional workflows, so a passing run republishes `Functional Tests - <leg>` as green. A retried, now-passing leg clears its own stale red check.
- **No per-leg comment spam** — a new `comment_mode` input on the `process-test-results` composite action (default `always`, backward compatible) lets the functional workflows pass `comment_mode: failures`. Success runs no longer post a comment for each matrix leg, while failure comments are preserved.
- **Simpler status aggregation** — the cloud `report-test-results` job now derives the `Functional Test Run` conclusion from `needs.{setup,build,tests}.result` instead of scanning the Actions API with `curl`/`jq`, and drops the now-unused `checks: read` permission. `needs.tests.result` already collapses all matrix legs (success only if every leg passes), and a docs-only run (build/tests skipped, setup successful) still reports success.

**Value**

- PR checks tell the truth after a retry — no more stuck-red functional-test results following a green re-run, so reviewers and the merge gate aren't misled.
- Less noise on PRs — no duplicate success comments across matrix legs.
- More robust and readable CI — status aggregation no longer depends on a raw Actions API call or an extra token permission.

No product code changes; this is CI/workflow only.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
