### PR TITLE
Fix flaky Test_Gateway* probe timing (#12298)

### DIFF
--- a/test/functional-portable/corerp/noncloud/resources/gateway_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/gateway_test.go
@@ -483,8 +483,15 @@ func testGatewayAvailability(t *testing.T, hostname, baseURL, path string, expec
 		attempts++
 		res, err := client.Do(req)
 		if err == nil && res.StatusCode == expectedStatusCode {
-			// Got expected status code, return
+			// Got expected status code, close the body and return.
+			res.Body.Close()
 			return nil
+		}
+
+		// Close the previously retained response body before overwriting it so we don't
+		// accumulate open bodies/connections across the widened poll budget.
+		if lastRes != nil {
+			lastRes.Body.Close()
 		}
 		lastRes, lastErr = res, err
 
@@ -519,6 +526,7 @@ func testGatewayAvailability(t *testing.T, hostname, baseURL, path string, expec
 			t.Logf("failed to dump response with error: %s", dumpErr)
 		}
 		t.Logf("response dump: %s", string(responseDump))
+		lastRes.Body.Close()
 	}
 
 	return fmt.Errorf("failed to make request to %s after %d attempts over %s", urlPath, attempts, timeout)

--- a/test/functional-portable/corerp/noncloud/resources/gateway_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/gateway_test.go
@@ -469,44 +469,59 @@ func testGatewayAvailability(t *testing.T, hostname, baseURL, path string, expec
 
 	client := newTestHTTPClient(isHttps, hostname)
 
-	retries := 2
+	// A freshly-deployed gateway can briefly return errors (e.g. HTTP 503 from Envoy) while
+	// Contour programs the xDS route/cluster for the new route. Poll over a realistic window
+	// instead of failing after only a couple of attempts. See radius-project/radius#12298.
 	retryBackoff := 5 * time.Second
-	for i := 1; i <= retries; i++ {
+	timeout := 90 * time.Second
+	deadline := time.Now().Add(timeout)
+
+	var lastRes *http.Response
+	var lastErr error
+	attempts := 0
+	for {
+		attempts++
 		res, err := client.Do(req)
 		if err == nil && res.StatusCode == expectedStatusCode {
 			// Got expected status code, return
 			return nil
 		}
+		lastRes, lastErr = res, err
 
-		// If we got an error, or the status code was not what we expected, log the error and retry
-		// Logging the request and response will help with debugging the issue
-
-		t.Logf("failed to make request to %s with error: %s", urlPath, err)
-		requestDump, err := httputil.DumpRequestOut(req, true)
+		// Log a concise message per attempt; the full request/response dump is emitted once
+		// below when the poll budget is exhausted to avoid flooding the test log.
 		if err != nil {
-			t.Logf("failed to dump request with error: %s", err)
-		}
-		t.Logf("request dump: %s", string(requestDump))
-
-		if res == nil {
-			t.Logf("response is nil")
+			t.Logf("attempt %d: failed to make request to %s with error: %s", attempts, urlPath, err)
+		} else {
+			t.Logf("attempt %d: expected status code %d, got %d from %s", attempts, expectedStatusCode, res.StatusCode, urlPath)
 		}
 
-		if res != nil && res.StatusCode != expectedStatusCode {
-			t.Logf("expected status code %d, got %d", expectedStatusCode, res.StatusCode)
-			responseDump, err := httputil.DumpResponse(res, true)
-			if err != nil {
-				t.Logf("failed to dump response with error: %s", err)
-			}
-			t.Logf("response dump: %s", string(responseDump))
+		if time.Now().After(deadline) {
+			break
 		}
 
 		// Wait for retryBackoff before trying again
 		time.Sleep(retryBackoff)
-		continue
 	}
 
-	return fmt.Errorf("failed to make request to %s after %d retries", urlPath, retries)
+	// The poll budget is exhausted; dump the last request and response to help with debugging.
+	requestDump, dumpErr := httputil.DumpRequestOut(req, true)
+	if dumpErr != nil {
+		t.Logf("failed to dump request with error: %s", dumpErr)
+	}
+	t.Logf("request dump: %s", string(requestDump))
+
+	if lastRes == nil {
+		t.Logf("last response is nil (last error: %v)", lastErr)
+	} else {
+		responseDump, dumpErr := httputil.DumpResponse(lastRes, true)
+		if dumpErr != nil {
+			t.Logf("failed to dump response with error: %s", dumpErr)
+		}
+		t.Logf("response dump: %s", string(responseDump))
+	}
+
+	return fmt.Errorf("failed to make request to %s after %d attempts over %s", urlPath, attempts, timeout)
 }
 
 func newTestHTTPClient(isHttps bool, hostname string) *http.Client {

--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -539,8 +539,6 @@ func matchesActualLabels(t *testing.T, expectedResources []K8sObject, actualReso
 					resourceExists = true
 					actualResources = append(actualResources[:idx], actualResources[idx+1:]...)
 					break
-				} else {
-					t.Logf("Resource: %s Expected labels %v, got %v", actualResource.GetName(), expectedResource.Labels, actualResource.GetLabels())
 				}
 			}
 		}


### PR DESCRIPTION
# Description

Fixes the intermittent `Test_Gateway*` failures in the `corerp-noncloud` functional job, where the gateway probe fails with a transient HTTP `503 Service Unavailable` from Envoy on `/healthz` via port-forward.

**Root cause:** a freshly-deployed gateway briefly returns `503` while Contour programs the Envoy xDS route/cluster for the new route. The probe `testGatewayAvailability` only retried **2× with a 5s backoff (~10s total)**, which is too short to cover that programming window.

This is a **test-only** change — no product code is modified.

## Changes

- **`test/functional-portable/corerp/noncloud/resources/gateway_test.go`** — widen the retry/poll budget in `testGatewayAvailability` from 2×5s to poll the expected status over **~90s** with a 5s backoff. The full request/response dump is now emitted **only once on final failure** (with a concise one-line message per attempt) to reduce log noise.
- **`test/validation/k8s.go`** — remove the misleading per-non-match `"Resource: … Expected labels … got …"` log line in `matchesActualLabels` that fired for *every* scanned pod during its linear label match. This was diagnostic noise that misled triage (label validation actually passes). Genuine match failures are still reported by the existing `remaining`-resources loop.

Gating the probe on the `HTTPProxy`/route reaching `Valid`/programmed status (the issue's "optional" item) was intentionally skipped — the widened poll budget directly addresses the root cause and keeps the change minimal and self-contained.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #12298

## Contributor checklist

- [x] Tests are changed as part of this PR (test-only change)
- [x] No product code is modified