### PR TITLE
Migrate gateway tests to use Radius.Compute/routes  

### DIFF
--- a/test/functional-portable/corerp/noncloud/resources/gateway_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/gateway_test.go
@@ -49,30 +49,33 @@ type GatewayTestConfig struct {
 func Test_GatewayDNS(t *testing.T) {
 	template := "testdata/corerp-resources-gateway-dns.bicep"
 	name := "corerp-resources-gateway-dns"
-	appNamespace := "default-corerp-resources-gateway-dns"
+	appNamespace := name
+
+	// The migrated Radius.Compute/routes HTTPRoute is created without hostnames, so it matches all hosts;
+	// any Host header reaches the route via the shared managed Gateway. The value is not used for matching.
+	hostname := "corerp-resources-gateway-dns.example.com"
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, testutil.GetMagpieImage()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: name,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: "http-gtwy-gtwy-dns",
-						Type: validation.GatewaysResource,
+						Type: validation.ComputeRoutesResource,
 						App:  name,
 					},
 					{
 						Name: "frontendcontainerdns",
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  name,
 					},
 					{
 						Name: "backendcontainerdns",
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  name,
 					},
 				},
@@ -84,33 +87,22 @@ func Test_GatewayDNS(t *testing.T) {
 						validation.NewK8sPodForResource(name, "backendcontainerdns"),
 						validation.NewK8sServiceForResource(name, "frontendcontainerdns"),
 						validation.NewK8sServiceForResource(name, "backendcontainerdns"),
-						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-gtwy-dns"),
-						validation.NewK8sHTTPProxyForResource(name, "frontendcontainerdns"),
-						validation.NewK8sHTTPProxyForResource(name, "backendcontainerdns"),
+						validation.NewK8sHTTPRouteForResource(name, "http-gtwy-gtwy-dns"),
 					},
 				},
 			},
 			PostStepVerify: func(ctx context.Context, t *testing.T, ct rp.RPTest) {
-				// Get hostname from root HTTPProxy in application namespace
-				metadata, err := testutil.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
-				require.NoError(t, err)
-				t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
-
-				// Set up pod port-forwarding for contour-envoy
+				// Set up pod port-forwarding for the shared Gateway API envoy
 				t.Logf("Setting up portforward")
 
-				err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpRemotePort, false, []GatewayTestConfig{
-					// /healthz is exposed on frontend container
+				err := testGatewayWithPortForward(t, ctx, ct, hostname, httpRemotePort, false, []GatewayTestConfig{
+					// /healthz is exposed on the frontend container, reached via the '/' rule
 					{
 						Path:               "healthz",
 						ExpectedStatusCode: http.StatusOK,
 					},
-					// /backend2 uses 'replacePrefix', so it can access /healthz on backend container
-					{
-						Path:               "backend2/healthz",
-						ExpectedStatusCode: http.StatusOK,
-					},
-					// since /backend1/healthz is not exposed on frontend container, it should return 404
+					// /backend1 routes to the backend container; Radius.Compute/routes has no path
+					// rewrite, the backend receives '/backend1/healthz' (which it does not serve).
 					{
 						Path:               "backend1/healthz",
 						ExpectedStatusCode: http.StatusNotFound,
@@ -122,31 +114,38 @@ func Test_GatewayDNS(t *testing.T) {
 		},
 	})
 
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, appNamespace)
+	test.PreSetup = preSetup
+	test.Steps[0].Executor = step.NewDeployExecutor(template, testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
+
 	test.Test(t)
 }
 
 func Test_Gateway_SSLPassthrough(t *testing.T) {
 	template := "testdata/corerp-resources-gateway-sslpassthrough.bicep"
 	name := "corerp-resources-gateway-sslpassthrough"
-	appNamespace := "default-corerp-resources-gateway-sslpassthrough"
+	appNamespace := name
+
+	// The TLSRoute matches on SNI; this hostname must equal the route's `hostnames` entry in the bicep and
+	// is used as the TLS ServerName (SNI) by the test client.
+	hostname := "ssl-gtwy.example.com"
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, testutil.GetMagpieImage(), "@testdata/parameters/test-tls-cert.parameters.json"),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: name,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: "ssl-gtwy-gtwy",
-						Type: validation.GatewaysResource,
+						Type: validation.ComputeRoutesResource,
 						App:  name,
 					},
 					{
 						Name: "ssl-gtwy-front-ctnr",
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  name,
 					},
 				},
@@ -155,22 +154,16 @@ func Test_Gateway_SSLPassthrough(t *testing.T) {
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
 						validation.NewK8sPodForResource(name, "ssl-gtwy-front-ctnr"),
-						validation.NewK8sHTTPProxyForResource(name, "ssl-gtwy-front-ctnr"),
-						validation.NewK8sHTTPProxyForResource(name, "ssl-gtwy-gtwy"),
+						validation.NewK8sTLSRouteForResource(name, "ssl-gtwy-gtwy"),
 						validation.NewK8sServiceForResource(name, "ssl-gtwy-front-ctnr"),
 					},
 				},
 			},
 			PostStepVerify: func(ctx context.Context, t *testing.T, ct rp.RPTest) {
-				// Get hostname from root HTTPProxy in application namespace
-				metadata, err := testutil.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
-				require.NoError(t, err)
-				t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
-
-				// Set up pod port-forwarding for contour-envoy
+				// Set up pod port-forwarding for the shared Gateway API envoy
 				t.Logf("Setting up portforward")
-				err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpsRemotePort, true, []GatewayTestConfig{
-					// /healthz is exposed on frontend container
+				err := testGatewayWithPortForward(t, ctx, ct, hostname, httpsRemotePort, true, []GatewayTestConfig{
+					// /healthz is exposed on frontend container (which terminates TLS itself)
 					{
 						Path:               "healthz",
 						ExpectedStatusCode: http.StatusOK,
@@ -187,6 +180,10 @@ func Test_Gateway_SSLPassthrough(t *testing.T) {
 			},
 		},
 	})
+
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, appNamespace)
+	test.PreSetup = preSetup
+	test.Steps[0].Executor = step.NewDeployExecutor(template, testutil.GetMagpieImage(), "@testdata/parameters/test-tls-cert.parameters.json", fmt.Sprintf("environment=%s", previewEnvID))
 
 	test.Test(t)
 }

--- a/test/functional-portable/corerp/noncloud/resources/simulated_environment_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/simulated_environment_test.go
@@ -32,7 +32,7 @@ import (
 func Test_Deployment_SimulatedEnv(t *testing.T) {
 	template := "testdata/corerp-resources-simulatedenv.bicep"
 	name := "corerp-resources-simulatedenv"
-	appNamespace := "default-corerp-resources-simulatedenv"
+	appNamespace := "corerp-resources-simulatedenv"
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
@@ -41,21 +41,20 @@ func Test_Deployment_SimulatedEnv(t *testing.T) {
 				Resources: []validation.RPResource{
 					{
 						Name: name,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
-						Name: "http-gtwy-gtwy-simulatedenv",
-						Type: validation.GatewaysResource,
-						App:  name,
+						Name: "corerp-resources-simulatedenv-env",
+						Type: validation.CoreEnvironmentsResource,
 					},
 					{
 						Name: "http-gtwy-front-ctnr-simulatedenv",
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  name,
 					},
 					{
 						Name: "http-gtwy-back-ctnr-simulatedenv",
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  name,
 					},
 				},

--- a/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-dns.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-dns.bicep
@@ -12,88 +12,93 @@ param port int = 3000
 @description('Specifies the image for the container resource.')
 param magpieimage string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
-	name: 'corerp-resources-gateway-dns'
-	location: location
-	properties: {
-		environment: environment
-	}
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'corerp-resources-gateway-dns'
+  location: location
+  properties: {
+    environment: environment
+  }
 }
 
-resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
-	name: 'http-gtwy-gtwy-dns'
-	location: location
-	properties: {
-		application: app.id
-		routes: [
-			{
-				path: '/'
-				destination: 'http://frontendcontainerdns:3000'
-			}
-			{
-				path: '/backend1'
-				destination: 'http://backendcontainerdns:3000'
-			}
-			{
-				// Route /backend2 requests to the backend, and
-				// transform the request to /
-				path: '/backend2'
-				destination: 'http://backendcontainerdns:3000'
-				replacePrefix: '/'
-			}
-		]
-	}
+// This route uses L7 HTTP path-based routing to direct traffic to multiple containers. A path-rewrite rule
+// (e.g. rewriting '/backend2' to the backend's '/healthz') is intentionally omitted because
+// Radius.Compute/routes has no filter/rewrite support; the remaining rules preserve the core
+// path-based routing intent.
+resource gateway 'Radius.Compute/routes@2025-08-01-preview' = {
+  name: 'http-gtwy-gtwy-dns'
+  location: location
+  properties: {
+    application: app.id
+    environment: environment
+    kind: 'HTTP'
+    rules: [
+      {
+        matches: [
+          {
+            httpPath: '/'
+          }
+        ]
+        destinationContainer: {
+          resourceId: frontendcontainerdns.id
+          containerName: 'frontendcontainerdns'
+          containerPort: port
+        }
+      }
+      {
+        matches: [
+          {
+            httpPath: '/backend1'
+          }
+        ]
+        destinationContainer: {
+          resourceId: backendcontainerdns.id
+          containerName: 'backendcontainerdns'
+          containerPort: port
+        }
+      }
+    ]
+  }
 }
 
-resource frontendcontainerdns 'Applications.Core/containers@2023-10-01-preview' = {
-	name: 'frontendcontainerdns'
-	location: location
-	properties: {
-		application: app.id
-		container: {
-			image: magpieimage
-			ports: {
-				web: {
-					containerPort: port
-				}
-			}
-			readinessProbe: {
-				kind: 'httpGet'
-				containerPort: port
-				path: '/healthz'
-			}
-		}
-		connections: {
-			backendcontainerdns: {
-				source: 'http://backendcontainerdns:3000'
-			}
-		}
-	}
+resource frontendcontainerdns 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'frontendcontainerdns'
+  location: location
+  properties: {
+    application: app.id
+    environment: environment
+    containers: {
+      frontendcontainerdns: {
+        image: magpieimage
+        ports: {
+          web: {
+            containerPort: port
+          }
+        }
+      }
+    }
+    connections: {
+      backendcontainerdns: {
+        source: backendcontainerdns.id
+      }
+    }
+  }
 }
 
-resource backendcontainerdns 'Applications.Core/containers@2023-10-01-preview' = {
-	name: 'backendcontainerdns'
-	location: location
-	properties: {
-		application: app.id
-		container: {
-			image: magpieimage
-			env: {
-				gatewayUrl: {
-					value: gateway.properties.url
-				}
-			}
-			ports: {
-				web: {
-					containerPort: port
-				}
-			}
-			readinessProbe: {
-				kind: 'httpGet'
-				containerPort: port
-				path: '/healthz'
-			}
-		}
-	}
+resource backendcontainerdns 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'backendcontainerdns'
+  location: location
+  properties: {
+    application: app.id
+    environment: environment
+    containers: {
+      backendcontainerdns: {
+        image: magpieimage
+        ports: {
+          web: {
+            containerPort: port
+          }
+        }
+      }
+    }
+  }
 }
-

--- a/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-sslpassthrough.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-sslpassthrough.bicep
@@ -1,7 +1,3 @@
-extension kubernetes with {
-  kubeConfig: ''
-  namespace: 'default'
-} as kubernetes
 extension radius
 
 @description('Specifies the location for resources.')
@@ -22,7 +18,7 @@ param tlscrt string
 @secure()
 param tlskey string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'corerp-resources-gateway-sslpassthrough'
   location: location
   properties: {
@@ -30,49 +26,62 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
+// A TLS route renders a Gateway API TLSRoute attached to the managed Gateway's Passthrough :443 listener,
+// matching on SNI (hostnames). The container continues to terminate its own TLS, preserving the original
+// passthrough intent.
+resource gateway 'Radius.Compute/routes@2025-08-01-preview' = {
   name: 'ssl-gtwy-gtwy'
   location: location
   properties: {
     application: app.id
-    tls: { 
-      sslPassthrough: true 
-    } 
-    routes: [
+    environment: environment
+    kind: 'TLS'
+    hostnames: [
+      'ssl-gtwy.example.com'
+    ]
+    rules: [
       {
-        destination: 'https://${frontendContainer.name}:${frontendContainer.properties.container.ports.web.port}'
+       matches: [
+          {}
+        ]
+        destinationContainer: {
+          resourceId: frontendContainer.id
+          containerName: 'ssl-gtwy-front-ctnr'
+          containerPort: port
+        }
       }
     ]
   }
 }
 
-resource frontendContainer 'Applications.Core/containers@2023-10-01-preview' = {
+resource frontendContainer 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'ssl-gtwy-front-ctnr'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
-      env: {
-        TLS_KEY: {
-          value: tlskey
+    environment: environment
+    containers: {
+      'ssl-gtwy-front-ctnr': {
+        image: magpieimage
+        env: {
+          TLS_KEY: {
+            value: tlskey
+          }
+          TLS_CERT: {
+            value: tlscrt
+          }
         }
-        TLS_CERT: {
-          value: tlscrt
+        ports: {
+          web: {
+            containerPort: port
+          }
         }
-      }
-      ports: {
-        web: {
-          containerPort: port
-          port: 443
+        readinessProbe: {
+          tcpSocket: {
+            port: port
+          }
         }
-      }
-      readinessProbe: {
-        kind: 'tcp'
-        containerPort: port
       }
     }
   }
 }
-
-

--- a/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-simulatedenv.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-simulatedenv.bicep
@@ -9,20 +9,23 @@ param port int = 3000
 @description('Specifies the image for the container resource.')
 param magpieimage string
 
-resource env 'Applications.Core/environments@2023-10-01-preview' = {
-  name: 'default'
+// Simulated environment: resources are recorded but never deployed to Kubernetes.
+// A gateway resource is intentionally omitted as incidental scaffolding: this test only asserts
+// that a simulated environment creates zero real pods.
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'corerp-resources-simulatedenv-env'
   location: 'global'
   properties: {
-    compute: {
-      kind: 'kubernetes'
-      resourceId: 'self'
-      namespace: 'corerp-resources-simulatedenv-env'
-    }
     simulated: true
+    providers: {
+      kubernetes: {
+        namespace: 'corerp-resources-simulatedenv'
+      }
+    }
   }
 }
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'corerp-resources-simulatedenv'
   location: location
   properties: {
@@ -30,80 +33,39 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
-resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
-  name: 'http-gtwy-gtwy-simulatedenv'
-  location: location
-  properties: {
-    application: app.id
-    routes: [
-      {
-        path: '/'
-        destination: 'http://http-gtwy-front-ctnr-simulatedenv:${port}'
-      }
-      {
-        path: '/backend1'
-        destination: 'http://http-gtwy-back-ctnr-simulatedenv:${port}'
-      }
-      {
-        // Route /backend2 requests to the backend, and
-        // transform the request to /
-        path: '/backend2'
-        destination: 'http://http-gtwy-back-ctnr-simulatedenv:${port}'
-        replacePrefix: '/'
-      }
-    ]
-  }
-}
-
-
-resource frontendContainer 'Applications.Core/containers@2023-10-01-preview' = {
+resource frontendContainer 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'http-gtwy-front-ctnr-simulatedenv'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
-      ports: {
-        web: {
-          containerPort: port
+    environment: env.id
+    containers: {
+      'http-gtwy-front-ctnr-simulatedenv': {
+        image: magpieimage
+        ports: {
+          web: {
+            containerPort: port
+          }
         }
-      }
-      readinessProbe: {
-        kind: 'httpGet'
-        containerPort: port
-        path: '/healthz'
-      }
-    }
-    connections: {
-      backend: {
-        source: 'http://http-gtwy-back-ctnr-simulatedenv:${port}'
       }
     }
   }
 }
 
-
-resource backendContainer 'Applications.Core/containers@2023-10-01-preview' = {
+resource backendContainer 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'http-gtwy-back-ctnr-simulatedenv'
   location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
-      env: {
-        gatewayUrl: {
-          value: gateway.properties.url
+    environment: env.id
+    containers: {
+      'http-gtwy-back-ctnr-simulatedenv': {
+        image: magpieimage
+        ports: {
+          web: {
+            containerPort: port
+          }
         }
-      }
-      ports: {
-        web: {
-          containerPort: port
-        }
-      }
-      readinessProbe: {
-        kind: 'httpGet'
-        containerPort: port
-        path: '/healthz'
       }
     }
   }

--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -99,6 +99,36 @@ func NewK8sHTTPProxyForResource(application string, name string) K8sObject {
 	}
 }
 
+// NewK8sHTTPRouteForResource creates a K8sObject for a Gateway API HTTPRoute with the Labels set to the
+// application and name provided. This is the Gateway API replacement for Contour HTTPProxy objects used by
+// the legacy Applications.Core/gateways type; the Radius.Compute/routes recipe renders HTTPRoute objects.
+func NewK8sHTTPRouteForResource(application string, name string) K8sObject {
+	return K8sObject{
+		GroupVersionResource: schema.GroupVersionResource{
+			Group:    "gateway.networking.k8s.io",
+			Version:  "v1",
+			Resource: "httproutes",
+		},
+		Kind:   "HTTPRoute",
+		Labels: kuberneteskeys.MakeSelectorLabels(application, name),
+	}
+}
+
+// NewK8sTLSRouteForResource creates a K8sObject for a Gateway API TLSRoute with the Labels set to the
+// application and name provided. The Radius.Compute/routes recipe renders a TLSRoute when the route kind is
+// TLS (SNI-based passthrough), which is the replacement for legacy gateway TLS passthrough.
+func NewK8sTLSRouteForResource(application string, name string) K8sObject {
+	return K8sObject{
+		GroupVersionResource: schema.GroupVersionResource{
+			Group:    "gateway.networking.k8s.io",
+			Version:  "v1alpha2",
+			Resource: "tlsroutes",
+		},
+		Kind:   "TLSRoute",
+		Labels: kuberneteskeys.MakeSelectorLabels(application, name),
+	}
+}
+
 // NewK8sServiceForResource creates a new K8sObject for a service with the Labels set to the application and name.
 func NewK8sServiceForResource(application string, name string) K8sObject {
 	return K8sObject{

--- a/test/validation/shared.go
+++ b/test/validation/shared.go
@@ -48,6 +48,7 @@ const (
 
 	// Radius.Compute resource types (new provider).
 	ComputeContainersResource = "radius.compute/containers"
+	ComputeRoutesResource     = "radius.compute/routes"
 
 	// Radius.Security resource types (new provider).
 	SecuritySecretsResource = "radius.security/secrets"


### PR DESCRIPTION
This pull request migrates the functional tests and Bicep templates for core resources from the legacy `Applications.Core` types to the new `Radius.Core` and `Radius.Compute` resource types, reflecting the adoption of the Gateway API and updated resource schemas. The changes also update the test validation logic and resource definitions to switch from Contour `HTTPProxy` to Gateway API `HTTPRoute`/`TLSRoute`, and making simulated environments more explicit. 

## Type of change
- This pull request adds or changes features of Radius and has an approved issue (#12115 ).

Fixes: #12115

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
