### PR TITLE
fix(database): refresh stored ETag on Postgres updates

### DIFF
--- a/pkg/components/database/postgres/postgresclient.go
+++ b/pkg/components/database/postgres/postgresclient.go
@@ -344,7 +344,7 @@ WITH updated AS (
 	INSERT INTO resources (id, original_id, resource_type, root_scope, routing_scope, etag, resource_data)
 	VALUES ($1, $2, $3, $4, $5, $6, $7)
 	ON CONFLICT (id) 
-	DO UPDATE SET resource_data = $7
+	DO UPDATE SET resource_data = $7, etag = $6
 	RETURNING id
 )
 SELECT
@@ -369,7 +369,7 @@ END AS result;`
 		// NOTE: we want to report ErrConcurrency for all failure cases here. This is what the tests do.
 		sql = `
 WITH updated AS (
-	UPDATE resources SET resource_data = $2
+	UPDATE resources SET resource_data = $2, etag = $4
 	WHERE id = $1 AND etag = $3
 	RETURNING id
 )
@@ -380,7 +380,7 @@ CASE
 	ELSE 'ErrConcurrency'
 END AS result;`
 
-		args = []any{databaseutil.NormalizePart(converted.String()), obj.Data, config.ETag}
+		args = []any{databaseutil.NormalizePart(converted.String()), obj.Data, config.ETag, obj.ETag}
 	}
 
 	result := ""

--- a/test/ucp/storetest/shared.go
+++ b/test/ucp/storetest/shared.go
@@ -281,6 +281,36 @@ func RunTest(t *testing.T, client database.Client, clear func(t *testing.T)) {
 		obj1Get, err := client.Get(ctx, Resource1ID.String())
 		require.NoError(t, err)
 		compareObjects(t, &obj1, obj1Get)
+
+		// The stored ETag must reflect the updated data so that subsequent
+		// reads and optimistic-concurrency writes agree on the current value.
+		require.Equal(t, obj1.ETag, obj1Get.ETag)
+	})
+
+	t.Run("save_can_update_repeatedly_with_matching_etag", func(t *testing.T) {
+		clear(t)
+
+		// Regression test: an update must refresh the stored ETag so that a
+		// caller can chain optimistic-concurrency updates using the ETag
+		// returned by the previous Save. Otherwise the second update fails
+		// with a spurious concurrency conflict.
+		obj1 := createObject(Resource1ID, Data1)
+		err := client.Save(ctx, &obj1)
+		require.NoError(t, err)
+		require.NotEmpty(t, obj1.ETag)
+
+		obj1.Data = Data2
+		err = client.Save(ctx, &obj1, database.WithETag(obj1.ETag))
+		require.NoError(t, err)
+
+		obj1.Data = Data1
+		err = client.Save(ctx, &obj1, database.WithETag(obj1.ETag))
+		require.NoError(t, err)
+
+		obj1Get, err := client.Get(ctx, Resource1ID.String())
+		require.NoError(t, err)
+		compareObjects(t, &obj1, obj1Get)
+		require.Equal(t, obj1.ETag, obj1Get.ETag)
 	})
 
 	t.Run("save_cannot_update_not_matching_etag", func(t *testing.T) {


### PR DESCRIPTION
# Description

The Postgres database client (`pkg/components/database/postgres/postgresclient.go`) only wrote the `etag` column on the initial `INSERT`. Both update paths in `Save` left the stored `etag` at its stale first-write value:

- Upsert path: `ON CONFLICT (id) DO UPDATE SET resource_data = $7` — updated data but not `etag`.
- Optimistic-concurrency path: `UPDATE resources SET resource_data = $2 WHERE id = $1 AND etag = $3` — updated data but not `etag`.

Meanwhile `Save` recomputes and returns a fresh ETag to the caller (`obj.ETag = etag.New(raw)`). After any update, the stored `etag` column drifts out of sync with both the stored data and the ETag the caller now holds. A caller chaining optimistic-concurrency writes with the ETag returned by the previous `Save` then fails with a spurious "concurrency conflict" — surfacing as `ResourceDeploymentFailure` at deploy time (e.g. for `Radius.Security/secrets`, which are created and then updated during async processing).

The apiserver store isn't affected because it replaces the whole entry (with a recomputed ETag) on every update.

## Fix

- Upsert path now does `DO UPDATE SET resource_data = $7, etag = $6`.
- OCC path now does `UPDATE resources SET resource_data = $2, etag = $4 ...`, passing the freshly computed `obj.ETag`.

## Tests

The existing `save_can_update_matching_etag` conformance test did only a single OCC update and ignored ETags in its comparison, so it never caught this. In `test/ucp/storetest/shared.go`:

- Added an assertion that `Get` returns the refreshed ETag after an update.
- Added `save_can_update_repeatedly_with_matching_etag`, which chains two consecutive OCC updates using each returned ETag. This reproduces the failure against the old code and passes with the fix. The shared harness covers all backends, including Postgres (`Test_PostgresClient`, run in CI).

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #issue_number

## Contributor checklist

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/`, if new APIs are being introduced.
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected.
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected.
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes affect documentation or user-facing behavior.
    - [x] Not applicable