### PR TITLE
fix(portable-resources): stop masking recipe errors when status save fails

### DIFF
--- a/pkg/portableresources/backend/controller/createorupdateresource.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource.go
@@ -219,7 +219,9 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 }
 
 // handleRecipeError handles recipe execution errors: logs, updates status, persists, and returns the appropriate result.
-// When redactionCompleted is true, all failure paths return NewFailedResult to prevent retries that would fail
+// A RecipeError is always terminal and returns NewFailedResult with the recipe's error details, even if the
+// best-effort status persistence fails, so the real recipe failure is never masked. For non-RecipeError failures,
+// when redactionCompleted is true the failure is made terminal (NewFailedResult) to prevent a retry that would fail
 // because sensitive data has already been nullified from the database.
 func (c *CreateOrUpdateResource[P, T]) handleRecipeError(ctx context.Context, err error, recipeDataModel datamodel.RecipeDataModel, resourceID string, etag string, logger logr.Logger, redactionCompleted bool) (ctrl.Result, error) {
 	var recipeErr *recipes.RecipeError
@@ -234,12 +236,12 @@ func (c *CreateOrUpdateResource[P, T]) handleRecipeError(ctx context.Context, er
 		}
 
 		// Save portable resource with updated deployment status to track errors during deletion.
-		err = c.DatabaseClient().Save(ctx, update, database.WithETag(etag))
-		if err != nil {
-			if redactionCompleted {
-				return ctrl.NewFailedResult(v1.ErrorDetails{Message: err.Error()}), err
-			}
-			return ctrl.Result{}, err
+		// This persistence is best-effort bookkeeping: if it fails we must still surface the
+		// original recipe error to the caller rather than masking it with the save error (for
+		// example a spurious ErrConcurrency). The operation is terminal either way, so there is
+		// nothing to be gained by returning the save error instead of the real recipe failure.
+		if saveErr := c.DatabaseClient().Save(ctx, update, database.WithETag(etag)); saveErr != nil {
+			logger.Error(saveErr, "failed to persist recipe error status; returning the original recipe error")
 		}
 
 		return ctrl.NewFailedResult(recipeErr.ErrorDetails), nil

--- a/pkg/portableresources/backend/controller/createorupdateresource_test.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource_test.go
@@ -497,6 +497,89 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 	}
 }
 
+func TestCreateOrUpdateResource_Run_RecipeErrorSurfacedWhenStatusSaveFails(t *testing.T) {
+	// Regression test: when a recipe fails with a RecipeError and the best-effort
+	// persistence of the failure status then also fails, the controller must surface
+	// the real recipe error to the caller, not the save error. Previously the save
+	// error (e.g. a spurious ErrConcurrency from the Postgres backend) masked the
+	// actionable recipe failure, so users saw "the operation failed due to a
+	// concurrency conflict" instead of the underlying recipe error.
+	mctrl := gomock.NewController(t)
+	msc := database.NewMockClient(mctrl)
+	eng := engine.NewMockEngine(mctrl)
+	cfg := configloader.NewMockConfigurationLoader(mctrl)
+
+	// No updatedApiVersion => the sensitive-field detection path is skipped and no
+	// UCP client/schema is required.
+	data := map[string]any{
+		"name":     "tr",
+		"type":     TestResourceType,
+		"id":       TestResourceID,
+		"location": v1.LocationGlobal,
+		"properties": map[string]any{
+			"application":       TestApplicationID,
+			"environment":       TestEnvironmentID,
+			"provisioningState": "Accepted",
+			"status": map[string]any{
+				"outputResources": []map[string]any{},
+			},
+			"recipe": map[string]any{
+				"name": "test-recipe",
+			},
+		},
+	}
+
+	msc.EXPECT().
+		Get(gomock.Any(), TestResourceID).
+		Return(&database.Object{Metadata: database.Metadata{ID: TestResourceID, ETag: "etag-1"}, Data: data}, nil).
+		Times(1)
+
+	configuration := &recipes.Configuration{
+		Runtime: recipes.RuntimeConfiguration{
+			Kubernetes: &recipes.KubernetesRuntime{
+				Namespace:            "test-namespace",
+				EnvironmentNamespace: "test-env-namespace",
+			},
+		},
+	}
+	cfg.EXPECT().LoadConfiguration(gomock.Any(), gomock.Any()).Return(configuration, nil).Times(1)
+
+	recipeErr := &recipes.RecipeError{
+		ErrorDetails: v1.ErrorDetails{
+			Code:    "RecipeDeploymentFailed",
+			Message: `terraform apply failure: secrets "dbsecret" already exists`,
+		},
+	}
+	eng.EXPECT().Execute(gomock.Any(), gomock.Any()).Return(&recipes.RecipeOutput{}, recipeErr).Times(1)
+
+	// The best-effort status-persistence save fails with a conflict; this must NOT
+	// mask the recipe error.
+	msc.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any()).Return(&database.ErrConcurrency{}).Times(1)
+
+	opts := ctrl.Options{DatabaseClient: msc}
+	recipeCfg := &controllerconfig.RecipeControllerConfig{Engine: eng, ConfigLoader: cfg}
+
+	ctrlr, err := NewCreateOrUpdateResource(opts, successProcessorReference, recipeCfg.Engine, recipeCfg.ConfigLoader)
+	require.NoError(t, err)
+
+	res, err := ctrlr.Run(context.Background(), &ctrl.Request{
+		OperationID:      uuid.New(),
+		OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT",
+		ResourceID:       TestResourceID,
+		CorrelationID:    uuid.NewString(),
+		OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
+	})
+
+	// The operation is terminal (no returned error to trigger a requeue), and the
+	// surfaced error must be the recipe error, not the save conflict.
+	require.NoError(t, err)
+	require.Equal(t, v1.ProvisioningStateFailed, res.ProvisioningState())
+	require.False(t, res.Requeue)
+	require.NotNil(t, res.Error)
+	require.Equal(t, recipeErr.ErrorDetails.Code, res.Error.Code)
+	require.Equal(t, recipeErr.ErrorDetails.Message, res.Error.Message)
+}
+
 func TestCreateOrUpdateResource_Run_SensitiveRedaction(t *testing.T) {
 	mctrl := gomock.NewController(t)
 	msc := database.NewMockClient(mctrl)


### PR DESCRIPTION
# Description

When a recipe fails with a `RecipeError`, `handleRecipeError` in [`createorupdateresource.go`](https://github.com/radius-project/radius/blob/main/pkg/portableresources/backend/controller/createorupdateresource.go) persists the failure status as best-effort bookkeeping. Previously, if that persistence save itself failed, the controller returned the **save** error instead of the real **recipe** error.

On the Postgres backend the sensitive-resource redaction double-save could produce a spurious `ErrConcurrency` at exactly that persistence step, so a deploy that actually failed with an actionable recipe error — for example `secrets "dbsecret" already exists` — surfaced to the user as `the operation failed due to a concurrency conflict`, hiding the real cause.

This was observed deploying a `Radius.Security/secrets` resource: the Terraform recipe genuinely failed (leftover Kubernetes secret in the target namespace), but the user only saw a concurrency conflict.

## Fix

A `RecipeError` is terminal either way, so always return the recipe's error details and log the persistence failure rather than overwriting the real cause with the save error.

## Tests

Adds `TestCreateOrUpdateResource_Run_RecipeErrorSurfacedWhenStatusSaveFails`, which drives a `RecipeError` through the engine with a failing status-persistence save and asserts the surfaced error is the recipe error (not the save conflict), that the result is terminal, and that it is not requeued. The test fails against the previous behavior (with the exact `the operation failed due to a concurrency conflict` symptom) and passes with this change.

## Relationship to #12312

The underlying Postgres ETag bug that made the persistence save fail in the first place is fixed separately in #12312 (refresh the stored ETag on Postgres updates). That fix removes the spurious `ErrConcurrency`; this PR is the complementary hardening so that **any** failure of the best-effort status save can never again mask the real recipe error. The two are independent and can merge in either order.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

## Contributor checklist

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/`, if new APIs are being introduced.
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected.
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected.
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes affect documentation or user-facing behavior.
    - [x] Not applicable
