### PR TITLE
ci: make "Collect Pod details" diagnostic step non-fatal

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -1026,6 +1026,10 @@ jobs:
 
       - name: Collect Pod details
         if: always()
+        # Diagnostic-only snapshot of cluster-wide pod state for post-mortem. A
+        # `kubectl describe pods -A` can race pod teardown and return a transient
+        # NotFound, so never let it fail the job.
+        continue-on-error: true
         env:
           MATRIX_NAME: ${{ matrix.name }}
         run: |

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -579,6 +579,10 @@ jobs:
 
       - name: Collect Pod details
         if: always()
+        # Diagnostic-only snapshot of cluster-wide pod state for post-mortem. A
+        # `kubectl describe pods -A` can race pod teardown and return a transient
+        # NotFound, so never let it fail the job.
+        continue-on-error: true
         env:
           MATRIX_NAME: ${{ matrix.name }}
         run: |

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -424,6 +424,10 @@ jobs:
 
       - name: Collect Pod details
         if: always()
+        # Diagnostic-only snapshot of cluster-wide pod state for post-mortem. A
+        # `kubectl describe pods -A` can race pod teardown and return a transient
+        # NotFound, so never let it fail the job.
+        continue-on-error: true
         run: |
           POD_STATE_LOG_FILENAME="${RADIUS_CONTAINER_LOG_BASE}/all-tests-pod-states.log"
           mkdir -p $(dirname $POD_STATE_LOG_FILENAME)


### PR DESCRIPTION
## Description

The **Collect Pod details** step in the functional-test workflows runs
`kubectl get pods -A` and `kubectl describe pods -A` to capture a cluster-wide
pod-state snapshot that is uploaded as a post-mortem artifact for failed
functional tests. It runs with `if: always()`, so it executes during teardown —
exactly when pods are being deleted.

A `kubectl describe pods -A` that races a pod deletion returns
`Error from server (NotFound)` with a non-zero exit code, which (under `bash -e`)
**fails the whole job even though the actual tests passed**. This produces
spurious red runs unrelated to the code under test.

Observed on PR #12106: the `msgrp-noncloud` leg reported `DONE 4 tests in 37.574s`
(all passing), then failed only in this diagnostic step with:

```
Error from server (NotFound): pods "rabbitmq-...-6b9fn" not found
##[error]Process completed with exit code 1.
```

## Changes

Mark the **Collect Pod details** step `continue-on-error: true` in all three
functional workflows:

- `.github/workflows/functional-test-noncloud.yaml`
- `.github/workflows/functional-test-cloud.yaml`
- `.github/workflows/long-running-azure.yaml`

The step is purely diagnostic, so a transient collection error must never fail
the job. The partial snapshot is still captured and uploaded — we keep the
debugging value (an all-namespace pod-state snapshot, which is the most useful
artifact for diagnosing infra/scheduling/image-pull failures) without letting it
gate the result. Removing the step was considered and rejected: its output is
genuinely useful, and the race is inherent to `describe -A` during teardown, so
the correct fix is to make the diagnostic non-fatal rather than delete it.

## Type of change

- This pull request fixes a bug in CI tooling and does not require an issue.

<!--
Auto-generated by the multi-cluster work (split out of PR #12106 per reviewer
request to keep the shared CI-infra change in its own PR).
-->
