### PR TITLE
Add test for Radius.Data/mySqlDatabases resource type.

### DIFF
--- a/test/functional-portable/corerp/noncloud/resources/mysqldatabase_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/mysqldatabase_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/radius-project/radius/test/rp"
+	"github.com/radius-project/radius/test/step"
+	"github.com/radius-project/radius/test/testutil"
+	"github.com/radius-project/radius/test/validation"
+)
+
+// Test_MySQLDatabase deploys a Radius.Data/mySqlDatabases resource using the default
+// preview-environment recipe pack and validates that the recipe-provisioned MySQL
+// Deployment/Service has a running Pod, and that a Radius.Compute/containers resource is
+// deployed with a connection to the database.
+func Test_MySQLDatabase(t *testing.T) {
+	template := "testdata/corerp-resources-mysqldatabase.bicep"
+	name := "corerp-resources-mysqldb"
+	appNamespace := "corerp-resources-mysqldb"
+
+	test := rp.NewRPTest(t, name, []rp.TestStep{
+		{
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
+					{
+						Name: name,
+						Type: validation.CoreApplicationsResource,
+					},
+					{
+						Name: "mysqldb-secret",
+						Type: validation.SecuritySecretsResource,
+						App:  name,
+					},
+					{
+						Name: "mysqldb-db",
+						Type: validation.DataMySQLDatabasesResource,
+						App:  name,
+					},
+					{
+						Name: "mysqldb-ctnr",
+						Type: validation.ComputeContainersResource,
+						App:  name,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					appNamespace: {
+						// The application container.
+						validation.NewK8sPodForResource(name, "mysqldb-ctnr"),
+						validation.NewK8sServiceForResource(name, "mysqldb-ctnr"),
+						// The MySQL Deployment and Service provisioned by the recipe.
+						validation.NewK8sPodForResource(name, "mysqldb-db"),
+						validation.NewK8sServiceForResource(name, "mysqldb-db"),
+					},
+				},
+			},
+		},
+	})
+
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, appNamespace)
+	test.PreSetup = preSetup
+	test.Steps[0].Executor = step.NewDeployExecutor(template, testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
+
+	test.Test(t)
+}

--- a/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-mysqldatabase.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-mysqldatabase.bicep
@@ -1,0 +1,69 @@
+extension radius
+
+@description('Specifies the location for resources.')
+param location string = 'global'
+
+@description('Specifies the image of the container resource.')
+param magpieimage string
+
+@description('Specifies the environment for resources.')
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'corerp-resources-mysqldb'
+  location: location
+  properties: {
+    environment: environment
+  }
+}
+
+resource dbSecret 'Radius.Security/secrets@2025-08-01-preview' = {
+  name: 'mysqldb-secret'
+  location: location
+  properties: {
+    environment: environment
+    application: app.id
+    data: {
+      USERNAME: {
+        value: 'admin'
+      }
+      PASSWORD: {
+        value: 'password'
+      }
+    }
+  }
+}
+
+resource mysql 'Radius.Data/mySqlDatabases@2025-08-01-preview' = {
+  name: 'mysqldb-db'
+  location: location
+  properties: {
+    environment: environment
+    application: app.id
+    secretName: dbSecret.name
+  }
+}
+
+resource container 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'mysqldb-ctnr'
+  location: location
+  properties: {
+    application: app.id
+    environment: environment
+    containers: {
+      mysqldbctnr: {
+        image: magpieimage
+        ports: {
+          web: {
+            containerPort: 3000
+          }
+        }
+      }
+    }
+    connections: {
+      mysqldb: {
+        source: mysql.id
+      }
+    }
+  }
+}

--- a/test/validation/shared.go
+++ b/test/validation/shared.go
@@ -54,6 +54,9 @@ const (
 	// Radius.Security resource types (new provider).
 	SecuritySecretsResource = "radius.security/secrets"
 
+	// Radius.Data resource types (new provider).
+	DataMySQLDatabasesResource = "radius.data/mySqlDatabases"
+
 	RabbitMQQueuesResource          = "applications.messaging/rabbitMQQueues"
 	DaprPubSubBrokersResource       = "applications.dapr/pubSubBrokers"
 	DaprSecretStoresResource        = "applications.dapr/secretStores"


### PR DESCRIPTION
# Description

This pull request introduces a new functional test for deploying and validating a `Radius.Data/mySqlDatabases` resource typeand its integration with other core resources.

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (#12113 ).

Fixes: #12113 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ ] Not applicable
