### PR TITLE
Resolve secretName / Radius.Security/secrets references into direct-module recipe parameters

### DIFF
--- a/pkg/dynamicrp/options.go
+++ b/pkg/dynamicrp/options.go
@@ -29,6 +29,7 @@ import (
 	"github.com/radius-project/radius/pkg/components/kubernetesclient/kubernetesclientprovider"
 	"github.com/radius-project/radius/pkg/components/queue/queueprovider"
 	"github.com/radius-project/radius/pkg/components/secret/secretprovider"
+	"github.com/radius-project/radius/pkg/dynamicrp/secretsloader"
 	"github.com/radius-project/radius/pkg/portableresources/processors"
 	"github.com/radius-project/radius/pkg/recipes"
 	"github.com/radius-project/radius/pkg/recipes/configloader"
@@ -119,7 +120,12 @@ func NewOptions(ctx context.Context, config *Config) (*Options, error) {
 	}
 
 	options.Recipes.ConfigurationLoader = configloader.NewEnvironmentLoader(sdk.NewClientOptions(options.UCP))
-	options.Recipes.SecretsLoader = configloader.NewSecretStoreLoader(sdk.NewClientOptions(options.UCP))
+
+	// The dispatching loader reads Radius.Security/secrets resources from their backing Kubernetes Secret
+	// (cleartext is never persisted to the database), and delegates other secret store types to the
+	// default Applications.Core/secretStores loader.
+	storeLoader := configloader.NewSecretStoreLoader(sdk.NewClientOptions(options.UCP))
+	options.Recipes.SecretsLoader = secretsloader.NewDispatchingLoader(storeLoader, databaseClient, options.KubernetesProvider)
 
 	// If this is set to nil, then the service will use the default recipe drivers.
 	//

--- a/pkg/dynamicrp/secretsloader/secretsloader.go
+++ b/pkg/dynamicrp/secretsloader/secretsloader.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package secretsloader provides a configloader.SecretsLoader that can read Radius.Security/secrets
+// resources in addition to the Applications.Core/secretStores resources handled by the default loader.
+//
+// Cleartext for a Radius.Security/secrets resource is never persisted to the database: the resource's
+// sensitive data is redacted before recipe execution. The cleartext lives only in the Kubernetes Secret
+// that the secret's own recipe materialized. This loader therefore reads the referenced secret's
+// status.outputResources, locates the backing Kubernetes Secret, and reads the live values on demand.
+package secretsloader
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/radius-project/radius/pkg/components/database"
+	"github.com/radius-project/radius/pkg/components/kubernetesclient/kubernetesclientprovider"
+	"github.com/radius-project/radius/pkg/dynamicrp/datamodel"
+	"github.com/radius-project/radius/pkg/recipes"
+	"github.com/radius-project/radius/pkg/recipes/configloader"
+	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
+	"github.com/radius-project/radius/pkg/ucp/resources"
+	resources_kubernetes "github.com/radius-project/radius/pkg/ucp/resources/kubernetes"
+)
+
+const (
+	// secretResourceType is the resource type of the user-defined secret resource.
+	secretResourceType = "Radius.Security/secrets"
+	// kubernetesSecretType is the output resource type of a Kubernetes Secret.
+	kubernetesSecretType = "core/Secret"
+)
+
+var _ configloader.SecretsLoader = (*dispatchingLoader)(nil)
+var _ configloader.SecretsLoader = (*udtSecretsLoader)(nil)
+
+// NewDispatchingLoader returns a configloader.SecretsLoader that routes each secret ID to the appropriate
+// backing loader based on its resource type: Radius.Security/secrets is read from its deployed Kubernetes
+// Secret, and all other types (e.g. Applications.Core/secretStores) are delegated to storeLoader.
+func NewDispatchingLoader(storeLoader configloader.SecretsLoader, databaseClient database.Client, kubeProvider *kubernetesclientprovider.KubernetesClientProvider) configloader.SecretsLoader {
+	return &dispatchingLoader{
+		storeLoader: storeLoader,
+		udtLoader:   &udtSecretsLoader{databaseClient: databaseClient, kubeProvider: kubeProvider},
+	}
+}
+
+// dispatchingLoader routes secret IDs to a type-specific loader.
+type dispatchingLoader struct {
+	storeLoader configloader.SecretsLoader
+	udtLoader   configloader.SecretsLoader
+}
+
+// LoadSecrets partitions the requested secret IDs by resource type and delegates each partition to the
+// loader that can read it, then merges the results.
+func (l *dispatchingLoader) LoadSecrets(ctx context.Context, secretStoreIDs map[string][]string) (map[string]recipes.SecretData, error) {
+	udtFilter := map[string][]string{}
+	storeFilter := map[string][]string{}
+	for id, keys := range secretStoreIDs {
+		parsed, err := resources.ParseResource(id)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse secret resource ID %q: %w", id, err)
+		}
+
+		if strings.EqualFold(parsed.Type(), secretResourceType) {
+			udtFilter[id] = keys
+		} else {
+			storeFilter[id] = keys
+		}
+	}
+
+	result := map[string]recipes.SecretData{}
+
+	if len(udtFilter) > 0 {
+		loaded, err := l.udtLoader.LoadSecrets(ctx, udtFilter)
+		if err != nil {
+			return nil, err
+		}
+		for id, data := range loaded {
+			result[id] = data
+		}
+	}
+
+	if len(storeFilter) > 0 {
+		if l.storeLoader == nil {
+			return nil, fmt.Errorf("no secret store loader is configured to load secrets from %d secret store(s)", len(storeFilter))
+		}
+		loaded, err := l.storeLoader.LoadSecrets(ctx, storeFilter)
+		if err != nil {
+			return nil, err
+		}
+		for id, data := range loaded {
+			result[id] = data
+		}
+	}
+
+	return result, nil
+}
+
+// udtSecretsLoader reads cleartext for Radius.Security/secrets resources from their backing Kubernetes Secret.
+type udtSecretsLoader struct {
+	databaseClient database.Client
+	kubeProvider   *kubernetesclientprovider.KubernetesClientProvider
+}
+
+// LoadSecrets reads each requested Radius.Security/secrets resource's live Kubernetes Secret and returns its data.
+func (l *udtSecretsLoader) LoadSecrets(ctx context.Context, secretStoreIDs map[string][]string) (map[string]recipes.SecretData, error) {
+	result := map[string]recipes.SecretData{}
+	for id, keys := range secretStoreIDs {
+		data, err := l.loadSecret(ctx, id, keys)
+		if err != nil {
+			return nil, err
+		}
+		result[id] = data
+	}
+
+	return result, nil
+}
+
+// loadSecret resolves a single Radius.Security/secrets resource to its cleartext data. It fails closed: if the
+// backing Kubernetes Secret cannot be located or read, an error is returned rather than partial/empty data.
+func (l *udtSecretsLoader) loadSecret(ctx context.Context, secretID string, keysFilter []string) (recipes.SecretData, error) {
+	if l.databaseClient == nil || l.kubeProvider == nil {
+		return recipes.SecretData{}, fmt.Errorf("secret loader is not fully configured for Radius.Security/secrets")
+	}
+
+	resource, err := database.GetResource[datamodel.DynamicResource](ctx, l.databaseClient, secretID)
+	if err != nil {
+		return recipes.SecretData{}, fmt.Errorf("failed to get secret resource %q: %w", secretID, err)
+	}
+
+	namespace, name, found := kubernetesSecretLocation(resource.OutputResources())
+	if !found {
+		return recipes.SecretData{}, fmt.Errorf("secret %q has no Kubernetes Secret output resource; only Kubernetes-backed Radius.Security/secrets are supported", secretID)
+	}
+
+	runtimeClient, err := l.kubeProvider.RuntimeClient()
+	if err != nil {
+		return recipes.SecretData{}, fmt.Errorf("failed to create Kubernetes client to read secret %q: %w", secretID, err)
+	}
+
+	ksecret := &corev1.Secret{}
+	if err := runtimeClient.Get(ctx, runtimeclient.ObjectKey{Namespace: namespace, Name: name}, ksecret); err != nil {
+		return recipes.SecretData{}, fmt.Errorf("failed to read Kubernetes Secret for secret %q: %w", secretID, err)
+	}
+
+	return buildSecretData(secretID, ksecret, keysFilter)
+}
+
+// kubernetesSecretLocation returns the namespace and name of the Kubernetes Secret output resource, if present.
+func kubernetesSecretLocation(outputResources []rpv1.OutputResource) (namespace string, name string, found bool) {
+	for _, outputResource := range outputResources {
+		if strings.EqualFold(outputResource.ID.Type(), kubernetesSecretType) {
+			_, _, namespace, name = resources_kubernetes.ToParts(outputResource.ID)
+			return namespace, name, true
+		}
+	}
+
+	return "", "", false
+}
+
+// buildSecretData converts the live Kubernetes Secret into recipes.SecretData. When keysFilter is empty, all
+// keys are returned; otherwise only the requested keys are returned and a missing key is an error.
+func buildSecretData(secretID string, ksecret *corev1.Secret, keysFilter []string) (recipes.SecretData, error) {
+	data := recipes.SecretData{
+		Type: secretResourceType,
+		Data: map[string]string{},
+	}
+
+	keys := keysFilter
+	if len(keys) == 0 {
+		keys = make([]string, 0, len(ksecret.Data))
+		for key := range ksecret.Data {
+			keys = append(keys, key)
+		}
+	}
+
+	for _, key := range keys {
+		value, ok := ksecret.Data[key]
+		if !ok {
+			return recipes.SecretData{}, fmt.Errorf("secret key %q was not found in secret %q", key, secretID)
+		}
+		data.Data[key] = string(value)
+	}
+
+	return data, nil
+}

--- a/pkg/dynamicrp/secretsloader/secretsloader_test.go
+++ b/pkg/dynamicrp/secretsloader/secretsloader_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secretsloader
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	"github.com/radius-project/radius/pkg/armrpc/rpctest"
+	"github.com/radius-project/radius/pkg/components/database"
+	"github.com/radius-project/radius/pkg/components/kubernetesclient/kubernetesclientprovider"
+	"github.com/radius-project/radius/pkg/dynamicrp/datamodel"
+	"github.com/radius-project/radius/pkg/recipes"
+	"github.com/radius-project/radius/pkg/recipes/configloader"
+	resources_kubernetes "github.com/radius-project/radius/pkg/ucp/resources/kubernetes"
+)
+
+const (
+	testSecretID    = "/planes/radius/local/resourceGroups/test-rg/providers/Radius.Security/secrets/db-secret"
+	testStoreID     = "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Core/secretStores/store"
+	testNamespace   = "test-namespace"
+	testK8sSecret   = "db-secret-k8s"
+	testInvalidID   = "not-a-valid-id"
+	testNoOutputsID = "/planes/radius/local/resourceGroups/test-rg/providers/Radius.Security/secrets/no-outputs"
+)
+
+// newSecretStoreObject builds a database.Object for a Radius.Security/secrets resource whose status
+// references the given Kubernetes Secret as an output resource. When secretName is empty, no Kubernetes
+// Secret output resource is included.
+func newSecretStoreObject(t *testing.T, resourceID, namespace, secretName string) *database.Object {
+	t.Helper()
+
+	outputResources := []any{}
+	if secretName != "" {
+		k8sID := resources_kubernetes.IDFromParts("local", "", "Secret", namespace, secretName)
+		outputResources = append(outputResources, map[string]any{
+			"localID":       "Secret",
+			"id":            k8sID.String(),
+			"radiusManaged": true,
+		})
+	}
+
+	resource := &datamodel.DynamicResource{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:   resourceID,
+				Name: "db-secret",
+				Type: "Radius.Security/secrets",
+			},
+		},
+		Properties: map[string]any{
+			"status": map[string]any{
+				"outputResources": outputResources,
+			},
+		},
+	}
+
+	return rpctest.FakeStoreObject(resource)
+}
+
+// newKubeProvider builds a Kubernetes client provider backed by a fake runtime client holding the given objects.
+func newKubeProvider(objects ...*corev1.Secret) *kubernetesclientprovider.KubernetesClientProvider {
+	builder := fake.NewClientBuilder()
+	for _, object := range objects {
+		builder = builder.WithObjects(object)
+	}
+
+	provider := kubernetesclientprovider.FromConfig(nil)
+	provider.SetRuntimeClient(builder.Build())
+	return provider
+}
+
+func Test_DispatchingLoader_RadiusSecuritySecrets(t *testing.T) {
+	t.Run("reads cleartext from the backing Kubernetes Secret", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		databaseClient := database.NewMockClient(ctrl)
+		databaseClient.EXPECT().Get(gomock.Any(), testSecretID).Return(newSecretStoreObject(t, testSecretID, testNamespace, testK8sSecret), nil)
+
+		kubeProvider := newKubeProvider(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: testK8sSecret, Namespace: testNamespace},
+			Data:       map[string][]byte{"password": []byte("s3cr3t"), "username": []byte("admin")},
+		})
+
+		loader := NewDispatchingLoader(nil, databaseClient, kubeProvider)
+
+		result, err := loader.LoadSecrets(context.Background(), map[string][]string{testSecretID: nil})
+		require.NoError(t, err)
+		require.Equal(t, map[string]recipes.SecretData{
+			testSecretID: {
+				Type: "Radius.Security/secrets",
+				Data: map[string]string{"password": "s3cr3t", "username": "admin"},
+			},
+		}, result)
+	})
+
+	t.Run("returns only the requested keys", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		databaseClient := database.NewMockClient(ctrl)
+		databaseClient.EXPECT().Get(gomock.Any(), testSecretID).Return(newSecretStoreObject(t, testSecretID, testNamespace, testK8sSecret), nil)
+
+		kubeProvider := newKubeProvider(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: testK8sSecret, Namespace: testNamespace},
+			Data:       map[string][]byte{"password": []byte("s3cr3t"), "username": []byte("admin")},
+		})
+
+		loader := NewDispatchingLoader(nil, databaseClient, kubeProvider)
+
+		result, err := loader.LoadSecrets(context.Background(), map[string][]string{testSecretID: {"password"}})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"password": "s3cr3t"}, result[testSecretID].Data)
+	})
+
+	t.Run("fails closed when the resource has no Kubernetes Secret output resource", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		databaseClient := database.NewMockClient(ctrl)
+		databaseClient.EXPECT().Get(gomock.Any(), testNoOutputsID).Return(newSecretStoreObject(t, testNoOutputsID, testNamespace, ""), nil)
+
+		loader := NewDispatchingLoader(nil, databaseClient, newKubeProvider())
+
+		_, err := loader.LoadSecrets(context.Background(), map[string][]string{testNoOutputsID: nil})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no Kubernetes Secret output resource")
+	})
+
+	t.Run("fails closed when the Kubernetes Secret is absent", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		databaseClient := database.NewMockClient(ctrl)
+		databaseClient.EXPECT().Get(gomock.Any(), testSecretID).Return(newSecretStoreObject(t, testSecretID, testNamespace, testK8sSecret), nil)
+
+		loader := NewDispatchingLoader(nil, databaseClient, newKubeProvider())
+
+		_, err := loader.LoadSecrets(context.Background(), map[string][]string{testSecretID: nil})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to read Kubernetes Secret")
+	})
+
+	t.Run("fails closed when a requested key is missing", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		databaseClient := database.NewMockClient(ctrl)
+		databaseClient.EXPECT().Get(gomock.Any(), testSecretID).Return(newSecretStoreObject(t, testSecretID, testNamespace, testK8sSecret), nil)
+
+		kubeProvider := newKubeProvider(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: testK8sSecret, Namespace: testNamespace},
+			Data:       map[string][]byte{"password": []byte("s3cr3t")},
+		})
+
+		loader := NewDispatchingLoader(nil, databaseClient, kubeProvider)
+
+		_, err := loader.LoadSecrets(context.Background(), map[string][]string{testSecretID: {"missing"}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "was not found")
+	})
+
+	t.Run("fails closed when the resource cannot be read from the database", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		databaseClient := database.NewMockClient(ctrl)
+		databaseClient.EXPECT().Get(gomock.Any(), testSecretID).Return(nil, errors.New("boom"))
+
+		loader := NewDispatchingLoader(nil, databaseClient, newKubeProvider())
+
+		_, err := loader.LoadSecrets(context.Background(), map[string][]string{testSecretID: nil})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get secret resource")
+	})
+
+	t.Run("fails closed when not configured", func(t *testing.T) {
+		loader := NewDispatchingLoader(nil, nil, nil)
+
+		_, err := loader.LoadSecrets(context.Background(), map[string][]string{testSecretID: nil})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not fully configured")
+	})
+}
+
+func Test_DispatchingLoader_Routing(t *testing.T) {
+	t.Run("delegates non-UDT secret types to the store loader", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		storeLoader := configloader.NewMockSecretsLoader(ctrl)
+		storeLoader.EXPECT().
+			LoadSecrets(gomock.Any(), map[string][]string{testStoreID: nil}).
+			Return(map[string]recipes.SecretData{
+				testStoreID: {Type: "generic", Data: map[string]string{"key": "value"}},
+			}, nil)
+
+		loader := NewDispatchingLoader(storeLoader, nil, nil)
+
+		result, err := loader.LoadSecrets(context.Background(), map[string][]string{testStoreID: nil})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"key": "value"}, result[testStoreID].Data)
+	})
+
+	t.Run("routes each type to its loader and merges the results", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		databaseClient := database.NewMockClient(ctrl)
+		databaseClient.EXPECT().Get(gomock.Any(), testSecretID).Return(newSecretStoreObject(t, testSecretID, testNamespace, testK8sSecret), nil)
+		kubeProvider := newKubeProvider(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: testK8sSecret, Namespace: testNamespace},
+			Data:       map[string][]byte{"password": []byte("s3cr3t")},
+		})
+
+		storeLoader := configloader.NewMockSecretsLoader(ctrl)
+		storeLoader.EXPECT().
+			LoadSecrets(gomock.Any(), map[string][]string{testStoreID: nil}).
+			Return(map[string]recipes.SecretData{
+				testStoreID: {Type: "generic", Data: map[string]string{"key": "value"}},
+			}, nil)
+
+		loader := NewDispatchingLoader(storeLoader, databaseClient, kubeProvider)
+
+		result, err := loader.LoadSecrets(context.Background(), map[string][]string{
+			testSecretID: nil,
+			testStoreID:  nil,
+		})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"password": "s3cr3t"}, result[testSecretID].Data)
+		require.Equal(t, map[string]string{"key": "value"}, result[testStoreID].Data)
+	})
+
+	t.Run("errors when a non-UDT secret is requested but no store loader is configured", func(t *testing.T) {
+		loader := NewDispatchingLoader(nil, nil, nil)
+
+		_, err := loader.LoadSecrets(context.Background(), map[string][]string{testStoreID: nil})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no secret store loader is configured")
+	})
+
+	t.Run("errors on an unparseable secret ID", func(t *testing.T) {
+		loader := NewDispatchingLoader(nil, nil, nil)
+
+		_, err := loader.LoadSecrets(context.Background(), map[string][]string{testInvalidID: nil})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse secret resource ID")
+	})
+}

--- a/pkg/portableresources/backend/controller/createorupdateresource.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource.go
@@ -89,6 +89,7 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 	currentETag := storedResource.ETag
 	var recipeProperties map[string]any
 	var secretReferencePaths []string
+	var secretBindingPaths []string
 	redactionCompleted := false
 
 	// Attempt to decrypt and redact sensitive fields before recipe execution.
@@ -102,6 +103,10 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 			// Detect properties that reference a Radius.Security/secrets resource by name so the engine can
 			// resolve them into recipe context (context.resource.secrets.<key>).
 			secretReferencePaths = schemautil.ExtractSecretReferenceFieldPaths(schema, "")
+
+			// Detect secrets arrays (x-radius-secret-binding) so the engine can load each listed
+			// secret's keys into recipe context (context.resource.secrets.<secretName>.<key>).
+			secretBindingPaths = schemautil.ExtractSecretBindingPaths(schema, "")
 
 			sensitiveFieldPaths := schemautil.ExtractSensitiveFieldPaths(schema, "")
 			if len(sensitiveFieldPaths) > 0 {
@@ -182,7 +187,7 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 	recipeDataModel, supportsRecipes := any(resource).(datamodel.RecipeDataModel)
 	var recipeOutput *recipes.RecipeOutput
 	if supportsRecipes && recipeDataModel.GetRecipe() != nil {
-		recipeOutput, err = c.executeRecipeIfNeeded(ctx, resource, recipeDataModel, previousOutputResources, config.Simulated, recipeProperties, secretReferencePaths)
+		recipeOutput, err = c.executeRecipeIfNeeded(ctx, resource, recipeDataModel, previousOutputResources, config.Simulated, recipeProperties, secretReferencePaths, secretBindingPaths)
 		if err != nil {
 			return c.handleRecipeError(ctx, err, recipeDataModel, req.ResourceID, currentETag, logger, redactionCompleted)
 		}
@@ -273,7 +278,7 @@ func (c *CreateOrUpdateResource[P, T]) copyOutputResources(resource P) []string 
 	return previousOutputResources
 }
 
-func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context, resource P, recipeDataModel datamodel.RecipeDataModel, prevState []string, simulated bool, recipeProperties map[string]any, secretReferencePaths []string) (*recipes.RecipeOutput, error) {
+func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context, resource P, recipeDataModel datamodel.RecipeDataModel, prevState []string, simulated bool, recipeProperties map[string]any, secretReferencePaths []string, secretBindingPaths []string) (*recipes.RecipeOutput, error) {
 	// Caller ensures recipeDataModel supports recipes and has a non-nil recipe
 	recipe := recipeDataModel.GetRecipe()
 
@@ -331,6 +336,14 @@ func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context
 		return nil, err
 	}
 	metadata.SecretReferences = secretReferences
+
+	// Resolve the x-radius-secret-binding array property to the list of secret IDs it references so the engine
+	// can load each bound secret's keys into the recipe context.
+	secretBindings, err := buildSecretBindings(resourceProperties, secretBindingPaths)
+	if err != nil {
+		return nil, err
+	}
+	metadata.SecretBindings = secretBindings
 
 	return c.engine.Execute(ctx, engine.ExecuteOptions{
 		BaseOptions: engine.BaseOptions{
@@ -397,6 +410,66 @@ func stringValueAtPath(properties map[string]any, path string) (string, bool) {
 
 	value, ok := current.(string)
 	return value, ok
+}
+
+// buildSecretBindings resolves an x-radius-secret-binding array property into the list of Radius.Security/secrets
+// resource IDs it references. Each entry must be a non-empty string that parses as a resource ID; the engine
+// loads every key of each secret into the recipe's Secrets under a "<secretName>.<key>" namespace for the
+// context.resource.secrets.<secretName>.<key> expression path. An unset property is skipped; a malformed entry
+// (non-string, empty, or not a resource ID) is an error so the deployment fails closed rather than silently
+// dropping a secret the recipe expects.
+func buildSecretBindings(properties map[string]any, secretBindingPaths []string) ([]string, error) {
+	if len(secretBindingPaths) == 0 {
+		return nil, nil
+	}
+
+	var secretIDs []string
+	for _, path := range secretBindingPaths {
+		raw, ok := valueAtPath(properties, path)
+		if !ok || raw == nil {
+			// The property is optional and unset; nothing to resolve.
+			continue
+		}
+
+		entries, ok := raw.([]any)
+		if !ok {
+			return nil, fmt.Errorf("secret binding property %q must be an array of secret IDs", path)
+		}
+
+		for i, entry := range entries {
+			id, ok := entry.(string)
+			if !ok || id == "" {
+				return nil, fmt.Errorf("secret binding %q[%d] must be a non-empty secret ID string", path, i)
+			}
+			if _, err := resources.ParseResource(id); err != nil {
+				return nil, fmt.Errorf("secret binding %q[%d] has invalid secret ID %q: %w", path, i, id, err)
+			}
+			secretIDs = append(secretIDs, id)
+		}
+	}
+
+	if len(secretIDs) == 0 {
+		return nil, nil
+	}
+
+	return secretIDs, nil
+}
+
+// valueAtPath returns the value at the given dot-separated path in a nested properties map.
+func valueAtPath(properties map[string]any, path string) (any, bool) {
+	var current any = properties
+	for _, segment := range strings.Split(path, ".") {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = m[segment]
+		if !ok {
+			return nil, false
+		}
+	}
+
+	return current, true
 }
 
 func deepCopyProperties(source map[string]any) (map[string]any, error) {

--- a/pkg/portableresources/backend/controller/createorupdateresource.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
@@ -36,8 +37,13 @@ import (
 	"github.com/radius-project/radius/pkg/resourceutil"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	schemautil "github.com/radius-project/radius/pkg/schema"
+	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
 )
+
+// secretReferenceResourceType is the resource type of a Radius.Security/secrets resource named by an
+// x-radius-secret-reference property.
+const secretReferenceResourceType = "Radius.Security/secrets"
 
 // CreateOrUpdateResource is the async operation controller to create or update portable resources.
 type CreateOrUpdateResource[P interface {
@@ -82,6 +88,7 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 
 	currentETag := storedResource.ETag
 	var recipeProperties map[string]any
+	var secretReferencePaths []string
 	redactionCompleted := false
 
 	// Attempt to decrypt and redact sensitive fields before recipe execution.
@@ -92,6 +99,10 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 		if schemaErr != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to fetch schema for sensitive field detection: %w", schemaErr)
 		} else if schema != nil {
+			// Detect properties that reference a Radius.Security/secrets resource by name so the engine can
+			// resolve them into recipe context (context.resource.secrets.<key>).
+			secretReferencePaths = schemautil.ExtractSecretReferenceFieldPaths(schema, "")
+
 			sensitiveFieldPaths := schemautil.ExtractSensitiveFieldPaths(schema, "")
 			if len(sensitiveFieldPaths) > 0 {
 				logger.Info("Sensitive fields detected for resource", "resourceID", req.ResourceID, "paths", sensitiveFieldPaths)
@@ -171,7 +182,7 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 	recipeDataModel, supportsRecipes := any(resource).(datamodel.RecipeDataModel)
 	var recipeOutput *recipes.RecipeOutput
 	if supportsRecipes && recipeDataModel.GetRecipe() != nil {
-		recipeOutput, err = c.executeRecipeIfNeeded(ctx, resource, recipeDataModel, previousOutputResources, config.Simulated, recipeProperties)
+		recipeOutput, err = c.executeRecipeIfNeeded(ctx, resource, recipeDataModel, previousOutputResources, config.Simulated, recipeProperties, secretReferencePaths)
 		if err != nil {
 			return c.handleRecipeError(ctx, err, recipeDataModel, req.ResourceID, currentETag, logger, redactionCompleted)
 		}
@@ -262,7 +273,7 @@ func (c *CreateOrUpdateResource[P, T]) copyOutputResources(resource P) []string 
 	return previousOutputResources
 }
 
-func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context, resource P, recipeDataModel datamodel.RecipeDataModel, prevState []string, simulated bool, recipeProperties map[string]any) (*recipes.RecipeOutput, error) {
+func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context, resource P, recipeDataModel datamodel.RecipeDataModel, prevState []string, simulated bool, recipeProperties map[string]any, secretReferencePaths []string) (*recipes.RecipeOutput, error) {
 	// Caller ensures recipeDataModel supports recipes and has a non-nil recipe
 	recipe := recipeDataModel.GetRecipe()
 
@@ -313,6 +324,14 @@ func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context
 		ConnectedResourcesProperties: connectedResourcesMetadata,
 	}
 
+	// Resolve x-radius-secret-reference properties to Radius.Security/secrets resource IDs so the engine
+	// can load their secret material into the recipe context.
+	secretReferences, err := buildSecretReferences(resource.GetBaseResource().ID, resourceProperties, secretReferencePaths)
+	if err != nil {
+		return nil, err
+	}
+	metadata.SecretReferences = secretReferences
+
 	return c.engine.Execute(ctx, engine.ExecuteOptions{
 		BaseOptions: engine.BaseOptions{
 			Recipe: metadata,
@@ -324,6 +343,60 @@ func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context
 
 func getResourceAPIVersion[P rpv1.RadiusResourceModel](resource P) string {
 	return resource.GetBaseResource().InternalMetadata.UpdatedAPIVersion
+}
+
+// buildSecretReferences resolves x-radius-secret-reference property values (each the name of a
+// Radius.Security/secrets resource) to fully qualified resource IDs scoped to the consuming resource's
+// resource group. Unset reference properties are skipped; a malformed reference is an error so the
+// deployment fails closed rather than passing an unresolved value to the recipe.
+func buildSecretReferences(resourceID string, properties map[string]any, secretReferencePaths []string) (map[string]string, error) {
+	if len(secretReferencePaths) == 0 {
+		return nil, nil
+	}
+
+	parsed, err := resources.ParseResource(resourceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse resource ID %q for secret reference resolution: %w", resourceID, err)
+	}
+
+	references := map[string]string{}
+	for _, path := range secretReferencePaths {
+		name, ok := stringValueAtPath(properties, path)
+		if !ok || name == "" {
+			// The reference property is optional and unset; nothing to resolve.
+			continue
+		}
+
+		secretID := fmt.Sprintf("%s/providers/%s/%s", parsed.RootScope(), secretReferenceResourceType, name)
+		if _, err := resources.ParseResource(secretID); err != nil {
+			return nil, fmt.Errorf("failed to construct secret resource ID for property %q with value %q: %w", path, name, err)
+		}
+		references[path] = secretID
+	}
+
+	if len(references) == 0 {
+		return nil, nil
+	}
+
+	return references, nil
+}
+
+// stringValueAtPath returns the string value at the given dot-separated path in a nested properties map.
+func stringValueAtPath(properties map[string]any, path string) (string, bool) {
+	var current any = properties
+	for _, segment := range strings.Split(path, ".") {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return "", false
+		}
+		current, ok = m[segment]
+		if !ok {
+			return "", false
+		}
+	}
+
+	value, ok := current.(string)
+	return value, ok
 }
 
 func deepCopyProperties(source map[string]any) (map[string]any, error) {

--- a/pkg/portableresources/backend/controller/createorupdateresource_test.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource_test.go
@@ -1102,3 +1102,81 @@ func TestCreateOrUpdateResource_Run_SensitiveMultipleFields(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ctrl.Result{}, res)
 }
+
+func Test_buildSecretReferences(t *testing.T) {
+	const resourceID = "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Test/testResources/my-resource"
+
+	t.Run("resolves a top-level reference to a sibling secret ID", func(t *testing.T) {
+		properties := map[string]any{"secretName": "db-secret"}
+
+		references, err := buildSecretReferences(resourceID, properties, []string{"secretName"})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{
+			"secretName": "/planes/radius/local/resourceGroups/test-rg/providers/Radius.Security/secrets/db-secret",
+		}, references)
+	})
+
+	t.Run("resolves a nested reference", func(t *testing.T) {
+		properties := map[string]any{"config": map[string]any{"secretName": "db-secret"}}
+
+		references, err := buildSecretReferences(resourceID, properties, []string{"config.secretName"})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{
+			"config.secretName": "/planes/radius/local/resourceGroups/test-rg/providers/Radius.Security/secrets/db-secret",
+		}, references)
+	})
+
+	t.Run("skips an unset reference", func(t *testing.T) {
+		references, err := buildSecretReferences(resourceID, map[string]any{}, []string{"secretName"})
+		require.NoError(t, err)
+		require.Nil(t, references)
+	})
+
+	t.Run("returns nil when there are no reference paths", func(t *testing.T) {
+		references, err := buildSecretReferences(resourceID, map[string]any{"secretName": "db-secret"}, nil)
+		require.NoError(t, err)
+		require.Nil(t, references)
+	})
+
+	t.Run("fails closed on an invalid resource ID", func(t *testing.T) {
+		_, err := buildSecretReferences("not-a-valid-id", map[string]any{"secretName": "db-secret"}, []string{"secretName"})
+		require.Error(t, err)
+	})
+}
+
+func Test_stringValueAtPath(t *testing.T) {
+	properties := map[string]any{
+		"secretName": "db-secret",
+		"config": map[string]any{
+			"secretName": "nested-secret",
+		},
+		"port": 5432,
+	}
+
+	t.Run("top-level string", func(t *testing.T) {
+		value, ok := stringValueAtPath(properties, "secretName")
+		require.True(t, ok)
+		require.Equal(t, "db-secret", value)
+	})
+
+	t.Run("nested string", func(t *testing.T) {
+		value, ok := stringValueAtPath(properties, "config.secretName")
+		require.True(t, ok)
+		require.Equal(t, "nested-secret", value)
+	})
+
+	t.Run("missing path", func(t *testing.T) {
+		_, ok := stringValueAtPath(properties, "missing")
+		require.False(t, ok)
+	})
+
+	t.Run("non-string value", func(t *testing.T) {
+		_, ok := stringValueAtPath(properties, "port")
+		require.False(t, ok)
+	})
+
+	t.Run("path through a non-map", func(t *testing.T) {
+		_, ok := stringValueAtPath(properties, "secretName.deeper")
+		require.False(t, ok)
+	})
+}

--- a/pkg/portableresources/backend/controller/createorupdateresource_test.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource_test.go
@@ -1144,6 +1144,85 @@ func Test_buildSecretReferences(t *testing.T) {
 	})
 }
 
+func Test_buildSecretBindings(t *testing.T) {
+	const secretID = "/planes/radius/local/resourceGroups/test-rg/providers/Radius.Security/secrets/db-secret"
+	const tlsSecretID = "/planes/radius/local/resourceGroups/test-rg/providers/Radius.Security/secrets/tls-secret"
+
+	t.Run("resolves an array of secret IDs", func(t *testing.T) {
+		properties := map[string]any{
+			"secrets": []any{secretID, tlsSecretID},
+		}
+
+		bindings, err := buildSecretBindings(properties, []string{"secrets"})
+		require.NoError(t, err)
+		require.Equal(t, []string{secretID, tlsSecretID}, bindings)
+	})
+
+	t.Run("resolves a nested array", func(t *testing.T) {
+		properties := map[string]any{
+			"config": map[string]any{
+				"secrets": []any{secretID},
+			},
+		}
+
+		bindings, err := buildSecretBindings(properties, []string{"config.secrets"})
+		require.NoError(t, err)
+		require.Equal(t, []string{secretID}, bindings)
+	})
+
+	t.Run("skips an unset property", func(t *testing.T) {
+		bindings, err := buildSecretBindings(map[string]any{}, []string{"secrets"})
+		require.NoError(t, err)
+		require.Nil(t, bindings)
+	})
+
+	t.Run("returns nil when there are no binding paths", func(t *testing.T) {
+		bindings, err := buildSecretBindings(map[string]any{"secrets": []any{secretID}}, nil)
+		require.NoError(t, err)
+		require.Nil(t, bindings)
+	})
+
+	t.Run("fails closed when the property is not an array", func(t *testing.T) {
+		properties := map[string]any{
+			"secrets": map[string]any{"username": secretID},
+		}
+
+		_, err := buildSecretBindings(properties, []string{"secrets"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be an array of secret IDs")
+	})
+
+	t.Run("fails closed on a non-string entry", func(t *testing.T) {
+		properties := map[string]any{
+			"secrets": []any{secretID, 42},
+		}
+
+		_, err := buildSecretBindings(properties, []string{"secrets"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be a non-empty secret ID string")
+	})
+
+	t.Run("fails closed on an empty entry", func(t *testing.T) {
+		properties := map[string]any{
+			"secrets": []any{""},
+		}
+
+		_, err := buildSecretBindings(properties, []string{"secrets"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be a non-empty secret ID string")
+	})
+
+	t.Run("fails closed on an invalid secret ID", func(t *testing.T) {
+		properties := map[string]any{
+			"secrets": []any{"not-a-valid-id"},
+		}
+
+		_, err := buildSecretBindings(properties, []string{"secrets"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid secret ID")
+	})
+}
+
 func Test_stringValueAtPath(t *testing.T) {
 	properties := map[string]any{
 		"secretName": "db-secret",

--- a/pkg/recipes/driver/bicep/bicep.go
+++ b/pkg/recipes/driver/bicep/bicep.go
@@ -125,6 +125,9 @@ func (d *bicepDriver) Execute(ctx context.Context, opts driver.ExecuteOptions) (
 	//update the recipe context with connected resources properties
 	recipeContext.Resource.Connections = opts.Recipe.ConnectedResourcesProperties
 
+	// update the recipe context with secret material referenced through x-radius-secret-reference properties
+	recipeContext.Resource.Secrets = opts.Recipe.Secrets
+
 	// get the parameters after resolving the conflict between developer and operator parameters
 	// if the recipe template also has the context parameter defined then add it to the parameter for deployment
 	isContextParameterDefined := hasContextParameter(recipeData)

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -28,6 +28,7 @@ import (
 	recipedriver "github.com/radius-project/radius/pkg/recipes/driver"
 	"github.com/radius-project/radius/pkg/recipes/util"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
+	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
 )
 
@@ -106,6 +107,14 @@ func (e *engine) executeCore(ctx context.Context, recipe recipes.ResourceMetadat
 	// Unlike connection enrichment, this is fail-closed: a referenced secret that cannot be loaded fails
 	// the deployment rather than passing an unresolved expression (a literal placeholder) to the module.
 	if err := e.enrichSecretReferences(ctx, &recipe); err != nil {
+		return nil, definition, recipes.NewRecipeError(recipes.RecipeConfigurationFailure, err.Error(), util.RecipeSetupError, recipes.GetErrorDetails(err))
+	}
+
+	// Enrich x-radius-secret-binding properties with their bound secret material so recipe parameter
+	// expressions (context.resource.secrets.<secretName>.<key>) can resolve developer-authored secrets. Like
+	// enrichSecretReferences, this is fail-closed: a bound secret that cannot be loaded fails the deployment
+	// rather than passing an unresolved expression (a literal placeholder) to the module.
+	if err := e.enrichSecretBindings(ctx, &recipe); err != nil {
 		return nil, definition, recipes.NewRecipeError(recipes.RecipeConfigurationFailure, err.Error(), util.RecipeSetupError, recipes.GetErrorDetails(err))
 	}
 
@@ -347,6 +356,66 @@ func (e *engine) enrichSecretReferences(ctx context.Context, recipe *recipes.Res
 
 		for key, val := range data.Data {
 			recipe.Secrets[key] = val
+		}
+	}
+
+	return nil
+}
+
+// enrichSecretBindings loads every key of each secret listed in an x-radius-secret-binding array property and
+// stores it on the recipe's tainted Secrets field under a "<secretName>.<key>" namespace, so the parameter
+// resolver can inject developer-authored secrets into module parameters via the
+// context.resource.secrets.<secretName>.<key> expression path. The secret name is parsed from the bound
+// resource ID. Like enrichSecretReferences, this is fail-closed: if a bound secret cannot be loaded, an error
+// is returned so the deployment fails rather than passing an unresolved expression to the module.
+func (e *engine) enrichSecretBindings(ctx context.Context, recipe *recipes.ResourceMetadata) error {
+	if recipe == nil || len(recipe.SecretBindings) == 0 {
+		return nil
+	}
+
+	if e.options.SecretsLoader == nil {
+		return fmt.Errorf("secrets loader is not configured; cannot resolve bound secrets")
+	}
+
+	// Collect the distinct secret IDs bound by the resource's properties.
+	secretIDs := map[string]bool{}
+	for _, secretID := range recipe.SecretBindings {
+		if secretID != "" {
+			secretIDs[secretID] = true
+		}
+	}
+	if len(secretIDs) == 0 {
+		return nil
+	}
+
+	if recipe.Secrets == nil {
+		recipe.Secrets = map[string]string{}
+	}
+
+	for secretID := range secretIDs {
+		parsed, err := resources.ParseResource(secretID)
+		if err != nil {
+			return fmt.Errorf("invalid bound secret ID %q: %w", secretID, err)
+		}
+		name := parsed.Name()
+
+		// A nil keys filter loads all secret keys for the bound secret.
+		loaded, err := e.options.SecretsLoader.LoadSecrets(ctx, map[string][]string{secretID: nil})
+		if err != nil {
+			return fmt.Errorf("failed to load bound secret %q: %w", secretID, err)
+		}
+
+		data, ok := loaded[secretID]
+		if !ok {
+			return fmt.Errorf("bound secret %q returned no data", secretID)
+		}
+
+		for key, val := range data.Data {
+			namespacedKey := name + "." + key
+			if existing, exists := recipe.Secrets[namespacedKey]; exists && existing != val {
+				return fmt.Errorf("bound secret namespace collision for %q: two secrets named %q provide different values for key %q", namespacedKey, name, key)
+			}
+			recipe.Secrets[namespacedKey] = val
 		}
 	}
 

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -101,6 +101,14 @@ func (e *engine) executeCore(ctx context.Context, recipe recipes.ResourceMetadat
 	// (context.resource.connections.<name>.secrets.<key>) can resolve developer-authored secrets.
 	e.enrichConnectionSecrets(ctx, &recipe)
 
+	// Enrich x-radius-secret-reference properties with their referenced secret material so recipe
+	// parameter expressions (context.resource.secrets.<key>) can resolve developer-authored secrets.
+	// Unlike connection enrichment, this is fail-closed: a referenced secret that cannot be loaded fails
+	// the deployment rather than passing an unresolved expression (a literal placeholder) to the module.
+	if err := e.enrichSecretReferences(ctx, &recipe); err != nil {
+		return nil, definition, recipes.NewRecipeError(recipes.RecipeConfigurationFailure, err.Error(), util.RecipeSetupError, recipes.GetErrorDetails(err))
+	}
+
 	res, err := driver.Execute(ctx, recipedriver.ExecuteOptions{
 		BaseOptions: recipedriver.BaseOptions{
 			Configuration: *configuration,
@@ -294,4 +302,53 @@ func (e *engine) enrichConnectionSecrets(ctx context.Context, recipe *recipes.Re
 			recipe.ConnectedResourcesProperties[name] = conn
 		}
 	}
+}
+
+// enrichSecretReferences loads secret material for x-radius-secret-reference properties and stores it on
+// the recipe's tainted Secrets field, so the parameter resolver can inject developer-authored secrets into
+// module parameters via the context.resource.secrets.<key> expression path. Unlike enrichConnectionSecrets,
+// this is fail-closed: if a referenced secret cannot be loaded, an error is returned so the deployment fails
+// rather than passing an unresolved expression (and therefore a literal placeholder) to the module.
+func (e *engine) enrichSecretReferences(ctx context.Context, recipe *recipes.ResourceMetadata) error {
+	if recipe == nil || len(recipe.SecretReferences) == 0 {
+		return nil
+	}
+
+	if e.options.SecretsLoader == nil {
+		return fmt.Errorf("secrets loader is not configured; cannot resolve referenced secrets")
+	}
+
+	// Collect the distinct secret IDs referenced by the resource's properties.
+	secretIDs := map[string]bool{}
+	for _, secretID := range recipe.SecretReferences {
+		if secretID != "" {
+			secretIDs[secretID] = true
+		}
+	}
+	if len(secretIDs) == 0 {
+		return nil
+	}
+
+	if recipe.Secrets == nil {
+		recipe.Secrets = map[string]string{}
+	}
+
+	for secretID := range secretIDs {
+		// A nil keys filter loads all secret keys for the referenced secret.
+		loaded, err := e.options.SecretsLoader.LoadSecrets(ctx, map[string][]string{secretID: nil})
+		if err != nil {
+			return fmt.Errorf("failed to load referenced secret %q: %w", secretID, err)
+		}
+
+		data, ok := loaded[secretID]
+		if !ok {
+			return fmt.Errorf("referenced secret %q returned no data", secretID)
+		}
+
+		for key, val := range data.Data {
+			recipe.Secrets[key] = val
+		}
+	}
+
+	return nil
 }

--- a/pkg/recipes/engine/engine_test.go
+++ b/pkg/recipes/engine/engine_test.go
@@ -1370,3 +1370,146 @@ func Test_enrichSecretReferences(t *testing.T) {
 		require.Nil(t, recipe.Secrets)
 	})
 }
+
+func Test_enrichSecretBindings(t *testing.T) {
+	const secretID = "/planes/radius/local/resourceGroups/test-rg/providers/Radius.Security/secrets/db-secret"
+	const tlsSecretID = "/planes/radius/local/resourceGroups/test-rg/providers/Radius.Security/secrets/tls-secret"
+
+	t.Run("namespaces all keys of a bound secret by its name", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secretsLoader := configloader.NewMockSecretsLoader(ctrl)
+		ctx := testcontext.New(t)
+		e := engine{options: Options{SecretsLoader: secretsLoader}}
+		recipe := &recipes.ResourceMetadata{
+			SecretBindings: []string{secretID},
+		}
+
+		secretsLoader.EXPECT().
+			LoadSecrets(ctx, map[string][]string{secretID: nil}).
+			Times(1).
+			Return(map[string]recipes.SecretData{
+				secretID: {Type: "Radius.Security/secrets", Data: map[string]string{"USERNAME": "radadmin", "PASSWORD": "s3cr3t"}},
+			}, nil)
+
+		err := e.enrichSecretBindings(ctx, recipe)
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"db-secret.USERNAME": "radadmin", "db-secret.PASSWORD": "s3cr3t"}, recipe.Secrets)
+	})
+
+	t.Run("namespaces multiple secrets distinctly", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secretsLoader := configloader.NewMockSecretsLoader(ctrl)
+		ctx := testcontext.New(t)
+		e := engine{options: Options{SecretsLoader: secretsLoader}}
+		recipe := &recipes.ResourceMetadata{
+			SecretBindings: []string{secretID, tlsSecretID},
+		}
+
+		secretsLoader.EXPECT().
+			LoadSecrets(ctx, map[string][]string{secretID: nil}).
+			Times(1).
+			Return(map[string]recipes.SecretData{
+				secretID: {Type: "Radius.Security/secrets", Data: map[string]string{"USERNAME": "radadmin"}},
+			}, nil)
+		secretsLoader.EXPECT().
+			LoadSecrets(ctx, map[string][]string{tlsSecretID: nil}).
+			Times(1).
+			Return(map[string]recipes.SecretData{
+				tlsSecretID: {Type: "Radius.Security/secrets", Data: map[string]string{"USERNAME": "tlsuser", "CA_CERT": "pem"}},
+			}, nil)
+
+		err := e.enrichSecretBindings(ctx, recipe)
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{
+			"db-secret.USERNAME":  "radadmin",
+			"tls-secret.USERNAME": "tlsuser",
+			"tls-secret.CA_CERT":  "pem",
+		}, recipe.Secrets)
+	})
+
+	t.Run("load error fails closed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secretsLoader := configloader.NewMockSecretsLoader(ctrl)
+		ctx := testcontext.New(t)
+		e := engine{options: Options{SecretsLoader: secretsLoader}}
+		recipe := &recipes.ResourceMetadata{
+			SecretBindings: []string{secretID},
+		}
+
+		secretsLoader.EXPECT().
+			LoadSecrets(ctx, map[string][]string{secretID: nil}).
+			Times(1).
+			Return(nil, errors.New("kubernetes secret not found"))
+
+		err := e.enrichSecretBindings(ctx, recipe)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "kubernetes secret not found")
+		require.Empty(t, recipe.Secrets)
+	})
+
+	t.Run("invalid secret ID fails closed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secretsLoader := configloader.NewMockSecretsLoader(ctrl)
+		ctx := testcontext.New(t)
+		e := engine{options: Options{SecretsLoader: secretsLoader}}
+		recipe := &recipes.ResourceMetadata{
+			SecretBindings: []string{"not-a-valid-id"},
+		}
+
+		err := e.enrichSecretBindings(ctx, recipe)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid bound secret ID")
+	})
+
+	t.Run("namespace collision fails closed", func(t *testing.T) {
+		// Two distinct secret IDs whose resource names are identical and whose data disagree on a key.
+		const dupA = "/planes/radius/local/resourceGroups/rg-a/providers/Radius.Security/secrets/db-secret"
+		const dupB = "/planes/radius/local/resourceGroups/rg-b/providers/Radius.Security/secrets/db-secret"
+		ctrl := gomock.NewController(t)
+		secretsLoader := configloader.NewMockSecretsLoader(ctrl)
+		ctx := testcontext.New(t)
+		e := engine{options: Options{SecretsLoader: secretsLoader}}
+		recipe := &recipes.ResourceMetadata{
+			SecretBindings: []string{dupA, dupB},
+		}
+
+		secretsLoader.EXPECT().
+			LoadSecrets(ctx, map[string][]string{dupA: nil}).
+			Times(1).
+			Return(map[string]recipes.SecretData{
+				dupA: {Type: "Radius.Security/secrets", Data: map[string]string{"USERNAME": "a"}},
+			}, nil)
+		secretsLoader.EXPECT().
+			LoadSecrets(ctx, map[string][]string{dupB: nil}).
+			Times(1).
+			Return(map[string]recipes.SecretData{
+				dupB: {Type: "Radius.Security/secrets", Data: map[string]string{"USERNAME": "b"}},
+			}, nil)
+
+		err := e.enrichSecretBindings(ctx, recipe)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "namespace collision")
+	})
+
+	t.Run("nil secrets loader with bindings fails closed", func(t *testing.T) {
+		ctx := testcontext.New(t)
+		e := engine{options: Options{}}
+		recipe := &recipes.ResourceMetadata{
+			SecretBindings: []string{secretID},
+		}
+
+		err := e.enrichSecretBindings(ctx, recipe)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "secrets loader is not configured")
+	})
+
+	t.Run("no bindings is a no-op", func(t *testing.T) {
+		ctx := testcontext.New(t)
+		e := engine{options: Options{}}
+		recipe := &recipes.ResourceMetadata{}
+
+		err := e.enrichSecretBindings(ctx, recipe)
+		require.NoError(t, err)
+		require.Nil(t, recipe.Secrets)
+	})
+}

--- a/pkg/recipes/engine/engine_test.go
+++ b/pkg/recipes/engine/engine_test.go
@@ -1284,3 +1284,89 @@ func Test_enrichConnectionSecrets(t *testing.T) {
 		require.Nil(t, recipe.ConnectedResourcesProperties["credentials"].Secrets)
 	})
 }
+
+func Test_enrichSecretReferences(t *testing.T) {
+	const secretID = "/planes/radius/local/resourceGroups/test-rg/providers/Radius.Security/secrets/db-secret"
+
+	t.Run("populates secrets from referenced secret", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secretsLoader := configloader.NewMockSecretsLoader(ctrl)
+		ctx := testcontext.New(t)
+		e := engine{options: Options{SecretsLoader: secretsLoader}}
+		recipe := &recipes.ResourceMetadata{
+			SecretReferences: map[string]string{"secretName": secretID},
+		}
+
+		secretsLoader.EXPECT().
+			LoadSecrets(ctx, map[string][]string{secretID: nil}).
+			Times(1).
+			Return(map[string]recipes.SecretData{
+				secretID: {Type: "Radius.Security/secrets", Data: map[string]string{"password": "s3cr3t"}},
+			}, nil)
+
+		err := e.enrichSecretReferences(ctx, recipe)
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"password": "s3cr3t"}, recipe.Secrets)
+	})
+
+	t.Run("load error fails closed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secretsLoader := configloader.NewMockSecretsLoader(ctrl)
+		ctx := testcontext.New(t)
+		e := engine{options: Options{SecretsLoader: secretsLoader}}
+		recipe := &recipes.ResourceMetadata{
+			SecretReferences: map[string]string{"secretName": secretID},
+		}
+
+		secretsLoader.EXPECT().
+			LoadSecrets(ctx, map[string][]string{secretID: nil}).
+			Times(1).
+			Return(nil, errors.New("kubernetes secret not found"))
+
+		err := e.enrichSecretReferences(ctx, recipe)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "kubernetes secret not found")
+		require.Empty(t, recipe.Secrets)
+	})
+
+	t.Run("missing data for referenced secret fails closed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secretsLoader := configloader.NewMockSecretsLoader(ctrl)
+		ctx := testcontext.New(t)
+		e := engine{options: Options{SecretsLoader: secretsLoader}}
+		recipe := &recipes.ResourceMetadata{
+			SecretReferences: map[string]string{"secretName": secretID},
+		}
+
+		secretsLoader.EXPECT().
+			LoadSecrets(ctx, map[string][]string{secretID: nil}).
+			Times(1).
+			Return(map[string]recipes.SecretData{}, nil)
+
+		err := e.enrichSecretReferences(ctx, recipe)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "returned no data")
+	})
+
+	t.Run("nil secrets loader with references fails closed", func(t *testing.T) {
+		ctx := testcontext.New(t)
+		e := engine{options: Options{}}
+		recipe := &recipes.ResourceMetadata{
+			SecretReferences: map[string]string{"secretName": secretID},
+		}
+
+		err := e.enrichSecretReferences(ctx, recipe)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "secrets loader is not configured")
+	})
+
+	t.Run("no secret references is a no-op", func(t *testing.T) {
+		ctx := testcontext.New(t)
+		e := engine{options: Options{}}
+		recipe := &recipes.ResourceMetadata{}
+
+		err := e.enrichSecretReferences(ctx, recipe)
+		require.NoError(t, err)
+		require.Nil(t, recipe.Secrets)
+	})
+}

--- a/pkg/recipes/paramresolver/resolver.go
+++ b/pkg/recipes/paramresolver/resolver.go
@@ -373,8 +373,9 @@ func buildTypedContextLookup(ctx *recipecontext.Context) map[string]any {
 }
 
 // buildSecretLookup builds a flat key-value map of secret material exposed by secret-typed connected
-// resources. Keys use the path context.resource.connections.<name>.secrets.<key>. This lookup is kept
-// separate from the non-secret context lookup so secret values can only be resolved through the
+// resources and by x-radius-secret-reference properties. Keys use the paths
+// context.resource.connections.<name>.secrets.<key> and context.resource.secrets.<key>. This lookup is
+// kept separate from the non-secret context lookup so secret values can only be resolved through the
 // whole-value secret path and are tagged for secure routing, never resolved as ordinary string values.
 func buildSecretLookup(ctx *recipecontext.Context) map[string]string {
 	secrets := map[string]string{}
@@ -386,6 +387,10 @@ func buildSecretLookup(ctx *recipecontext.Context) map[string]string {
 		for key, val := range conn.Secrets {
 			secrets[fmt.Sprintf("context.resource.connections.%s.secrets.%s", connName, key)] = val
 		}
+	}
+
+	for key, val := range ctx.Resource.Secrets {
+		secrets[fmt.Sprintf("context.resource.secrets.%s", key)] = val
 	}
 
 	return secrets

--- a/pkg/recipes/paramresolver/resolver_test.go
+++ b/pkg/recipes/paramresolver/resolver_test.go
@@ -52,6 +52,9 @@ func testContext() *recipecontext.Context {
 					},
 				},
 			},
+			Secrets: map[string]string{
+				"apiKey": "k3y-v@lue",
+			},
 		},
 		Application: recipecontext.ResourceInfo{
 			Name: "my-app",
@@ -530,6 +533,26 @@ func Test_SecretExpressions(t *testing.T) {
 				"token": "{{context.resource.connections.db.secrets.missing}}",
 			},
 			expectedSecureKeys: map[string]bool{},
+		},
+		{
+			name: "secret-reference secret resolves and is tagged secure",
+			params: map[string]any{
+				"apiKey": "{{context.resource.secrets.apiKey}}",
+				"sku":    "Standard",
+			},
+			expectedValues: map[string]any{
+				"apiKey": "k3y-v@lue",
+				"sku":    "Standard",
+			},
+			expectedSecureKeys: map[string]bool{"apiKey": true},
+		},
+		{
+			name: "secret-reference secret interpolated into a surrounding string is rejected",
+			params: map[string]any{
+				"header": "Bearer {{context.resource.secrets.apiKey}}",
+			},
+			expectErr:   true,
+			errContains: "may only be used as the entire parameter value",
 		},
 	}
 

--- a/pkg/recipes/recipecontext/types.go
+++ b/pkg/recipes/recipecontext/types.go
@@ -62,6 +62,12 @@ type Resource struct {
 	// context.resource.connections.[connection-name].name
 	// context.resource.connections.[connection-name].type
 	Connections map[string]recipes.ConnectedResource `json:"connections,omitempty"`
+
+	// Secrets holds resolved secret material referenced by the resource through x-radius-secret-reference
+	// properties, keyed by secret key. It is tagged json:"-" so it is never serialized into the recipe
+	// context, logs, or IaC state. Recipe authors reference it via the context.resource.secrets.<key>
+	// expression path, and resolved values are routed to @secure()/sensitive module parameters.
+	Secrets map[string]string `json:"-"`
 }
 
 // ResourceInfo represents name and id of the resource

--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -371,6 +371,7 @@ func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, opt
 		//update the recipe context with connected resources properties
 		if options.ResourceRecipe != nil {
 			recipectx.Resource.Connections = options.ResourceRecipe.ConnectedResourcesProperties
+			recipectx.Resource.Secrets = options.ResourceRecipe.Secrets
 		}
 
 		if err = tfConfig.AddRecipeContext(ctx, options.EnvRecipe.Name, recipectx); err != nil {
@@ -388,6 +389,7 @@ func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, opt
 
 		if options.ResourceRecipe != nil {
 			recipectx.Resource.Connections = options.ResourceRecipe.ConnectedResourcesProperties
+			recipectx.Resource.Secrets = options.ResourceRecipe.Secrets
 		}
 
 		// Merge environment-level and resource-level parameters (resource parameters take precedence),

--- a/pkg/recipes/types.go
+++ b/pkg/recipes/types.go
@@ -109,6 +109,16 @@ type ResourceMetadata struct {
 	// The key is connection name and the value contains the connected resource's metadata and properties.
 	// These are passed into the recipe context.
 	ConnectedResourcesProperties map[string]ConnectedResource
+	// SecretReferences maps a resource property path marked with x-radius-secret-reference (e.g. "secretName")
+	// to the fully qualified Radius.Security/secrets resource ID that the property's value names. It is
+	// populated by the resource controller from the resource's schema and properties, and consumed by the
+	// engine to load the referenced secret's data into Secrets.
+	SecretReferences map[string]string
+	// Secrets holds resolved secret material for secret-reference properties, keyed by secret key. It is
+	// populated only from the referenced secret's deployed material (never from Properties) and is tagged
+	// json:"-" so it is never serialized into the recipe context, logs, or IaC state. Recipe authors
+	// reference it via the context.resource.secrets.<key> expression path.
+	Secrets map[string]string `json:"-"`
 	// Parameters represents key/value pairs to pass into the recipe template. Overrides any parameters set by the environment.
 	Parameters map[string]any
 }

--- a/pkg/recipes/types.go
+++ b/pkg/recipes/types.go
@@ -114,6 +114,11 @@ type ResourceMetadata struct {
 	// populated by the resource controller from the resource's schema and properties, and consumed by the
 	// engine to load the referenced secret's data into Secrets.
 	SecretReferences map[string]string
+	// SecretBindings lists the Radius.Security/secrets resource IDs declared by a resource's
+	// x-radius-secret-binding array property. It is populated by the resource controller from the resource's
+	// schema and properties, and consumed by the engine to load every key of each secret into Secrets under a
+	// "<secretName>.<key>" namespace for the context.resource.secrets.<secretName>.<key> expression path.
+	SecretBindings []string
 	// Secrets holds resolved secret material for secret-reference properties, keyed by secret key. It is
 	// populated only from the referenced secret's deployed material (never from Properties) and is tagged
 	// json:"-" so it is never serialized into the recipe context, logs, or IaC state. Recipe authors

--- a/pkg/schema/annotations.go
+++ b/pkg/schema/annotations.go
@@ -201,6 +201,50 @@ func ExtractSecretReferenceFieldPaths(schema map[string]any, prefix string) []st
 	return paths
 }
 
+// ExtractSecretBindingPaths recursively walks the schema and returns paths to properties marked with the
+// x-radius-secret-binding annotation. Each such property is a "secrets binding": an array of Radius.Security/secrets
+// resource IDs the resource depends on. The marked property is treated as a leaf: it is not traversed further,
+// because the concrete secret IDs are read from the resource's properties at deploy time and every key of each
+// secret is exposed to recipes under the context.resource.secrets.<secretName>.<key> path. The prefix parameter
+// builds up the path as we traverse nested objects.
+func ExtractSecretBindingPaths(schema map[string]any, prefix string) []string {
+	var paths []string
+
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return paths
+	}
+
+	for fieldName, fieldSchema := range properties {
+		fieldSchemaMap, ok := fieldSchema.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		// Build the full path for this field.
+		var fullPath string
+		if prefix == "" {
+			fullPath = fieldName
+		} else {
+			fullPath = prefix + "." + fieldName
+		}
+
+		// A field marked as a secrets array is treated as a leaf.
+		if isBinding, ok := fieldSchemaMap[annotationRadiusSecretBinding].(bool); ok && isBinding {
+			paths = append(paths, fullPath)
+			continue
+		}
+
+		// Recursively check nested objects.
+		if nestedProps, ok := fieldSchemaMap["properties"].(map[string]any); ok {
+			nestedSchema := map[string]any{"properties": nestedProps}
+			paths = append(paths, ExtractSecretBindingPaths(nestedSchema, fullPath)...)
+		}
+	}
+
+	return paths
+}
+
 // A field path can contain field names, wildcards, and array indices.
 type FieldPathSegment struct {
 	Type  SegmentType

--- a/pkg/schema/annotations.go
+++ b/pkg/schema/annotations.go
@@ -159,7 +159,48 @@ func ExtractSensitiveFieldPaths(schema map[string]any, prefix string) []string {
 	return paths
 }
 
-// FieldPathSegment represents a single segment in a field path.
+// ExtractSecretReferenceFieldPaths recursively walks the schema and returns paths to string fields marked
+// with the x-radius-secret-reference annotation. Each such field holds the name of a Radius.Security/secrets
+// resource. The prefix parameter builds up the path as we traverse nested objects. A marked field is treated
+// as a leaf: its nested properties (if any) are not traversed.
+func ExtractSecretReferenceFieldPaths(schema map[string]any, prefix string) []string {
+	var paths []string
+
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return paths
+	}
+
+	for fieldName, fieldSchema := range properties {
+		fieldSchemaMap, ok := fieldSchema.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		// Build the full path for this field.
+		var fullPath string
+		if prefix == "" {
+			fullPath = fieldName
+		} else {
+			fullPath = prefix + "." + fieldName
+		}
+
+		// A field marked as a secret reference is treated as a leaf.
+		if isRef, ok := fieldSchemaMap[annotationRadiusSecretReference].(bool); ok && isRef {
+			paths = append(paths, fullPath)
+			continue
+		}
+
+		// Recursively check nested objects.
+		if nestedProps, ok := fieldSchemaMap["properties"].(map[string]any); ok {
+			nestedSchema := map[string]any{"properties": nestedProps}
+			paths = append(paths, ExtractSecretReferenceFieldPaths(nestedSchema, fullPath)...)
+		}
+	}
+
+	return paths
+}
+
 // A field path can contain field names, wildcards, and array indices.
 type FieldPathSegment struct {
 	Type  SegmentType

--- a/pkg/schema/annotations_test.go
+++ b/pkg/schema/annotations_test.go
@@ -513,6 +513,91 @@ func TestExtractSecretReferenceFieldPaths(t *testing.T) {
 	})
 }
 
+func TestExtractSecretBindingPaths(t *testing.T) {
+	t.Run("top-level marked property", func(t *testing.T) {
+		schema := map[string]any{
+			"properties": map[string]any{
+				"secrets": map[string]any{
+					"type":                        "array",
+					annotationRadiusSecretBinding: true,
+					"items":                       map[string]any{"type": "string"},
+				},
+				"host": map[string]any{
+					"type": "string",
+				},
+			},
+		}
+
+		require.Equal(t, []string{"secrets"}, ExtractSecretBindingPaths(schema, ""))
+	})
+
+	t.Run("nested marked property", func(t *testing.T) {
+		schema := map[string]any{
+			"properties": map[string]any{
+				"config": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"secrets": map[string]any{
+							"type":                        "array",
+							annotationRadiusSecretBinding: true,
+							"items":                       map[string]any{"type": "string"},
+						},
+					},
+				},
+			},
+		}
+
+		require.Equal(t, []string{"config.secrets"}, ExtractSecretBindingPaths(schema, ""))
+	})
+
+	t.Run("marked property is treated as a leaf", func(t *testing.T) {
+		// A marked property is a leaf: the extractor must not descend into its sub-schema, even if that
+		// sub-schema contains another marked property.
+		schema := map[string]any{
+			"properties": map[string]any{
+				"secrets": map[string]any{
+					"type":                        "array",
+					annotationRadiusSecretBinding: true,
+					"properties": map[string]any{
+						"nested": map[string]any{
+							"type":                        "array",
+							annotationRadiusSecretBinding: true,
+						},
+					},
+				},
+			},
+		}
+
+		require.Equal(t, []string{"secrets"}, ExtractSecretBindingPaths(schema, ""))
+	})
+
+	t.Run("no marked properties", func(t *testing.T) {
+		schema := map[string]any{
+			"properties": map[string]any{
+				"host": map[string]any{
+					"type": "string",
+				},
+			},
+		}
+
+		require.Empty(t, ExtractSecretBindingPaths(schema, ""))
+	})
+
+	t.Run("with prefix", func(t *testing.T) {
+		schema := map[string]any{
+			"properties": map[string]any{
+				"secrets": map[string]any{
+					"type":                        "array",
+					annotationRadiusSecretBinding: true,
+					"items":                       map[string]any{"type": "string"},
+				},
+			},
+		}
+
+		require.Equal(t, []string{"parent.secrets"}, ExtractSecretBindingPaths(schema, "parent"))
+	})
+}
+
 func TestGetSensitiveFieldPaths(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/schema/annotations_test.go
+++ b/pkg/schema/annotations_test.go
@@ -433,6 +433,86 @@ func TestExtractSensitiveFieldPaths_WithPrefix(t *testing.T) {
 	require.Equal(t, []string{"parent.secret"}, result)
 }
 
+func TestExtractSecretReferenceFieldPaths(t *testing.T) {
+	t.Run("top-level marked field", func(t *testing.T) {
+		schema := map[string]any{
+			"properties": map[string]any{
+				"secretName": map[string]any{
+					"type":                          "string",
+					annotationRadiusSecretReference: true,
+				},
+				"host": map[string]any{
+					"type": "string",
+				},
+			},
+		}
+
+		require.Equal(t, []string{"secretName"}, ExtractSecretReferenceFieldPaths(schema, ""))
+	})
+
+	t.Run("nested marked field", func(t *testing.T) {
+		schema := map[string]any{
+			"properties": map[string]any{
+				"config": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"secretName": map[string]any{
+							"type":                          "string",
+							annotationRadiusSecretReference: true,
+						},
+					},
+				},
+			},
+		}
+
+		require.Equal(t, []string{"config.secretName"}, ExtractSecretReferenceFieldPaths(schema, ""))
+	})
+
+	t.Run("marked field is treated as a leaf", func(t *testing.T) {
+		schema := map[string]any{
+			"properties": map[string]any{
+				"secretName": map[string]any{
+					"type":                          "object",
+					annotationRadiusSecretReference: true,
+					"properties": map[string]any{
+						"nested": map[string]any{
+							"type":                          "string",
+							annotationRadiusSecretReference: true,
+						},
+					},
+				},
+			},
+		}
+
+		require.Equal(t, []string{"secretName"}, ExtractSecretReferenceFieldPaths(schema, ""))
+	})
+
+	t.Run("no marked fields", func(t *testing.T) {
+		schema := map[string]any{
+			"properties": map[string]any{
+				"host": map[string]any{
+					"type": "string",
+				},
+			},
+		}
+
+		require.Empty(t, ExtractSecretReferenceFieldPaths(schema, ""))
+	})
+
+	t.Run("with prefix", func(t *testing.T) {
+		schema := map[string]any{
+			"properties": map[string]any{
+				"secretName": map[string]any{
+					"type":                          "string",
+					annotationRadiusSecretReference: true,
+				},
+			},
+		}
+
+		require.Equal(t, []string{"parent.secretName"}, ExtractSecretReferenceFieldPaths(schema, "parent"))
+	})
+}
+
 func TestGetSensitiveFieldPaths(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/schema/validator.go
+++ b/pkg/schema/validator.go
@@ -40,6 +40,12 @@ const (
 // Constants for annotation names
 const (
 	annotationRadiusSensitive = "x-radius-sensitive"
+
+	// annotationRadiusSecretReference marks a string property whose value is the name of a
+	// Radius.Security/secrets resource. Radius resolves the referenced secret's data and exposes it
+	// to recipes through the context.resource.secrets.<key> expression path. Unlike x-radius-sensitive
+	// (which marks the secret value itself), this annotation marks a reference to a secret by name.
+	annotationRadiusSecretReference = "x-radius-secret-reference"
 )
 
 // joinPath concatenates two path segments with a dot separator for property path tracking.

--- a/pkg/schema/validator.go
+++ b/pkg/schema/validator.go
@@ -46,6 +46,15 @@ const (
 	// to recipes through the context.resource.secrets.<key> expression path. Unlike x-radius-sensitive
 	// (which marks the secret value itself), this annotation marks a reference to a secret by name.
 	annotationRadiusSecretReference = "x-radius-secret-reference"
+
+	// annotationRadiusSecretBinding marks an array property whose items are resource IDs of
+	// Radius.Security/secrets resources the resource depends on. Radius loads every key of each
+	// listed secret and exposes the values to recipes through the
+	// context.resource.secrets.<secretName>.<key> expression path, where <secretName> is the secret
+	// resource's name and <key> is a key within that secret's data. Unlike x-radius-secret-reference
+	// (a single secret named by a string property), this annotation binds a list of secrets by ID and
+	// namespaces their keys by the secret resource name.
+	annotationRadiusSecretBinding = "x-radius-secret-binding"
 )
 
 // joinPath concatenates two path segments with a dot separator for property path tracking.


### PR DESCRIPTION
> **Part 2 of 2** · stacked on **#12249** (Part 1: connection-based secrets) · this is the **`secretName` → `Radius.Security/secrets`** half ("Option A": read the deployed Kubernetes Secret via `status.outputResources`). **Review/merge #12249 first** — this PR's diff is shown against its branch (Part 2 only, 16 files, +942/−6) and will be retargeted to `main` once Part 1 lands.

# Description

This PR adds the second developer-facing path for handing a secret to a direct-module recipe: a resource **property that references a `Radius.Security/secrets` resource by name** (marked `x-radius-secret-reference`, e.g. `secretName`), resolved into recipe parameters as `context.resource.secrets.<key>`. It builds on the connection-based path from #12249.

## Why this is Phase 1 (not Phase 2)

Phase 2 = **external** secret stores (Azure Key Vault / AWS Secrets Manager / Vault) where Radius holds only a reference. This PR reads Radius's **own Kubernetes materialization** of a developer-supplied secret — the same consumption model `Applications.Core/secretStores` already uses in production — so it is in-scope Phase 1. Scoped to Kubernetes-backed `Radius.Security/secrets`; externally-backed secrets remain Phase 2.

## How it works

Because a secret's sensitive data is redacted from the database before recipe execution, the cleartext is read on demand from the secret's **deployed Kubernetes Secret** via `status.outputResources` (never the redacted `Properties.Data`).

- **Schema** (`pkg/schema`): adds the `x-radius-secret-reference` annotation and `ExtractSecretReferenceFieldPaths`, which returns the property paths that name a secret.
- **Controller** (`pkg/portableresources/backend/controller`): resolves each referenced property value (a secret name) into a sibling `Radius.Security/secrets` resource ID scoped to the consuming resource's resource group, threaded onto `ResourceMetadata.SecretReferences`. A malformed reference is an error (fail-closed).
- **Engine** (`pkg/recipes/engine`): `enrichSecretReferences` loads the referenced secret's material into the recipe's tainted `Secrets`. **Fail-closed**: a referenced secret that cannot be loaded fails the deployment rather than passing a literal `{{…}}` placeholder to the module.
- **Loader** (`pkg/dynamicrp/secretsloader`, new): a type-aware dispatcher. `Radius.Security/secrets` is read from its backing Kubernetes Secret (located via the resource's `core/Secret` output resource); all other secret store types delegate to the existing `Applications.Core/secretStores` loader. Cleartext is reachable only by the in-process engine — never re-persisted to the database and never exposed via a GET.
- **Param resolver / drivers**: exposes `context.resource.secrets.<key>` with the same whole-value-only + secure-tagging rules as the connection path (ARM `@secure()` / Terraform `sensitive = true`).

## Testing

- **Loader** (`Test_DispatchingLoader_*`): reads cleartext from the backing K8s Secret, honors a requested-key filter, routes UDT vs store types and merges results, and fails closed when there is no output resource / the Secret is absent / a requested key is missing / the resource can't be read.
- **Engine** (`Test_enrichSecretReferences`): populates `recipe.Secrets`; fails closed on loader error / missing data / unconfigured loader; empty references are a no-op.
- **Schema** (`TestExtractSecretReferenceFieldPaths`), **controller** (`Test_buildSecretReferences`, `Test_stringValueAtPath`), and **resolver** (`Test_SecretExpressions`, extended for `resource.secrets.<key>` resolution, secure-tagging, and whole-value-only enforcement).
- `gofmt -l` (clean), `go build ./...`, `go vet`, and `go test` are green across all affected packages; existing #12249 tests are unaffected.

## Out of scope

- External (Key Vault / Secrets Manager / Vault) secret references — Phase 2.
- Docs — planned follow-up.

Addresses #12244 (Phase 2 reference-passthrough remains open, so this does not close the issue).