### PR TITLE
Migrate dynamicrp tests

### DIFF
--- a/test/functional-portable/dynamicrp/noncloud/resources/dynamicrp_test.go
+++ b/test/functional-portable/dynamicrp/noncloud/resources/dynamicrp_test.go
@@ -18,9 +18,11 @@ package resource_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/radius-project/radius/pkg/cli/recipepack"
 	"github.com/radius-project/radius/test"
 	"github.com/radius-project/radius/test/radcli"
 	"github.com/radius-project/radius/test/rp"
@@ -46,14 +48,23 @@ import (
 //   - Validates that the container can access port information from the user-defined resource via environment variables
 func Test_DynamicRP_Recipe(t *testing.T) {
 	template := "testdata/usertypealpha-recipe.bicep"
+	recipePackTemplate := "testdata/usertypealpha-recipe-pack.bicep"
+	recipePackName := "usertypealpha-recipe-pack"
 	appName := "usertypealpha-recipe-app"
-	appNamespace := "usertypealpha-recipe-env-usertypealpha-recipe-app"
+	appNamespace := "usertypealpha-recipe-app"
 	containerName := "usertypealphacntr"
 	resourceTypeName := "Test.Resources/userTypeAlpha"
 	resourceTypeParam := strings.Split(resourceTypeName, "/")[1]
 	filepath := "testdata/testresourcetypes.yaml"
 	options := rp.NewRPTestOptions(t)
 	cli := radcli.NewCLI(t, options.ConfigFilePath)
+
+	// Provision the preview environment (and its default recipe pack, which
+	// provides the Radius.Compute/containers recipe) before the test steps run.
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(appName, options.Workspace.Scope, appNamespace)
+	envName := appName + "-env"
+	defaultPackID := recipepack.DefaultRecipePackID()
+	customPackID := fmt.Sprintf("%s/providers/Radius.Core/recipePacks/%s", options.Workspace.Scope, recipePackName)
 
 	test := rp.NewRPTest(t, appName, []rp.TestStep{
 		{
@@ -72,21 +83,31 @@ func Test_DynamicRP_Recipe(t *testing.T) {
 			},
 		},
 		{
-			// The next step is to deploy a bicep file using a default recipe for the resource type registered.
-			Executor: step.NewDeployExecutor(template, testutil.GetBicepRecipeRegistry(), testutil.GetBicepRecipeVersion()),
+			// Create the custom recipe pack (UDT recipe) and attach it to the preview
+			// environment alongside the default pack so the environment has recipes for
+			// both the user-defined type and the container.
+			Executor: step.NewFuncExecutor(func(ctx context.Context, t *testing.T, options test.TestOptions) {
+				err := cli.Deploy(ctx, recipePackTemplate, "", "", testutil.GetBicepRecipeRegistry(), testutil.GetBicepRecipeVersion())
+				require.NoError(t, err)
+				_, err = cli.EnvironmentUpdatePreview(ctx, envName, "", defaultPackID+","+customPackID, "")
+				require.NoError(t, err)
+			}),
+			SkipKubernetesOutputResourceValidation: true,
+			SkipObjectValidation:                   true,
+			SkipResourceDeletion:                   true,
+		},
+		{
+			// The next step is to deploy a bicep file using the registered recipe for the resource type.
+			Executor: step.NewDeployExecutor(template, fmt.Sprintf("environment=%s", previewEnvID)),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "usertypealpha-recipe-env",
-						Type: validation.EnvironmentsResource,
-					},
-					{
 						Name: appName,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: containerName,
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 					},
 					{
 						Name: "usertypealphainstance",
@@ -96,12 +117,16 @@ func Test_DynamicRP_Recipe(t *testing.T) {
 						Name: "usertypealphalatest",
 						Type: resourceTypeName,
 					},
+					{
+						Name: recipePackName,
+						Type: validation.CoreRecipePacksResource,
+					},
 				},
 			},
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(appName, "usertypealpha").ValidateLabels(false),
+						validation.NewK8sPodForResource(appName, containerName).ValidateLabels(false),
 					},
 				},
 			},
@@ -133,6 +158,7 @@ func Test_DynamicRP_Recipe(t *testing.T) {
 		},
 	})
 
+	test.PreSetup = preSetup
 	test.Test(t)
 }
 
@@ -143,14 +169,24 @@ func Test_DynamicRP_Recipe(t *testing.T) {
 func Test_Postgres_EnvScoped_ExistingResource(t *testing.T) {
 	envTemplate := "testdata/postgres-env-scoped-resource.bicep"
 	existingTemplate := "testdata/postgres-existing-and-cntr.bicep"
+	recipePackTemplate := "testdata/postgres-recipe-pack.bicep"
+	recipePackName := "dynamicrp-postgres-recipe-pack"
 	name := "dynamicrp-postgres-env"
-	appNamespace := "dynamicrp-postgres-existing-app"
+	appNamespace := "dynamicrp-postgres-env"
 	appName := "dynamicrp-postgres-existing"
 	resourceTypeName := "Test.Resources/postgres"
 	resourceTypeParam := strings.Split(resourceTypeName, "/")[1]
 	filepath := "testdata/testresourcetypes.yaml"
 	options := rp.NewRPTestOptions(t)
 	cli := radcli.NewCLI(t, options.ConfigFilePath)
+
+	// Provision the shared preview environment (and its default recipe pack, which
+	// provides the Radius.Compute/containers recipe) before the test steps run.
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, options.Workspace.Scope, name)
+	envName := name + "-env"
+	defaultPackID := recipepack.DefaultRecipePackID()
+	customPackID := fmt.Sprintf("%s/providers/Radius.Core/recipePacks/%s", options.Workspace.Scope, recipePackName)
+
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
 			// The first step in this test is to create/register a user-defined resource type using the CLI.
@@ -168,13 +204,27 @@ func Test_Postgres_EnvScoped_ExistingResource(t *testing.T) {
 			},
 		},
 		{
-			Executor: step.NewDeployExecutor(envTemplate, testutil.GetBicepRecipeRegistry(), testutil.GetBicepRecipeVersion()),
+			// Create the custom postgres recipe pack and attach it to the preview
+			// environment alongside the default pack so the environment has recipes for
+			// both the postgres resource and the container.
+			Executor: step.NewFuncExecutor(func(ctx context.Context, t *testing.T, options test.TestOptions) {
+				err := cli.Deploy(ctx, recipePackTemplate, "", "", testutil.GetBicepRecipeRegistry(), testutil.GetBicepRecipeVersion())
+				require.NoError(t, err)
+				_, err = cli.EnvironmentUpdatePreview(ctx, envName, "", defaultPackID+","+customPackID, "")
+				require.NoError(t, err)
+			}),
+			SkipKubernetesOutputResourceValidation: true,
+			SkipObjectValidation:                   true,
+			SkipResourceDeletion:                   true,
+		},
+		{
+			// Deploy the environment-scoped postgres resource into the shared environment.
+			Executor: step.NewDeployExecutor(envTemplate, fmt.Sprintf("environment=%s", previewEnvID)),
+			// Deletion is consolidated into the final step so the recipe-backed
+			// container is torn down before the shared environment is deleted.
+			SkipResourceDeletion: true,
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
-					{
-						Name: name,
-						Type: validation.EnvironmentsResource,
-					},
 					{
 						Name: "existing-postgres",
 						Type: "test.resources/postgres",
@@ -190,22 +240,26 @@ func Test_Postgres_EnvScoped_ExistingResource(t *testing.T) {
 			},
 		},
 		{
-			Executor: step.NewDeployExecutor(existingTemplate),
+			// Deploy an app + container that consume the existing postgres resource.
+			Executor: step.NewDeployExecutor(existingTemplate, fmt.Sprintf("environment=%s", previewEnvID)),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: appName,
-						Type: validation.ApplicationsResource,
-						App:  appName,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: "postgres-cntr",
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  appName,
 					},
 					{
 						Name: "existing-postgres",
 						Type: "test.resources/postgres",
+					},
+					{
+						Name: recipePackName,
+						Type: validation.CoreRecipePacksResource,
 					},
 				},
 			},
@@ -223,6 +277,7 @@ func Test_Postgres_EnvScoped_ExistingResource(t *testing.T) {
 			},
 		},
 	})
+	test.PreSetup = preSetup
 	test.Test(t)
 }
 
@@ -239,7 +294,7 @@ func Test_Postgres_EnvScoped_ExistingResource(t *testing.T) {
 func Test_DynamicRP_ExternalResource(t *testing.T) {
 	template := "testdata/externalresource.bicep"
 	appName := "udt-externalresource-app"
-	appNamespace := "udt-externalresource-env-udt-externalresource-app"
+	appNamespace := "udt-externalresource-app"
 	expectedEnvName := "CONNECTION_EXTERNALRESOURCE_CONFIGMAP"
 	expectedEnvValue := `{"app1.sample.properties":"property1=value1\nproperty2=value2","app2.sample.properties":"property3=value3\nproperty4=value4"}`
 	resourceTypeName := "Test.Resources/externalResource"
@@ -270,20 +325,20 @@ func Test_DynamicRP_ExternalResource(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "udt-externalresource-env",
-						Type: validation.EnvironmentsResource,
-					},
-					{
 						Name: appName,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: containerName,
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 					},
 					{
 						Name: "udt-externalresource",
 						Type: resourceTypeName,
+					},
+					{
+						Name: "udt-externalresource-env",
+						Type: validation.CoreEnvironmentsResource,
 					},
 				},
 			},
@@ -309,28 +364,16 @@ func Test_DynamicRP_ExternalResource(t *testing.T) {
 				require.NotNil(t, targetContainer, "Container not found")
 
 				found := false
-				var secretName, secretKey string
 				for _, env := range targetContainer.Env {
 					if env.Name == expectedEnvName {
-						require.NotNil(t, env.ValueFrom)
-						require.NotNil(t, env.ValueFrom.SecretKeyRef)
-						require.Equal(t, env.Name, env.ValueFrom.SecretKeyRef.Key)
-						secretName = env.ValueFrom.SecretKeyRef.Name
-						secretKey = env.ValueFrom.SecretKeyRef.Key
+						// The Radius.Compute/containers model injects connection
+						// values directly as the environment variable value.
+						require.Equal(t, expectedEnvValue, env.Value, "Environment variable value does not match expected value")
 						found = true
 						break
 					}
 				}
 				require.True(t, found, "Environment variable %q not found", expectedEnvName)
-
-				// Verify the secret contains the expected value
-				secret, err := test.Options.K8sClient.CoreV1().Secrets(appNamespace).Get(ctx, secretName, metav1.GetOptions{})
-				require.NoError(t, err)
-				require.NotNil(t, secret.Data)
-
-				secretValue, exists := secret.Data[secretKey]
-				require.True(t, exists, "Secret key %s not found in secret %s", secretKey, secretName)
-				require.Equal(t, expectedEnvValue, string(secretValue), "Secret value does not match expected value")
 			},
 		},
 	})
@@ -350,7 +393,7 @@ func Test_DynamicRP_ExternalResource(t *testing.T) {
 func Test_UDT_ConnectionTo_UDT(t *testing.T) {
 	existingTemplate := "testdata/udt2udt-connection.bicep"
 	name := "dynamicrp-udt2udt"
-	appNamespace := "udttoudtapp"
+	appNamespace := "dynamicrp-udt2udt"
 	appName := "udttoudtapp"
 	childResourceTypeName := "Test.Resources/externalResource"
 	childResourceTypeParam := strings.Split(childResourceTypeName, "/")[1]
@@ -400,8 +443,7 @@ func Test_UDT_ConnectionTo_UDT(t *testing.T) {
 				Resources: []validation.RPResource{
 					{
 						Name: appName,
-						Type: validation.ApplicationsResource,
-						App:  appName,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: "udttoudtparent",
@@ -411,6 +453,14 @@ func Test_UDT_ConnectionTo_UDT(t *testing.T) {
 					{
 						Name: "udttoudtchild",
 						Type: "test.resources/externalresource",
+					},
+					{
+						Name: "udttoudtenv",
+						Type: validation.CoreEnvironmentsResource,
+					},
+					{
+						Name: "udt2udt-recipe-pack",
+						Type: validation.CoreRecipePacksResource,
 					},
 				},
 			},
@@ -464,7 +514,7 @@ func Test_UDT_ConnectionTo_UDT(t *testing.T) {
 func Test_UDT_ConnectionTo_UDTTF(t *testing.T) {
 	existingTemplate := "testdata/udt2udt-connection-tf.bicep"
 	name := "dynamicrp-udt2udt-tf"
-	appNamespace := "udttoudtapp"
+	appNamespace := "dynamicrp-udt2udt-tf"
 	appName := "udttoudtapp"
 	expectedEnvName := "CONN_INJECTED"
 	childResourceTypeName := "Test.Resources/externalResource"
@@ -514,8 +564,7 @@ func Test_UDT_ConnectionTo_UDTTF(t *testing.T) {
 				Resources: []validation.RPResource{
 					{
 						Name: appName,
-						Type: validation.ApplicationsResource,
-						App:  appName,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: "udttoudtparent",
@@ -525,6 +574,14 @@ func Test_UDT_ConnectionTo_UDTTF(t *testing.T) {
 					{
 						Name: "udttoudtchild",
 						Type: "test.resources/externalresource",
+					},
+					{
+						Name: "udttoudtenv",
+						Type: validation.CoreEnvironmentsResource,
+					},
+					{
+						Name: "udt2udt-tf-recipe-pack",
+						Type: validation.CoreRecipePacksResource,
 					},
 				},
 			},
@@ -651,16 +708,16 @@ func Test_DynamicRP_TypeAnyValidation_Valid(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "udt-platformoptions-env",
-						Type: validation.EnvironmentsResource,
-					},
-					{
 						Name: appName,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: "udt-valid-platformoptions",
 						Type: resourceTypeName,
+					},
+					{
+						Name: "udt-platformoptions-env",
+						Type: validation.CoreEnvironmentsResource,
 					},
 				},
 			},

--- a/test/functional-portable/dynamicrp/noncloud/resources/recipepacks_test.go
+++ b/test/functional-portable/dynamicrp/noncloud/resources/recipepacks_test.go
@@ -89,22 +89,21 @@ func runRecipePacksDeploymentTest(t *testing.T, template, appName, appNamespace,
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: recipePackResourceName,
-						Type: "radius.core/recipepacks",
-					},
-					{
-						Name: environmentResourceName,
-						Type: "radius.core/environments",
-					},
-					{
 						Name: appName,
-						Type: validation.ApplicationsResource,
-						App:  appName,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: rrtResourceName,
 						Type: "test.resources/usertypealpha",
 						App:  appName,
+					},
+					{
+						Name: environmentResourceName,
+						Type: validation.CoreEnvironmentsResource,
+					},
+					{
+						Name: recipePackResourceName,
+						Type: validation.CoreRecipePacksResource,
 					},
 				},
 			},

--- a/test/functional-portable/dynamicrp/noncloud/resources/sensitive_fields_test.go
+++ b/test/functional-portable/dynamicrp/noncloud/resources/sensitive_fields_test.go
@@ -55,7 +55,7 @@ import (
 func Test_DynamicRP_SensitiveFieldEncryption(t *testing.T) {
 	template := "testdata/sensitive-resource.bicep"
 	appName := "udt-sensitive-app"
-	appNamespace := "udt-sensitive-env-udt-sensitive-app"
+	appNamespace := "udt-sensitive-app"
 	resourceTypeName := "Test.Resources/sensitiveResource"
 	resourceName := "udt-sensitive-instance"
 	filepath := "testdata/testresourcetypes.yaml"
@@ -102,16 +102,16 @@ func Test_DynamicRP_SensitiveFieldEncryption(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "udt-sensitive-env",
-						Type: validation.EnvironmentsResource,
-					},
-					{
 						Name: appName,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: resourceName,
 						Type: resourceTypeName,
+					},
+					{
+						Name: "udt-sensitive-env",
+						Type: validation.CoreEnvironmentsResource,
 					},
 				},
 			},
@@ -132,16 +132,20 @@ func Test_DynamicRP_SensitiveFieldEncryption(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "udt-sensitive-env",
-						Type: validation.EnvironmentsResource,
-					},
-					{
 						Name: appName,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: resourceName,
 						Type: resourceTypeName,
+					},
+					{
+						Name: "udt-sensitive-env",
+						Type: validation.CoreEnvironmentsResource,
+					},
+					{
+						Name: "udt-sensitive-recipe-pack",
+						Type: validation.CoreRecipePacksResource,
 					},
 				},
 			},

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/externalresource.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/externalresource.bicep
@@ -8,19 +8,19 @@ extension kubernetes with {
 @description('Specifies the location for resources.')
 param location string = 'global'
 
-resource env 'Applications.Core/environments@2023-10-01-preview' = {
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
   name: 'udt-externalresource-env'
   location: location
   properties: {
-    compute: {
-      kind: 'kubernetes'
-      resourceId: 'self'
-      namespace: 'udt-externalresource-env'
+    providers: {
+      kubernetes: {
+        namespace: 'udt-externalresource-app'
+      }
     }
   }
 }
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'udt-externalresource-app'
   location: location
   properties: {
@@ -28,14 +28,18 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource externalresourcecntr 'Applications.Core/containers@2023-10-01-preview' = {
-    name: 'externalresourcecntr'
-    properties: {
-      application: app.id
-      container: {
+resource externalresourcecntr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'externalresourcecntr'
+  location: location
+  properties: {
+    application: app.id
+    environment: env.id
+    containers: {
+      externalresourcecntr: {
         image: 'ghcr.io/radius-project/mirror/debian:latest'
         command: ['/bin/sh']
         args: ['-c', 'while true; do echo hello; sleep 10;done']
+      }
     }
     connections: {
       externalresource: {

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/postgres-env-scoped-resource.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/postgres-env-scoped-resource.bicep
@@ -1,39 +1,21 @@
 extension testresources
 extension radius
 
-param registry string
-
-param version string
+@description('The ID of the shared environment to deploy the postgres resource into.')
+param environment string
 
 @description('PostgreSQL password')
 @secure()
 param password string = newGuid()
 
-resource udtenv 'Applications.Core/environments@2023-10-01-preview' = {
-  name: 'dynamicrp-postgres-env'
-  location: 'global'
-  properties: {
-    compute: {
-      kind: 'kubernetes'
-      resourceId: 'self'
-      namespace: 'dynamicrp-postgres-env'
-    }
-    recipes: {
-      'Test.Resources/postgres': {
-        default: {
-          templateKind: 'bicep'
-          templatePath: '${registry}/test/testrecipes/test-bicep-recipes/dynamicrp_postgress_recipe:${version}'
-        }
-      }
-    }
-  }
-}
-
+// Environment-scoped postgres resource provisioned by the custom postgres recipe.
+// The recipe is registered via the custom recipe pack attached to the preview
+// environment; the container recipe comes from the default recipe pack.
 resource udtpg 'Test.Resources/postgres@2025-01-01-preview' = {
   name: 'existing-postgres'
   location: 'global'
   properties: {
-    environment: udtenv.id
+    environment: environment
     password: password
   }
 }

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/postgres-existing-and-cntr.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/postgres-existing-and-cntr.bicep
@@ -1,35 +1,31 @@
 extension radius
 extension testresources
 
-param  environment string
+@description('The ID of the shared environment that owns the existing postgres resource.')
+param environment string
 
-resource udtapp 'Applications.Core/applications@2023-10-01-preview' = {
+resource udtapp 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'dynamicrp-postgres-existing'
   location: 'global'
   properties: {
     environment: environment
-    extensions: [
-      {
-        kind: 'kubernetesNamespace'
-        namespace: 'dynamicrp-postgres-existing-app'
-      }
-    ]
   }
 }
 
-
-resource udtcntr 'Applications.Core/containers@2023-10-01-preview' = {
-    name: 'postgres-cntr'
-    properties: {
-      application: udtapp.id
-      container: {
+resource udtcntr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'postgres-cntr'
+  location: 'global'
+  properties: {
+    application: udtapp.id
+    environment: environment
+    containers: {
+      'postgres-cntr': {
         image: 'ghcr.io/radius-project/samples/demo:latest'
         ports: {
           web: {
             containerPort: 3000
           }
         }
-  
         env: {
           CONNECTION_POSTGRES_HOST: {
             value: udtpgexisting.properties.host
@@ -47,11 +43,13 @@ resource udtcntr 'Applications.Core/containers@2023-10-01-preview' = {
             value: udtpgexisting.properties.password
           }
         }
+      }
     }
-  
-    }
+  }
 }
 
-resource udtpgexisting 'Test.Resources/postgres@2025-01-01-preview' existing= {
+// Reference the env-scoped postgres resource provisioned by
+// postgres-env-scoped-resource.bicep using the 'existing' keyword.
+resource udtpgexisting 'Test.Resources/postgres@2025-01-01-preview' existing = {
   name: 'existing-postgres'
 }

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/postgres-recipe-pack.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/postgres-recipe-pack.bicep
@@ -1,0 +1,21 @@
+extension radius
+
+param registry string
+
+param version string
+
+// Custom recipe pack that registers the postgres recipe. It is attached to the
+// preview environment alongside the default recipe pack (which provides the
+// Radius.Compute/containers recipe) via `rad env update --preview --recipe-packs`.
+resource recipepack 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'dynamicrp-postgres-recipe-pack'
+  location: 'global'
+  properties: {
+    recipes: {
+      'Test.Resources/postgres': {
+        kind: 'bicep'
+        source: '${registry}/test/testrecipes/test-bicep-recipes/dynamicrp_postgress_recipe:${version}'
+      }
+    }
+  }
+}

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/recipepacks-test-by-name.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/recipepacks-test-by-name.bicep
@@ -54,7 +54,7 @@ resource env 'Radius.Core/environments@2025-08-01-preview' = {
   ]
 }
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'recipepacks-byname-app'
   location: 'global'
   properties: {

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/recipepacks-test-no-provider.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/recipepacks-test-no-provider.bicep
@@ -36,7 +36,7 @@ resource env 'Radius.Core/environments@2025-08-01-preview' = {
   }
 }
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'recipepacks-test-app-no-provider'
   location: 'global'
   properties: {

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/recipepacks-test.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/recipepacks-test.bicep
@@ -53,7 +53,7 @@ resource env 'Radius.Core/environments@2025-08-01-preview' = {
   }
 }
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'recipepacks-test-app'
   location: 'global'
   properties: {

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/sensitive-resource.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/sensitive-resource.bicep
@@ -19,27 +19,35 @@ param connectionConfigUrl string
 @secure()
 param connectionConfigToken string
 
-resource env 'Applications.Core/environments@2023-10-01-preview' = {
-  name: 'udt-sensitive-env'
+resource recipepack 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'udt-sensitive-recipe-pack'
   location: location
   properties: {
-    compute: {
-      kind: 'kubernetes'
-      resourceId: 'self'
-      namespace: 'udt-sensitive-env'
-    }
     recipes: {
       'Test.Resources/sensitiveResource': {
-        default: {
-          templateKind: 'bicep'
-          templatePath: '${registry}/test/testrecipes/test-bicep-recipes/dynamicrp_sensitive_recipe:${version}'
-        }
+        kind: 'bicep'
+        source: '${registry}/test/testrecipes/test-bicep-recipes/dynamicrp_sensitive_recipe:${version}'
       }
     }
   }
 }
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'udt-sensitive-env'
+  location: location
+  properties: {
+    recipePacks: [
+      recipepack.id
+    ]
+    providers: {
+      kubernetes: {
+        namespace: 'udt-sensitive-app'
+      }
+    }
+  }
+}
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'udt-sensitive-app'
   location: location
   properties: {

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/testResourceSchema-invalid.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/testResourceSchema-invalid.bicep
@@ -4,19 +4,19 @@ extension radius
 @description('Specifies the location for resources.')
 param location string = 'global'
 
-resource env 'Applications.Core/environments@2023-10-01-preview' = {
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
   name: 'udt-schemavalidation-env'
   location: location
   properties: {
-    compute: {
-      kind: 'kubernetes'
-      resourceId: 'self'
-      namespace: 'udt-schemavalidation-env'
+    providers: {
+      kubernetes: {
+        namespace: 'udt-schemavalidation-app'
+      }
     }
   }
 }
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'udt-schemavalidation-app'
   location: location
   properties: {
@@ -25,12 +25,12 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
 }
 
 // This resource should fail schema validation due to type mismatches
-resource testResourceSchema 'Test.Resources/testResourceSchema@2023-10-01-preview'  = {
+resource testResourceSchema 'Test.Resources/testResourceSchema@2023-10-01-preview' = {
   name: 'udt-schemavalidation'
   location: location
   properties: {
     application: app.id
     environment: env.id
     validationData: 123
-    }
+  }
 }

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/testResourceSchema-validAny.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/testResourceSchema-validAny.bicep
@@ -4,19 +4,19 @@ extension radius
 @description('Specifies the location for resources.')
 param location string = 'global'
 
-resource env 'Applications.Core/environments@2023-10-01-preview' = {
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
   name: 'udt-platformoptions-env'
   location: location
   properties: {
-    compute: {
-      kind: 'kubernetes'
-      resourceId: 'self'
-      namespace: 'udt-platformoptions-env'
+    providers: {
+      kubernetes: {
+        namespace: 'udt-platformoptions-app'
+      }
     }
   }
 }
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'udt-platformoptions-app'
   location: location
   properties: {

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/udt2udt-connection-tf.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/udt2udt-connection-tf.bicep
@@ -1,9 +1,5 @@
 extension radius
 extension testresources
-extension kubernetes with {
-  kubeConfig: ''
-  namespace: 'udttoudtapp'
-} as kubernetes
 
 @description('The URL of the server hosting test Terraform modules.')
 param moduleServer string
@@ -11,40 +7,42 @@ param moduleServer string
 @description('Specifies the port the container listens on.')
 param port int = 8080
 
-resource udttoudtenv 'Applications.Core/environments@2023-10-01-preview' = {
-  name: 'udttoudtenv'
+resource recipepack 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'udt2udt-tf-recipe-pack'
   location: 'global'
   properties: {
-    compute: {
-      kind: 'kubernetes'
-      resourceId: 'self'
-      namespace: 'udttoudtenv'
-    }
     recipes: {
       'Test.Resources/userTypeAlpha': {
-        default: {
-          templateKind: 'terraform'
-          templatePath: '${moduleServer}/parent-udt.zip'
-          parameters: {
-            port: port
-          }
+        kind: 'terraform'
+        source: '${moduleServer}/parent-udt.zip'
+        parameters: {
+          port: port
         }
       }
     }
   }
 }
 
-resource udttoudtapp 'Applications.Core/applications@2023-10-01-preview' = {
+resource udttoudtenv 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'udttoudtenv'
+  location: 'global'
+  properties: {
+    recipePacks: [
+      recipepack.id
+    ]
+    providers: {
+      kubernetes: {
+        namespace: 'dynamicrp-udt2udt-tf'
+      }
+    }
+  }
+}
+
+resource udttoudtapp 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'udttoudtapp'
   location: 'global'
   properties: {
     environment: udttoudtenv.id
-    extensions: [
-      {
-        kind: 'kubernetesNamespace'
-        namespace: 'udttoudtapp'
-      }
-    ]
   }
 }
 
@@ -58,7 +56,7 @@ resource udttoudtparent 'Test.Resources/userTypeAlpha@2023-10-01-preview' = {
         source: udttoudtchild.id
       }
     }
-  }     
+  }
 }
 
 resource udttoudtchild 'Test.Resources/externalResource@2023-10-01-preview' = {

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/udt2udt-connection.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/udt2udt-connection.bicep
@@ -1,9 +1,5 @@
 extension radius
 extension testresources
-extension kubernetes with {
-  kubeConfig: ''
-  namespace: 'udttoudtapp'
-} as kubernetes
 param registry string
 
 param version string
@@ -11,58 +7,57 @@ param version string
 @description('Specifies the port the container listens on.')
 param port int = 8080
 
-resource udttoudtenv 'Applications.Core/environments@2023-10-01-preview' = {
-  name: 'udttoudtenv'
+resource recipepack 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'udt2udt-recipe-pack'
   location: 'global'
   properties: {
-    compute: {
-      kind: 'kubernetes'
-      resourceId: 'self'
-      namespace: 'udttoudtenv'
-    }
     recipes: {
       'Test.Resources/userTypeAlpha': {
-        default: {
-          templateKind: 'bicep'
-          templatePath: '${registry}/test/testrecipes/test-bicep-recipes/dynamicrp_recipe:${version}'
-          parameters: {
-            port: port
-          }
+        kind: 'bicep'
+        source: '${registry}/test/testrecipes/test-bicep-recipes/dynamicrp_recipe:${version}'
+        parameters: {
+          port: port
         }
       }
     }
   }
 }
 
-resource udttoudtapp 'Applications.Core/applications@2023-10-01-preview' = {
+resource udttoudtenv 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'udttoudtenv'
+  location: 'global'
+  properties: {
+    recipePacks: [
+      recipepack.id
+    ]
+    providers: {
+      kubernetes: {
+        namespace: 'dynamicrp-udt2udt'
+      }
+    }
+  }
+}
+
+resource udttoudtapp 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'udttoudtapp'
   location: 'global'
   properties: {
     environment: udttoudtenv.id
-    extensions: [
-      {
-        kind: 'kubernetesNamespace'
-        namespace: 'udttoudtapp'
-      }
-    ]
   }
 }
 
-
 resource udttoudtparent 'Test.Resources/userTypeAlpha@2023-10-01-preview' = {
-    name: 'udttoudtparent'
-    properties: {
-      environment: udttoudtenv.id
-      application: udttoudtapp.id
-      connections: {
+  name: 'udttoudtparent'
+  properties: {
+    environment: udttoudtenv.id
+    application: udttoudtapp.id
+    connections: {
       externalresource: {
         source: udttoudtchild.id
       }
     }
   }
-    
 }
-
 
 resource udttoudtchild 'Test.Resources/externalResource@2023-10-01-preview' = {
   name: 'udttoudtchild'

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha-recipe-pack.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha-recipe-pack.bicep
@@ -1,0 +1,30 @@
+extension radius
+
+param registry string
+
+param version string
+
+@description('Specifies the location for resources.')
+param location string = 'global'
+
+@description('Specifies the port the container listens on.')
+param port int = 8080
+
+// Custom recipe pack that registers the user-defined type recipe. It is attached
+// to the preview environment alongside the default recipe pack (which provides the
+// Radius.Compute/containers recipe) via `rad env update --preview --recipe-packs`.
+resource recipepack 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'usertypealpha-recipe-pack'
+  location: location
+  properties: {
+    recipes: {
+      'Test.Resources/userTypeAlpha': {
+        kind: 'bicep'
+        source: '${registry}/test/testrecipes/test-bicep-recipes/dynamicrp_recipe:${version}'
+        parameters: {
+          port: port
+        }
+      }
+    }
+  }
+}

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha-recipe.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha-recipe.bicep
@@ -1,52 +1,28 @@
 extension testresources
 extension radius
 
-param registry string
-
-param version string
+@description('The ID of the environment to deploy into.')
+param environment string
 
 @description('Specifies the location for resources.')
 param location string = 'global'
 
-@description('Specifies the port the container listens on.')
-param port int = 8080
-
-resource env 'Applications.Core/environments@2023-10-01-preview' = {
-  name: 'usertypealpha-recipe-env'
-  location: location
-  properties: {
-    compute: {
-      kind: 'kubernetes'
-      resourceId: 'self'
-      namespace: 'usertypealpha-recipe-env'
-    }
-    recipes: {
-      'Test.Resources/userTypeAlpha': {
-        default: {
-          templateKind: 'bicep'
-          templatePath: '${registry}/test/testrecipes/test-bicep-recipes/dynamicrp_recipe:${version}'
-          parameters: {
-            port: port
-          }
-        }
-      }
-    }
-  }
-}
-
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'usertypealpha-recipe-app'
   location: location
   properties: {
-    environment: env.id
+    environment: environment
   }
 }
 
-resource usertypealphacntr 'Applications.Core/containers@2023-10-01-preview' = {
-    name: 'usertypealphacntr'
-    properties: {
-      application: app.id
-      container: {
+resource usertypealphacntr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'usertypealphacntr'
+  location: location
+  properties: {
+    application: app.id
+    environment: environment
+    containers: {
+      usertypealphacntr: {
         image: 'ghcr.io/radius-project/mirror/debian:latest'
         command: ['/bin/sh']
         args: ['-c', 'while true; do echo hello; sleep 10;done']
@@ -57,6 +33,7 @@ resource usertypealphacntr 'Applications.Core/containers@2023-10-01-preview' = {
         }
       }
     }
+  }
 }
 
 resource usertypealpha 'Test.Resources/userTypeAlpha@2023-10-01-preview' = {
@@ -64,7 +41,7 @@ resource usertypealpha 'Test.Resources/userTypeAlpha@2023-10-01-preview' = {
   location: location
   properties: {
     application: app.id
-    environment: env.id
+    environment: environment
   }
 }
 
@@ -73,6 +50,6 @@ resource usertypealphalatest 'Test.Resources/userTypeAlpha@2025-01-01-preview' =
   location: location
   properties: {
     application: app.id
-    environment: env.id
+    environment: environment
   }
 }

--- a/test/validation/shared.go
+++ b/test/validation/shared.go
@@ -45,6 +45,7 @@ const (
 	// Radius.Core resource types (new provider).
 	CoreEnvironmentsResource = "radius.core/environments"
 	CoreApplicationsResource = "radius.core/applications"
+	CoreRecipePacksResource  = "radius.core/recipePacks"
 
 	// Radius.Compute resource types (new provider).
 	ComputeContainersResource = "radius.compute/containers"
@@ -117,6 +118,10 @@ func DeleteRPResource(ctx context.Context, t *testing.T, cli *radcli.CLI, client
 		t.Logf("deleting Radius.Core environment: %s", resource.Name)
 		_, err := cli.EnvironmentDeletePreview(ctx, resource.Name, "")
 		return err
+	} else if resource.Type == CoreRecipePacksResource {
+		t.Logf("deleting Radius.Core recipe pack: %s", resource.Name)
+		_, err := client.DeleteResource(ctx, resource.Type, resource.Name, true)
+		return err
 	}
 
 	// Other resource types (containers, databases, etc.) are cleaned up
@@ -186,6 +191,13 @@ func ValidateRPResources(ctx context.Context, t *testing.T, expected *RPResource
 			}
 
 			require.True(t, found, fmt.Sprintf("application %s was not found", expectedResource.Name))
+		} else if expectedResource.Type == CoreEnvironmentsResource || expectedResource.Type == CoreApplicationsResource {
+			// New Radius.Core environments/applications are retrieved directly by
+			// type + name. They carry no "application" property, so the app-scoping
+			// assertion below is intentionally skipped for them.
+			res, err := client.GetResource(ctx, expectedResource.Type, expectedResource.Name)
+			require.NoError(t, err)
+			require.NotNil(t, res, "resource %s with type %s does not exist", expectedResource.Name, expectedResource.Type)
 		} else {
 			res, err := client.GetResource(ctx, expectedResource.Type, expectedResource.Name)
 			require.NoError(t, err)


### PR DESCRIPTION
This pull request migrates DynamicRP tests from the legacy Applications.Core/*  resource types to the new recipe-driven  Radius.Core/*,  Radius.Compute/*  types. 

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (#11489 ).

Fixes: Part of #11489

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
