### PR TITLE
schema for icons

### DIFF
--- a/bicep-tools/pkg/converter/baseresource_test.go
+++ b/bicep-tools/pkg/converter/baseresource_test.go
@@ -18,7 +18,7 @@ func TestBaseResource_DecodedFromCanonicalYAML(t *testing.T) {
 		t.Fatalf("loadBaseResource: %v", err)
 	}
 
-	for _, name := range []string{"application", "environment", "connections", "codeReference"} {
+	for _, name := range []string{"application", "environment", "connections", "codeReference", "icon"} {
 		if _, ok := base.properties[name]; !ok {
 			t.Errorf("expected base property %q to be decoded from base.yaml", name)
 		}
@@ -59,7 +59,7 @@ func TestApplyBaseResource_MergesIntoBareSchema(t *testing.T) {
 
 	base.apply(schema)
 
-	for _, name := range []string{"size", "application", "environment", "connections", "codeReference"} {
+	for _, name := range []string{"size", "application", "environment", "connections", "codeReference", "icon"} {
 		if _, ok := schema.Properties[name]; !ok {
 			t.Errorf("expected property %q to be present after merge", name)
 		}
@@ -129,7 +129,7 @@ func TestApplyBaseResource_EmptySchema(t *testing.T) {
 
 	base.apply(schema)
 
-	expected := []string{"application", "environment", "connections", "codeReference"}
+	expected := []string{"application", "environment", "connections", "codeReference", "icon"}
 	if len(schema.Properties) != len(expected) {
 		t.Errorf("expected exactly %d merged base properties, got %d (%v)", len(expected), len(schema.Properties), schema.Properties)
 	}

--- a/bicep-tools/pkg/converter/converter_test.go
+++ b/bicep-tools/pkg/converter/converter_test.go
@@ -848,7 +848,7 @@ func TestConvert_MultipleTypesAndAPIVersions(t *testing.T) {
 			t.Errorf("expected generated properties type %q in TypesContent; have=%v", name, keys(propertiesObjectsByName))
 			continue
 		}
-		for _, base := range []string{"application", "environment", "connections", "codeReference"} {
+		for _, base := range []string{"application", "environment", "connections", "codeReference", "icon"} {
 			if _, ok := props[base]; !ok {
 				t.Errorf("%s missing merged base property %q; have=%v", name, base, keys(props))
 			}

--- a/hack/bicep-types-radius/generated/index.json
+++ b/hack/bicep-types-radius/generated/index.json
@@ -46,13 +46,13 @@
       "$ref": "applications/applications.messaging/2023-10-01-preview/types.json#/69"
     },
     "Radius.Compute/containers@2025-08-01-preview": {
-      "$ref": "radius/radius.compute/2025-08-01-preview/types.json#/126"
+      "$ref": "radius/radius.compute/2025-08-01-preview/types.json#/129"
     },
     "Radius.Compute/persistentVolumes@2025-08-01-preview": {
-      "$ref": "radius/radius.compute/2025-08-01-preview/types.json#/145"
+      "$ref": "radius/radius.compute/2025-08-01-preview/types.json#/151"
     },
     "Radius.Compute/routes@2025-08-01-preview": {
-      "$ref": "radius/radius.compute/2025-08-01-preview/types.json#/202"
+      "$ref": "radius/radius.compute/2025-08-01-preview/types.json#/211"
     },
     "Radius.Core/applications@2025-08-01-preview": {
       "$ref": "radius/radius.core/2025-08-01-preview/types.json#/66"
@@ -70,10 +70,10 @@
       "$ref": "radius/radius.core/2025-08-01-preview/types.json#/205"
     },
     "Radius.Data/mySqlDatabases@2025-08-01-preview": {
-      "$ref": "radius/radius.data/2025-08-01-preview/types.json#/22"
+      "$ref": "radius/radius.data/2025-08-01-preview/types.json#/25"
     },
     "Radius.Security/secrets@2025-08-01-preview": {
-      "$ref": "radius/radius.security/2025-08-01-preview/types.json#/27"
+      "$ref": "radius/radius.security/2025-08-01-preview/types.json#/30"
     }
   },
   "resourceFunctions": {},

--- a/hack/bicep-types-radius/generated/radius/radius.compute/2025-08-01-preview/index.json
+++ b/hack/bicep-types-radius/generated/radius/radius.compute/2025-08-01-preview/index.json
@@ -1,13 +1,13 @@
 {
   "resources": {
     "Radius.Compute/containers@2025-08-01-preview": {
-      "$ref": "types.json#/126"
+      "$ref": "types.json#/129"
     },
     "Radius.Compute/persistentVolumes@2025-08-01-preview": {
-      "$ref": "types.json#/145"
+      "$ref": "types.json#/151"
     },
     "Radius.Compute/routes@2025-08-01-preview": {
-      "$ref": "types.json#/202"
+      "$ref": "types.json#/211"
     }
   },
   "resourceFunctions": {},

--- a/hack/bicep-types-radius/generated/radius/radius.compute/2025-08-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/radius/radius.compute/2025-08-01-preview/types.json
@@ -962,12 +962,38 @@
     }
   },
   {
+    "$type": "StringType"
+  },
+  {
+    "$type": "StringType"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "icon",
+    "properties": {
+      "bytes": {
+        "description": "Verbatim SVG file content as a UTF-8 string. Populated by `rad resource-type create --icon \u003cpath\u003e`; never edited in the source YAML.",
+        "flags": 0,
+        "type": {
+          "$ref": "#/99"
+        }
+      },
+      "hash": {
+        "description": "Server-computed SHA-256 of `icon.bytes`. Content-addresses the icon for graph responses.",
+        "flags": 0,
+        "type": {
+          "$ref": "#/100"
+        }
+      }
+    }
+  },
+  {
     "$type": "AnyType"
   },
   {
     "$type": "ObjectType",
     "additionalProperties": {
-      "$ref": "#/99"
+      "$ref": "#/102"
     },
     "name": "platformOptions",
     "properties": {}
@@ -991,13 +1017,13 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/102"
+        "$ref": "#/105"
       },
       {
-        "$ref": "#/103"
+        "$ref": "#/106"
       },
       {
-        "$ref": "#/104"
+        "$ref": "#/107"
       }
     ]
   },
@@ -1013,10 +1039,10 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/106"
+        "$ref": "#/109"
       },
       {
-        "$ref": "#/107"
+        "$ref": "#/110"
       }
     ]
   },
@@ -1028,7 +1054,7 @@
         "description": "(Optional) Set to `memory` for a tmpfs (RAM backed filesystem). Note that while tmpfs is very fast storage counts against the memory limit of the container.",
         "flags": 0,
         "type": {
-          "$ref": "#/108"
+          "$ref": "#/111"
         }
       }
     }
@@ -1049,13 +1075,13 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/110"
+        "$ref": "#/113"
       },
       {
-        "$ref": "#/111"
+        "$ref": "#/114"
       },
       {
-        "$ref": "#/112"
+        "$ref": "#/115"
       }
     ]
   },
@@ -1070,14 +1096,14 @@
         "description": "(Optional) Set to `ReadWriteOnce` if no other Containers can mount in read/write mode. Set to `ReadOnlyMany` to enable other Containers to mount in read-only mode. Set to `ReadWriteMany` to allow multiple containers to mount in read/write mode. Assumed to be `ReadWriteOnce` if not specified.",
         "flags": 0,
         "type": {
-          "$ref": "#/113"
+          "$ref": "#/116"
         }
       },
       "resourceId": {
         "description": "(Required) The Radius PersistentVolume resource ID.",
         "flags": 0,
         "type": {
-          "$ref": "#/114"
+          "$ref": "#/117"
         }
       }
     }
@@ -1093,21 +1119,21 @@
         "description": "(Optional) An empty directory.",
         "flags": 0,
         "type": {
-          "$ref": "#/109"
+          "$ref": "#/112"
         }
       },
       "persistentVolume": {
         "description": "(Optional) Mount an existing Radius PersistentVolume resource.",
         "flags": 0,
         "type": {
-          "$ref": "#/115"
+          "$ref": "#/118"
         }
       },
       "secretName": {
         "description": "(Optional) The Radius Secret resource name.",
         "flags": 0,
         "type": {
-          "$ref": "#/116"
+          "$ref": "#/119"
         }
       }
     }
@@ -1115,7 +1141,7 @@
   {
     "$type": "ObjectType",
     "additionalProperties": {
-      "$ref": "#/117"
+      "$ref": "#/120"
     },
     "name": "volumes",
     "properties": {}
@@ -1171,32 +1197,39 @@
           "$ref": "#/98"
         }
       },
+      "icon": {
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "flags": 2,
+        "type": {
+          "$ref": "#/101"
+        }
+      },
       "platformOptions": {
         "description": "(Optional) If enabled by the platform engineer, properties to be passed to the Recipe for the specified platform.",
         "flags": 0,
         "type": {
-          "$ref": "#/100"
+          "$ref": "#/103"
         }
       },
       "replicas": {
         "description": "(Optional) The minimum number of replicas for the set of containers.",
         "flags": 0,
         "type": {
-          "$ref": "#/101"
+          "$ref": "#/104"
         }
       },
       "restartPolicy": {
         "description": "(Optional) Defines how a containers behave when they terminate. `Always` will restart containers regardless of their exit status. `OnFailure` will restart containers if they return a non-zero exit code.",
         "flags": 0,
         "type": {
-          "$ref": "#/105"
+          "$ref": "#/108"
         }
       },
       "volumes": {
         "description": "(Optional) List of volumes that can be mounted by a container.",
         "flags": 0,
         "type": {
-          "$ref": "#/118"
+          "$ref": "#/121"
         }
       }
     }
@@ -1226,7 +1259,7 @@
         "description": "The API version.",
         "flags": 10,
         "type": {
-          "$ref": "#/122"
+          "$ref": "#/125"
         }
       },
       "application": {
@@ -1276,67 +1309,74 @@
           "$ref": "#/98"
         }
       },
+      "icon": {
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "flags": 2,
+        "type": {
+          "$ref": "#/101"
+        }
+      },
       "id": {
         "description": "The resource id.",
         "flags": 2,
         "type": {
-          "$ref": "#/124"
+          "$ref": "#/127"
         }
       },
       "location": {
         "description": "The resource location.",
         "flags": 0,
         "type": {
-          "$ref": "#/121"
+          "$ref": "#/124"
         }
       },
       "name": {
         "description": "The resource name.",
         "flags": 17,
         "type": {
-          "$ref": "#/120"
+          "$ref": "#/123"
         }
       },
       "platformOptions": {
         "description": "(Optional) If enabled by the platform engineer, properties to be passed to the Recipe for the specified platform.",
         "flags": 2,
         "type": {
-          "$ref": "#/100"
+          "$ref": "#/103"
         }
       },
       "properties": {
         "description": "The resource properties.",
         "flags": 1,
         "type": {
-          "$ref": "#/119"
+          "$ref": "#/122"
         }
       },
       "replicas": {
         "description": "(Optional) The minimum number of replicas for the set of containers.",
         "flags": 2,
         "type": {
-          "$ref": "#/101"
+          "$ref": "#/104"
         }
       },
       "restartPolicy": {
         "description": "(Optional) Defines how a containers behave when they terminate. `Always` will restart containers regardless of their exit status. `OnFailure` will restart containers if they return a non-zero exit code.",
         "flags": 2,
         "type": {
-          "$ref": "#/105"
+          "$ref": "#/108"
         }
       },
       "type": {
         "description": "The resource type.",
         "flags": 10,
         "type": {
-          "$ref": "#/123"
+          "$ref": "#/126"
         }
       },
       "volumes": {
         "description": "(Optional) List of volumes that can be mounted by a container.",
         "flags": 2,
         "type": {
-          "$ref": "#/118"
+          "$ref": "#/121"
         }
       }
     }
@@ -1344,7 +1384,7 @@
   {
     "$type": "ResourceType",
     "body": {
-      "$ref": "#/125"
+      "$ref": "#/128"
     },
     "name": "Radius.Compute/containers@2025-08-01-preview",
     "readableScopes": 0,
@@ -1366,13 +1406,13 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/127"
+        "$ref": "#/130"
       },
       {
-        "$ref": "#/128"
+        "$ref": "#/131"
       },
       {
-        "$ref": "#/129"
+        "$ref": "#/132"
       }
     ]
   },
@@ -1400,7 +1440,7 @@
         "description": "Resource ID of the source resource for this connection.",
         "flags": 1,
         "type": {
-          "$ref": "#/133"
+          "$ref": "#/136"
         }
       }
     }
@@ -1408,13 +1448,39 @@
   {
     "$type": "ObjectType",
     "additionalProperties": {
-      "$ref": "#/134"
+      "$ref": "#/137"
     },
     "name": "connections",
     "properties": {}
   },
   {
     "$type": "StringType"
+  },
+  {
+    "$type": "StringType"
+  },
+  {
+    "$type": "StringType"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "icon",
+    "properties": {
+      "bytes": {
+        "description": "Verbatim SVG file content as a UTF-8 string. Populated by `rad resource-type create --icon \u003cpath\u003e`; never edited in the source YAML.",
+        "flags": 0,
+        "type": {
+          "$ref": "#/140"
+        }
+      },
+      "hash": {
+        "description": "Server-computed SHA-256 of `icon.bytes`. Content-addresses the icon for graph responses.",
+        "flags": 0,
+        "type": {
+          "$ref": "#/141"
+        }
+      }
+    }
   },
   {
     "$type": "IntegerType"
@@ -1427,42 +1493,49 @@
         "description": "(Optional) The access modes which are permitted to be requested by a Container. Assumed to be all modes if not specified.",
         "flags": 0,
         "type": {
-          "$ref": "#/130"
+          "$ref": "#/133"
         }
       },
       "application": {
         "description": "(Optional) The Radius Application ID. `myApplication.id` for example.",
         "flags": 0,
         "type": {
-          "$ref": "#/131"
+          "$ref": "#/134"
         }
       },
       "codeReference": {
         "description": "Optional URI to the source code of this resource type. ex: https://github.com/radius-project/radius/blob/4fab87e8127adf1db6f43b7029d5235fbe82c5c9/cmd/controller/main.go#L27",
         "flags": 0,
         "type": {
-          "$ref": "#/132"
+          "$ref": "#/135"
         }
       },
       "connections": {
         "description": "Map of connection name to connection data.",
         "flags": 0,
         "type": {
-          "$ref": "#/135"
+          "$ref": "#/138"
         }
       },
       "environment": {
         "description": "(Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.",
         "flags": 1,
         "type": {
-          "$ref": "#/136"
+          "$ref": "#/139"
+        }
+      },
+      "icon": {
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "flags": 2,
+        "type": {
+          "$ref": "#/142"
         }
       },
       "sizeInGib": {
         "description": "(Required) The size of the volume in gibibytes. `1` represents 1024 MiB.",
         "flags": 1,
         "type": {
-          "$ref": "#/137"
+          "$ref": "#/143"
         }
       }
     }
@@ -1492,84 +1565,91 @@
         "description": "(Optional) The access modes which are permitted to be requested by a Container. Assumed to be all modes if not specified.",
         "flags": 2,
         "type": {
-          "$ref": "#/130"
+          "$ref": "#/133"
         }
       },
       "apiVersion": {
         "description": "The API version.",
         "flags": 10,
         "type": {
-          "$ref": "#/141"
+          "$ref": "#/147"
         }
       },
       "application": {
         "description": "(Optional) The Radius Application ID. `myApplication.id` for example.",
         "flags": 2,
         "type": {
-          "$ref": "#/131"
+          "$ref": "#/134"
         }
       },
       "codeReference": {
         "description": "Optional URI to the source code of this resource type. ex: https://github.com/radius-project/radius/blob/4fab87e8127adf1db6f43b7029d5235fbe82c5c9/cmd/controller/main.go#L27",
         "flags": 2,
         "type": {
-          "$ref": "#/132"
+          "$ref": "#/135"
         }
       },
       "connections": {
         "description": "Map of connection name to connection data.",
         "flags": 2,
         "type": {
-          "$ref": "#/135"
+          "$ref": "#/138"
         }
       },
       "environment": {
         "description": "(Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.",
         "flags": 2,
         "type": {
-          "$ref": "#/136"
+          "$ref": "#/139"
+        }
+      },
+      "icon": {
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "flags": 2,
+        "type": {
+          "$ref": "#/142"
         }
       },
       "id": {
         "description": "The resource id.",
         "flags": 2,
         "type": {
-          "$ref": "#/143"
+          "$ref": "#/149"
         }
       },
       "location": {
         "description": "The resource location.",
         "flags": 0,
         "type": {
-          "$ref": "#/140"
+          "$ref": "#/146"
         }
       },
       "name": {
         "description": "The resource name.",
         "flags": 17,
         "type": {
-          "$ref": "#/139"
+          "$ref": "#/145"
         }
       },
       "properties": {
         "description": "The resource properties.",
         "flags": 1,
         "type": {
-          "$ref": "#/138"
+          "$ref": "#/144"
         }
       },
       "sizeInGib": {
         "description": "(Required) The size of the volume in gibibytes. `1` represents 1024 MiB.",
         "flags": 2,
         "type": {
-          "$ref": "#/137"
+          "$ref": "#/143"
         }
       },
       "type": {
         "description": "The resource type.",
         "flags": 10,
         "type": {
-          "$ref": "#/142"
+          "$ref": "#/148"
         }
       }
     }
@@ -1577,7 +1657,7 @@
   {
     "$type": "ResourceType",
     "body": {
-      "$ref": "#/144"
+      "$ref": "#/150"
     },
     "name": "Radius.Compute/persistentVolumes@2025-08-01-preview",
     "readableScopes": 0,
@@ -1607,7 +1687,7 @@
         "description": "Resource ID of the source resource for this connection.",
         "flags": 1,
         "type": {
-          "$ref": "#/148"
+          "$ref": "#/154"
         }
       }
     }
@@ -1615,7 +1695,7 @@
   {
     "$type": "ObjectType",
     "additionalProperties": {
-      "$ref": "#/149"
+      "$ref": "#/155"
     },
     "name": "connections",
     "properties": {}
@@ -1629,7 +1709,33 @@
   {
     "$type": "ArrayType",
     "itemType": {
-      "$ref": "#/152"
+      "$ref": "#/158"
+    }
+  },
+  {
+    "$type": "StringType"
+  },
+  {
+    "$type": "StringType"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "icon",
+    "properties": {
+      "bytes": {
+        "description": "Verbatim SVG file content as a UTF-8 string. Populated by `rad resource-type create --icon \u003cpath\u003e`; never edited in the source YAML.",
+        "flags": 0,
+        "type": {
+          "$ref": "#/160"
+        }
+      },
+      "hash": {
+        "description": "Server-computed SHA-256 of `icon.bytes`. Content-addresses the icon for graph responses.",
+        "flags": 0,
+        "type": {
+          "$ref": "#/161"
+        }
+      }
     }
   },
   {
@@ -1652,16 +1758,16 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/154"
+        "$ref": "#/163"
       },
       {
-        "$ref": "#/155"
+        "$ref": "#/164"
       },
       {
-        "$ref": "#/156"
+        "$ref": "#/165"
       },
       {
-        "$ref": "#/157"
+        "$ref": "#/166"
       }
     ]
   },
@@ -1695,19 +1801,19 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/161"
+        "$ref": "#/170"
       },
       {
-        "$ref": "#/162"
+        "$ref": "#/171"
       },
       {
-        "$ref": "#/163"
+        "$ref": "#/172"
       },
       {
-        "$ref": "#/164"
+        "$ref": "#/173"
       },
       {
-        "$ref": "#/165"
+        "$ref": "#/174"
       }
     ]
   },
@@ -1718,19 +1824,19 @@
       "hostname": {
         "flags": 0,
         "type": {
-          "$ref": "#/159"
+          "$ref": "#/168"
         }
       },
       "port": {
         "flags": 0,
         "type": {
-          "$ref": "#/160"
+          "$ref": "#/169"
         }
       },
       "protocol": {
         "flags": 0,
         "type": {
-          "$ref": "#/166"
+          "$ref": "#/175"
         }
       }
     }
@@ -1752,21 +1858,21 @@
         "description": "(Required) The specific container to target within the Container resource.",
         "flags": 1,
         "type": {
-          "$ref": "#/168"
+          "$ref": "#/177"
         }
       },
       "containerPort": {
         "description": "(Required) The port to target from the container.",
         "flags": 1,
         "type": {
-          "$ref": "#/169"
+          "$ref": "#/178"
         }
       },
       "resourceId": {
         "description": "(Required) The Radius Container resource ID.",
         "flags": 1,
         "type": {
-          "$ref": "#/170"
+          "$ref": "#/179"
         }
       }
     }
@@ -1785,14 +1891,14 @@
         "description": "(Required) The name of the HTTP Header to be matched. Must be exact.",
         "flags": 1,
         "type": {
-          "$ref": "#/172"
+          "$ref": "#/181"
         }
       },
       "value": {
         "description": "(Required) Value of HTTP Header to be matched.",
         "flags": 1,
         "type": {
-          "$ref": "#/173"
+          "$ref": "#/182"
         }
       }
     }
@@ -1800,7 +1906,7 @@
   {
     "$type": "ArrayType",
     "itemType": {
-      "$ref": "#/174"
+      "$ref": "#/183"
     }
   },
   {
@@ -1843,31 +1949,31 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/176"
+        "$ref": "#/185"
       },
       {
-        "$ref": "#/177"
+        "$ref": "#/186"
       },
       {
-        "$ref": "#/178"
+        "$ref": "#/187"
       },
       {
-        "$ref": "#/179"
+        "$ref": "#/188"
       },
       {
-        "$ref": "#/180"
+        "$ref": "#/189"
       },
       {
-        "$ref": "#/181"
+        "$ref": "#/190"
       },
       {
-        "$ref": "#/182"
+        "$ref": "#/191"
       },
       {
-        "$ref": "#/183"
+        "$ref": "#/192"
       },
       {
-        "$ref": "#/184"
+        "$ref": "#/193"
       }
     ]
   },
@@ -1888,14 +1994,14 @@
         "description": "(Required) Name of the HTTP query parameter to be matched. Specify only when kind is HTTP.",
         "flags": 1,
         "type": {
-          "$ref": "#/187"
+          "$ref": "#/196"
         }
       },
       "value": {
         "description": "(Required) Value of the HTTP query parameter to be matched.",
         "flags": 1,
         "type": {
-          "$ref": "#/188"
+          "$ref": "#/197"
         }
       }
     }
@@ -1903,7 +2009,7 @@
   {
     "$type": "ArrayType",
     "itemType": {
-      "$ref": "#/189"
+      "$ref": "#/198"
     }
   },
   {
@@ -1914,28 +2020,28 @@
         "description": "(Optional) HTTP headers to match. Specify only when kind is HTTP. Multiple match values are ANDed together. A request must match all the specified headers to match.",
         "flags": 0,
         "type": {
-          "$ref": "#/175"
+          "$ref": "#/184"
         }
       },
       "httpMethod": {
         "description": "(Optional) The HTTP method to match. Specify only when kind is HTTP.",
         "flags": 0,
         "type": {
-          "$ref": "#/185"
+          "$ref": "#/194"
         }
       },
       "httpPath": {
         "description": "(Optional) The HTTP request path to match. Trailing space is ignored. Requests for `/abc`, `/abc/`, and ``/abc/def/` will all match `/abc`.",
         "flags": 0,
         "type": {
-          "$ref": "#/186"
+          "$ref": "#/195"
         }
       },
       "httpQueryParams": {
         "description": "(Optional) HTTP query parameters to match. Specify only when kind is HTTP.",
         "flags": 0,
         "type": {
-          "$ref": "#/190"
+          "$ref": "#/199"
         }
       }
     }
@@ -1943,7 +2049,7 @@
   {
     "$type": "ArrayType",
     "itemType": {
-      "$ref": "#/191"
+      "$ref": "#/200"
     }
   },
   {
@@ -1953,14 +2059,14 @@
       "destinationContainer": {
         "flags": 1,
         "type": {
-          "$ref": "#/171"
+          "$ref": "#/180"
         }
       },
       "matches": {
         "description": "(Required) Matches define conditions used for matching a request.",
         "flags": 1,
         "type": {
-          "$ref": "#/192"
+          "$ref": "#/201"
         }
       }
     }
@@ -1968,7 +2074,7 @@
   {
     "$type": "ArrayType",
     "itemType": {
-      "$ref": "#/193"
+      "$ref": "#/202"
     }
   },
   {
@@ -1979,56 +2085,63 @@
         "description": "(Required) The Radius Application ID. `myApplication.id` for example.",
         "flags": 1,
         "type": {
-          "$ref": "#/146"
+          "$ref": "#/152"
         }
       },
       "codeReference": {
         "description": "Optional URI to the source code of this resource type. ex: https://github.com/radius-project/radius/blob/4fab87e8127adf1db6f43b7029d5235fbe82c5c9/cmd/controller/main.go#L27",
         "flags": 0,
         "type": {
-          "$ref": "#/147"
+          "$ref": "#/153"
         }
       },
       "connections": {
         "description": "Map of connection name to connection data.",
         "flags": 0,
         "type": {
-          "$ref": "#/150"
+          "$ref": "#/156"
         }
       },
       "environment": {
         "description": "(Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.",
         "flags": 1,
         "type": {
-          "$ref": "#/151"
+          "$ref": "#/157"
         }
       },
       "hostnames": {
         "description": "(Optional) Use only when kind is HTTP or TLS. When HTTP, match against the HTTP Host header. When using TLS, match against the SNI attribute of TLS ClientHello message. Hostname may be preceded by a * wildcard.",
         "flags": 0,
         "type": {
-          "$ref": "#/153"
+          "$ref": "#/159"
+        }
+      },
+      "icon": {
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "flags": 2,
+        "type": {
+          "$ref": "#/162"
         }
       },
       "kind": {
         "description": "(Optional) The type of rule. If not specified, `HTTPRoute` is assumed. `HTTPRoute` provides L7 ingress with support for matching based on the hostname and HTTP header. `TCPRoute` provides L4 ingress with no support for matching (all traffic is forwarded to the Container). `TLSRoute` provides L4 ingress with the ability to match based on Server Name Indication (SNI) which is equivalent to hostname in TLS. `UDPRoute` is similar to TCPRoutes but uses UDP.",
         "flags": 0,
         "type": {
-          "$ref": "#/158"
+          "$ref": "#/167"
         }
       },
       "listener": {
         "description": "(Read Only) The Gateway Listener the route is assigned to.",
         "flags": 2,
         "type": {
-          "$ref": "#/167"
+          "$ref": "#/176"
         }
       },
       "rules": {
         "description": "(Required) Rules define semantics for matching a network connection request based on conditions and forwarding the request to a Container.",
         "flags": 1,
         "type": {
-          "$ref": "#/194"
+          "$ref": "#/203"
         }
       }
     }
@@ -2058,98 +2171,105 @@
         "description": "The API version.",
         "flags": 10,
         "type": {
-          "$ref": "#/198"
+          "$ref": "#/207"
         }
       },
       "application": {
         "description": "(Required) The Radius Application ID. `myApplication.id` for example.",
         "flags": 2,
         "type": {
-          "$ref": "#/146"
+          "$ref": "#/152"
         }
       },
       "codeReference": {
         "description": "Optional URI to the source code of this resource type. ex: https://github.com/radius-project/radius/blob/4fab87e8127adf1db6f43b7029d5235fbe82c5c9/cmd/controller/main.go#L27",
         "flags": 2,
         "type": {
-          "$ref": "#/147"
+          "$ref": "#/153"
         }
       },
       "connections": {
         "description": "Map of connection name to connection data.",
         "flags": 2,
         "type": {
-          "$ref": "#/150"
+          "$ref": "#/156"
         }
       },
       "environment": {
         "description": "(Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.",
         "flags": 2,
         "type": {
-          "$ref": "#/151"
+          "$ref": "#/157"
         }
       },
       "hostnames": {
         "description": "(Optional) Use only when kind is HTTP or TLS. When HTTP, match against the HTTP Host header. When using TLS, match against the SNI attribute of TLS ClientHello message. Hostname may be preceded by a * wildcard.",
         "flags": 2,
         "type": {
-          "$ref": "#/153"
+          "$ref": "#/159"
+        }
+      },
+      "icon": {
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "flags": 2,
+        "type": {
+          "$ref": "#/162"
         }
       },
       "id": {
         "description": "The resource id.",
         "flags": 2,
         "type": {
-          "$ref": "#/200"
+          "$ref": "#/209"
         }
       },
       "kind": {
         "description": "(Optional) The type of rule. If not specified, `HTTPRoute` is assumed. `HTTPRoute` provides L7 ingress with support for matching based on the hostname and HTTP header. `TCPRoute` provides L4 ingress with no support for matching (all traffic is forwarded to the Container). `TLSRoute` provides L4 ingress with the ability to match based on Server Name Indication (SNI) which is equivalent to hostname in TLS. `UDPRoute` is similar to TCPRoutes but uses UDP.",
         "flags": 2,
         "type": {
-          "$ref": "#/158"
+          "$ref": "#/167"
         }
       },
       "listener": {
         "description": "(Read Only) The Gateway Listener the route is assigned to.",
         "flags": 2,
         "type": {
-          "$ref": "#/167"
+          "$ref": "#/176"
         }
       },
       "location": {
         "description": "The resource location.",
         "flags": 0,
         "type": {
-          "$ref": "#/197"
+          "$ref": "#/206"
         }
       },
       "name": {
         "description": "The resource name.",
         "flags": 17,
         "type": {
-          "$ref": "#/196"
+          "$ref": "#/205"
         }
       },
       "properties": {
         "description": "The resource properties.",
         "flags": 1,
         "type": {
-          "$ref": "#/195"
+          "$ref": "#/204"
         }
       },
       "rules": {
         "description": "(Required) Rules define semantics for matching a network connection request based on conditions and forwarding the request to a Container.",
         "flags": 2,
         "type": {
-          "$ref": "#/194"
+          "$ref": "#/203"
         }
       },
       "type": {
         "description": "The resource type.",
         "flags": 10,
         "type": {
-          "$ref": "#/199"
+          "$ref": "#/208"
         }
       }
     }
@@ -2157,7 +2277,7 @@
   {
     "$type": "ResourceType",
     "body": {
-      "$ref": "#/201"
+      "$ref": "#/210"
     },
     "name": "Radius.Compute/routes@2025-08-01-preview",
     "readableScopes": 0,

--- a/hack/bicep-types-radius/generated/radius/radius.compute/2025-08-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/radius/radius.compute/2025-08-01-preview/types.json
@@ -972,7 +972,7 @@
     "name": "icon",
     "properties": {
       "bytes": {
-        "description": "Verbatim SVG file content as a UTF-8 string. Populated by `rad resource-type create --icon \u003cpath\u003e`; never edited in the source YAML.",
+        "description": "Verbatim SVG file content as a UTF-8 string. Populated at resource-type registration time; never edited in the source YAML.",
         "flags": 0,
         "type": {
           "$ref": "#/99"
@@ -1198,7 +1198,7 @@
         }
       },
       "icon": {
-        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
         "flags": 2,
         "type": {
           "$ref": "#/101"
@@ -1310,7 +1310,7 @@
         }
       },
       "icon": {
-        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
         "flags": 2,
         "type": {
           "$ref": "#/101"
@@ -1467,7 +1467,7 @@
     "name": "icon",
     "properties": {
       "bytes": {
-        "description": "Verbatim SVG file content as a UTF-8 string. Populated by `rad resource-type create --icon \u003cpath\u003e`; never edited in the source YAML.",
+        "description": "Verbatim SVG file content as a UTF-8 string. Populated at resource-type registration time; never edited in the source YAML.",
         "flags": 0,
         "type": {
           "$ref": "#/140"
@@ -1525,7 +1525,7 @@
         }
       },
       "icon": {
-        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
         "flags": 2,
         "type": {
           "$ref": "#/142"
@@ -1604,7 +1604,7 @@
         }
       },
       "icon": {
-        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
         "flags": 2,
         "type": {
           "$ref": "#/142"
@@ -1723,7 +1723,7 @@
     "name": "icon",
     "properties": {
       "bytes": {
-        "description": "Verbatim SVG file content as a UTF-8 string. Populated by `rad resource-type create --icon \u003cpath\u003e`; never edited in the source YAML.",
+        "description": "Verbatim SVG file content as a UTF-8 string. Populated at resource-type registration time; never edited in the source YAML.",
         "flags": 0,
         "type": {
           "$ref": "#/160"
@@ -2117,7 +2117,7 @@
         }
       },
       "icon": {
-        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
         "flags": 2,
         "type": {
           "$ref": "#/162"
@@ -2210,7 +2210,7 @@
         }
       },
       "icon": {
-        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
         "flags": 2,
         "type": {
           "$ref": "#/162"

--- a/hack/bicep-types-radius/generated/radius/radius.data/2025-08-01-preview/index.json
+++ b/hack/bicep-types-radius/generated/radius/radius.data/2025-08-01-preview/index.json
@@ -1,7 +1,7 @@
 {
   "resources": {
     "Radius.Data/mySqlDatabases@2025-08-01-preview": {
-      "$ref": "types.json#/22"
+      "$ref": "types.json#/25"
     }
   },
   "resourceFunctions": {},

--- a/hack/bicep-types-radius/generated/radius/radius.data/2025-08-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/radius/radius.data/2025-08-01-preview/types.json
@@ -59,7 +59,7 @@
     "name": "icon",
     "properties": {
       "bytes": {
-        "description": "Verbatim SVG file content as a UTF-8 string. Populated by `rad resource-type create --icon \u003cpath\u003e`; never edited in the source YAML.",
+        "description": "Verbatim SVG file content as a UTF-8 string. Populated at resource-type registration time; never edited in the source YAML.",
         "flags": 0,
         "type": {
           "$ref": "#/9"
@@ -153,7 +153,7 @@
         }
       },
       "icon": {
-        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
         "flags": 2,
         "type": {
           "$ref": "#/11"
@@ -253,7 +253,7 @@
         }
       },
       "icon": {
-        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
         "flags": 2,
         "type": {
           "$ref": "#/11"

--- a/hack/bicep-types-radius/generated/radius/radius.data/2025-08-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/radius/radius.data/2025-08-01-preview/types.json
@@ -49,6 +49,32 @@
     "$type": "StringType"
   },
   {
+    "$type": "StringType"
+  },
+  {
+    "$type": "StringType"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "icon",
+    "properties": {
+      "bytes": {
+        "description": "Verbatim SVG file content as a UTF-8 string. Populated by `rad resource-type create --icon \u003cpath\u003e`; never edited in the source YAML.",
+        "flags": 0,
+        "type": {
+          "$ref": "#/9"
+        }
+      },
+      "hash": {
+        "description": "Server-computed SHA-256 of `icon.bytes`. Content-addresses the icon for graph responses.",
+        "flags": 0,
+        "type": {
+          "$ref": "#/10"
+        }
+      }
+    }
+  },
+  {
     "$type": "IntegerType"
   },
   {
@@ -70,13 +96,13 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/11"
+        "$ref": "#/14"
       },
       {
-        "$ref": "#/12"
+        "$ref": "#/15"
       },
       {
-        "$ref": "#/13"
+        "$ref": "#/16"
       }
     ]
   },
@@ -126,25 +152,32 @@
           "$ref": "#/8"
         }
       },
+      "icon": {
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "flags": 2,
+        "type": {
+          "$ref": "#/11"
+        }
+      },
       "port": {
         "description": "(Read-only) The port number used to connect to the database.",
         "flags": 2,
         "type": {
-          "$ref": "#/9"
+          "$ref": "#/12"
         }
       },
       "secretName": {
         "description": "(Required) The name of the secret containing the database credentials.",
         "flags": 1,
         "type": {
-          "$ref": "#/10"
+          "$ref": "#/13"
         }
       },
       "version": {
         "description": "(Optional) The major MySQL server version in the X.Y format. Assumed to be 8.4 if not specified.",
         "flags": 0,
         "type": {
-          "$ref": "#/14"
+          "$ref": "#/17"
         }
       }
     }
@@ -174,7 +207,7 @@
         "description": "The API version.",
         "flags": 10,
         "type": {
-          "$ref": "#/18"
+          "$ref": "#/21"
         }
       },
       "application": {
@@ -219,60 +252,67 @@
           "$ref": "#/8"
         }
       },
+      "icon": {
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "flags": 2,
+        "type": {
+          "$ref": "#/11"
+        }
+      },
       "id": {
         "description": "The resource id.",
         "flags": 2,
         "type": {
-          "$ref": "#/20"
+          "$ref": "#/23"
         }
       },
       "location": {
         "description": "The resource location.",
         "flags": 0,
         "type": {
-          "$ref": "#/17"
+          "$ref": "#/20"
         }
       },
       "name": {
         "description": "The resource name.",
         "flags": 17,
         "type": {
-          "$ref": "#/16"
+          "$ref": "#/19"
         }
       },
       "port": {
         "description": "(Read-only) The port number used to connect to the database.",
         "flags": 2,
         "type": {
-          "$ref": "#/9"
+          "$ref": "#/12"
         }
       },
       "properties": {
         "description": "The resource properties.",
         "flags": 1,
         "type": {
-          "$ref": "#/15"
+          "$ref": "#/18"
         }
       },
       "secretName": {
         "description": "(Required) The name of the secret containing the database credentials.",
         "flags": 2,
         "type": {
-          "$ref": "#/10"
+          "$ref": "#/13"
         }
       },
       "type": {
         "description": "The resource type.",
         "flags": 10,
         "type": {
-          "$ref": "#/19"
+          "$ref": "#/22"
         }
       },
       "version": {
         "description": "(Optional) The major MySQL server version in the X.Y format. Assumed to be 8.4 if not specified.",
         "flags": 2,
         "type": {
-          "$ref": "#/14"
+          "$ref": "#/17"
         }
       }
     }
@@ -280,7 +320,7 @@
   {
     "$type": "ResourceType",
     "body": {
-      "$ref": "#/21"
+      "$ref": "#/24"
     },
     "name": "Radius.Data/mySqlDatabases@2025-08-01-preview",
     "readableScopes": 0,

--- a/hack/bicep-types-radius/generated/radius/radius.security/2025-08-01-preview/index.json
+++ b/hack/bicep-types-radius/generated/radius/radius.security/2025-08-01-preview/index.json
@@ -1,7 +1,7 @@
 {
   "resources": {
     "Radius.Security/secrets@2025-08-01-preview": {
-      "$ref": "types.json#/27"
+      "$ref": "types.json#/30"
     }
   },
   "resourceFunctions": {},

--- a/hack/bicep-types-radius/generated/radius/radius.security/2025-08-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/radius/radius.security/2025-08-01-preview/types.json
@@ -104,7 +104,7 @@
     "name": "icon",
     "properties": {
       "bytes": {
-        "description": "Verbatim SVG file content as a UTF-8 string. Populated by `rad resource-type create --icon \u003cpath\u003e`; never edited in the source YAML.",
+        "description": "Verbatim SVG file content as a UTF-8 string. Populated at resource-type registration time; never edited in the source YAML.",
         "flags": 0,
         "type": {
           "$ref": "#/13"
@@ -206,7 +206,7 @@
         }
       },
       "icon": {
-        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
         "flags": 2,
         "type": {
           "$ref": "#/15"
@@ -285,7 +285,7 @@
         }
       },
       "icon": {
-        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
         "flags": 2,
         "type": {
           "$ref": "#/15"

--- a/hack/bicep-types-radius/generated/radius/radius.security/2025-08-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/radius/radius.security/2025-08-01-preview/types.json
@@ -94,6 +94,32 @@
     "$type": "StringType"
   },
   {
+    "$type": "StringType"
+  },
+  {
+    "$type": "StringType"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "icon",
+    "properties": {
+      "bytes": {
+        "description": "Verbatim SVG file content as a UTF-8 string. Populated by `rad resource-type create --icon \u003cpath\u003e`; never edited in the source YAML.",
+        "flags": 0,
+        "type": {
+          "$ref": "#/13"
+        }
+      },
+      "hash": {
+        "description": "Server-computed SHA-256 of `icon.bytes`. Content-addresses the icon for graph responses.",
+        "flags": 0,
+        "type": {
+          "$ref": "#/14"
+        }
+      }
+    }
+  },
+  {
     "$type": "StringLiteralType",
     "value": "generic"
   },
@@ -121,15 +147,6 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/13"
-      },
-      {
-        "$ref": "#/14"
-      },
-      {
-        "$ref": "#/15"
-      },
-      {
         "$ref": "#/16"
       },
       {
@@ -137,6 +154,15 @@
       },
       {
         "$ref": "#/18"
+      },
+      {
+        "$ref": "#/19"
+      },
+      {
+        "$ref": "#/20"
+      },
+      {
+        "$ref": "#/21"
       }
     ]
   },
@@ -179,11 +205,18 @@
           "$ref": "#/12"
         }
       },
+      "icon": {
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "flags": 2,
+        "type": {
+          "$ref": "#/15"
+        }
+      },
       "kind": {
         "description": "(Optional) The kind of content of the secret. If not specified, generic is assumed. basicAuthentication, awsIRSA, and azureWorkloadIdentity should only be used for configuring authentication to OCI registries for storing Bicep templates. This will change in the future.",
         "flags": 0,
         "type": {
-          "$ref": "#/19"
+          "$ref": "#/22"
         }
       }
     }
@@ -213,7 +246,7 @@
         "description": "The API version.",
         "flags": 10,
         "type": {
-          "$ref": "#/23"
+          "$ref": "#/26"
         }
       },
       "application": {
@@ -251,46 +284,53 @@
           "$ref": "#/12"
         }
       },
+      "icon": {
+        "description": "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon \u003cpath\u003e`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource.",
+        "flags": 2,
+        "type": {
+          "$ref": "#/15"
+        }
+      },
       "id": {
         "description": "The resource id.",
         "flags": 2,
         "type": {
-          "$ref": "#/25"
+          "$ref": "#/28"
         }
       },
       "kind": {
         "description": "(Optional) The kind of content of the secret. If not specified, generic is assumed. basicAuthentication, awsIRSA, and azureWorkloadIdentity should only be used for configuring authentication to OCI registries for storing Bicep templates. This will change in the future.",
         "flags": 2,
         "type": {
-          "$ref": "#/19"
+          "$ref": "#/22"
         }
       },
       "location": {
         "description": "The resource location.",
         "flags": 0,
         "type": {
-          "$ref": "#/22"
+          "$ref": "#/25"
         }
       },
       "name": {
         "description": "The resource name.",
         "flags": 17,
         "type": {
-          "$ref": "#/21"
+          "$ref": "#/24"
         }
       },
       "properties": {
         "description": "The resource properties.",
         "flags": 1,
         "type": {
-          "$ref": "#/20"
+          "$ref": "#/23"
         }
       },
       "type": {
         "description": "The resource type.",
         "flags": 10,
         "type": {
-          "$ref": "#/24"
+          "$ref": "#/27"
         }
       }
     }
@@ -298,7 +338,7 @@
   {
     "$type": "ResourceType",
     "body": {
-      "$ref": "#/26"
+      "$ref": "#/29"
     },
     "name": "Radius.Security/secrets@2025-08-01-preview",
     "readableScopes": 0,

--- a/pkg/cli/manifest/registermanifest_test.go
+++ b/pkg/cli/manifest/registermanifest_test.go
@@ -710,6 +710,7 @@ func TestValidateManifest_MergesBaseResourceManifest(t *testing.T) {
 	require.Contains(t, props, "environment")
 	require.Contains(t, props, "connections")
 	require.Contains(t, props, "codeReference")
+	require.Contains(t, props, "icon")
 	require.Contains(t, schemaMap["required"], "environment")
 }
 

--- a/pkg/cli/manifest/validation_test.go
+++ b/pkg/cli/manifest/validation_test.go
@@ -605,7 +605,7 @@ func TestApplyBaseResourceManifest(t *testing.T) {
 	t.Run("merges base properties when author declares no properties", func(t *testing.T) {
 		// Two equally valid empty-schema shapes: an object with no properties
 		// block, and a totally empty schema mapping. Both should end up with
-		// just the four merged base properties and environment required.
+		// the merged base properties and environment required.
 		cases := []struct {
 			name   string
 			schema map[string]any
@@ -613,6 +613,8 @@ func TestApplyBaseResourceManifest(t *testing.T) {
 			{"object with no properties block", map[string]any{"type": "object"}},
 			{"totally empty schema", map[string]any{}},
 		}
+
+		expectedBaseProperties := []string{"application", "environment", "connections", "codeReference", "icon"}
 
 		for _, c := range cases {
 			t.Run(c.name, func(t *testing.T) {
@@ -632,8 +634,8 @@ func TestApplyBaseResourceManifest(t *testing.T) {
 				schemaMap := provider.Types["emptyWidget"].APIVersions["2026-06-01-preview"].Schema.(map[string]any)
 				props, ok := schemaMap["properties"].(map[string]any)
 				require.True(t, ok, "expected properties block to be created during merge")
-				require.Len(t, props, 4, "expected exactly the four merged base properties, got %v", props)
-				for _, name := range []string{"application", "environment", "connections", "codeReference"} {
+				require.Len(t, props, len(expectedBaseProperties), "expected exactly the merged base properties, got %v", props)
+				for _, name := range expectedBaseProperties {
 					require.Contains(t, props, name)
 				}
 				require.Contains(t, schemaMap["required"], "environment")

--- a/pkg/resourceutil/utils.go
+++ b/pkg/resourceutil/utils.go
@@ -29,7 +29,7 @@ const (
 )
 
 // BasicProperties is a list of common properties that are expected to be present in all resources
-var BasicProperties = []string{"application", "environment", "status", "connections", "codeReference"}
+var BasicProperties = []string{"application", "environment", "status", "connections", "codeReference", "icon"}
 
 // marshalAndUnmarshalResource serializes a resource to JSON and then deserializes it into the target structure
 func marshalAndUnmarshalResource[P any, T any](resource P, target *T) error {

--- a/pkg/schema/baseresource/base.yaml
+++ b/pkg/schema/baseresource/base.yaml
@@ -29,5 +29,16 @@ properties:
   codeReference:
     type: string
     description: "Optional URI to the source code of this resource type. ex: https://github.com/radius-project/radius/blob/4fab87e8127adf1db6f43b7029d5235fbe82c5c9/cmd/controller/main.go#L27"
+  icon:
+    type: object
+    readOnly: true
+    description: "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon <path>`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource."
+    properties:
+      bytes:
+        type: string
+        description: "Verbatim SVG file content as a UTF-8 string. Populated by `rad resource-type create --icon <path>`; never edited in the source YAML."
+      hash:
+        type: string
+        description: "Server-computed SHA-256 of `icon.bytes`. Content-addresses the icon for graph responses."
 required:
   - environment

--- a/pkg/schema/baseresource/base.yaml
+++ b/pkg/schema/baseresource/base.yaml
@@ -32,11 +32,11 @@ properties:
   icon:
     type: object
     readOnly: true
-    description: "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time (`rad resource-type create --icon <path>`) and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource."
+    description: "Optional icon associated with the resource type, rendered by Radius graph views. Populated at resource-type registration time and by server-side hash computation; deployed resource instances never set it. Marked read-only so it never appears on the Bicep authoring surface for a resource."
     properties:
       bytes:
         type: string
-        description: "Verbatim SVG file content as a UTF-8 string. Populated by `rad resource-type create --icon <path>`; never edited in the source YAML."
+        description: "Verbatim SVG file content as a UTF-8 string. Populated at resource-type registration time; never edited in the source YAML."
       hash:
         type: string
         description: "Server-computed SHA-256 of `icon.bytes`. Content-addresses the icon for graph responses."

--- a/pkg/schema/baseresource/loader_test.go
+++ b/pkg/schema/baseresource/loader_test.go
@@ -159,9 +159,9 @@ func TestApply_InvalidRequired(t *testing.T) {
 
 func TestPropertyNames(t *testing.T) {
 	names := mustLoad(t).PropertyNames()
-	require.ElementsMatch(t, []string{"application", "environment", "connections", "codeReference"}, names)
+	require.ElementsMatch(t, []string{"application", "environment", "connections", "codeReference", "icon"}, names)
 	// Sorted for deterministic output.
-	require.Equal(t, []string{"application", "codeReference", "connections", "environment"}, names)
+	require.Equal(t, []string{"application", "codeReference", "connections", "environment", "icon"}, names)
 }
 
 func TestRequiredNames(t *testing.T) {
@@ -184,4 +184,32 @@ func TestConnectionsShapePreserved(t *testing.T) {
 	additionalProps, err := toStringMap(additional["properties"])
 	require.NoError(t, err)
 	require.Contains(t, additionalProps, "source")
+}
+
+// TestIconShapePreserved verifies that Apply merges the icon property as a
+// nested object with `bytes` and `hash` sub-properties, and that the whole
+// object is marked read-only so it never appears on the Bicep authoring
+// surface (see bicep-tools/pkg/converter/converter.go — readOnly maps to
+// TypePropertyFlagsReadOnly). icon is intentionally absent from the base
+// "required" list so the whole property is optional on every resource type.
+func TestIconShapePreserved(t *testing.T) {
+	b := mustLoad(t)
+	schema := map[string]any{"type": "object"}
+	require.NoError(t, b.Apply(schema))
+
+	props, err := schemaProperties(schema)
+	require.NoError(t, err)
+
+	icon, err := toStringMap(props["icon"])
+	require.NoError(t, err)
+	require.Equal(t, "object", icon["type"])
+	require.Equal(t, true, icon["readOnly"], "icon must be read-only so Bicep authoring surfaces exclude it")
+
+	iconProps, err := toStringMap(icon["properties"])
+	require.NoError(t, err)
+	require.Contains(t, iconProps, "bytes")
+	require.Contains(t, iconProps, "hash")
+
+	// icon itself is optional.
+	require.NotContains(t, b.RequiredNames(), "icon")
 }

--- a/pkg/schema/validator.go
+++ b/pkg/schema/validator.go
@@ -36,6 +36,7 @@ const (
 	reservedPropRecipe        = "recipe"
 	reservedPropConnections   = "connections"
 	reservedPropCodeReference = "codeReference"
+	reservedPropIcon          = "icon"
 )
 
 // Constants for annotation names
@@ -826,6 +827,17 @@ func (v *Validator) checkReservedProperties(schema *openapi3.Schema) error {
 						errors.Add(err)
 					}
 				}
+			}
+		}
+
+		// icon groups the SVG bytes and their server-computed hash under a single
+		// nested object. If an author redeclares it, enforce the object shape so
+		// the merged base definition (see pkg/schema/baseresource/base.yaml) stays
+		// consistent across all resource types.
+		if propName == reservedPropIcon {
+			if propRef.Value != nil && propRef.Value.Type != nil && !propRef.Value.Type.Is("object") {
+				err := NewConstraintError(propName, fmt.Sprintf("property '%s' must be an object", reservedPropIcon))
+				errors.Add(err)
 			}
 		}
 	}

--- a/pkg/schema/validator.go
+++ b/pkg/schema/validator.go
@@ -830,10 +830,6 @@ func (v *Validator) checkReservedProperties(schema *openapi3.Schema) error {
 			}
 		}
 
-		// icon groups the SVG bytes and their server-computed hash under a single
-		// nested object. If an author redeclares it, enforce the object shape so
-		// the merged base definition (see pkg/schema/baseresource/base.yaml) stays
-		// consistent across all resource types.
 		if propName == reservedPropIcon {
 			if propRef.Value != nil && propRef.Value.Type != nil && !propRef.Value.Type.Is("object") {
 				err := NewConstraintError(propName, fmt.Sprintf("property '%s' must be an object", reservedPropIcon))

--- a/pkg/schema/validator_test.go
+++ b/pkg/schema/validator_test.go
@@ -1664,6 +1664,54 @@ func TestValidator_checkReservedProperties(t *testing.T) {
 		require.Contains(t, validationErrors.Errors[0].Message, "property 'codeReference' must be a string")
 	})
 
+	t.Run("icon property must be an object", func(t *testing.T) {
+		// icon is a reserved base property (see pkg/schema/baseresource/base.yaml)
+		// with a nested {bytes, hash} shape. An author who redeclares it with a
+		// non-object type is rejected so the merged base definition stays
+		// consistent across all resource types.
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"icon": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.Error(t, err)
+		validationErrors, ok := err.(*ValidationErrors)
+		require.True(t, ok)
+		require.Len(t, validationErrors.Errors, 1)
+		require.Equal(t, "icon", validationErrors.Errors[0].Field)
+		require.Contains(t, validationErrors.Errors[0].Message, "property 'icon' must be an object")
+	})
+
+	t.Run("icon property as an object is accepted", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"icon": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"object"},
+					},
+				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+		}
+		require.NoError(t, validator.checkReservedProperties(schema))
+	})
+
 	t.Run("valid environment property as string", func(t *testing.T) {
 		schema := &openapi3.Schema{
 			Type: &openapi3.Types{"object"},


### PR DESCRIPTION
# Description

Every resource type can have a Radius icon associated with it. 
Adding model support for icon. 

Test steps:

cd "$RADIUS"
make generate-bicep-types

make publish-bicep-extension \
  BICEP_PUBLISH_TARGET="$RADIUS/bin/radius-types.tgz"

mkdir -p ~/icon-test && cd ~/icon-test
cat > bicepconfig.json <<JSON
{
  "experimentalFeaturesEnabled": { "extensibility": true },
  "extensions": {
    "radius": "$RADIUS/bin/radius-types.tgz",
    "aws":    "br:biceptypes.azurecr.io/aws:latest"
  }
}
JSON


Create ~/icon-test/test.bicep


// test.bicep — verifies `icon` is read-only on RRT schemas.
//
// (a) Uncomment the `icon: {...}` block inside `c.properties` and expect a
//     compile error / IntelliSense to hide the property.
// (b) The output line at the bottom exercises the read surface — Bicep
//     intentionally still allows dot-access on readOnly properties.

extension radius

param environment string

resource app 'Radius.Core/applications@2025-08-01-preview' = {
  name: 'icon-test-app'
  properties: {
    environment: environment
  }
}

resource c 'Radius.Compute/containers@2025-08-01-preview' = {
  name: 'icon-test-container'
  properties: {
    application: app.id
    environment: environment
    containers: {
      demo: {
        image: 'nginx:latest'
      }
    }

    // 👇 Uncomment to test the write-side rejection. Expected diagnostic:
    //    "icon" is a read-only property and cannot be assigned to.
    // icon: {
    //   bytes: '<svg/>'
    // }
  }
}

// Read-side access is intentionally allowed by Bicep for readOnly
// properties. This line should compile without a diagnostic.
output iconHash string = c.properties.icon.hash

## Type of change

<!--
Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.
If you are making a bug fix or functionality change to Radius and do not have an associated issue link, please create one now. 
-->
- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
- This pull request is a design document and only includes files in the eng/design-notes directory.

<!-- Please update the following to link the associated issue. This is required for some kinds of changes (see above). -->
Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
