### PR TITLE
Fix purge-old-images workflow logging thousands of 404 errors

### DIFF
--- a/.github/scripts/purge-ghcr-dev-images.sh
+++ b/.github/scripts/purge-ghcr-dev-images.sh
@@ -1,0 +1,305 @@
+#!/bin/bash
+
+# ------------------------------------------------------------
+# Copyright 2023 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+# ============================================================================
+# Purge old pr-* tagged GHCR container images under the org's dev/* packages.
+#
+# Replaces the snok/container-retention-policy action. GHCR's list-versions API
+# is eventually consistent and keeps returning versions that were already
+# deleted (with their old tags) for days, so a naive delete loop logs thousands
+# of harmless "404 Not Found" errors every run. There is no API to force GHCR to
+# refresh its listing, so this script treats 404/410 as the expected "already
+# gone" state (silent) and persists those version ids in a "ghost" cache so
+# subsequent runs skip them entirely.
+#
+# The ghost cache is self-healing: each run persists only the already-gone ids
+# it actually observed this run (cached ids GHCR still lists, plus this run's
+# fresh 404s and successful deletes). An id that GHCR finally stops listing is
+# simply not re-observed, so it drops out of the cache on the next run. This
+# keeps the cache bounded to the current staleness backlog without needing
+# age-based expiry; GHOST_CACHE_MAX is only a hard backstop.
+#
+# Only throwaway dev/* pr-* CI images are ever touched, and only when every one
+# of a version's tags matches the pr-* pattern, so latest/longr* shared images
+# are never deleted. Deleting a tagged parent index cascade-removes its
+# multi-arch children in GHCR, and orphaning a week-old test child is harmless,
+# so no separate multi-arch protection is needed.
+#
+# Auth: GITHUB_TOKEN must be a classic PAT with read:packages + delete:packages.
+# Deps: gh, jq.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_NAME
+
+# Defaults (override via flags or environment).
+ORG="${ORG:-radius-project}"
+IMAGE_PREFIX="${IMAGE_PREFIX:-dev/}"
+TAG_REGEX="${TAG_REGEX:-^pr-}"
+CUTOFF_DAYS="${CUTOFF_DAYS:-7}"
+GHOST_CACHE_FILE="${GHOST_CACHE_FILE:-.ghcr-ghost-cache/ghosts.txt}"
+DRY_RUN="${DRY_RUN:-false}"
+# Space deletes to stay under the ~180 deletes/min secondary rate limit.
+DELETE_PACING_MS="${DELETE_PACING_MS:-350}"
+# Cap the ghost cache so it cannot grow without bound.
+GHOST_CACHE_MAX="${GHOST_CACHE_MAX:-20000}"
+
+# Counters.
+DELETED=0
+GHOST_CACHED_SKIPS=0
+GHOST_NEW=0
+REAL_FAILURES=0
+LOADED_GHOSTS=0
+
+# GHOST_IDS: already-gone ids loaded from the cache; looked up to skip this run.
+# KEEP_IDS:  already-gone ids to persist for next run (self-healing set) - the
+#            cached ids GHCR still lists plus this run's fresh 404s and deletes.
+declare -A GHOST_IDS=()
+declare -A KEEP_IDS=()
+declare -a REAL_FAILURE_IDS=()
+
+usage() {
+    echo "Usage: ${SCRIPT_NAME} [OPTIONS]"
+    echo "Options:"
+    echo "  -o, --org NAME           Organization (default: radius-project)"
+    echo "  -p, --prefix STR         Image name prefix to match (default: dev/)"
+    echo "  -c, --cutoff-days N      Delete versions older than N days (default: 7)"
+    echo "  -g, --ghost-cache FILE   Ghost id cache file"
+    echo "  -d, --dry-run            List candidates without deleting"
+    echo "  -h, --help               Show this help"
+    exit 0
+}
+
+validate_requirements() {
+    for tool in gh jq curl; do
+        if ! command -v "${tool}" > /dev/null 2>&1; then
+            echo "Error: required tool '${tool}' is not installed" >&2
+            exit 1
+        fi
+    done
+    TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+    if [[ -z "${TOKEN}" ]]; then
+        echo "Error: GH_TOKEN/GITHUB_TOKEN (classic PAT) is required" >&2
+        exit 1
+    fi
+    # gh reads GH_TOKEN; keep it in sync with whatever the caller provided.
+    export GH_TOKEN="${TOKEN}"
+}
+
+load_ghost_cache() {
+    if [[ -f "${GHOST_CACHE_FILE}" ]]; then
+        local id
+        while IFS= read -r id; do
+            [[ -n "${id}" ]] && GHOST_IDS["${id}"]=1
+        done < "${GHOST_CACHE_FILE}"
+    fi
+    LOADED_GHOSTS="${#GHOST_IDS[@]}"
+    echo "Loaded ${LOADED_GHOSTS} ghost version ids from ${GHOST_CACHE_FILE}"
+}
+
+# Print dev/* container package names, one per line.
+list_packages() {
+    local url names
+    url="/orgs/${ORG}/packages?package_type=container&per_page=100"
+    names="$(gh api --paginate "${url}" --jq '.[].name')"
+    grep -E "^${IMAGE_PREFIX}" <<< "${names}" || true
+}
+
+# Print "<id> <tab> <encoded-package>" for each deletable version of a package.
+# A version is deletable when it has at least one tag, every tag matches
+# TAG_REGEX, and it is older than the cutoff.
+list_deletable_versions() {
+    local pkg="$1"
+    local encoded cutoff_epoch url raw ids id
+    encoded="${pkg//\//%2F}"
+    cutoff_epoch="$(date -u -d "${CUTOFF_DAYS} days ago" +%s)"
+    url="/orgs/${ORG}/packages/container/${encoded}/versions?per_page=100"
+
+    raw="$(gh api --paginate "${url}")"
+    ids="$(jq -r --arg re "${TAG_REGEX}" --argjson cutoff "${cutoff_epoch}" '
+        .[]
+        | {id, updated_at, tags: (.metadata.container.tags // [])}
+        | select((.tags | length) > 0)
+        | select([.tags[] | test($re)] | all)
+        | select((.updated_at | fromdateiso8601) < $cutoff)
+        | .id
+    ' <<< "${raw}")"
+
+    while IFS= read -r id; do
+        [[ -n "${id}" ]] && printf '%s\t%s\n' "${id}" "${encoded}"
+    done <<< "${ids}"
+}
+
+# Delete a single version. Returns 0 on delete/already-gone, 1 on real failure.
+delete_version() {
+    local id="$1" encoded="$2"
+    local attempt=0 max_attempts=5 status wait
+
+    while ((attempt < max_attempts)); do
+        ((attempt += 1))
+        status="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -X DELETE \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/orgs/${ORG}/packages/container/${encoded}/versions/${id}")"
+
+        case "${status}" in
+            204)
+                # We just deleted it; keep it so next run skips it instead of
+                # re-issuing a delete that GHCR would answer with a 404.
+                ((DELETED += 1))
+                KEEP_IDS["${id}"]=1
+                return 0
+                ;;
+            404 | 410)
+                # Already gone: skip it silently now and on future runs.
+                GHOST_IDS["${id}"]=1
+                KEEP_IDS["${id}"]=1
+                ((GHOST_NEW += 1))
+                return 0
+                ;;
+            403 | 429)
+                # Secondary rate limit: back off and retry.
+                wait=$((attempt * attempt * 5))
+                echo "Rate limited on ${id} (status ${status}); backing off ${wait}s" >&2
+                sleep "${wait}"
+                ;;
+            *)
+                echo "Real failure deleting ${id} (status ${status})" >&2
+                REAL_FAILURE_IDS+=("${id}")
+                ((REAL_FAILURES += 1))
+                return 1
+                ;;
+        esac
+    done
+
+    echo "Giving up on ${id} after ${max_attempts} attempts" >&2
+    REAL_FAILURE_IDS+=("${id}")
+    ((REAL_FAILURES += 1))
+    return 1
+}
+
+write_ghost_cache() {
+    local dir sorted
+    dir="$(dirname "${GHOST_CACHE_FILE}")"
+    mkdir -p "${dir}"
+    # Persist only the ids observed this run (self-healing eviction). sort -n so
+    # the GHOST_CACHE_MAX backstop keeps the newest (highest) ids if ever hit.
+    sorted="$(printf '%s\n' "${!KEEP_IDS[@]}" | grep -E '^[0-9]+$' | sort -n -u)"
+    if [[ -n "${sorted}" ]]; then
+        tail -n "${GHOST_CACHE_MAX}" <<< "${sorted}" > "${GHOST_CACHE_FILE}"
+    else
+        : > "${GHOST_CACHE_FILE}"
+    fi
+    echo "Wrote $(wc -l < "${GHOST_CACHE_FILE}") ghost ids to ${GHOST_CACHE_FILE}"
+}
+
+main() {
+    validate_requirements
+    load_ghost_cache
+
+    echo "=============================================================="
+    echo "Purging ${IMAGE_PREFIX}* images older than ${CUTOFF_DAYS}d in ${ORG}"
+    echo "Tag filter: ${TAG_REGEX}  Dry run: ${DRY_RUN}"
+    echo "=============================================================="
+
+    local packages=()
+    mapfile -t packages < <(list_packages)
+    echo "Found ${#packages[@]} ${IMAGE_PREFIX}* packages"
+
+    local candidates=0
+    local pkg id encoded
+    for pkg in "${packages[@]}"; do
+        [[ -z "${pkg}" ]] && continue
+        while IFS=$'\t' read -r id encoded; do
+            [[ -z "${id}" ]] && continue
+            ((candidates += 1))
+
+            if [[ -n "${GHOST_IDS[${id}]:-}" ]]; then
+                # GHCR still lists this known-gone id; keep skipping it next run.
+                ((GHOST_CACHED_SKIPS += 1))
+                KEEP_IDS["${id}"]=1
+                continue
+            fi
+
+            if [[ "${DRY_RUN}" == "true" ]]; then
+                echo "[dry-run] would delete ${pkg} version ${id}"
+                continue
+            fi
+
+            delete_version "${id}" "${encoded}" || true
+            sleep "$(awk "BEGIN{print ${DELETE_PACING_MS}/1000}")"
+        done < <(list_deletable_versions "${pkg}")
+    done
+
+    if [[ "${DRY_RUN}" != "true" ]]; then
+        write_ghost_cache
+    fi
+
+    echo "=============================================================="
+    echo "Summary"
+    echo "  packages scanned : ${#packages[@]}"
+    echo "  candidates       : ${candidates}"
+    echo "  deleted          : ${DELETED}"
+    echo "  already-gone     : $((GHOST_CACHED_SKIPS + GHOST_NEW)) (cached ${GHOST_CACHED_SKIPS}, new-404 ${GHOST_NEW})"
+    echo "  cache evicted    : $((LOADED_GHOSTS - GHOST_CACHED_SKIPS)) (loaded ${LOADED_GHOSTS}, no longer listed)"
+    echo "  real failures    : ${REAL_FAILURES}"
+    echo "=============================================================="
+
+    if ((REAL_FAILURES > 0)); then
+        echo "Failed version ids: ${REAL_FAILURE_IDS[*]}" >&2
+        exit 1
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o | --org)
+            ORG="$2"
+            shift 2
+            ;;
+        -p | --prefix)
+            IMAGE_PREFIX="$2"
+            shift 2
+            ;;
+        -c | --cutoff-days)
+            CUTOFF_DAYS="$2"
+            shift 2
+            ;;
+        -g | --ghost-cache)
+            GHOST_CACHE_FILE="$2"
+            shift 2
+            ;;
+        -d | --dry-run)
+            DRY_RUN="true"
+            shift
+            ;;
+        -h | --help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+main "$@"

--- a/.github/scripts/purge-ghcr-dev-images.sh
+++ b/.github/scripts/purge-ghcr-dev-images.sh
@@ -41,7 +41,7 @@
 # so no separate multi-arch protection is needed.
 #
 # Auth: GITHUB_TOKEN must be a classic PAT with read:packages + delete:packages.
-# Deps: gh, jq.
+# Deps: gh, jq, curl, awk.
 # ============================================================================
 
 set -euo pipefail
@@ -88,7 +88,7 @@ usage() {
 }
 
 validate_requirements() {
-    for tool in gh jq curl; do
+    for tool in gh jq curl awk; do
         if ! command -v "${tool}" > /dev/null 2>&1; then
             echo "Error: required tool '${tool}' is not installed" >&2
             exit 1

--- a/.github/workflows/purge-old-images.yaml
+++ b/.github/workflows/purge-old-images.yaml
@@ -5,6 +5,11 @@ name: Purge test container images
 on:
   # Enable manual trigger
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: List candidates without deleting anything
+        type: boolean
+        default: true
   schedule:
     # Run twice a day
     - cron: 30 0,12 * * *
@@ -20,32 +25,53 @@ jobs:
     if: github.repository == 'radius-project/radius'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
-    permissions: {}
+    permissions:
+      contents: read # Required to check out the purge script
     steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # GHCR's list-package-versions API is eventually consistent: it keeps
+      # returning versions (with their old tags) long after they were deleted,
+      # so a naive delete loop logs thousands of harmless "404 Not Found" errors
+      # every run. We persist those already-gone version ids in a cache so
+      # subsequent runs skip them instead of re-issuing the failed deletes.
+      - name: Restore ghost version cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .ghcr-ghost-cache
+          key: ghcr-ghost-versions-${{ github.run_id }}
+          restore-keys: |
+            ghcr-ghost-versions-
+
       # GitHub Container Registry package APIs are only accessible to classic
       # personal access tokens (and the built-in GITHUB_TOKEN). GitHub App
       # installation tokens cannot list or delete org packages — the list
       # endpoint returns "400 Invalid argument" and deletes are rejected. See
       # https://github.com/snok/container-retention-policy/issues/94 (GitHub
-      # Support confirmation). The wildcard image-names below also requires the
-      # list-packages endpoint, so a classic PAT is required here.
+      # Support confirmation). The wildcard dev/* image selection also requires
+      # the list-packages endpoint, so a classic PAT is required here.
       #
       # secrets.GH_RAD_CI_BOT_PAT must be a classic PAT with the following scopes:
       #   - read:packages   (list package versions)
       #   - delete:packages (delete old package versions)
-      - name: Delete 'dev' containers older than a week
-        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
+      - name: Delete 'dev' pr-* containers older than a week
+        env:
+          GH_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+        run: |
+          ./.github/scripts/purge-ghcr-dev-images.sh \
+            --org "${{ github.repository_owner }}" \
+            --prefix "dev/" \
+            --cutoff-days 7 \
+            --ghost-cache ".ghcr-ghost-cache/ghosts.txt"
+
+      - name: Save ghost version cache
+        if: always()
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          account: ${{ github.repository_owner }}
-          token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
-          image-names: dev/*
-          image-tags: pr-*
-          # Only delete the pr-* tagged image indexes. GHCR cascade-removes their
-          # untagged child manifests automatically, so we avoid issuing thousands
-          # of redundant deletes for already-removed children (which otherwise log
-          # as "404 Package not found" errors).
-          tag-selection: tagged
-          cut-off: 1w
+          path: .ghcr-ghost-cache
+          key: ghcr-ghost-versions-${{ github.run_id }}
 
   create_issue_on_failure:
     name: Create issue for failing purge old images resources run

--- a/.github/workflows/purge-old-images.yaml
+++ b/.github/workflows/purge-old-images.yaml
@@ -31,6 +31,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # Ensure the cache path exists so the restore/save steps are idempotent:
+      # in dry-run mode the script never writes the cache, so on a first-run /
+      # cache-miss the directory would otherwise be absent when cache/save runs.
+      - name: Prepare ghost cache directory
+        run: mkdir -p .ghcr-ghost-cache
+
       # GHCR's list-package-versions API is eventually consistent: it keeps
       # returning versions (with their old tags) long after they were deleted,
       # so a naive delete loop logs thousands of harmless "404 Not Found" errors


### PR DESCRIPTION
## Problem
The `purge-old-images` workflow succeeds (exit 0) but every run's log contains thousands of `404 Not Found` "Failed to delete package version" errors (~4,795 of ~5,632 selected versions in a recent run; ~80% of the same version IDs recur across runs 12h apart).

## Root cause
GHCR's list-package-versions API is eventually consistent and keeps returning versions that were already deleted (with their old `pr-*` tags) for days. `snok/container-retention-policy` re-selects and re-DELETEs those ghosts every run; each 404 lands in the action's catch-all `error!` arm (logged, marked failed, but does not fail the job). There is no upstream toggle to silence it, and no GHCR API to force the listing to refresh.

## Fix
Replace the action with an owned, idempotent purge script plus a self-healing ghost-ID skip cache:
- `.github/scripts/purge-ghcr-dev-images.sh` lists `dev/*` container packages and selects versions where every tag matches `^pr-` (so `latest`/`longr*` shared images are never touched) and `updated_at` is older than the cutoff (7 days).
- Deletes via `curl` with status branching: `204` = deleted, `404/410` = already-gone (silent), `403/429` = back off + retry, anything else = real failure -> job exits non-zero. So the job now fails **only** on genuine errors.
- Already-gone IDs are persisted in a ghost cache (via `actions/cache`, rolling `run_id` key + `restore-keys` prefix). The cache is **self-healing**: each run persists only the already-gone IDs observed that run (cached IDs GHCR still lists + this run's fresh 404s + this run's successful deletes), so an ID GHCR finally stops listing drops out next run. `GHOST_CACHE_MAX` (`sort -n | tail`) is a hard backstop.
- Workflow gains a `workflow_dispatch` `dry_run` input (default `true`) for safe validation, scoped `permissions: contents: read`, and keeps the classic-PAT auth and the failure-issue job.

## Validation
- shfmt / shellcheck / `bash -n` clean; workflow YAML parses.
- Mocked end-to-end tests cover selection (skips mixed-tag / recent / untagged), all delete branches, dry-run, real-failure exit code, and self-healing eviction (run 1 caches deleted+404 IDs; run 2 evicts the ID GHCR stopped listing; run 3 steady state = zero 404 noise).

## How to validate in CI
1. `workflow_dispatch` with `dry_run=true` — confirm candidate counts look right, zero deletes, zero 404 ERROR lines.
2. `workflow_dispatch` with `dry_run=false` once — confirm deletes succeed, ghosts silent, cache saved.
3. Next scheduled run should show a smaller candidate set (cache warmed) and a clean log.

## Follow-ups (not in this PR)
- Shared recipe images tagged `latest`/`longr*` are still skipped by design; truly cleaning them needs a separate tag-level policy.
- `create_issue_on_failure` has no dedup/auto-close.
- Report the GHCR stale-listing behavior to GitHub Support.