### PR TITLE
fix(codeql): skip SARIF upload in merge queue to avoid ref-not-found error

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -129,8 +129,12 @@ jobs:
           args: -no-fail -fmt sarif -out gosec-results.sarif ./...
         continue-on-error: true
 
+      # Skip the code-scanning upload in the merge queue: the ephemeral
+      # `refs/heads/gh-readonly-queue/...` ref is rejected by the SARIF upload
+      # API ("ref not found"). The analysis above still runs as the required gate;
+      # results are uploaded on `push`/`pull_request` against persistent refs.
       - name: Upload GoSec result
-        if: ${{ always() && matrix.language == 'custom-gosec' }}
+        if: ${{ always() && github.event_name != 'merge_group' && matrix.language == 'custom-gosec' }}
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: gosec-results.sarif
@@ -145,8 +149,12 @@ jobs:
           upload: never
           output: .codeql-results
 
+      # Skip the code-scanning upload in the merge queue: the ephemeral
+      # `refs/heads/gh-readonly-queue/...` ref is rejected by the SARIF upload
+      # API ("ref not found"). The analysis above still runs as the required gate;
+      # results are uploaded on `push`/`pull_request` against persistent refs.
       - name: Upload CodeQL result
-        if: ${{ always() && !startsWith(matrix.language, 'custom-') }}
+        if: ${{ always() && github.event_name != 'merge_group' && !startsWith(matrix.language, 'custom-') }}
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: ${{ format('{0}/{1}.sarif', steps.codeql-analyze.outputs.sarif-output, matrix.language) }}


### PR DESCRIPTION
## Description

The **CodeQL Advanced -> Analyze (go)** and **Analyze (custom-gosec)** jobs fail when a PR runs in the merge queue:

```text
ref 'refs/heads/gh-readonly-queue/main/pr-12277-...' not found in this repository
CodeQL Process completed with exit code 1.
```

**Root cause:** PR #12212 added the `merge_group` trigger to `codeql.yml`, but the `github/codeql-action/upload-sarif` steps post code-scanning results against the ephemeral `refs/heads/gh-readonly-queue/...` ref that the merge queue creates. The code-scanning SARIF upload API rejects that ref ("ref not found"), failing the matrix legs and, in turn, the required `CodeQL` aggregator check - which stalls the queue.

**Fix:** Skip only the two SARIF upload steps (`Upload GoSec result`, `Upload CodeQL result`) on `merge_group` events by adding `github.event_name != 'merge_group'` to their conditions. The CodeQL analysis itself (`make build` + queries; `analyze` already runs with `upload: never`) still executes, so the required check keeps its gating value. Results continue to upload normally on `push` to `main` and on `pull_request`, which use persistent refs.

Follow-up to #12212; part of the merge-queue rollout tracked in #10843.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Related to: #10843

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
