### PR TITLE
[WIP] migrate azure test

### DIFF
--- a/test/functional-portable/corerp/cloud/resources/azure_connections_test.go
+++ b/test/functional-portable/corerp/cloud/resources/azure_connections_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resource_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -30,25 +31,24 @@ func Test_AzureConnections(t *testing.T) {
 	name := "corerp-azure-connection-database-service"
 	containerResourceName := "db-service"
 	template := "testdata/corerp-azure-connection-database-service.bicep"
+	appNamespace := name
 
 	if os.Getenv("AZURE_COSMOS_MONGODB_ACCOUNT_ID") == "" {
 		t.Error("AZURE_COSMOS_MONGODB_ACCOUNT_ID environment variable must be set to run this test.")
 	}
 	cosmosmongodbresourceid := "cosmosmongodbresourceid=" + os.Getenv("AZURE_COSMOS_MONGODB_ACCOUNT_ID")
-	appNamespace := "default-corerp-azure-connection-database-service"
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, testutil.GetMagpieImage(), cosmosmongodbresourceid),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: name,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
 						Name: containerResourceName,
-						Type: validation.ContainersResource,
+						Type: validation.ComputeContainersResource,
 						App:  name,
 					},
 				},
@@ -62,6 +62,10 @@ func Test_AzureConnections(t *testing.T) {
 			},
 		},
 	})
+
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, appNamespace)
+	test.PreSetup = preSetup
+	test.Steps[0].Executor = step.NewDeployExecutor(template, testutil.GetMagpieImage(), cosmosmongodbresourceid, fmt.Sprintf("environment=%s", previewEnvID))
 
 	test.RequiredFeatures = []rp.RequiredFeature{rp.FeatureAzure}
 	test.Test(t)

--- a/test/functional-portable/corerp/cloud/resources/testdata/corerp-azure-connection-database-service.bicep
+++ b/test/functional-portable/corerp/cloud/resources/testdata/corerp-azure-connection-database-service.bicep
@@ -1,26 +1,35 @@
 extension radius
 
+@description('Specifies the location for resources.')
+param location string = 'global'
+
+@description('Specifies the image of the container resource.')
 param magpieimage string
 
+@description('Specifies the environment for resources.')
 param environment string
 
+@description('Specifies the resource ID of the Azure Cosmos DB for MongoDB account to connect to.')
 param cosmosmongodbresourceid string
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'corerp-azure-connection-database-service'
-  location: 'global'
+  location: location
   properties: {
     environment: environment
   }
 }
 
-resource store 'Applications.Core/containers@2023-10-01-preview' = {
+resource store 'Radius.Compute/containers@2025-08-01-preview' = {
   name: 'db-service'
-  location: 'global'
+  location: location
   properties: {
     application: app.id
-    container: {
-      image: magpieimage
+    environment: environment
+    containers: {
+      'db-service': {
+        image: magpieimage
+      }
     }
     connections: {
       databaseresource: {


### PR DESCRIPTION
# Description

Migrates the  Test_AzureConnections  functional test from the legacy  Applications.Core/*  resource types to the new Radius resource types, continuing the test-migration effort .

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (#11489).

Fixes: #11489

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
