### PR TITLE
fix(ci): run cloud functional-test setup on trusted PRs

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -215,8 +215,11 @@ jobs:
     name: Setup
     needs: [authorize]
     # Gate on the single authorize decision; the schedule guard keeps scheduled
-    # runs limited to the canonical repository.
-    if: needs.authorize.result == 'success' && (github.event_name != 'schedule' || github.repository == vars.RADIUS_REPOSITORY)
+    # runs limited to the canonical repository. always() is required so the skip
+    # that propagates from the intentionally-skipped approval-gate on trusted
+    # (same-repo) PRs does not also skip setup; the explicit authorize check still
+    # enforces the gate.
+    if: always() && needs.authorize.result == 'success' && (github.event_name != 'schedule' || github.repository == vars.RADIUS_REPOSITORY)
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -355,8 +358,9 @@ jobs:
   build:
     name: Build Radius for test
     needs: [setup, changes]
-    # Skip if only docs/markdown changed
-    if: always() && needs.changes.outputs.only_changed != 'true'
+    # Require setup to have produced REL_VERSION/CHECKOUT_REF (otherwise the image
+    # tag would be empty); also skip if only docs/markdown changed.
+    if: always() && needs.setup.result == 'success' && needs.changes.outputs.only_changed != 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
# Description

The "Functional Tests (with Cloud Resources)" workflow (`functional-test-cloud.yaml`) fails the **Build Radius for test** job on trusted (same-repo) pull requests with an invalid image reference such as:

```text
invalid reference format
ghcr.io/radius-project/dev/ucpd:        # empty tag
```

## Root cause

The workflow gates execution behind a chain: `check-trust` → `approval-gate` → `authorize` → `setup` → `changes` → `build`.

For **trusted / same-repo** PRs the `approval-gate` job is *intentionally* skipped (it only runs for external forks). In GitHub Actions a skipped job propagates a skip to everything downstream **unless** the dependent job uses a status-check function (`always()`, `success()`, etc.).

Every downstream job already follows that pattern — `changes`, `build`, and `tests` all start with `always()` — **except `setup`**:

```yaml
# before
if: needs.authorize.result == 'success' && (github.event_name != 'schedule' || github.repository == vars.RADIUS_REPOSITORY)
```

So on trusted PRs the skip propagated into `setup`, `setup` was skipped, and it never produced `REL_VERSION` / `CHECKOUT_REF`. `changes` then skipped too, but `build` (which uses `always()`) still ran — with an empty `REL_VERSION`, producing the empty image tag and failing.

This affects every trusted PR (e.g. several recent PRs failed the same cloud check). It only surfaces through `pull_request_target`, which always runs the **base branch's** copy of the workflow — so the fix must land on `main` to take effect.

## Fix

Two minimal `if:` changes, both aligning `setup`/`build` with the pattern already used by `changes`/`tests`:

1. `setup` — add `always()` so the skipped `approval-gate` no longer skips it; the explicit `needs.authorize.result == 'success'` check still enforces the gate.
2. `build` — add `needs.setup.result == 'success'` so it can never run with an empty `REL_VERSION` again.

Validated with `actionlint` (clean).

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
