### PR TITLE
refactor: single TypeSpec Bicep emitter build on the generate-bicep-types path

### DIFF
--- a/build/generate.mk
+++ b/build/generate.mk
@@ -178,7 +178,10 @@ generate-go: ## Generates go with 'go generate' (Mocks).
 # as individual YAML files (e.g. containers.yaml, routes.yaml).
 DEFAULTS_YAML := deploy/manifest/defaults.yaml
 BICEP_TYPES_CONTRIB_API_VERSION ?= 2025-08-01-preview
-BICEP_TYPES_OUTPUT_BASE := hack/bicep-types-radius/generated/radius
+# Shared locations for the TypeSpec Bicep emitter package and its generated output.
+BICEP_TYPES_EMITTER_DIR := hack/bicep-types-radius/src/typespec-bicep-types
+BICEP_TYPES_GENERATED_DIR := hack/bicep-types-radius/generated
+BICEP_TYPES_OUTPUT_BASE := $(BICEP_TYPES_GENERATED_DIR)/radius
 BICEP_TYPES_CONTRIB_MANIFEST_DIR := deploy/manifest/built-in-providers/self-hosted
 
 .PHONY: generate-bicep-types
@@ -187,12 +190,19 @@ generate-bicep-types: ## Generate Bicep extensibility types
 	@$(MAKE) generate-bicep-types-contrib
 	@$(MAKE) rebuild-bicep-types-index
 
-.PHONY: generate-bicep-types-core
-generate-bicep-types-core: generate-tsp-installed ## Generate Bicep extensibility types from TypeSpec.
-	@echo "$(ARROW) Generating Bicep extensibility types from TypeSpec..."
+# Install dependencies and compile the TypeSpec Bicep emitter. Factored into its own
+# target so the aggregate `generate-bicep-types` path builds it once (via
+# generate-bicep-types-core) instead of building it a second time in
+# rebuild-bicep-types-index.
+.PHONY: generate-bicep-types-emitter
+generate-bicep-types-emitter: generate-pnpm-installed
 	@echo "$(ARROW) Build the TypeSpec Bicep emitter..."
-	CI=true pnpm -C hack/bicep-types-radius/src/typespec-bicep-types install && pnpm -C hack/bicep-types-radius/src/typespec-bicep-types run build
-	node hack/bicep-types-radius/src/typespec-bicep-types/dist/src/cmd/compile-projects.js --typespec-dir typespec --out-dir hack/bicep-types-radius/generated
+	CI=true pnpm -C $(BICEP_TYPES_EMITTER_DIR) install && pnpm -C $(BICEP_TYPES_EMITTER_DIR) run build
+
+.PHONY: generate-bicep-types-core
+generate-bicep-types-core: generate-tsp-installed generate-bicep-types-emitter ## Generate Bicep extensibility types from TypeSpec.
+	@echo "$(ARROW) Generating Bicep extensibility types from TypeSpec..."
+	node $(BICEP_TYPES_EMITTER_DIR)/dist/src/cmd/compile-projects.js --typespec-dir typespec --out-dir $(BICEP_TYPES_GENERATED_DIR)
 
 .PHONY: generate-yq-installed
 generate-yq-installed:
@@ -209,11 +219,15 @@ generate-bicep-types-contrib: generate-yq-installed ## Generates Bicep types.jso
 		"$(BICEP_TYPES_OUTPUT_BASE)" \
 		"$(BICEP_TYPES_CONTRIB_API_VERSION)"
 
+# rebuild-bicep-types-index rebuilds the unified index from the per-namespace
+# types.json files. It builds the emitter only when it is not already built (e.g.
+# when run standalone); the aggregate generate-bicep-types path builds it once in
+# generate-bicep-types-core.
 .PHONY: rebuild-bicep-types-index
 rebuild-bicep-types-index:
 	@echo "$(ARROW) Rebuilding unified Bicep types index..."
-	CI=true pnpm -C hack/bicep-types-radius/src/typespec-bicep-types install && pnpm -C hack/bicep-types-radius/src/typespec-bicep-types run build
-	node hack/bicep-types-radius/src/typespec-bicep-types/dist/src/cmd/rebuild-index.js --out-dir hack/bicep-types-radius/generated --release-version ${VERSION}
+	@test -f $(BICEP_TYPES_EMITTER_DIR)/dist/src/cmd/rebuild-index.js || $(MAKE) generate-bicep-types-emitter
+	node $(BICEP_TYPES_EMITTER_DIR)/dist/src/cmd/rebuild-index.js --out-dir $(BICEP_TYPES_GENERATED_DIR) --release-version ${VERSION}
 
 # Publishing the unified `radius` Bicep extension. Runnable locally against any
 # OCI registry (e.g. a local Zot/CRane-backed registry, or biceptypes.azurecr.io


### PR DESCRIPTION
# Description

`build/generate.mk` installed and built the TypeSpec Bicep emitter (`pnpm install && pnpm run build`) in **both** `generate-bicep-types-core` and `rebuild-bicep-types-index`. On the aggregate `generate-bicep-types` path (`core -> contrib -> rebuild-index`) the same package was therefore built twice.

This change factors the install + build into a dedicated `generate-bicep-types-emitter` target:

- `generate-bicep-types-core` lists it as a prerequisite, so the emitter is always built fresh when types are generated.
- `rebuild-bicep-types-index` builds the emitter only when it is not already built (`test -f $(BICEP_TYPES_EMITTER_DIR)/dist/src/cmd/rebuild-index.js || $(MAKE) generate-bicep-types-emitter`). On the aggregate path `generate-bicep-types-core` has already built it, so the build runs once; when `rebuild-bicep-types-index` is invoked standalone it still builds the emitter.

The repeated emitter package and generated-output paths are also pulled into the `BICEP_TYPES_EMITTER_DIR` and `BICEP_TYPES_GENERATED_DIR` variables. The generated output is unchanged.

Verified with `make -n generate-bicep-types`: the emitter `pnpm ... run build` command now appears once on the aggregate path.

Addresses the review comment on #12268: <https://github.com/radius-project/radius/pull/12268#discussion_r3483449640>

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
