### PR TITLE
refactor(security): migrate internal hashing from SHA-1 to SHA-256

### DIFF
--- a/docs/release-notes/v0.60.0-draft.md
+++ b/docs/release-notes/v0.60.0-draft.md
@@ -1,0 +1,46 @@
+<!--
+DRAFT release note - NOT the final, published release note.
+
+This is a staging draft for the SHA-1 -> SHA-256 internal hashing migration. The real
+release note is produced by the release process as `vX.Y.Z.md` (see ./README.md) with the
+auto-generated changelog and contributor list. When the release is cut:
+  1. Move the "Modernized internal hashing" entry below into the generated note's Highlights.
+  2. Delete this draft file.
+The `-draft` suffix keeps this file out of the `vX.Y.Z.md` release-note pattern on purpose.
+-->
+
+## Announcing Radius v0.60.0
+
+Today we're happy to announce the release of Radius v0.60.0. Check out the [highlights](#highlights) below, along with the [full changelog](#full-changelog) for more details.
+
+We would like to extend our thanks to all the [new](#new-contributors) and existing contributors who helped make this release possible!
+
+## Intro to Radius
+
+If you're new to Radius, check out our website, [radapp.io](https://radapp.io), for more information. Also visit our [getting started guide](https://docs.radapp.io/getting-started/) to learn how to install Radius and create your first app.
+
+## Highlights
+
+### Modernized internal hashing (SHA-1 to SHA-256)
+
+Radius now uses SHA-256 instead of SHA-1 to generate internal resource identifiers, Terraform recipe state keys, ETags, and change-detection tokens. These hashes are used only for uniqueness and change detection - never for security.
+
+**This upgrade is transparent and requires no action.** Your existing applications, environments, resources, and Terraform-recipe state are automatically recognized through a built-in compatibility layer. As a result of this change, nothing is redeployed, no pods are restarted, and no Terraform state is recreated.
+
+A future release will complete the transition by migrating stored data fully to SHA-256 and removing the SHA-1 compatibility layer. That step will be automatic and called out in its own release notes. As always, upgrade one minor version at a time.
+
+## Breaking changes
+
+There are no breaking changes in this release. The SHA-1 to SHA-256 hashing change described above is fully backward compatible - existing data is read through a compatibility fallback, and no customer action is required.
+
+## New contributors
+
+<!-- PASTE THE OUTPUT OF THE GENERATED CONTRIBUTOR LIST HERE -->
+
+## Upgrading to Radius v0.60.0
+
+You can upgrade to this release by upgrading your Radius CLI then running `rad upgrade kubernetes`. Only incremental version upgrades are supported. Consult the [upgrade documentation](https://docs.radapp.io/guides/operations/kubernetes/kubernetes-upgrade/) for full details.
+
+## Full changelog
+
+<!-- PASTE THE OUTPUT OF THE GENERATED CHANGELOG HERE -->

--- a/eng/design-notes/security/2026-06-sha1-to-sha256-migration.md
+++ b/eng/design-notes/security/2026-06-sha1-to-sha256-migration.md
@@ -6,7 +6,7 @@
 
 Radius uses hashing in several places to generate deterministic, unique values: resource identifiers (Kubernetes object names, tracked-resource names), Terraform recipe state-secret suffixes, ETags, and change-detection tokens for the Kubernetes controllers. Historically these used **SHA-1**. SHA-1 is cryptographically broken and is flagged by CodeQL (`go/weak-cryptographic-algorithm`), even though Radius only uses it for **non-cryptographic** uniqueness and change detection - never for security (see the [UCP threat model](./2024-11-ucp-component-threat-model.md#use-of-cryptography)).
 
-This document describes the staged migration from SHA-1 to **SHA-256**. The guiding constraint is that the migration must be **non-breaking and transparent to existing installations**: an upgrade must not lose data, must not trigger redeployments or pod restarts, and must require no customer action. The migration is delivered in three phases. Phases 1 and 2 (the backward-compatible compatibility layer) are complete; Phase 3 (removing SHA-1 entirely) is intentionally deferred to a future release after the compatibility layer has been broadly adopted.
+This document describes the staged migration from SHA-1 to **SHA-256**. The guiding constraint is that the migration must be **non-breaking and transparent to existing installations**: an upgrade must not lose data, must not trigger workload redeployment or pod restarts, and must require no customer action. The migration is delivered in three phases. Phases 1 and 2 (the backward-compatible compatibility layer) are complete; Phase 3 (removing SHA-1 entirely) is intentionally deferred to a future release after the compatibility layer has been broadly adopted.
 
 ## Terms and definitions
 
@@ -171,7 +171,7 @@ Read-fallback helpers return a not-found error only when neither the current nor
 - **Unit tests**: `pkg/hashutil` (NIST SHA-256 and SHA-1 vectors); updated expected values in the reconciler, tracked-resource, Terraform-backend, and datastore name tests; new legacy-value tests for each `Legacy*` helper.
 - **Behavioral tests**: dual-accept (a stored legacy hash is treated as up-to-date) and read-fallback (a pre-created legacy-keyed record is found, updated in place without duplication, and deleted).
 - **Integration / envtest**: the UCP `radius` integration suite (PUT, track, list, delete) and the `apiserverstore` envtest suite both pass with the migration in place.
-- **Phase 3 (future)**: the bulk re-key migration (path 3b) must add idempotency and resumability tests, plus a mixed-data test (some records under SHA-1, some under SHA-256).
+- **Phase 3 (future)**: the bulk re-key migration (path 3b) must add idempotency and resumable-migration tests, plus a mixed-data test (some records under SHA-1, some under SHA-256).
 
 ## Security
 

--- a/eng/design-notes/security/2026-06-sha1-to-sha256-migration.md
+++ b/eng/design-notes/security/2026-06-sha1-to-sha256-migration.md
@@ -1,0 +1,188 @@
+# SHA-1 to SHA-256 Internal Hashing Migration
+
+- **Author**: GitHub Copilot (assisted), on behalf of the Radius maintainers
+
+## Overview
+
+Radius uses hashing in several places to generate deterministic, unique values: resource identifiers (Kubernetes object names, tracked-resource names), Terraform recipe state-secret suffixes, ETags, and change-detection tokens for the Kubernetes controllers. Historically these used **SHA-1**. SHA-1 is cryptographically broken and is flagged by CodeQL (`go/weak-cryptographic-algorithm`), even though Radius only uses it for **non-cryptographic** uniqueness and change detection - never for security (see the [UCP threat model](./2024-11-ucp-component-threat-model.md#use-of-cryptography)).
+
+This document describes the staged migration from SHA-1 to **SHA-256**. The guiding constraint is that the migration must be **non-breaking and transparent to existing installations**: an upgrade must not lose data, must not trigger redeployments or pod restarts, and must require no customer action. The migration is delivered in three phases. Phases 1 and 2 (the backward-compatible compatibility layer) are complete; Phase 3 (removing SHA-1 entirely) is intentionally deferred to a future release after the compatibility layer has been broadly adopted.
+
+## Terms and definitions
+
+| Term                 | Definition                                                                                                                                                               |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Current hash         | SHA-256, used for all newly written values.                                                                                                                              |
+| Legacy hash          | SHA-1, retained only to read values written by older versions of Radius.                                                                                                 |
+| Dual-accept          | A compare path that treats a stored value as matching if it equals **either** the current (SHA-256) or legacy (SHA-1) hash. Used for change-detection hashes.            |
+| Read-fallback        | A lookup path that tries the current (SHA-256) key, then falls back to the legacy (SHA-1) key. Used for persisted identifiers.                                           |
+| Operate-in-place     | When an existing record is found under its legacy key, it is updated or deleted under that same legacy key rather than being re-keyed. New records use the current key.  |
+| Persisted identifier | A hash used as a stable storage key (datastore object name, Terraform state-secret suffix, tracked-resource name). Changing it without a fallback orphans existing data. |
+
+## Objectives
+
+> **Issue Reference:** [radius-project/radius#8084](https://github.com/radius-project/radius/issues/8084); CodeQL code-scanning alerts 827 and 928-935.
+
+### Goals
+
+- Replace SHA-1 with SHA-256 for all non-cryptographic hashing in the control plane.
+- Guarantee a **non-breaking, transparent upgrade**: no data loss, no redeployment or restart of workloads, no Terraform state recreation, no customer action.
+- Isolate the remaining SHA-1 usage into a single, clearly documented location so the final removal is a one-file change and the CodeQL surface is minimal.
+- Provide a clear path to **zero SHA-1** (Phase 3) and the prerequisites for it.
+
+### Non goals
+
+- Changing any public REST API, CLI command, or Bicep/Helm surface. The hashes involved are internal and opaque to users.
+- Migrating SHA-1 usages that are **rendered into externally observable output** in this pass - specifically the Kubernetes secret-hash pod annotation and the ACI gateway DNS prefix. These require either a one-time workload rollout / endpoint change or deeper apply-layer work and are tracked as open decisions for Phase 3.
+- Re-keying already-stored data to SHA-256 in Phases 1 and 2. Existing records are maintained in place under their legacy keys; bulk re-keying (if pursued) is Phase 3 work.
+
+## Design
+
+### High Level Design
+
+A single foundation package, `pkg/hashutil`, centralizes hashing. `Hex(data) string` returns SHA-256 hex and is used for **all new values**. `LegacyHex(data) string` returns SHA-1 hex and lives in `pkg/hashutil/legacy.go`, which is the **only** file in the codebase that imports `crypto/sha1`. Deleting that file completes the migration (Phase 3).
+
+Each SHA-1 call site is migrated using one of three patterns, chosen by how the hash is used:
+
+- **Transient / recomputed hashes** swap directly to SHA-256. This is safe because the value is recomputed and compared, never persisted as a lookup key.
+- **Change-detection hashes that gate an operation** use **dual-accept**: write SHA-256, but on compare accept SHA-256 **or** legacy SHA-1. This ensures an upgraded control plane recognizes existing state as up-to-date and does **not** trigger an operation.
+- **Persisted identifiers** use **read-fallback with operate-in-place**: write and look up under SHA-256, fall back to the SHA-1 key on a miss, and keep existing records under their legacy key until they are deleted.
+
+```mermaid
+flowchart TD
+    A[Hash call site] --> B{How is the value used?}
+    B -->|Recomputed, compared, not a key| C[Swap to SHA-256 directly]
+    B -->|Change-detection gating an op| D[Dual-accept: SHA-256 write, accept SHA-256 or SHA-1]
+    B -->|Persisted lookup key| E[Read-fallback: try SHA-256, fall back to SHA-1, operate in place]
+    C --> F[pkg/hashutil.Hex]
+    D --> F
+    E --> F
+    D --> G[pkg/hashutil.LegacyHex]
+    E --> G
+    G --> H[legacy.go: only crypto/sha1 import, delete in Phase 3]
+```
+
+### Detailed Design
+
+Migration status by site. All completed sites are validated by unit tests; the datastore and tracked resources are additionally validated by envtest and integration tests.
+
+| Site                                                                                | Pattern                                                         | Status         |
+|-------------------------------------------------------------------------------------|-----------------------------------------------------------------|----------------|
+| `pkg/ucp/util/etag/etag.go` (ETags)                                                 | Direct swap (opaque token)                                      | Done           |
+| `pkg/controller/reconciler/annotations.go` (config hash)                            | Dual-accept                                                     | Done           |
+| `pkg/controller/reconciler/deploymenttemplate_reconciler.go` (spec hash)            | Dual-accept                                                     | Done           |
+| `pkg/ucp/trackedresource/{name,update}.go` + `proxy.go` (tracking names)            | Read-fallback (`ResolveTrackingEntry`)                          | Done (e2e)     |
+| `pkg/recipes/terraform/config/backends/kubernetes.go` (state-secret suffix)         | Read-fallback (`resolveSecretSuffix`)                           | Done           |
+| `pkg/components/database/apiserverstore/apiserverclient.go` (datastore object name) | Read-fallback (`getResourceWithFallback`, `getResourceForSave`) | Done (envtest) |
+| `pkg/kubernetes/secrets.go` (`HashSecretData` to pod annotation)                    | Deferred, still SHA-1                                           | Open decision  |
+| `pkg/corerp/renderers/aci/gateway/render.go` (DNS prefix)                           | Deferred, still SHA-1                                           | Open decision  |
+
+Notes on the two deferred sites:
+
+- **`HashSecretData`** feeds the `radapp.io/secret-hash` annotation on the **pod template** via a stateless renderer ([`pkg/corerp/renderers/container/render.go`](../../../pkg/corerp/renderers/container/render.go)). Any algorithm change rewrites the annotation for otherwise-unchanged secrets, which forces a one-time rolling restart of every affected workload on upgrade. A no-rollout migration requires preserving the existing annotation when the secret is unchanged, which the stateless renderer cannot do without reading live cluster state. It is intentionally left on SHA-1 with an explanatory `NOTE` in `secrets.go`.
+- **ACI gateway DNS prefix** becomes part of a public IP DNS label; changing it changes the endpoint. ACI support is experimental.
+
+### Advantages
+
+- **Non-breaking**: existing data is read via fallback, and no operations are triggered on upgrade.
+- **Minimal SHA-1 surface**: a single `legacy.go` file, so the final removal is a one-file change.
+- **Simple and reviewable**: operate-in-place avoids dual-write and cross-object optimistic-concurrency complexity.
+
+### Disadvantages
+
+- Existing records are **not** re-keyed automatically; they remain under SHA-1 keys until deleted. Reaching "zero SHA-1" therefore requires either accepting an isolated legacy read-path (and dismissing one CodeQL alert) or a dedicated bulk re-keying migration (Phase 3).
+- The fallback is one-directional: during a rolling upgrade window, data newly written by a new pod in the SHA-256 format is briefly invisible to a still-running old pod that lacks the fallback.
+
+### Proposed Option
+
+Ship the compatibility layer (Phases 1 and 2) now; defer SHA-1 removal (Phase 3) to a later release. This maximizes safety and transparency for current installations while establishing the foundation and the data path needed to finish the migration.
+
+## Phased rollout
+
+### Phase 1: Foundation and safe swaps (DONE)
+
+- Introduce `pkg/hashutil` (`Hex` plus isolated `LegacyHex`).
+- Migrate transient hashes (ETags) and convert the two controller change-detection hashes to dual-accept, so an upgrade triggers no container PUT, no DeploymentTemplate re-deployment, and no pod rollout.
+- Keep `HashSecretData` on SHA-1 (documented) to avoid a workload rollout.
+
+### Phase 2: Persisted-identifier read-fallback (DONE)
+
+- Tracked resources, the Terraform state-secret suffix, and the datastore object name each migrated to SHA-256 with a SHA-1 read-fallback and operate-in-place semantics.
+- Validated with unit tests, the UCP `radius` integration tests, and the apiserverstore envtest suite, including a dedicated test that pre-creates a legacy-named object and confirms it is found, updated **in place** without duplication, and deleted via the fallback.
+
+### Phase 3: Remove SHA-1 (FUTURE, after several releases)
+
+Phase 3 is **not** done now and should land only after the Phase 1 and 2 compatibility layer has shipped and been adopted across several releases, so that SHA-256-aware code is broadly deployed in the field. There are two acceptable end-states.
+
+Prerequisites (both paths):
+
+1. Phases 1 and 2 released and adopted (allow a deprecation window of several minor releases).
+1. Resolve the two deferred sites (`HashSecretData`, ACI DNS) by either accepting a one-time workload rollout / endpoint change, or implementing apply-time annotation preservation.
+
+**Path 3a: Isolate and dismiss (lowest effort).**
+
+- Keep `pkg/hashutil/legacy.go` as the single, documented, read-only SHA-1 path.
+- Dismiss the corresponding CodeQL alert with the justification "non-cryptographic, backward compatibility for stored identifiers."
+- No data migration and no customer action, ever. SHA-1 remains in the binary but is contained and audited.
+
+**Path 3b: Bulk re-key, then delete `legacy.go` (true zero SHA-1).**
+
+- Ship an **automatic, idempotent, resumable** data migration that re-keys stored data to SHA-256:
+  - **Datastore** (`apiserverstore`): enumerate every `Resource` object, re-save each entry under its SHA-256 object name, and delete the legacy-named object. Idempotent (safe to re-run) and resumable (process in batches; a record already under the SHA-256 name is skipped).
+  - **Terraform state**: copy or rename each `tfstate-default-<sha1>` secret to `tfstate-default-<sha256>`, or allow state to migrate naturally as recipes are re-executed, since `resolveSecretSuffix` writes new state under SHA-256 once the legacy secret is gone.
+  - **Tracked resources**: re-key entries to SHA-256 names, or allow them to age out as resources are deleted and re-tracked.
+- Run the migration as a pre-upgrade job or a one-shot controller reconcile, gated so the cluster is not serving mixed-version traffic during the re-key.
+- After the migration has completed in a release, a **subsequent** release deletes `legacy.go` and all `LegacyHex` and fallback code paths.
+- Customer guidance: upgrade **sequentially** through the migration release (do not skip it).
+
+> Recommendation: start with **3a** unless a strict "zero SHA-1 in the binary" mandate exists, in which case schedule **3b**. The choice can be made independently of Phases 1 and 2.
+
+## API design
+
+N/A. No public REST API, CLI, or Bicep/Helm changes. All affected hashes are internal and opaque.
+
+## CLI Design
+
+N/A.
+
+## Implementation Details
+
+### UCP
+
+- `pkg/ucp/util/etag/etag.go`: `New` uses `hashutil.Hex` (SHA-256). ETags are computed at save time, stored, and compared as opaque strings, so existing ETags remain valid until a record is rewritten.
+- `pkg/ucp/trackedresource`: `NameFor` uses SHA-256 (truncated to 40 hex to preserve the 63-character ARM/UCP name budget); `LegacyNameFor` and `LegacyIDFor` are added; `ResolveTrackingEntry` performs the current-then-legacy lookup and is used by both `Updater.run` and the proxy enqueue path.
+- `pkg/components/database/apiserverstore/apiserverclient.go`: `resourceName` uses SHA-256 truncated to 40 hex (to stay within the 253-character Kubernetes object-name limit); `legacyResourceName` is added; `getResourceWithFallback` (Get/Delete) and `getResourceForSave` (Save, operate-in-place) are added.
+
+### Portable Resources / Recipes RP
+
+- `pkg/recipes/terraform/config/backends/kubernetes.go`: `generateSecretSuffix` uses SHA-256, `generateLegacySecretSuffix` (SHA-1) is added, and `BuildBackend` resolves the suffix current-then-legacy via the existing `ValidateBackendExists` check (guarded for the nil-client tooling path). The resolved suffix flows through `generateConfig` to both `ValidateBackendExists` and the state-secret `Delete`, keeping apply and destroy consistent.
+
+### Core RP / Controller
+
+- `pkg/controller/reconciler/{annotations,deploymenttemplate_reconciler}.go`: `computeHash` uses `hashutil.Hex`; `IsUpToDate` and `isUpToDate` accept SHA-256 **or** legacy SHA-1.
+- `pkg/kubernetes/secrets.go` (`HashSecretData`) and `pkg/corerp/renderers/aci/gateway/render.go` are intentionally unchanged (still SHA-1); see the open decisions above.
+
+### Error Handling
+
+Read-fallback helpers return a not-found error only when neither the current nor the legacy key exists, preserving the existing `ErrNotFound` and `ErrConcurrency` semantics of each store. A non not-found error from either lookup is propagated unchanged.
+
+## Test plan
+
+- **Unit tests**: `pkg/hashutil` (NIST SHA-256 and SHA-1 vectors); updated expected values in the reconciler, tracked-resource, Terraform-backend, and datastore name tests; new legacy-value tests for each `Legacy*` helper.
+- **Behavioral tests**: dual-accept (a stored legacy hash is treated as up-to-date) and read-fallback (a pre-created legacy-keyed record is found, updated in place without duplication, and deleted).
+- **Integration / envtest**: the UCP `radius` integration suite (PUT, track, list, delete) and the `apiserverstore` envtest suite both pass with the migration in place.
+- **Phase 3 (future)**: the bulk re-key migration (path 3b) must add idempotency and resumability tests, plus a mixed-data test (some records under SHA-1, some under SHA-256).
+
+## Security
+
+SHA-1 in Radius is used only for non-cryptographic uniqueness and change detection (per the [UCP threat model](./2024-11-ucp-component-threat-model.md#use-of-cryptography)). Moving to SHA-256 removes the weak-algorithm finding from the affected sites and concentrates the remaining SHA-1 usage in a single audited file (`pkg/hashutil/legacy.go`) pending Phase 3. No secrets, credentials, or authentication paths are affected.
+
+## Compatibility
+
+The upgrade is backward compatible and transparent: existing data is read via the SHA-1 fallback, no workloads are redeployed or restarted, and no Terraform state is recreated.
+
+One nuance applies during the rolling-upgrade window. The fallback is one-directional (new code reads old data, but old code cannot read new-format data). All Radius control-plane components run `replicas: 1`, so this window is limited to the brief pod-replacement transition rather than a sustained mixed-version cluster, and Radius's operation retries cover transient overlaps. Operators who want zero risk can let in-flight deployments and recipe operations drain before upgrading.
+
+## Monitoring and Logging
+
+No new metrics are required for Phases 1 and 2. For Phase 3 path 3b, the bulk re-key migration should log progress (records scanned, re-keyed, skipped) and expose a completion signal so operators can confirm the migration finished before the subsequent SHA-1-removal release.

--- a/eng/design-notes/security/2026-06-sha1-to-sha256-migration.md
+++ b/eng/design-notes/security/2026-06-sha1-to-sha256-migration.md
@@ -40,7 +40,7 @@ This document describes the staged migration from SHA-1 to **SHA-256**. The guid
 
 ### High Level Design
 
-A single foundation package, `pkg/hashutil`, centralizes hashing. `Hex(data) string` returns SHA-256 hex and is used for **all new values**. `LegacyHex(data) string` returns SHA-1 hex and lives in `pkg/hashutil/legacy.go`, which is the **only** file in the codebase that imports `crypto/sha1`. Deleting that file completes the migration (Phase 3).
+A single foundation package, `pkg/hashutil`, centralizes hashing. `Hex(data) string` returns SHA-256 hex and is used for **all new values**. `LegacyHex(data) string` returns SHA-1 hex and lives in `pkg/hashutil/legacy.go`, the single SHA-1 implementation behind `hashutil`. A few call sites outside `hashutil` still compute SHA-1 directly and are deferred to Phase 3 (the Kubernetes secret-hash annotation and the ACI gateway DNS prefix, covered under Detailed Design). Once those sites are migrated and all stored SHA-1 values have been re-keyed, deleting `legacy.go` completes the migration.
 
 Each SHA-1 call site is migrated using one of three patterns, chosen by how the hash is used:
 
@@ -59,7 +59,7 @@ flowchart TD
     E --> F
     D --> G[pkg/hashutil.LegacyHex]
     E --> G
-    G --> H[legacy.go: only crypto/sha1 import, delete in Phase 3]
+    G --> H[legacy.go: hashutil SHA-1 impl, delete in Phase 3]
 ```
 
 ### Detailed Design

--- a/pkg/components/database/apiserverstore/apiserverclient.go
+++ b/pkg/components/database/apiserverstore/apiserverclient.go
@@ -42,7 +42,6 @@ package apiserverstore
 
 import (
 	"context"
-	"crypto/sha1"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -51,6 +50,7 @@ import (
 	"github.com/radius-project/radius/pkg/components/database"
 	ucpv1alpha1 "github.com/radius-project/radius/pkg/components/database/apiserverstore/api/ucp.dev/v1alpha1"
 	"github.com/radius-project/radius/pkg/components/database/databaseutil"
+	"github.com/radius-project/radius/pkg/hashutil"
 	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
 	"github.com/radius-project/radius/pkg/ucp/util/etag"
@@ -170,10 +170,8 @@ func (c *APIServerClient) Get(ctx context.Context, id string, options ...databas
 		return nil, &database.ErrInvalid{Message: "invalid argument. 'id' must refer to a named resource, not a collection"}
 	}
 
-	resourceName := resourceName(parsed)
-
 	resource := ucpv1alpha1.Resource{}
-	err = c.client.Get(ctx, runtimeclient.ObjectKey{Namespace: c.namespace, Name: resourceName}, &resource)
+	err = c.getResourceWithFallback(ctx, parsed, &resource)
 	if err != nil && apierrors.IsNotFound(err) {
 		return nil, &database.ErrNotFound{ID: id}
 	} else if err != nil {
@@ -206,13 +204,11 @@ func (c *APIServerClient) Delete(ctx context.Context, id string, options ...data
 		return &database.ErrInvalid{Message: "invalid argument. 'id' must refer to a named resource, not a collection"}
 	}
 
-	resourceName := resourceName(parsed)
-
 	config := database.NewDeleteConfig(options...)
 
 	err = c.doWithRetry(func() (bool, error) {
 		resource := ucpv1alpha1.Resource{}
-		err := c.client.Get(ctx, runtimeclient.ObjectKey{Namespace: c.namespace, Name: resourceName}, &resource)
+		err := c.getResourceWithFallback(ctx, parsed, &resource)
 		if err != nil && apierrors.IsNotFound(err) && config.ETag != "" {
 			return false, &database.ErrConcurrency{}
 		} else if err != nil && apierrors.IsNotFound(err) {
@@ -284,22 +280,16 @@ func (c *APIServerClient) Save(ctx context.Context, obj *database.Object, option
 		return err
 	}
 
-	resourceName := resourceName(id)
-
 	config := database.NewSaveConfig(options...)
 
 	err = c.doWithRetry(func() (bool, error) {
-		found := true
-		resource := ucpv1alpha1.Resource{}
-		err = c.client.Get(ctx, runtimeclient.ObjectKey{Namespace: c.namespace, Name: resourceName}, &resource)
-		if err != nil && apierrors.IsNotFound(err) {
-			found = false
-		} else if err != nil {
+		name, resource, found, err := c.getResourceForSave(ctx, id)
+		if err != nil {
 			return false, err
 		}
 
 		// These need to be initialized if we're creating the object.
-		resource.Name = resourceName
+		resource.Name = name
 		resource.Namespace = c.namespace
 
 		converted, err := convert(obj)
@@ -398,28 +388,89 @@ func normalizeName(name string) string {
 }
 
 func resourceName(id resources.ID) string {
-	// The kubernetes resource names we use are built according to the following format
-	//
-	// resource.<resource name>.<id hash> (for a resource)
-	// scope.<resource name>.<id hash> (for a scope)
-	hasher := sha1.New()
-	_, _ = hasher.Write([]byte(strings.ToLower(id.String())))
-	hash := hasher.Sum(nil)
+	return makeResourceName(id, hashutil.Hex([]byte(strings.ToLower(id.String()))))
+}
+
+// legacyResourceName computes the Kubernetes object name using the legacy SHA-1 hash.
+//
+// Deprecated: SHA-1 is retained only to locate resources written by older versions of Radius during
+// the migration to SHA-256. Use resourceName for new values. See
+// https://github.com/radius-project/radius/issues/8084.
+func legacyResourceName(id resources.ID) string {
+	return makeResourceName(id, hashutil.LegacyHex([]byte(strings.ToLower(id.String()))))
+}
+
+// makeResourceName builds the Kubernetes object name from the resource ID and a hex hash of the ID.
+//
+// The kubernetes resource names we use are built according to the following format:
+//
+//	resource.<resource name>.<id hash> (for a resource)
+//	scope.<resource name>.<id hash> (for a scope)
+func makeResourceName(id resources.ID, hash string) string {
+	// The hash is truncated to 40 hex characters (the width of the legacy SHA-1 hash) so the name
+	// continues to fit within the 253-character Kubernetes object name limit.
+	const hashLength = 40
+	if len(hash) > hashLength {
+		hash = hash[:hashLength]
+	}
 
 	prefix := database.UCPResourcePrefix
 	if id.IsScope() {
 		prefix = database.UCPScopePrefix
 	}
 
-	noramlizedName := normalizeName(id.Name())
+	normalizedName := normalizeName(id.Name())
 	// 211 = 253 (max length of Kubernetes Object name) - 40 (hex hash length) - 2 (dot separators)
 	maxResourceNameLen := 211 - len(prefix)
-	if len(noramlizedName) >= maxResourceNameLen {
-		noramlizedName = noramlizedName[:maxResourceNameLen]
+	if len(normalizedName) >= maxResourceNameLen {
+		normalizedName = normalizedName[:maxResourceNameLen]
 	}
 
 	// example: resource.resource1.ec291e26078b7ea8a74abfac82530005a0ecbf15
-	return fmt.Sprintf("%s.%s.%x", prefix, noramlizedName, hash)
+	return fmt.Sprintf("%s.%s.%s", prefix, normalizedName, hash)
+}
+
+// getResourceWithFallback reads the Kubernetes Resource object that stores id, preferring the
+// current (SHA-256) object name and falling back to the legacy (SHA-1) name written by older
+// versions of Radius. The returned error is NotFound only if neither object exists. See
+// https://github.com/radius-project/radius/issues/8084.
+func (c *APIServerClient) getResourceWithFallback(ctx context.Context, id resources.ID, resource *ucpv1alpha1.Resource) error {
+	err := c.client.Get(ctx, runtimeclient.ObjectKey{Namespace: c.namespace, Name: resourceName(id)}, resource)
+	if apierrors.IsNotFound(err) {
+		return c.client.Get(ctx, runtimeclient.ObjectKey{Namespace: c.namespace, Name: legacyResourceName(id)}, resource)
+	}
+
+	return err
+}
+
+// getResourceForSave reads the Kubernetes Resource object that should store id for a write. It
+// prefers the current (SHA-256) name, but falls back to the legacy (SHA-1) name when id's entry
+// already exists there so existing data is updated in place rather than duplicated. New resources
+// are created under the current name. It returns the name to operate under, the object (empty if it
+// does not exist), and whether the object already exists. See
+// https://github.com/radius-project/radius/issues/8084.
+func (c *APIServerClient) getResourceForSave(ctx context.Context, id resources.ID) (string, ucpv1alpha1.Resource, bool, error) {
+	current := resourceName(id)
+	resource := ucpv1alpha1.Resource{}
+	err := c.client.Get(ctx, runtimeclient.ObjectKey{Namespace: c.namespace, Name: current}, &resource)
+	if err == nil {
+		return current, resource, true, nil
+	} else if !apierrors.IsNotFound(err) {
+		return "", ucpv1alpha1.Resource{}, false, err
+	}
+
+	// The current-named object does not exist. Fall back to the legacy name if this resource's entry
+	// was written by an older version of Radius, so we update it in place.
+	legacy := legacyResourceName(id)
+	legacyResource := ucpv1alpha1.Resource{}
+	err = c.client.Get(ctx, runtimeclient.ObjectKey{Namespace: c.namespace, Name: legacy}, &legacyResource)
+	if err == nil && findIndex(&legacyResource, id) != nil {
+		return legacy, legacyResource, true, nil
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		return "", ucpv1alpha1.Resource{}, false, err
+	}
+
+	return current, ucpv1alpha1.Resource{}, false, nil
 }
 
 func assignLabels(resource *ucpv1alpha1.Resource) labels.Set {

--- a/pkg/components/database/apiserverstore/apiserverclient.go
+++ b/pkg/components/database/apiserverstore/apiserverclient.go
@@ -393,8 +393,8 @@ func resourceName(id resources.ID) string {
 
 // legacyResourceName computes the Kubernetes object name using the legacy SHA-1 hash.
 //
-// Deprecated: SHA-1 is retained only to locate resources written by older versions of Radius during
-// the migration to SHA-256. Use resourceName for new values. See
+// SHA-1 is retained only to locate resources written by older versions of Radius during the
+// migration to SHA-256. Use resourceName for new values. See
 // https://github.com/radius-project/radius/issues/8084.
 func legacyResourceName(id resources.ID) string {
 	return makeResourceName(id, hashutil.LegacyHex([]byte(strings.ToLower(id.String()))))

--- a/pkg/components/database/apiserverstore/apiserverclient_test.go
+++ b/pkg/components/database/apiserverstore/apiserverclient_test.go
@@ -46,47 +46,47 @@ func Test_ResourceName_Normalize(t *testing.T) {
 		{
 			"ucp_resourcegroup_with_valid_characters",
 			"/planes/radius/local/resourceGroups/test-Group",
-			"scope.test-group.b8fcfb5d6a16e6f9cd10cd4c0377082bed734c6f",
+			"scope.test-group.67fbba5bd74b18ae00a6a91be9f43a55a48eee99",
 		},
 		{
 			"ucp_resourcegroup_with_underscore",
 			"/planes/radius/local/resourceGroups/test_group",
-			"scope.testx5fgroup.0fb96a9aa19f9c2e101405b80929ecc5cae090d0",
+			"scope.testx5fgroup.ba43ebf75323cc0f3db85cd03612c29526944768",
 		},
 		{
 			"ucp_resourcegroup_with_colon",
 			"/planes/radius/local/resourceGroups/test:group",
-			"scope.testx3agroup.a01f2550797ca2e5d80b6032f361dea167e6c1f5",
+			"scope.testx3agroup.34a1c433a894e07210075f068e81982855bb708a",
 		},
 		{
 			"ucp_resourcegroup_with_undercore_char_code",
 			"/planes/radius/local/resourceGroups/testx5fgroup",
-			"scope.testx5fgroup.38e1d2520da9c33fb1f82e7c697ebfb7ec28da2e",
+			"scope.testx5fgroup.ed102966e22c47a92f3c3b2fb31cb535b127a6fb",
 		},
 		{
 			"ucp_resourcegroup_with_long_resourcegroup_name",
 			"/planes/radius/local/resourceGroups/" + strings.Repeat("longResourceGroupName", 50),
-			"scope.longresourcegroupnamelongresourcegroupnamelongresourcegroupnamelongresourcegroupnamelongresourcegroupnamelongresourcegroupnamelongresourcegroupnamelongresourcegroupnamelongresourcegroupnamelongresourcegroup.77d9b26654021c6b2acc6434ea3da6bf6fd2ee63",
+			"scope.longresourcegroupnamelongresourcegroupnamelongresourcegroupnamelongresourcegroupnamelongresourcegroupnamelongresourcegroupnamelongresourcegroupnamelongresourcegroupnamelongresourcegroupnamelongresourcegroup.7934e91c6c33eda65102b1b07847cbb38e1c808f",
 		},
 		{
 			"ucp_id_with_underscore",
 			"/planes/radius/local/resourceGroups/test_group/providers/Applications.Core/environments/cool_test",
-			"resource.coolx5ftest.d42a57ad9f2f44521a1b0a63626fb9da20a31f45",
+			"resource.coolx5ftest.11c22a1c449df72a5983a3d59bd4f74dcade368f",
 		},
 		{
 			"ucp_id_with_dot",
 			"/planes/radius/local/resourceGroups/test_group/providers/Applications.Core/environments/cool.test",
-			"resource.coolx2etest.abdff8cc92a10c748a2f8907b0b187cff1f9de14",
+			"resource.coolx2etest.b31698511fc6c1925886f805e5320fe22b797610",
 		},
 		{
 			"ucp_id_with_hyphen",
 			"/planes/radius/local/resourceGroups/test_group/providers/Applications.Core/environments/cool-test",
-			"resource.cool-test.0424033ec7fe861358037a96b8510f168a459e5a",
+			"resource.cool-test.9fdd9424fe5520537d421b24ef5c9baa27d77af1",
 		},
 		{
 			"ucp_id_with_long_resource_name",
 			"/planes/radius/local/resourceGroups/test_group/providers/Applications.Core/environments/" + strings.Repeat("longResourceName", 50),
-			"resource.longresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourc.0d69e6d1293c114e5c6d1e905893b44d29f5ea71",
+			"resource.longresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourcenamelongresourc.b8407bd19b9b40a6b5aadf286deea390389ea5b4",
 		},
 	}
 
@@ -161,6 +161,62 @@ func Test_APIServer_Client(t *testing.T) {
 		}
 
 		require.Equal(t, expected, resource.Labels)
+	})
+
+	t.Run("legacy_named_resource_is_found_updated_and_deleted", func(t *testing.T) {
+		clear(t)
+
+		// Simulate a resource written by an older version of Radius: the Kubernetes object is stored
+		// under the legacy (SHA-1) name. The SHA-256 migration must continue to find, update, and
+		// delete it without orphaning the existing data.
+		legacyName := legacyResourceName(shared.Resource1ID)
+		legacyObject := ucpv1alpha1.Resource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      legacyName,
+				Namespace: ns,
+			},
+			Entries: []ucpv1alpha1.ResourceEntry{
+				{
+					ID:   shared.Resource1ID.String(),
+					ETag: etag.New(shared.MarshalOrPanic(shared.Data1)),
+					Data: &runtime.RawExtension{Raw: shared.MarshalOrPanic(shared.Data1)},
+				},
+			},
+		}
+		err := rc.Create(ctx, &legacyObject)
+		require.NoError(t, err)
+
+		// Get must find the resource via the legacy-name fallback.
+		got, err := client.Get(ctx, shared.Resource1ID.String())
+		require.NoError(t, err)
+		require.Equal(t, shared.Resource1ID.String(), got.ID)
+
+		// Save must update the existing legacy object in place rather than creating a new object under
+		// the current (SHA-256) name.
+		obj := database.Object{
+			Metadata: database.Metadata{ID: shared.Resource1ID.String()},
+			Data:     shared.Data2,
+		}
+		err = client.Save(ctx, &obj)
+		require.NoError(t, err)
+
+		// The current (SHA-256) named object must NOT exist - the data stays under the legacy name.
+		currentName := resourceName(shared.Resource1ID)
+		err = rc.Get(ctx, runtimeclient.ObjectKey{Namespace: ns, Name: currentName}, &ucpv1alpha1.Resource{})
+		require.True(t, apierrors.IsNotFound(err), "save must not duplicate the resource under the current name")
+
+		updated := ucpv1alpha1.Resource{}
+		err = rc.Get(ctx, runtimeclient.ObjectKey{Namespace: ns, Name: legacyName}, &updated)
+		require.NoError(t, err)
+		require.Len(t, updated.Entries, 1)
+		require.Equal(t, shared.Resource1ID.String(), updated.Entries[0].ID)
+
+		// Delete must remove the resource via the legacy-name fallback.
+		err = client.Delete(ctx, shared.Resource1ID.String())
+		require.NoError(t, err)
+
+		err = rc.Get(ctx, runtimeclient.ObjectKey{Namespace: ns, Name: legacyName}, &ucpv1alpha1.Resource{})
+		require.True(t, apierrors.IsNotFound(err))
 	})
 
 	t.Run("save_resource_and_validate_kubernetes_object_uppercase_name", func(t *testing.T) {

--- a/pkg/controller/reconciler/annotations.go
+++ b/pkg/controller/reconciler/annotations.go
@@ -17,13 +17,12 @@ limitations under the License.
 package reconciler
 
 import (
-	"crypto/sha1"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
 
 	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
+	"github.com/radius-project/radius/pkg/hashutil"
 	"github.com/radius-project/radius/pkg/ucp/resources"
 	appsv1 "k8s.io/api/apps/v1"
 )
@@ -82,9 +81,21 @@ func (c *deploymentConfiguration) computeHash() (string, error) {
 		return "", err
 	}
 
-	sum := sha1.Sum(b)
-	hash := hex.EncodeToString(sum[:])
-	return hash, nil
+	return hashutil.Hex(b), nil
+}
+
+// matchesHash reports whether stored matches the current configuration hash.
+//
+// It accepts both the current SHA-256 hash and the legacy SHA-1 hash so that
+// upgrading Radius (which changes the hash algorithm) does not flag an otherwise
+// unchanged configuration as out-of-date and trigger an unnecessary update.
+func (c *deploymentConfiguration) matchesHash(stored string) bool {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return false
+	}
+
+	return stored == hashutil.Hex(b) || stored == hashutil.LegacyHex(b)
 }
 
 type deploymentStatus struct {
@@ -234,12 +245,7 @@ func (annotations *deploymentAnnotations) IsUpToDate() bool {
 		return false
 	}
 
-	hash, err := annotations.Configuration.computeHash()
-	if err != nil {
-		return false // If the hash cannot be computed, we assume the configuration is outdated.
-	}
-
-	return hash == annotations.ConfigurationHash
+	return annotations.Configuration.matchesHash(annotations.ConfigurationHash)
 }
 
 // OperationInProgress returns true if there is an operation in progress for the given deployment.

--- a/pkg/controller/reconciler/deploymenttemplate_reconciler.go
+++ b/pkg/controller/reconciler/deploymenttemplate_reconciler.go
@@ -18,8 +18,6 @@ package reconciler
 
 import (
 	"context"
-	"crypto/sha1"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -37,6 +35,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/radius-project/radius/pkg/cli/clients"
 	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
+	"github.com/radius-project/radius/pkg/hashutil"
 	sdkclients "github.com/radius-project/radius/pkg/sdk/clients"
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
 	corev1 "k8s.io/api/core/v1"
@@ -606,20 +605,23 @@ func computeHash(deploymentTemplate *radappiov1alpha3.DeploymentTemplate) (strin
 		return "", err
 	}
 
-	sum := sha1.Sum(b)
-	hash := hex.EncodeToString(sum[:])
-	return hash, nil
+	return hashutil.Hex(b), nil
 }
 
 // isUpToDate returns true if the desired state of the DeploymentTemplate
 // matches the observed state.
+//
+// It accepts both the current SHA-256 hash and the legacy SHA-1 hash so that
+// upgrading Radius (which changes the hash algorithm) does not flag an otherwise
+// unchanged DeploymentTemplate as out-of-date and trigger an unnecessary deployment.
 func isUpToDate(deploymentTemplate *radappiov1alpha3.DeploymentTemplate) bool {
-	hash, err := computeHash(deploymentTemplate)
+	b, err := json.Marshal(deploymentTemplate.Spec)
 	if err != nil {
 		return false
 	}
 
-	return deploymentTemplate.Status.StatusHash == hash
+	stored := deploymentTemplate.Status.StatusHash
+	return stored == hashutil.Hex(b) || stored == hashutil.LegacyHex(b)
 }
 
 // updateFailedStatus updates the deployment template status to failed state and clears the operation.

--- a/pkg/controller/reconciler/deploymenttemplate_reconciler_test.go
+++ b/pkg/controller/reconciler/deploymenttemplate_reconciler_test.go
@@ -124,7 +124,7 @@ func Test_DeploymentTemplateReconciler_ComputeHash(t *testing.T) {
 			deploymentTemplate: &radappiov1alpha3.DeploymentTemplate{
 				Spec: radappiov1alpha3.DeploymentTemplateSpec{},
 			},
-			expected: "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f",
+			expected: "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
 		},
 		{
 			name: "simple",
@@ -135,7 +135,7 @@ func Test_DeploymentTemplateReconciler_ComputeHash(t *testing.T) {
 					ProviderConfig: "{}",
 				},
 			},
-			expected: "47ee899e74561942ee36a02ffd80be955e251583",
+			expected: "950829dab3e33b280e2ef52a7484c51d19a51498a74aab1d7f4d2781d6e65953",
 		},
 		{
 			name: "complex",
@@ -146,7 +146,7 @@ func Test_DeploymentTemplateReconciler_ComputeHash(t *testing.T) {
 					ProviderConfig: `{"AWS":{"type":"aws","value":{"scope":"scope"}}}`,
 				},
 			},
-			expected: "5c83b7122697599db2a47f2d5f7e29f4b9e3c869",
+			expected: "ff16a7bcb2db8d7c1280eb761b376939dfc3856a74cfd77b986a1c0f25abf5dd",
 		},
 	}
 
@@ -167,6 +167,23 @@ func Test_DeploymentTemplateReconciler_IsUpToDate(t *testing.T) {
 	}{
 		{
 			name: "up-to-date",
+			deploymentTemplate: &radappiov1alpha3.DeploymentTemplate{
+				Spec: radappiov1alpha3.DeploymentTemplateSpec{
+					Template:       "{}",
+					Parameters:     map[string]string{},
+					ProviderConfig: "{}",
+				},
+				Status: radappiov1alpha3.DeploymentTemplateStatus{
+					StatusHash: "950829dab3e33b280e2ef52a7484c51d19a51498a74aab1d7f4d2781d6e65953",
+				},
+			},
+			expected: true,
+		},
+		{
+			// Verifies the SHA-1 -> SHA-256 migration is non-breaking: a StatusHash written
+			// by an older version of Radius (legacy SHA-1 of the "simple" spec) is still
+			// considered up-to-date, so upgrading does not trigger an unnecessary deployment.
+			name: "legacy-hash-up-to-date",
 			deploymentTemplate: &radappiov1alpha3.DeploymentTemplate{
 				Spec: radappiov1alpha3.DeploymentTemplateSpec{
 					Template:       "{}",
@@ -202,7 +219,7 @@ func Test_DeploymentTemplateReconciler_IsUpToDate(t *testing.T) {
 					ProviderConfig: `{"AWS":{"type":"aws","value":{"scope":"scope"}}}`,
 				},
 				Status: radappiov1alpha3.DeploymentTemplateStatus{
-					StatusHash: "5c83b7122697599db2a47f2d5f7e29f4b9e3c869",
+					StatusHash: "ff16a7bcb2db8d7c1280eb761b376939dfc3856a74cfd77b986a1c0f25abf5dd",
 				},
 			},
 			expected: true,

--- a/pkg/hashutil/hashutil.go
+++ b/pkg/hashutil/hashutil.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package hashutil provides deterministic content hashing used across Radius to
+// generate stable identifiers and change-detection tokens (for example resource
+// names, ETags, and configuration hashes).
+//
+// These hashes are NOT used for cryptographic or security purposes. They exist
+// only to produce unique, deterministic values and to detect whether content has
+// changed.
+//
+// New values must be produced with Hex (SHA-256). The legacy SHA-1 helper exists
+// only so that Radius can recognize values written by older versions while they
+// are migrated to SHA-256; see https://github.com/radius-project/radius/issues/8084.
+package hashutil
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// Hex returns the SHA-256 hash of data encoded as a lowercase hexadecimal string.
+//
+// This is the hashing function that should be used for all new values.
+func Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/hashutil/hashutil_test.go
+++ b/pkg/hashutil/hashutil_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hashutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Hex(t *testing.T) {
+	// NIST SHA-256 test vectors.
+	require.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Hex([]byte("")))
+	require.Equal(t, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", Hex([]byte("abc")))
+}
+
+func Test_LegacyHex(t *testing.T) {
+	// NIST SHA-1 test vectors. These must remain stable so that values written by
+	// older versions of Radius continue to be recognized during migration.
+	require.Equal(t, "da39a3ee5e6b4b0d3255bfef95601890afd80709", LegacyHex([]byte("")))
+	require.Equal(t, "a9993e364706816aba3e25717850c26c9cd0d89d", LegacyHex([]byte("abc")))
+}

--- a/pkg/hashutil/legacy.go
+++ b/pkg/hashutil/legacy.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hashutil
+
+// This file is intentionally the single location in the Radius codebase that imports
+// crypto/sha1. SHA-1 is used here only for non-cryptographic, backward-compatible
+// reads of identifiers and change-detection tokens written by older versions of
+// Radius while they are migrated to SHA-256. Deleting this file (once all stored
+// SHA-1 values have been migrated) completes the migration away from SHA-1.
+//
+// See https://github.com/radius-project/radius/issues/8084.
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+)
+
+// LegacyHex returns the SHA-1 hash of data encoded as a lowercase hexadecimal string.
+//
+// Deprecated: SHA-1 is cryptographically broken and is retained only so that Radius
+// can recognize values written by older versions during the migration to SHA-256.
+// Use Hex for all new values. Do not use LegacyHex to produce new values.
+func LegacyHex(data []byte) string {
+	sum := sha1.Sum(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/hashutil/legacy.go
+++ b/pkg/hashutil/legacy.go
@@ -31,9 +31,9 @@ import (
 
 // LegacyHex returns the SHA-1 hash of data encoded as a lowercase hexadecimal string.
 //
-// Deprecated: SHA-1 is cryptographically broken and is retained only so that Radius
-// can recognize values written by older versions during the migration to SHA-256.
-// Use Hex for all new values. Do not use LegacyHex to produce new values.
+// SHA-1 is cryptographically broken and is retained only so that Radius can recognize
+// values written by older versions during the migration to SHA-256. Use Hex for all new
+// values; do not use LegacyHex to produce new values.
 func LegacyHex(data []byte) string {
 	sum := sha1.Sum(data)
 	return hex.EncodeToString(sum[:])

--- a/pkg/hashutil/legacy.go
+++ b/pkg/hashutil/legacy.go
@@ -16,11 +16,15 @@ limitations under the License.
 
 package hashutil
 
-// This file is intentionally the single location in the Radius codebase that imports
-// crypto/sha1. SHA-1 is used here only for non-cryptographic, backward-compatible
-// reads of identifiers and change-detection tokens written by older versions of
-// Radius while they are migrated to SHA-256. Deleting this file (once all stored
-// SHA-1 values have been migrated) completes the migration away from SHA-1.
+// This file centralizes the SHA-1 implementation behind pkg/hashutil. SHA-1 is used here
+// only for non-cryptographic, backward-compatible reads of identifiers and change-detection
+// tokens written by older versions of Radius while they are migrated to SHA-256.
+//
+// A few call sites outside hashutil still compute SHA-1 directly and are migrated in a later
+// phase - notably the Kubernetes secret-hash pod annotation (pkg/kubernetes/secrets.go) and
+// the ACI gateway DNS prefix (pkg/corerp/renderers/aci/gateway/render.go). Once those are
+// migrated and all stored SHA-1 values have been re-keyed, deleting this file completes the
+// migration away from SHA-1.
 //
 // See https://github.com/radius-project/radius/issues/8084.
 

--- a/pkg/kubernetes/secrets.go
+++ b/pkg/kubernetes/secrets.go
@@ -26,6 +26,12 @@ import (
 //
 // This can be used as a Kubernetes annotation to force a Deployment to redeploy pods
 // when the secret changes.
+//
+// NOTE: This intentionally still uses SHA-1. The resulting value is embedded in the
+// Pod template annotation (radapp.io/secret-hash) by a stateless renderer, so changing
+// the algorithm would change the annotation for otherwise-unchanged secrets and force a
+// rollout of every workload on upgrade. Migrating this to SHA-256 requires preserving the
+// existing annotation when the secret is unchanged. See issue #8084.
 func HashSecretData(secretData map[string][]byte) string {
 	// Sort keys so we can hash deterministically
 	keys := []string{}

--- a/pkg/recipes/terraform/config/backends/kubernetes.go
+++ b/pkg/recipes/terraform/config/backends/kubernetes.go
@@ -136,6 +136,12 @@ func (p *kubernetesBackend) ValidateBackendExists(ctx context.Context, name stri
 	return true, nil
 }
 
+// secretSuffixLength is the number of hexadecimal characters of the hash used for the Terraform
+// state secret suffix. The Terraform Kubernetes backend stores secret_suffix as a Kubernetes label
+// value (limited to 63 characters), so the SHA-256 hash (64 hex characters) is truncated. 40
+// characters (160 bits) matches the legacy SHA-1 width and keeps ample collision resistance.
+const secretSuffixLength = 40
+
 // generateSecretSuffix returns a unique string from the resourceID, environmentID, and applicationID
 // which is used as key for kubernetes secret in defining terraform backend.
 func generateSecretSuffix(resourceRecipe *recipes.ResourceMetadata) (string, error) {
@@ -144,7 +150,7 @@ func generateSecretSuffix(resourceRecipe *recipes.ResourceMetadata) (string, err
 		return "", err
 	}
 
-	return hashutil.Hex([]byte(input)), nil
+	return hashutil.Hex([]byte(input))[:secretSuffixLength], nil
 }
 
 // generateLegacySecretSuffix returns the legacy SHA-1 based secret suffix.

--- a/pkg/recipes/terraform/config/backends/kubernetes.go
+++ b/pkg/recipes/terraform/config/backends/kubernetes.go
@@ -149,8 +149,8 @@ func generateSecretSuffix(resourceRecipe *recipes.ResourceMetadata) (string, err
 
 // generateLegacySecretSuffix returns the legacy SHA-1 based secret suffix.
 //
-// Deprecated: SHA-1 is retained only to locate Terraform state secrets created by older versions of
-// Radius during the migration to SHA-256. Use generateSecretSuffix for new values. See
+// SHA-1 is retained only to locate Terraform state secrets created by older versions of Radius
+// during the migration to SHA-256. Use generateSecretSuffix for new values. See
 // https://github.com/radius-project/radius/issues/8084.
 func generateLegacySecretSuffix(resourceRecipe *recipes.ResourceMetadata) (string, error) {
 	input, err := secretSuffixInput(resourceRecipe)

--- a/pkg/recipes/terraform/config/backends/kubernetes.go
+++ b/pkg/recipes/terraform/config/backends/kubernetes.go
@@ -18,11 +18,11 @@ package backends
 
 import (
 	"context"
-	"crypto/sha1"
 	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/radius-project/radius/pkg/hashutil"
 	"github.com/radius-project/radius/pkg/recipes"
 	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
@@ -62,12 +62,59 @@ func NewKubernetesBackend(k8sClientSet kubernetes.Interface) Backend {
 // in-cluster config is not present.
 // https://developer.hashicorp.com/terraform/language/settings/backends/kubernetes
 func (p *kubernetesBackend) BuildBackend(resourceRecipe *recipes.ResourceMetadata) (map[string]any, error) {
-	secretSuffix, err := generateSecretSuffix(resourceRecipe)
+	secretSuffix, err := p.resolveSecretSuffix(resourceRecipe)
 	if err != nil {
 		return nil, err
 	}
 
 	return generateKubernetesBackendConfig(secretSuffix)
+}
+
+// resolveSecretSuffix returns the secret suffix to use for the Terraform state backend.
+//
+// It prefers the current (SHA-256) suffix, but falls back to the legacy (SHA-1) suffix when a
+// Terraform state secret already exists under the legacy name (written by an older version of
+// Radius). New deployments use the current suffix. This keeps the SHA-1 -> SHA-256 migration from
+// losing existing Terraform state. See https://github.com/radius-project/radius/issues/8084.
+func (p *kubernetesBackend) resolveSecretSuffix(resourceRecipe *recipes.ResourceMetadata) (string, error) {
+	currentSuffix, err := generateSecretSuffix(resourceRecipe)
+	if err != nil {
+		return "", err
+	}
+
+	// Some callers only need the computed suffix and do not provide a Kubernetes client (for example
+	// test tooling). Without a client we cannot check for an existing state secret, so use the current
+	// suffix.
+	if p.k8sClientSet == nil {
+		return currentSuffix, nil
+	}
+
+	// A background context is sufficient here: this is a single, short-lived existence check used to
+	// pick the correct (current vs legacy) state secret name before Terraform runs.
+	ctx := context.Background()
+
+	exists, err := p.ValidateBackendExists(ctx, KubernetesBackendNamePrefix+currentSuffix)
+	if err != nil {
+		return "", err
+	}
+	if exists {
+		return currentSuffix, nil
+	}
+
+	legacySuffix, err := generateLegacySecretSuffix(resourceRecipe)
+	if err != nil {
+		return "", err
+	}
+
+	exists, err = p.ValidateBackendExists(ctx, KubernetesBackendNamePrefix+legacySuffix)
+	if err != nil {
+		return "", err
+	}
+	if exists {
+		return legacySuffix, nil
+	}
+
+	return currentSuffix, nil
 }
 
 // ValidateBackendExists checks if the Kubernetes secret for Terraform state file exists.
@@ -92,6 +139,31 @@ func (p *kubernetesBackend) ValidateBackendExists(ctx context.Context, name stri
 // generateSecretSuffix returns a unique string from the resourceID, environmentID, and applicationID
 // which is used as key for kubernetes secret in defining terraform backend.
 func generateSecretSuffix(resourceRecipe *recipes.ResourceMetadata) (string, error) {
+	input, err := secretSuffixInput(resourceRecipe)
+	if err != nil {
+		return "", err
+	}
+
+	return hashutil.Hex([]byte(input)), nil
+}
+
+// generateLegacySecretSuffix returns the legacy SHA-1 based secret suffix.
+//
+// Deprecated: SHA-1 is retained only to locate Terraform state secrets created by older versions of
+// Radius during the migration to SHA-256. Use generateSecretSuffix for new values. See
+// https://github.com/radius-project/radius/issues/8084.
+func generateLegacySecretSuffix(resourceRecipe *recipes.ResourceMetadata) (string, error) {
+	input, err := secretSuffixInput(resourceRecipe)
+	if err != nil {
+		return "", err
+	}
+
+	return hashutil.LegacyHex([]byte(input)), nil
+}
+
+// secretSuffixInput returns the deterministic input string that the Terraform state secret suffix is
+// derived from for the given recipe.
+func secretSuffixInput(resourceRecipe *recipes.ResourceMetadata) (string, error) {
 	parsedResourceID, err := resources.Parse(resourceRecipe.ResourceID)
 	if err != nil {
 		return "", err
@@ -111,22 +183,11 @@ func generateSecretSuffix(resourceRecipe *recipes.ResourceMetadata) (string, err
 		appName = parsedAppID.Name()
 	}
 
-	var inputString string
 	if appName != "" {
-		inputString = strings.ToLower(fmt.Sprintf("%s-%s-%s", parsedEnvID.Name(), appName, parsedResourceID.String()))
-	} else {
-		inputString = strings.ToLower(fmt.Sprintf("%s-%s", parsedEnvID.Name(), parsedResourceID.String()))
+		return strings.ToLower(fmt.Sprintf("%s-%s-%s", parsedEnvID.Name(), appName, parsedResourceID.String())), nil
 	}
 
-	hasher := sha1.New()
-	_, err = hasher.Write([]byte(inputString))
-	if err != nil {
-		return "", err
-	}
-	hash := hasher.Sum(nil)
-	suffix := fmt.Sprintf("%x", hash)
-
-	return suffix, nil
+	return strings.ToLower(fmt.Sprintf("%s-%s", parsedEnvID.Name(), parsedResourceID.String())), nil
 }
 
 // generateKubernetesBackendConfig returns Terraform backend configuration to store Terraform state file for the deployment.

--- a/pkg/recipes/terraform/config/backends/kubernetes_test.go
+++ b/pkg/recipes/terraform/config/backends/kubernetes_test.go
@@ -19,6 +19,7 @@ package backends
 import (
 	"context"
 	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 	"testing"
@@ -93,11 +94,22 @@ func Test_GenerateKubernetesBackendConfig(t *testing.T) {
 
 func Test_GenerateSecretSuffix(t *testing.T) {
 	_, resourceRecipe := getTestInputs()
-	hasher := sha1.New()
+	hasher := sha256.New()
 	_, err := hasher.Write([]byte(strings.ToLower(fmt.Sprintf("%s-%s-%s", envName, appName, resourceRecipe.ResourceID))))
 	require.NoError(t, err)
 	expSecret := fmt.Sprintf("%x", hasher.Sum(nil))
 	secret, err := generateSecretSuffix(&resourceRecipe)
+	require.NoError(t, err)
+	require.Equal(t, expSecret, secret)
+}
+
+func Test_GenerateLegacySecretSuffix(t *testing.T) {
+	_, resourceRecipe := getTestInputs()
+	hasher := sha1.New()
+	_, err := hasher.Write([]byte(strings.ToLower(fmt.Sprintf("%s-%s-%s", envName, appName, resourceRecipe.ResourceID))))
+	require.NoError(t, err)
+	expSecret := fmt.Sprintf("%x", hasher.Sum(nil))
+	secret, err := generateLegacySecretSuffix(&resourceRecipe)
 	require.NoError(t, err)
 	require.Equal(t, expSecret, secret)
 }
@@ -126,13 +138,57 @@ func Test_GenerateSecretSuffix_invalid_appid(t *testing.T) {
 func Test_GenerateSecretSuffix_empty_appid(t *testing.T) {
 	_, resourceRecipe := getTestInputs()
 	resourceRecipe.ApplicationID = ""
-	hasher := sha1.New()
+	hasher := sha256.New()
 	_, err := hasher.Write([]byte(strings.ToLower(fmt.Sprintf("%s-%s", envName, resourceRecipe.ResourceID))))
 	require.NoError(t, err)
 	expSecret := fmt.Sprintf("%x", hasher.Sum(nil))
 	secret, err := generateSecretSuffix(&resourceRecipe)
 	require.NoError(t, err)
 	require.Equal(t, expSecret, secret)
+}
+
+func Test_BuildBackend_NewDeploymentUsesCurrentSuffix(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+	_, resourceRecipe := getTestInputs()
+
+	currentSuffix, err := generateSecretSuffix(&resourceRecipe)
+	require.NoError(t, err)
+
+	// No existing Terraform state secret: a new deployment uses the current (SHA-256) suffix.
+	b := NewKubernetesBackend(fake.NewClientset())
+	config, err := b.BuildBackend(&resourceRecipe)
+	require.NoError(t, err)
+
+	backend := config["kubernetes"].(map[string]any)
+	require.Equal(t, currentSuffix, backend["secret_suffix"])
+}
+
+func Test_BuildBackend_ExistingLegacyStateUsesLegacySuffix(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+	_, resourceRecipe := getTestInputs()
+
+	legacySuffix, err := generateLegacySecretSuffix(&resourceRecipe)
+	require.NoError(t, err)
+
+	// Simulate a Terraform state secret created by an older version of Radius (legacy SHA-1 suffix).
+	clientset := fake.NewClientset()
+	_, err = clientset.CoreV1().Secrets(RadiusNamespace).Create(context.Background(), &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KubernetesBackendNamePrefix + legacySuffix,
+			Namespace: RadiusNamespace,
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// The existing legacy state secret must be reused so Terraform state is not lost.
+	b := NewKubernetesBackend(clientset)
+	config, err := b.BuildBackend(&resourceRecipe)
+	require.NoError(t, err)
+
+	backend := config["kubernetes"].(map[string]any)
+	require.Equal(t, legacySuffix, backend["secret_suffix"])
 }
 
 func Test_ValidateBackendExists(t *testing.T) {

--- a/pkg/recipes/terraform/config/backends/kubernetes_test.go
+++ b/pkg/recipes/terraform/config/backends/kubernetes_test.go
@@ -97,10 +97,12 @@ func Test_GenerateSecretSuffix(t *testing.T) {
 	hasher := sha256.New()
 	_, err := hasher.Write([]byte(strings.ToLower(fmt.Sprintf("%s-%s-%s", envName, appName, resourceRecipe.ResourceID))))
 	require.NoError(t, err)
-	expSecret := fmt.Sprintf("%x", hasher.Sum(nil))
+	expSecret := fmt.Sprintf("%x", hasher.Sum(nil))[:secretSuffixLength]
 	secret, err := generateSecretSuffix(&resourceRecipe)
 	require.NoError(t, err)
 	require.Equal(t, expSecret, secret)
+	// The Terraform Kubernetes backend stores secret_suffix as a label value (max 63 chars).
+	require.LessOrEqual(t, len(secret), 63)
 }
 
 func Test_GenerateLegacySecretSuffix(t *testing.T) {
@@ -141,7 +143,7 @@ func Test_GenerateSecretSuffix_empty_appid(t *testing.T) {
 	hasher := sha256.New()
 	_, err := hasher.Write([]byte(strings.ToLower(fmt.Sprintf("%s-%s", envName, resourceRecipe.ResourceID))))
 	require.NoError(t, err)
-	expSecret := fmt.Sprintf("%x", hasher.Sum(nil))
+	expSecret := fmt.Sprintf("%x", hasher.Sum(nil))[:secretSuffixLength]
 	secret, err := generateSecretSuffix(&resourceRecipe)
 	require.NoError(t, err)
 	require.Equal(t, expSecret, secret)

--- a/pkg/ucp/frontend/controller/radius/proxy.go
+++ b/pkg/ucp/frontend/controller/radius/proxy.go
@@ -253,7 +253,13 @@ func (p *ProxyController) UpdateTrackedResource(ctx context.Context, downstreamU
 func (p *ProxyController) EnqueueTrackedResourceUpdate(ctx context.Context, id resources.ID, apiVersion string) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
-	trackingID := trackedresource.IDFor(id)
+	// Resolve the tracking ID, preferring an existing entry under the current (SHA-256) tracking
+	// ID and falling back to a legacy (SHA-1) entry written by older versions of Radius. This keeps
+	// the SHA-1 -> SHA-256 migration from orphaning existing tracked resources. See issue #8084.
+	trackingID, _, err := trackedresource.ResolveTrackingEntry(ctx, p.DatabaseClient(), id)
+	if err != nil {
+		return err
+	}
 
 	// Create a serviceCtx for the operation that we're going to process on the resource.
 	serviceCtx := *v1.ARMRequestContextFromContext(ctx)
@@ -320,7 +326,7 @@ retry:
 		return nil
 	}
 
-	err := p.StatusManager().QueueAsyncOperation(ctx, &serviceCtx, statusmanager.QueueOperationOptions{OperationTimeout: ProcessOperationTimeout, RetryAfter: ProcessOperationRetryAfter})
+	err = p.StatusManager().QueueAsyncOperation(ctx, &serviceCtx, statusmanager.QueueOperationOptions{OperationTimeout: ProcessOperationTimeout, RetryAfter: ProcessOperationRetryAfter})
 	if err != nil {
 		return err
 	}

--- a/pkg/ucp/frontend/controller/radius/proxy_test.go
+++ b/pkg/ucp/frontend/controller/radius/proxy_test.go
@@ -232,10 +232,11 @@ func Test_Run(t *testing.T) {
 			Get(gomock.Any(), locationResource.ID).
 			Return(&database.Object{Data: locationResource}, nil).Times(1)
 
-		// Tracking entry created
+		// Tracking entry created. The entry is read three times for a new resource: the current and
+		// legacy IDs during ResolveTrackingEntry, then once more in the enqueue retry loop.
 		databaseClient.EXPECT().
 			Get(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(nil, &database.ErrNotFound{}).Times(1)
+			Return(nil, &database.ErrNotFound{}).Times(3)
 		databaseClient.EXPECT().
 			Save(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(nil).Times(1)
@@ -299,7 +300,7 @@ func Test_Run(t *testing.T) {
 		}
 		databaseClient.EXPECT().
 			Get(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(existingEntry, nil).Times(1)
+			Return(existingEntry, nil).Times(2)
 		databaseClient.EXPECT().
 			Save(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(nil).Times(1)

--- a/pkg/ucp/trackedresource/name.go
+++ b/pkg/ucp/trackedresource/name.go
@@ -46,8 +46,8 @@ func NameFor(id resources.ID) string {
 
 // LegacyNameFor computes the tracked resource name using the legacy SHA-1 hash.
 //
-// Deprecated: SHA-1 is retained only to locate tracked resource entries written by older versions of
-// Radius during the migration to SHA-256. Use NameFor for new values. See
+// SHA-1 is retained only to locate tracked resource entries written by older versions of Radius
+// during the migration to SHA-256. Use NameFor for new values. See
 // https://github.com/radius-project/radius/issues/8084.
 func LegacyNameFor(id resources.ID) string {
 	if id.IsEmpty() {
@@ -92,8 +92,8 @@ func IDFor(id resources.ID) resources.ID {
 
 // LegacyIDFor computes the resource ID of a tracked resource entry using the legacy SHA-1 name.
 //
-// Deprecated: used only to locate tracked resource entries written by older versions of Radius
-// during the migration to SHA-256. See https://github.com/radius-project/radius/issues/8084.
+// Used only to locate tracked resource entries written by older versions of Radius during the
+// migration to SHA-256. See https://github.com/radius-project/radius/issues/8084.
 func LegacyIDFor(id resources.ID) resources.ID {
 	if id.IsEmpty() {
 		return resources.ID{}

--- a/pkg/ucp/trackedresource/name.go
+++ b/pkg/ucp/trackedresource/name.go
@@ -17,13 +17,18 @@ limitations under the License.
 package trackedresource
 
 import (
-	"crypto/sha1"
 	"fmt"
 	"strings"
 
+	"github.com/radius-project/radius/pkg/hashutil"
 	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	"github.com/radius-project/radius/pkg/ucp/resources"
 )
+
+// hashLength is the number of hexadecimal characters of the resource-ID hash appended to a
+// tracked resource name. It matches the width of the legacy SHA-1 hash (40) so that names
+// continue to fit within the 63-character ARM/UCP name limit (22 prefix + 1 separator + 40 hash).
+const hashLength = 40
 
 // NameFor computes the resource name of a tracked resource from its ID.
 //
@@ -36,12 +41,32 @@ func NameFor(id resources.ID) string {
 		return ""
 	}
 
-	// We need to generate a valid ARM/UCP name. The original resource name is used as a prefix for readability
-	// followed by the hash of the resource ID.
+	return nameWithHash(id, hashutil.Hex([]byte(strings.ToLower(id.String()))))
+}
+
+// LegacyNameFor computes the tracked resource name using the legacy SHA-1 hash.
+//
+// Deprecated: SHA-1 is retained only to locate tracked resource entries written by older versions of
+// Radius during the migration to SHA-256. Use NameFor for new values. See
+// https://github.com/radius-project/radius/issues/8084.
+func LegacyNameFor(id resources.ID) string {
+	if id.IsEmpty() {
+		return ""
+	}
+
+	return nameWithHash(id, hashutil.LegacyHex([]byte(strings.ToLower(id.String()))))
+}
+
+// nameWithHash builds a tracked resource name from the tracked resource's name (used as a
+// human-readable prefix) and a hex hash of its ID.
+func nameWithHash(id resources.ID, hash string) string {
+	// We need to generate a valid ARM/UCP name. The original resource name is used as a prefix for
+	// readability followed by the hash of the resource ID.
 	//
 	// example:  my-resource-ec291e26078b7ea8a74abfac82530005a0ecbf15
 	//
-	// We want this to fit in 63 characters so we allow a prefix of 22 characters a separator and a hash of 40 characters.
+	// We want this to fit in 63 characters so we allow a prefix of 22 characters, a separator, and a
+	// hash of 40 characters.
 	const prefixLength = 22
 
 	prefix := strings.ToLower(id.Name())
@@ -49,18 +74,11 @@ func NameFor(id resources.ID) string {
 		prefix = prefix[:prefixLength]
 	}
 
-	hasher := sha1.New()
-
-	// It's OK to ignore the error here, it's part of the API because io.Writer is being used, but the implementation
-	// does not return errors.
-	_, err := hasher.Write([]byte(strings.ToLower(id.String())))
-	if err != nil {
-		panic("unexpected error writing to hash: " + err.Error())
+	if len(hash) > hashLength {
+		hash = hash[:hashLength]
 	}
 
-	hash := hasher.Sum(nil)
-
-	return fmt.Sprintf("%s-%x", prefix, hash)
+	return fmt.Sprintf("%s-%s", prefix, hash)
 }
 
 // IDFor computes the resource ID of a tracked resource entry from the original resource ID.
@@ -69,6 +87,23 @@ func IDFor(id resources.ID) resources.ID {
 		return resources.ID{}
 	}
 
+	return idWithName(id, NameFor(id))
+}
+
+// LegacyIDFor computes the resource ID of a tracked resource entry using the legacy SHA-1 name.
+//
+// Deprecated: used only to locate tracked resource entries written by older versions of Radius
+// during the migration to SHA-256. See https://github.com/radius-project/radius/issues/8084.
+func LegacyIDFor(id resources.ID) resources.ID {
+	if id.IsEmpty() {
+		return resources.ID{}
+	}
+
+	return idWithName(id, LegacyNameFor(id))
+}
+
+// idWithName builds the tracking entry ID for the given resource ID and computed name.
+func idWithName(id resources.ID, name string) resources.ID {
 	// Tracking ID is the ID of the entry that will store the data.
 	//
 	// Example:
@@ -79,7 +114,7 @@ func IDFor(id resources.ID) resources.ID {
 		[]resources.TypeSegment{
 			{
 				Type: v20231001preview.ResourceType,
-				Name: NameFor(id),
+				Name: name,
 			},
 		}, nil))
 }

--- a/pkg/ucp/trackedresource/name_test.go
+++ b/pkg/ucp/trackedresource/name_test.go
@@ -29,10 +29,23 @@ var (
 
 func Test_NameFor(t *testing.T) {
 	name := NameFor(testID)
-	require.Equal(t, "test-app-303153687ee5adbcf353bc6c2caa4373f31e04c6", name)
+	require.Equal(t, "test-app-578debcee1fa4c9d11de5dd86eb2945e08b4b12f", name)
 }
 
 func Test_IDFor(t *testing.T) {
 	id := IDFor(testID)
+	require.Equal(t, resources.MustParse("/planes/radius/local/resourceGroups/test-group/providers/System.Resources/resources/test-app-578debcee1fa4c9d11de5dd86eb2945e08b4b12f"), id)
+}
+
+// Test_LegacyNameFor and Test_LegacyIDFor lock the legacy SHA-1 values so that Radius can
+// continue to locate tracked resource entries written by older versions during the migration
+// to SHA-256. See https://github.com/radius-project/radius/issues/8084.
+func Test_LegacyNameFor(t *testing.T) {
+	name := LegacyNameFor(testID)
+	require.Equal(t, "test-app-303153687ee5adbcf353bc6c2caa4373f31e04c6", name)
+}
+
+func Test_LegacyIDFor(t *testing.T) {
+	id := LegacyIDFor(testID)
 	require.Equal(t, resources.MustParse("/planes/radius/local/resourceGroups/test-group/providers/System.Resources/resources/test-app-303153687ee5adbcf353bc6c2caa4373f31e04c6"), id)
 }

--- a/pkg/ucp/trackedresource/update.go
+++ b/pkg/ucp/trackedresource/update.go
@@ -134,7 +134,7 @@ func (u *Updater) Update(ctx context.Context, downstream string, id resources.ID
 		ctx := logr.NewContext(ctx, logger)
 		logger.V(ucplog.LevelDebug).Info("beginning attempt")
 
-		err := u.run(ctx, id, trackingID, destination, apiVersion)
+		err := u.run(ctx, id, destination, apiVersion)
 		if errors.Is(err, &InProgressErr{}) && attempt == u.AttemptCount {
 			// Preserve the InprogressErr for the last attempt.
 			return err
@@ -151,12 +151,45 @@ func (u *Updater) Update(ctx context.Context, downstream string, id resources.ID
 	return fmt.Errorf("failed to update tracked resource after %d attempts", u.AttemptCount)
 }
 
-func (u *Updater) run(ctx context.Context, id resources.ID, trackingID resources.ID, destination *url.URL, apiVersion string) error {
+// ResolveTrackingEntry reads the tracking entry for id from the database, preferring the
+// current (SHA-256) tracking ID and falling back to the legacy (SHA-1) tracking ID written
+// by older versions of Radius.
+//
+// It returns the tracking ID to operate under (the current ID when the resource is not yet
+// tracked) and the existing stored object, if any. Existing entries continue to be maintained
+// under whichever ID they were created with until they are deleted; new entries are created
+// under the current ID. This keeps the SHA-1 -> SHA-256 migration non-breaking. See
+// https://github.com/radius-project/radius/issues/8084.
+func ResolveTrackingEntry(ctx context.Context, client database.Client, id resources.ID) (resources.ID, *database.Object, error) {
+	currentID := IDFor(id)
+	obj, err := client.Get(ctx, currentID.String())
+	if err == nil {
+		return currentID, obj, nil
+	} else if !errors.Is(err, &database.ErrNotFound{}) {
+		return currentID, nil, err
+	}
+
+	// No entry under the current ID; fall back to the legacy ID in case this resource was
+	// tracked by an older version of Radius.
+	legacyID := LegacyIDFor(id)
+	obj, err = client.Get(ctx, legacyID.String())
+	if err == nil {
+		return legacyID, obj, nil
+	} else if !errors.Is(err, &database.ErrNotFound{}) {
+		return currentID, nil, err
+	}
+
+	return currentID, nil, nil
+}
+
+func (u *Updater) run(ctx context.Context, id resources.ID, destination *url.URL, apiVersion string) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
-	obj, err := u.DatabaseClient.Get(ctx, trackingID.String())
-	if errors.Is(err, &database.ErrNotFound{}) {
-		// This is fine. It might be a new resource.
-	} else if err != nil {
+
+	// Read the existing tracking entry, preferring the current (SHA-256) tracking ID and falling
+	// back to the legacy (SHA-1) tracking ID written by older versions of Radius. We operate under
+	// whichever ID the entry already exists so the migration is non-breaking.
+	trackingID, obj, err := ResolveTrackingEntry(ctx, u.DatabaseClient, id)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/ucp/trackedresource/update.go
+++ b/pkg/ucp/trackedresource/update.go
@@ -130,7 +130,7 @@ func (u *Updater) Update(ctx context.Context, downstream string, id resources.ID
 	logger = logger.WithValues("id", id, "trackingID", trackingID, "destination", destination.String())
 	logger.V(ucplog.LevelDebug).Info("updating tracked resource")
 	for attempt := 1; attempt <= u.AttemptCount; attempt++ {
-		logger.WithValues("attempt", attempt)
+		logger := logger.WithValues("attempt", attempt)
 		ctx := logr.NewContext(ctx, logger)
 		logger.V(ucplog.LevelDebug).Info("beginning attempt")
 

--- a/pkg/ucp/trackedresource/update_test.go
+++ b/pkg/ucp/trackedresource/update_test.go
@@ -77,6 +77,10 @@ func Test_Update(t *testing.T) {
 			Get(gomock.Any(), IDFor(testID).String()).
 			Return(nil, &database.ErrNotFound{}).
 			Times(1)
+		databaseClient.EXPECT().
+			Get(gomock.Any(), LegacyIDFor(testID).String()).
+			Return(nil, &database.ErrNotFound{}).
+			Times(1)
 
 		// Mock a successful (terminal) response from the downstream API.
 		roundTripper.RespondWithJSON(t, http.StatusOK, resource)
@@ -119,6 +123,10 @@ func Test_Update(t *testing.T) {
 			Get(gomock.Any(), IDFor(testID).String()).
 			Return(nil, &database.ErrNotFound{}).
 			Times(1)
+		databaseClient.EXPECT().
+			Get(gomock.Any(), LegacyIDFor(testID).String()).
+			Return(nil, &database.ErrNotFound{}).
+			Times(1)
 
 		// Mock a successful (terminal) response from the downstream API.
 		roundTripper.RespondWithJSON(t, http.StatusOK, resource)
@@ -157,6 +165,10 @@ func Test_Update(t *testing.T) {
 			Get(gomock.Any(), IDFor(testID).String()).
 			Return(nil, &database.ErrNotFound{}).
 			Times(1)
+		databaseClient.EXPECT().
+			Get(gomock.Any(), LegacyIDFor(testID).String()).
+			Return(nil, &database.ErrNotFound{}).
+			Times(1)
 
 		// Mock a successful (non-terminal) response from the downstream API.
 		roundTripper.RespondWithJSON(t, http.StatusOK, resource)
@@ -178,6 +190,10 @@ func Test_Update(t *testing.T) {
 
 		databaseClient.EXPECT().
 			Get(gomock.Any(), IDFor(testID).String()).
+			Return(nil, &database.ErrNotFound{}).
+			Times(1)
+		databaseClient.EXPECT().
+			Get(gomock.Any(), LegacyIDFor(testID).String()).
 			Return(nil, &database.ErrNotFound{}).
 			Times(1)
 
@@ -230,6 +246,10 @@ func Test_run(t *testing.T) {
 			Get(gomock.Any(), IDFor(testID).String()).
 			Return(nil, &database.ErrNotFound{}).
 			Times(1)
+		databaseClient.EXPECT().
+			Get(gomock.Any(), LegacyIDFor(testID).String()).
+			Return(nil, &database.ErrNotFound{}).
+			Times(1)
 
 		// Mock a successful (terminal) response from the downstream API.
 		roundTripper.RespondWithJSON(t, http.StatusOK, resource)
@@ -247,7 +267,53 @@ func Test_run(t *testing.T) {
 			}).
 			Times(1)
 
-		err := updater.run(testcontext.New(t), testID, IDFor(testID), testURL, apiVersion)
+		err := updater.run(testcontext.New(t), testID, testURL, apiVersion)
+		require.NoError(t, err)
+	})
+
+	t.Run("successful update (legacy entry)", func(t *testing.T) {
+		updater, databaseClient, roundTripper := setupUpdater(t)
+
+		resource := map[string]any{
+			"id":         testID.String(),
+			"name":       testID.Name(),
+			"type":       testID.Type(),
+			"properties": map[string]any{},
+		}
+
+		etag := "some-etag"
+		dm := datamodel.GenericResourceFromID(testID, LegacyIDFor(testID))
+		dm.Properties.APIVersion = apiVersion
+
+		// No entry exists under the current (SHA-256) ID, but an entry written by an older
+		// version of Radius exists under the legacy (SHA-1) ID. We must find and update it in
+		// place rather than orphaning it under a new ID.
+		databaseClient.EXPECT().
+			Get(gomock.Any(), IDFor(testID).String()).
+			Return(nil, &database.ErrNotFound{}).
+			Times(1)
+		databaseClient.EXPECT().
+			Get(gomock.Any(), LegacyIDFor(testID).String()).
+			Return(&database.Object{Metadata: database.Metadata{ETag: etag}, Data: dm}, nil).
+			Times(1)
+
+		// Mock a successful (terminal) response from the downstream API.
+		roundTripper.RespondWithJSON(t, http.StatusOK, resource)
+
+		databaseClient.EXPECT().
+			Save(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, obj *database.Object, options ...database.SaveOptions) error {
+				require.Equal(t, LegacyIDFor(testID).String(), obj.ID)
+
+				dm := obj.Data.(*datamodel.GenericResource)
+				require.Equal(t, LegacyIDFor(testID).String(), dm.ID)
+				require.Equal(t, testID.String(), dm.Properties.ID)
+				require.Equal(t, apiVersion, dm.Properties.APIVersion)
+				return nil
+			}).
+			Times(1)
+
+		err := updater.run(testcontext.New(t), testID, testURL, apiVersion)
 		require.NoError(t, err)
 	})
 
@@ -286,7 +352,7 @@ func Test_run(t *testing.T) {
 			}).
 			Times(1)
 
-		err := updater.run(testcontext.New(t), testID, IDFor(testID), testURL, apiVersion)
+		err := updater.run(testcontext.New(t), testID, testURL, apiVersion)
 		require.NoError(t, err)
 	})
 
@@ -310,7 +376,7 @@ func Test_run(t *testing.T) {
 			Return(nil).
 			Times(1)
 
-		err := updater.run(testcontext.New(t), testID, IDFor(testID), testURL, apiVersion)
+		err := updater.run(testcontext.New(t), testID, testURL, apiVersion)
 		require.NoError(t, err)
 	})
 
@@ -330,11 +396,15 @@ func Test_run(t *testing.T) {
 			Get(gomock.Any(), IDFor(testID).String()).
 			Return(nil, &database.ErrNotFound{}).
 			Times(1)
+		databaseClient.EXPECT().
+			Get(gomock.Any(), LegacyIDFor(testID).String()).
+			Return(nil, &database.ErrNotFound{}).
+			Times(1)
 
 		// Mock a successful (terminal) response from the downstream API.
 		roundTripper.RespondWithJSON(t, http.StatusOK, resource)
 
-		err := updater.run(testcontext.New(t), testID, IDFor(testID), testURL, apiVersion)
+		err := updater.run(testcontext.New(t), testID, testURL, apiVersion)
 		require.Error(t, err)
 		require.ErrorIs(t, err, &InProgressErr{})
 	})

--- a/pkg/ucp/util/etag/etag.go
+++ b/pkg/ucp/util/etag/etag.go
@@ -22,12 +22,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+
+	"github.com/radius-project/radius/pkg/hashutil"
 )
 
 // New generates a unique string based on the SHA-256 hash of the input data.
 func New(data []byte) string {
-	hash := sha256.Sum256(data)
-	return fmt.Sprintf("%d-%x", int(len(hash)), hash)
+	return fmt.Sprintf("%d-%s", sha256.Size, hashutil.Hex(data))
 }
 
 // NewFromRevision takes in an int64 and returns a hexadecimal string representation of it.

--- a/pkg/ucp/util/etag/etag.go
+++ b/pkg/ucp/util/etag/etag.go
@@ -17,16 +17,16 @@ limitations under the License.
 package etag
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
 )
 
-// New generates a unique string based on the SHA1 hash of the input data.
+// New generates a unique string based on the SHA-256 hash of the input data.
 func New(data []byte) string {
-	hash := sha1.Sum(data)
+	hash := sha256.Sum256(data)
 	return fmt.Sprintf("%d-%x", int(len(hash)), hash)
 }
 


### PR DESCRIPTION
# Description

Radius used **SHA-1** for internal, non-cryptographic hashing — resource identifiers (datastore object names, tracked-resource names), Terraform recipe state-secret suffixes, ETags, and controller change-detection tokens. SHA-1 is cryptographically broken and flagged by CodeQL (`go/weak-cryptographic-algorithm`), so it should be modernized even though Radius never uses it for security.

This PR migrates that hashing to **SHA-256** behind a backward-compatible compatibility layer. **The upgrade is transparent: no data loss, no redeployments or pod restarts, no Terraform state recreation, and no customer action.**

### How it stays non-breaking

- New shared package `pkg/hashutil`: `Hex` (SHA-256) for all new values; `LegacyHex` (SHA-1) isolated in a single `legacy.go` for backward-compatible reads.
- **Transient hashes** (ETags) are swapped directly to SHA-256.
- **Change-detection hashes** (controller config/spec) use _dual-accept_: write SHA-256, accept SHA-256 **or** legacy SHA-1 on compare, so an upgrade triggers no container PUT, re-deployment, or pod rollout.
- **Persisted identifiers** (datastore object name, Terraform state suffix, tracked-resource name) use _read-fallback_: try SHA-256, fall back to SHA-1, and keep existing records in place — no orphaning or duplication.

### Value

- Modernizes a weak hashing algorithm and concentrates the remaining SHA-1 into one audited, dismissible file.
- Zero disruption for existing installations — validated by unit tests plus the UCP `radius` integration suite and the `apiserverstore` envtest suite (including a dedicated legacy-fallback test).
- Establishes the foundation and data path for a future "zero SHA-1" cleanup (Phase 3), captured in the included design note.

### Scope

Phases 1 and 2 (the compatibility layer). `HashSecretData` (pod-template annotation) and the ACI gateway DNS prefix are intentionally left on SHA-1 to avoid a workload rollout / endpoint change; their migration and the final SHA-1 removal are deferred to Phase 3 — see `eng/design-notes/security/2026-06-sha1-to-sha256-migration.md`.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #8084

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [x] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
