### PR TITLE
Fix flaky pkg/controller/reconciler tests by awaiting manager shutdown

### DIFF
--- a/pkg/controller/reconciler/deployment_reconciler_test.go
+++ b/pkg/controller/reconciler/deployment_reconciler_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package reconciler
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -62,7 +60,6 @@ func SetupDeploymentTest(t *testing.T) (*mockRadiusClient, client.Client) {
 
 	// Shut down the manager when the test exits.
 	ctx, cancel := testcontext.NewWithCancel(t)
-	t.Cleanup(cancel)
 
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme: scheme,
@@ -88,12 +85,7 @@ func SetupDeploymentTest(t *testing.T) (*mockRadiusClient, client.Client) {
 	}).SetupWithManager(mgr)
 	require.NoError(t, err)
 
-	go func() {
-		// Cannot use require/assert here - accessing testing.T from a non-test goroutine causes a data race.
-		if err := mgr.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			panic(fmt.Sprintf("manager exited with error: %v", err))
-		}
-	}()
+	startManager(t, mgr, ctx, cancel)
 
 	return radius, mgr.GetClient()
 }

--- a/pkg/controller/reconciler/deploymentresource_reconciler_test.go
+++ b/pkg/controller/reconciler/deploymentresource_reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package reconciler
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -66,7 +65,6 @@ func SetupDeploymentResourceTest(t *testing.T) (*mockRadiusClient, *sdkclients.M
 
 	// Shut down the manager when the test exits.
 	ctx, cancel := testcontext.NewWithCancel(t)
-	t.Cleanup(cancel)
 
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme: scheme,
@@ -96,12 +94,7 @@ func SetupDeploymentResourceTest(t *testing.T) (*mockRadiusClient, *sdkclients.M
 	}).SetupWithManager(mgr)
 	require.NoError(t, err)
 
-	go func() {
-		// Cannot use require/assert here - accessing testing.T from a non-test goroutine causes a data race.
-		if err := mgr.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			panic(fmt.Sprintf("manager exited with error: %v", err))
-		}
-	}()
+	startManager(t, mgr, ctx, cancel)
 
 	return mockRadiusClient, mockResourceDeploymentsClient, mgr.GetClient()
 }

--- a/pkg/controller/reconciler/deploymenttemplate_reconciler_test.go
+++ b/pkg/controller/reconciler/deploymenttemplate_reconciler_test.go
@@ -17,10 +17,8 @@ limitations under the License.
 package reconciler
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -60,7 +58,6 @@ func SetupDeploymentTemplateTest(t *testing.T) (*mockRadiusClient, *sdkclients.M
 
 	// Shut down the manager when the test exits.
 	ctx, cancel := testcontext.NewWithCancel(t)
-	t.Cleanup(cancel)
 
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme: scheme,
@@ -103,12 +100,7 @@ func SetupDeploymentTemplateTest(t *testing.T) (*mockRadiusClient, *sdkclients.M
 	}).SetupWithManager(mgr)
 	require.NoError(t, err)
 
-	go func() {
-		// Cannot use require/assert here - accessing testing.T from a non-test goroutine causes a data race.
-		if err := mgr.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			panic(fmt.Sprintf("manager exited with error: %v", err))
-		}
-	}()
+	startManager(t, mgr, ctx, cancel)
 
 	return mockRadiusClient, mockResourceDeploymentsClient, mgr.GetClient()
 }

--- a/pkg/controller/reconciler/flux_controller_test.go
+++ b/pkg/controller/reconciler/flux_controller_test.go
@@ -162,10 +162,11 @@ func setupFluxControllerTest(t *testing.T, opts setupFluxControllerTestOptions, 
 	require.NoError(t, err)
 
 	mgrCtx, mgrCancel := context.WithCancel(ctx)
-	t.Cleanup(mgrCancel)
 
 	managerErr := make(chan error, 1)
+	managerStopped := make(chan struct{})
 	go func() {
+		defer close(managerStopped)
 		t.Log("Starting manager...")
 		if err := mgr.Start(mgrCtx); err != nil {
 			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
@@ -174,6 +175,13 @@ func setupFluxControllerTest(t *testing.T, opts setupFluxControllerTestOptions, 
 		}
 		t.Log("Manager stopped.")
 	}()
+
+	// Cancel the manager context and wait for the manager goroutine to fully exit before the test
+	// completes, so it does not leak into subsequent tests or into package teardown.
+	t.Cleanup(func() {
+		mgrCancel()
+		<-managerStopped
+	})
 
 	t.Log("Waiting for cache to be ready")
 	waitCtx, waitCancel := context.WithTimeout(ctx, 30*time.Second)

--- a/pkg/controller/reconciler/flux_controller_test.go
+++ b/pkg/controller/reconciler/flux_controller_test.go
@@ -177,10 +177,12 @@ func setupFluxControllerTest(t *testing.T, opts setupFluxControllerTestOptions, 
 	}()
 
 	// Cancel the manager context and wait for the manager goroutine to fully exit before the test
-	// completes, so it does not leak into subsequent tests or into package teardown.
+	// completes, so it does not leak into subsequent tests or into package teardown. The wait is
+	// bounded so a manager that fails to stop fails the test instead of hanging until the global
+	// `go test` timeout.
 	t.Cleanup(func() {
 		mgrCancel()
-		<-managerStopped
+		waitForManagerShutdown(t, managerStopped)
 	})
 
 	t.Log("Waiting for cache to be ready")

--- a/pkg/controller/reconciler/main_test.go
+++ b/pkg/controller/reconciler/main_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	"github.com/go-logr/logr"
 	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -30,6 +31,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // config holds a reference to the rest config for the test environment.
@@ -51,6 +53,14 @@ type testWebhookOptions struct {
 //
 // We're using this to ensure that one (and only one) copy of env-test is booted up.
 func TestMain(m *testing.M) {
+	// Provide controller-runtime with a logger up front. Without this, the manager's shutdown path
+	// calls into the global logger before SetLogger is ever called, which triggers
+	// controller-runtime's eventuallyFulfillRoot fallback: after a ~30s delay it prints a
+	// "log.SetLogger(...) was never called" warning with a goroutine stack dump. That noisy, delayed
+	// path showed up at the point of an intermittent package-level test failure. A discard logger is
+	// safe here because it never writes to testing.T after a test completes.
+	runtimelog.SetLogger(logr.Discard())
+
 	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
 		// We don't know how to start the envtest environment. Just go ahead and call the tests so they can skip.
 		os.Exit(m.Run()) //nolint:forbidigo // this is OK inside the TestMain function.

--- a/pkg/controller/reconciler/recipe_reconciler_test.go
+++ b/pkg/controller/reconciler/recipe_reconciler_test.go
@@ -17,9 +17,7 @@ limitations under the License.
 package reconciler
 
 import (
-	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
@@ -47,7 +45,6 @@ func SetupRecipeTest(t *testing.T) (*mockRadiusClient, client.Client) {
 
 	// Shut down the manager when the test exits.
 	ctx, cancel := testcontext.NewWithCancel(t)
-	t.Cleanup(cancel)
 
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme: scheme,
@@ -73,12 +70,7 @@ func SetupRecipeTest(t *testing.T) (*mockRadiusClient, client.Client) {
 	}).SetupWithManager(mgr)
 	require.NoError(t, err)
 
-	go func() {
-		// Cannot use require/assert here - accessing testing.T from a non-test goroutine causes a data race.
-		if err := mgr.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			panic(fmt.Sprintf("manager exited with error: %v", err))
-		}
-	}()
+	startManager(t, mgr, ctx, cancel)
 
 	return radius, mgr.GetClient()
 }

--- a/pkg/controller/reconciler/recipe_webhook_test.go
+++ b/pkg/controller/reconciler/recipe_webhook_test.go
@@ -17,9 +17,7 @@ limitations under the License.
 package reconciler
 
 import (
-	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -258,7 +256,6 @@ func setupWebhookTest(t *testing.T) (*mockRadiusClient, client.Client) {
 
 	// Shut down the manager when the test exits.
 	ctx, cancel := testcontext.NewWithCancel(t)
-	t.Cleanup(cancel)
 
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme: scheme,
@@ -288,12 +285,7 @@ func setupWebhookTest(t *testing.T) (*mockRadiusClient, client.Client) {
 	err = (&RecipeWebhook{}).SetupWebhookWithManager(mgr)
 	require.NoError(t, err)
 
-	go func() {
-		// Cannot use require/assert here - accessing testing.T from a non-test goroutine causes a data race.
-		if err := mgr.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			panic(fmt.Sprintf("manager exited with error: %v", err))
-		}
-	}()
+	startManager(t, mgr, ctx, cancel)
 
 	// wait for the webhook server to get ready
 	var dialErr error

--- a/pkg/controller/reconciler/shared_test.go
+++ b/pkg/controller/reconciler/shared_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package reconciler
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -35,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 const (
@@ -42,6 +45,32 @@ const (
 	recipeTestWaitInterval            = time.Millisecond * 200
 	recipeTestControllerDelayInterval = time.Millisecond * 100
 )
+
+// startManager starts the controller-runtime manager in a background goroutine and registers a
+// t.Cleanup that cancels the manager's context and then blocks until the manager goroutine has
+// fully exited.
+//
+// Awaiting shutdown matters: cancelling the context only signals the manager to stop, it does not
+// wait for mgr.Start to return. Without this wait, manager goroutines outlive the test that owns
+// them and race with subsequent tests and package teardown (env.Stop in TestMain), which made this
+// suite intermittently fail at the package level with no named failing test.
+func startManager(t *testing.T, mgr manager.Manager, ctx context.Context, cancel context.CancelFunc) {
+	t.Helper()
+
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		// Cannot use require/assert here - accessing testing.T from a non-test goroutine causes a data race.
+		if err := mgr.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			panic(fmt.Sprintf("manager exited with error: %v", err))
+		}
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+		<-stopped
+	})
+}
 
 func createEnvironment(radius *mockRadiusClient, resourceGroup, name string) {
 	id := fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Applications.Core/environments/%s", resourceGroup, name)

--- a/pkg/controller/reconciler/shared_test.go
+++ b/pkg/controller/reconciler/shared_test.go
@@ -44,11 +44,18 @@ const (
 	recipeTestWaitDuration            = time.Second * 10
 	recipeTestWaitInterval            = time.Millisecond * 200
 	recipeTestControllerDelayInterval = time.Millisecond * 100
+
+	// managerShutdownTimeout bounds how long test cleanup waits for a controller-runtime manager to
+	// exit after its context is cancelled. It is comfortably above controller-runtime's default 30s
+	// graceful shutdown timeout, so a clean shutdown always finishes first. If it is exceeded, cleanup
+	// reports a failure instead of hanging until the global `go test` timeout, which would obscure the
+	// root cause.
+	managerShutdownTimeout = time.Second * 60
 )
 
 // startManager starts the controller-runtime manager in a background goroutine and registers a
 // t.Cleanup that cancels the manager's context and then blocks until the manager goroutine has
-// fully exited.
+// fully exited (or managerShutdownTimeout elapses).
 //
 // Awaiting shutdown matters: cancelling the context only signals the manager to stop, it does not
 // wait for mgr.Start to return. Without this wait, manager goroutines outlive the test that owns
@@ -60,7 +67,8 @@ func startManager(t *testing.T, mgr manager.Manager, ctx context.Context, cancel
 	stopped := make(chan struct{})
 	go func() {
 		defer close(stopped)
-		// Cannot use require/assert here - accessing testing.T from a non-test goroutine causes a data race.
+		// Don't use require/assert here: they can call t.FailNow/t.Fail, which must run on the test
+		// goroutine, not this background one.
 		if err := mgr.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			panic(fmt.Sprintf("manager exited with error: %v", err))
 		}
@@ -68,8 +76,20 @@ func startManager(t *testing.T, mgr manager.Manager, ctx context.Context, cancel
 
 	t.Cleanup(func() {
 		cancel()
-		<-stopped
+		waitForManagerShutdown(t, stopped)
 	})
+}
+
+// waitForManagerShutdown blocks until the manager goroutine signals it has exited by closing
+// stopped, or fails the test if that does not happen within managerShutdownTimeout.
+func waitForManagerShutdown(t *testing.T, stopped <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-stopped:
+	case <-time.After(managerShutdownTimeout):
+		t.Errorf("timed out after %s waiting for the controller-runtime manager to shut down", managerShutdownTimeout)
+	}
 }
 
 func createEnvironment(radius *mockRadiusClient, resourceGroup, name string) {


### PR DESCRIPTION
# Description

The `pkg/controller/reconciler` envtest suite is intermittently flaky. It recently failed on an unrelated PR ([failed run — Run Unit Tests, attempt 2](https://github.com/radius-project/radius/actions/runs/28501678146/job/84590792709)) and then passed on re-run, with no code change in between.

### Root cause

The failure surfaced as a **package-level failure with no named failing test**:

```
=== FAIL: pkg/controller/reconciler  (0.00s)
FAIL
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
  > ...eventuallyFulfillRoot() ...
  > ...manager.(*controllerManager).engageStopProcedure...
FAIL	github.com/radius-project/radius/pkg/controller/reconciler	30.179s
```

Every test setup started a controller-runtime manager in a **detached goroutine** and only called `t.Cleanup(cancel)`:

```go
ctx, cancel := testcontext.NewWithCancel(t)
t.Cleanup(cancel)
...
go func() {
    if err := mgr.Start(ctx); err != nil && !errors.Is(err, context.Canceled) { panic(...) }
}()
```

`cancel()` only *signals* shutdown — it never waits for `mgr.Start` to return. So manager goroutines outlived the test that owned them and raced with subsequent tests and package teardown (`env.Stop` in `TestMain`), which intermittently pushed the test binary to a non-zero exit.

Because `SetLogger` was never called, a still-shutting-down manager also hit controller-runtime's `eventuallyFulfillRoot` fallback, which prints the `log.SetLogger(...) was never called` warning with a goroutine stack dump after a ~30s delay — exactly the output captured at the failure point (note the 30.179s package time).

This is test-harness flakiness, not a product bug: the triggering PR only touched Helm chart templates and had nothing to do with this package.

### Changes (test-only)

- Add a shared `startManager` helper in `shared_test.go` that runs the manager and, on `t.Cleanup`, cancels its context **and blocks until the goroutine fully exits**, so no manager leaks past its test.
- Use the helper in the five standard reconciler/webhook setups, and apply the same await-shutdown pattern to the Flux controller test.
- Call `runtimelog.SetLogger(logr.Discard())` once in `TestMain` so controller-runtime always has a logger, eliminating the noisy, ~30s-delayed fallback path. A discard logger is safe here because it never writes to `testing.T` after a test completes.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [x] Not applicable