### PR TITLE
revert: cloud functional-test per-PR concurrency serialization

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -54,17 +54,6 @@ on:
 
 permissions: {}
 
-# Reduce self-contention on the shared Azure ACI 'StandardCores' quota (the
-# bottleneck behind Test_ACI's ContainerGroupQuotaReached flakes): serialize cloud
-# functional-test runs per pull request so a single PR pushing rapid commits does
-# not run several ACI-provisioning runs at once. Keyed by PR number because under
-# pull_request_target github.ref is the base ref, which would otherwise collapse
-# every PR into one group and cancel unrelated runs. cancel-in-progress is limited
-# to pull_request_target so the merge queue and scheduled runs are never cancelled.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
-
 env:
   GOPROXY: https://proxy.golang.org
   # Azure Keyvault CSI driver chart version


### PR DESCRIPTION
# Description

Reverts the per-PR `concurrency` serialization on the **Functional Tests (with Cloud Resources)** workflow that was introduced a couple of days ago in #12221:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
```

**Why revert**

- It was added to reduce self-contention on the shared Azure ACI `StandardCores` quota (the `Test_ACI` `ContainerGroupQuotaReached` flakes), but it has **not met that expected result**.
- Meanwhile it **roughly doubled the wall-clock time of cloud functional testing on PRs**: serializing runs per PR means a new run queues behind the previous one for the same PR (the *"waiting for Functional Tests (with Cloud Resources) #… to complete"* state) instead of running in parallel.

**Effect**

Removing the block restores parallel execution of cloud functional-test runs. Cloud and noncloud functional tests are independent workflows (noncloud has no `concurrency` block), so this only removes the cloud-vs-cloud, same-PR queuing — noncloud is unaffected.

Only `.github/workflows/functional-test-cloud.yaml` changes (the `concurrency` block and its comment, 11 lines removed).

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
