### PR TITLE
test(aci): disable Test_ACI to cut corerp-cloud CI time (~2x)

### DIFF
--- a/test/functional-portable/corerp/cloud/resources/aci_test.go
+++ b/test/functional-portable/corerp/cloud/resources/aci_test.go
@@ -38,6 +38,16 @@ import (
 )
 
 func Test_ACI(t *testing.T) {
+	// Disabled: this test dominates the corerp-cloud functional leg's wall-clock
+	// time. It provisions real Azure Container Instances (plus a VNet/NSG/ILB) and
+	// is wrapped in a 2x retry with 60s backoff to tolerate the subscription-shared
+	// 'StandardCores' ACI quota (ContainerGroupQuotaReached). When the quota is
+	// exhausted by concurrent CI runs the deploy is retried end-to-end, so a single
+	// run can take ~11-12 minutes (vs <1 minute for every other test in the leg) and
+	// roughly doubles the cloud workflow's total time. Re-enable once the ACI tests
+	// are isolated onto their own quota-aware lane. See #12044 and #12163.
+	t.Skip("Test_ACI is temporarily disabled: real ACI provisioning + quota retries dominate corerp-cloud CI time. See #12044, #12163.")
+
 	name := "aci-app"
 	containerResourceName := "frontend"
 	containerResourceName2 := "magpie"


### PR DESCRIPTION
# Description

`Test_ACI` is the single biggest contributor to `corerp-cloud` functional-test wall time, and disabling it roughly **halves** the cloud functional workflow's duration.

It deploys **real Azure Container Instances** (plus a supporting VNet, NSG, and internal load balancer) via the built-in `compute.kind: 'aci'` path, then independently re-reads those Azure resources in `PostStepVerify`. Because the subscription-shared `StandardCores` ACI quota (`ContainerGroupQuotaReached`) is frequently exhausted by concurrent CI runs, the test is wrapped in a **2x retry with 60s backoff** — so on quota contention the entire app deploy is retried end-to-end.

## Timing impact (measured)

Per-test durations from a recent `corerp-cloud` run (junit results):

| Test | Duration |
| --- | --- |
| **`Test_ACI`** | **~11m36s** |
| `Test_AWS_LogsLogGroup_Existing` | 0m52s |
| `Test_AWSRedeployWithUpdatedResourceUpdatesResource` | 0m51s |
| `Test_AWS_MultiIdentifier_Resource` | 0m44s |
| `Test_TerraformRecipe_AzureResourceGroup` | 0m44s |
| every other test in the leg | < 1m each |

- `Test_ACI` alone accounts for **more than half** of the `corerp-cloud` leg's wall-clock time.
- The `corerp-cloud` leg is the **long pole** of the `functional-test-cloud` workflow (`Build Radius for test` ~8m40s runs first, then the cloud legs).
- The cloud workflow has been swinging **~27 → 42 minutes** on `main` for weeks, and that entire swing tracks `Test_ACI`: when ACI hits quota and burns its retries it runs ~36m+ and drags the whole workflow toward ~42m; when ACI is fast (~11m) the workflow lands near ~27m.

In short, this one test **roughly doubles** the cloud functional run on bad-quota days while every other test finishes in under a minute.

## What changed

- Add `t.Skip(...)` at the top of `Test_ACI` with a comment explaining the cost and the conditions for re-enabling.
- The fast `Test_isTransientAzureError` unit test in the same file is **left enabled** — it has no deploy and runs in milliseconds.

## Follow-up

Re-enable once the ACI tests are isolated onto their own quota-aware lane (so an exhausted `StandardCores` quota can't serialize in front of the ~26 sub-minute tests), and/or the CI subscription's container-group quota is raised. Related: #12044 (Test_ACI cleanup timeout flake) and #12163 (restructure the test matrix into functional vs integration/E2E).

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius.

## Contributor checklist

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/`, if new APIs are being introduced.
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected.
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected.
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes affect documentation or any user-facing behavior.
    - [x] Not applicable
