### PR TITLE
add icons support

### DIFF
--- a/pkg/cli/cmd/resourcetype/create/create.go
+++ b/pkg/cli/cmd/resourcetype/create/create.go
@@ -44,7 +44,7 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 		Short: "Create or update a resource type",
 		Long: `Create or update a resource type from a resource type definition file.
 
-Resource types define the resources that Radius can deploy and the API for those resources. They are defined by a name, one or more API versions, and an OpenAPI schema. 
+Resource types define the resources that Radius can deploy and the API for those resources. They are defined by a name, one or more API versions, and an OpenAPI schema.
 
 Input can be passed in using a JSON or YAML file using the --from-file option.
 
@@ -61,7 +61,7 @@ rad resource-type create myType --from-file /path/to/input.json
 
 # Create all resource types from a YAML file
 rad resource-type create --from-file /path/to/input.yaml
- 
+
 # Create all resource types from a JSON file
 rad resource-type create --from-file /path/to/input.json
 `,
@@ -72,6 +72,7 @@ rad resource-type create --from-file /path/to/input.json
 	commonflags.AddOutputFlag(cmd)
 	commonflags.AddWorkspaceFlag(cmd)
 	commonflags.AddFromFileFlagVar(cmd, &runner.ResourceProviderManifestFilePath)
+	cmd.Flags().StringVar(&runner.IconFilePath, "icon", "", "Path to an SVG file to associate with the resource type(s) being created. The icon's bytes and a SHA-256 hash are stored with the resource type.")
 
 	return cmd, runner
 }
@@ -87,6 +88,10 @@ type Runner struct {
 	ResourceProviderManifestFilePath string
 	ResourceProvider                 *manifest.ResourceProvider
 	ResourceTypeName                 string
+
+	// IconFilePath is the optional path to an SVG file whose bytes and hash are
+	// stored alongside the resource type(s) being created.
+	IconFilePath string
 }
 
 // NewRunner creates an instance of the runner for the `rad resource-type create` command.
@@ -125,6 +130,10 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		if !ok {
 			return clierrors.Message("Resource type %q not found in the manifest", r.ResourceTypeName)
 		}
+	}
+
+	if r.IconFilePath != "" && r.ResourceTypeName == "" && len(resourcesTypes) > 1 {
+		return clierrors.Message("The --icon flag can only be used with a single resource type. When the manifest defines multiple types, specify a single type to register: rad resource-type create <typeName> --from-file <file> --icon <path>")
 	}
 
 	return nil
@@ -172,7 +181,7 @@ func (r *Runner) registerTypes(ctx context.Context, typeNames []string) error {
 
 	// Register each type individually and emit a single concise line per type.
 	for _, typeName := range typesToRegister {
-		err = manifest.RegisterType(ctx, r.UCPClientFactory, defaultPlaneName, r.ResourceProviderManifestFilePath, typeName, nil)
+		err = manifest.RegisterType(ctx, r.UCPClientFactory, defaultPlaneName, r.ResourceProviderManifestFilePath, typeName, r.IconFilePath, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/cmd/resourcetype/create/create_test.go
+++ b/pkg/cli/cmd/resourcetype/create/create_test.go
@@ -55,6 +55,12 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder:  framework.ConfigHolder{Config: config},
 		},
+		{
+			Name:          "Invalid: multiple types with icon and no type name",
+			Input:         []string{"--from-file", "testdata/valid.yaml", "--icon", "icon.svg"},
+			ExpectedValid: false,
+			ConfigHolder:  framework.ConfigHolder{Config: config},
+		},
 	}
 
 	radcli.SharedValidateValidation(t, NewCommand, testcases)

--- a/pkg/cli/manifest/registermanifest.go
+++ b/pkg/cli/manifest/registermanifest.go
@@ -30,6 +30,7 @@ import (
 	"github.com/radius-project/radius/pkg/cli/clients"
 	"github.com/radius-project/radius/pkg/to"
 	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/ucp/datamodel"
 )
 
 const (
@@ -207,8 +208,11 @@ func CreateEmptyResourceProvider(ctx context.Context, clientFactory *v20231001pr
 	return nil
 }
 
-// RegisterType registers a type specified in a manifest file
-func RegisterType(ctx context.Context, clientFactory *v20231001preview.ClientFactory, planeName string, filePath string, typeName string, logger func(format string, args ...any)) error {
+// RegisterType registers a type specified in a manifest file. When iconFilePath is
+// non-empty, the SVG file at that path is read and its verbatim UTF-8 bytes are set
+// as the resource type's `icon` on ResourceTypeProperties. The control plane computes
+// and returns the `iconHash`.
+func RegisterType(ctx context.Context, clientFactory *v20231001preview.ClientFactory, planeName string, filePath string, typeName string, iconFilePath string, logger func(format string, args ...any)) error {
 	if filePath == "" {
 		return fmt.Errorf("invalid manifest file path")
 	}
@@ -225,6 +229,20 @@ func RegisterType(ctx context.Context, clientFactory *v20231001preview.ClientFac
 		return fmt.Errorf("type %s not found in manifest file %s", typeName, filePath)
 	}
 
+	// Resolve the icon once (if provided). The verbatim SVG bytes are sent to the
+	// control plane, which computes the hash.
+	var icon *string
+	if iconFilePath != "" {
+		bytes, err := os.ReadFile(iconFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to read icon file %s: %w", iconFilePath, err)
+		}
+		if err := datamodel.ValidateIcon(bytes); err != nil {
+			return fmt.Errorf("invalid icon file %s: %w", iconFilePath, err)
+		}
+		icon = to.Ptr(string(bytes))
+	}
+
 	if len(resourceType.Capabilities) == 0 {
 		logIfEnabled(logger, "Creating resource type %s/%s", resourceProvider.Namespace, typeName)
 	} else {
@@ -237,6 +255,7 @@ func RegisterType(ctx context.Context, clientFactory *v20231001preview.ClientFac
 				Capabilities:      to.SliceOfPtrs(resourceType.Capabilities...),
 				DefaultAPIVersion: resourceType.DefaultAPIVersion,
 				Description:       resourceType.Description,
+				Icon:              icon,
 			},
 		}, nil)
 		if err != nil {

--- a/pkg/cli/manifest/registermanifest_test.go
+++ b/pkg/cli/manifest/registermanifest_test.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -214,7 +216,7 @@ func TestRegisterType(t *testing.T) {
 			clientFactory := createTestClientFactory(t)
 			logger, logBuffer := createTestLogger()
 
-			err := RegisterType(context.Background(), clientFactory, tt.planeName, tt.filePath, tt.resourceTypeName, logger)
+			err := RegisterType(context.Background(), clientFactory, tt.planeName, tt.filePath, tt.resourceTypeName, "", logger)
 			if tt.expectError {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedErrorMessage)
@@ -924,10 +926,43 @@ func TestRegisterType_ErrorScenarios(t *testing.T) {
 			logger, _ := createTestLogger()
 
 			testErrorScenario(t, func() error {
-				return RegisterType(context.Background(), clientFactory, "local", tt.filePath, tt.typeName, logger)
+				return RegisterType(context.Background(), clientFactory, "local", tt.filePath, tt.typeName, "", logger)
 			}, tt.expectError, tt.expectedErrorMessage)
 		})
 	}
+}
+
+func TestRegisterType_IconFileNotFound(t *testing.T) {
+	t.Parallel()
+
+	clientFactory := createTestClientFactory(t)
+	logger, _ := createTestLogger()
+
+	err := RegisterType(context.Background(), clientFactory, "local",
+		"testdata/registerdirectory/resourceprovider-valid2.yaml", "testResource3",
+		"testdata/nonexistent-icon.svg", logger)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read icon file testdata/nonexistent-icon.svg")
+}
+
+func TestRegisterType_IconValidationRejectsBadSVG(t *testing.T) {
+	t.Parallel()
+
+	clientFactory := createTestClientFactory(t)
+	logger, _ := createTestLogger()
+
+	dir := t.TempDir()
+	badIcon := filepath.Join(dir, "bad.svg")
+	require.NoError(t, os.WriteFile(badIcon, []byte(`<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`), 0o600))
+
+	err := RegisterType(context.Background(), clientFactory, "local",
+		"testdata/registerdirectory/resourceprovider-valid2.yaml", "testResource3",
+		badIcon, logger)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid icon file")
+	require.Contains(t, err.Error(), "<script>")
 }
 
 func TestRegisterFile_ErrorScenarios(t *testing.T) {

--- a/pkg/ucp/api/v20231001preview/fake/zz_generated_internal.go
+++ b/pkg/ucp/api/v20231001preview/fake/zz_generated_internal.go
@@ -30,6 +30,17 @@ func initServer[T any](mu *sync.Mutex, dst **T, src func() *T) {
 	mu.Unlock()
 }
 
+func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
+	if v == "" {
+		return nil, nil
+	}
+	t, err := parse(v)
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
 func newTracker[T any]() *tracker[T] {
 	return &tracker[T]{
 		items: map[string]*T{},

--- a/pkg/ucp/api/v20231001preview/fake/zz_generated_resourceproviders_server.go
+++ b/pkg/ucp/api/v20231001preview/fake/zz_generated_resourceproviders_server.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"regexp"
 	"slices"
+	"strconv"
 )
 
 // ResourceProvidersServer is a fake server for instances of the v20231001preview.ResourceProvidersClient type.
@@ -252,6 +253,7 @@ func (r *ResourceProvidersServerTransport) dispatchGetProviderSummary(req *http.
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
+	qp := req.URL.Query()
 	planeNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("planeName")])
 	if err != nil {
 		return nil, err
@@ -260,7 +262,17 @@ func (r *ResourceProvidersServerTransport) dispatchGetProviderSummary(req *http.
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := r.srv.GetProviderSummary(req.Context(), planeNameParam, resourceProviderNameParam, nil)
+	includeIconsParam, err := parseOptional(qp.Get("includeIcons"), strconv.ParseBool)
+	if err != nil {
+		return nil, err
+	}
+	var options *v20231001preview.ResourceProvidersClientGetProviderSummaryOptions
+	if includeIconsParam != nil {
+		options = &v20231001preview.ResourceProvidersClientGetProviderSummaryOptions{
+			IncludeIcons: includeIconsParam,
+		}
+	}
+	respr, errRespr := r.srv.GetProviderSummary(req.Context(), planeNameParam, resourceProviderNameParam, options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/pkg/ucp/api/v20231001preview/fake/zz_generated_resourcetypes_server.go
+++ b/pkg/ucp/api/v20231001preview/fake/zz_generated_resourcetypes_server.go
@@ -32,6 +32,10 @@ type ResourceTypesServer struct {
 	// HTTP status codes to indicate success: http.StatusOK
 	Get func(ctx context.Context, planeName string, resourceProviderName string, resourceTypeName string, options *v20231001preview.ResourceTypesClientGetOptions) (resp azfake.Responder[v20231001preview.ResourceTypesClientGetResponse], errResp azfake.ErrorResponder)
 
+	// GetIcon is the fake for method ResourceTypesClient.GetIcon
+	// HTTP status codes to indicate success: http.StatusOK
+	GetIcon func(ctx context.Context, planeName string, resourceProviderName string, resourceTypeName string, hashParam string, options *v20231001preview.ResourceTypesClientGetIconOptions) (resp azfake.Responder[v20231001preview.ResourceTypesClientGetIconResponse], errResp azfake.ErrorResponder)
+
 	// NewListPager is the fake for method ResourceTypesClient.NewListPager
 	// HTTP status codes to indicate success: http.StatusOK
 	NewListPager func(planeName string, resourceProviderName string, options *v20231001preview.ResourceTypesClientListOptions) (resp azfake.PagerResponder[v20231001preview.ResourceTypesClientListResponse])
@@ -85,6 +89,8 @@ func (r *ResourceTypesServerTransport) dispatchToMethodFake(req *http.Request, m
 				res.resp, res.err = r.dispatchBeginDelete(req)
 			case "ResourceTypesClient.Get":
 				res.resp, res.err = r.dispatchGet(req)
+			case "ResourceTypesClient.GetIcon":
+				res.resp, res.err = r.dispatchGetIcon(req)
 			case "ResourceTypesClient.NewListPager":
 				res.resp, res.err = r.dispatchNewListPager(req)
 			default:
@@ -236,6 +242,56 @@ func (r *ResourceTypesServerTransport) dispatchGet(req *http.Request) (*http.Res
 	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).ResourceTypeResource, req)
 	if err != nil {
 		return nil, err
+	}
+	return resp, nil
+}
+
+func (r *ResourceTypesServerTransport) dispatchGetIcon(req *http.Request) (*http.Response, error) {
+	if r.srv.GetIcon == nil {
+		return nil, &nonRetriableError{errors.New("fake for method GetIcon not implemented")}
+	}
+	const regexStr = `/planes/radius/(?P<planeName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/System\.Resources/resourceproviders/(?P<resourceProviderName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourcetypes/(?P<resourceTypeName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/icons/(?P<hash>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
+	regex := regexp.MustCompile(regexStr)
+	matches := regex.FindStringSubmatch(req.URL.EscapedPath())
+	if len(matches) < 5 {
+		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
+	}
+	planeNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("planeName")])
+	if err != nil {
+		return nil, err
+	}
+	resourceProviderNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("resourceProviderName")])
+	if err != nil {
+		return nil, err
+	}
+	resourceTypeNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("resourceTypeName")])
+	if err != nil {
+		return nil, err
+	}
+	hashParamParam, err := url.PathUnescape(matches[regex.SubexpIndex("hash")])
+	if err != nil {
+		return nil, err
+	}
+	respr, errRespr := r.srv.GetIcon(req.Context(), planeNameParam, resourceProviderNameParam, resourceTypeNameParam, hashParamParam, nil)
+	if respErr := server.GetError(errRespr, req); respErr != nil {
+		return nil, respErr
+	}
+	respContent := server.GetResponseContent(respr)
+	if !slices.Contains([]int{http.StatusOK}, respContent.HTTPStatus) {
+		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
+	}
+	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
+		Body:        server.GetResponse(respr).Body,
+		ContentType: req.Header.Get("Content-Type"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if val := server.GetResponse(respr).CacheControl; val != nil {
+		resp.Header.Set("cache-control", "public, max-age=31536000, immutable")
+	}
+	if val := server.GetResponse(respr).ContentType; val != nil {
+		resp.Header.Set("content-type", "image/svg+xml")
 	}
 	return resp, nil
 }

--- a/pkg/ucp/api/v20231001preview/resourceprovidersummary_conversion.go
+++ b/pkg/ucp/api/v20231001preview/resourceprovidersummary_conversion.go
@@ -60,6 +60,8 @@ func (dst *ResourceProviderSummary) ConvertFrom(src v1.DataModelInterface) error
 			DefaultAPIVersion: resourceType.DefaultAPIVersion,
 			APIVersions:       apiVersions,
 			Description:       resourceType.Description,
+			Icon:              resourceType.Icon,
+			IconHash:          resourceType.IconHash,
 		}
 	}
 

--- a/pkg/ucp/api/v20231001preview/resourceprovidersummary_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/resourceprovidersummary_conversion_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/radius-project/radius/pkg/ucp/datamodel"
 	"github.com/radius-project/radius/test/testutil"
 
@@ -84,4 +85,29 @@ func Test_ResourceProviderSummary_DataModelToVersioned(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_ResourceProviderSummary_Icon_DataModelToVersioned(t *testing.T) {
+	dm := &datamodel.ResourceProviderSummary{
+		Properties: datamodel.ResourceProviderSummaryProperties{
+			ResourceTypes: map[string]datamodel.ResourceProviderSummaryPropertiesResourceType{
+				"testResources": {
+					Icon:     to.Ptr(`<svg/>`),
+					IconHash: to.Ptr("deadbeef"),
+				},
+			},
+		},
+	}
+	dm.Name = "Applications.Test"
+
+	versioned := &ResourceProviderSummary{}
+	err := versioned.ConvertFrom(dm)
+	require.NoError(t, err)
+
+	rt := versioned.ResourceTypes["testResources"]
+	require.NotNil(t, rt)
+	require.NotNil(t, rt.Icon)
+	require.Equal(t, `<svg/>`, *rt.Icon)
+	require.NotNil(t, rt.IconHash)
+	require.Equal(t, "deadbeef", *rt.IconHash)
 }

--- a/pkg/ucp/api/v20231001preview/resourcetype_conversion.go
+++ b/pkg/ucp/api/v20231001preview/resourcetype_conversion.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v20231001preview
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
@@ -58,6 +60,19 @@ func (src *ResourceTypeResource) ConvertTo() (v1.DataModelInterface, error) {
 
 	dst.Properties.Description = src.Properties.Description
 
+	// The icon is written by the client as verbatim SVG bytes. The hash is
+	// server-computed (read-only on the wire) so it content-addresses exactly
+	// the bytes that were stored.
+	dst.Properties.Icon = src.Properties.Icon
+	if src.Properties.Icon != nil {
+		iconBytes := []byte(*src.Properties.Icon)
+		if err := datamodel.ValidateIcon(iconBytes); err != nil {
+			return nil, v1.NewClientErrInvalidRequest(fmt.Sprintf("invalid icon: %s", err.Error()))
+		}
+		sum := sha256.Sum256(iconBytes)
+		dst.Properties.IconHash = to.Ptr(hex.EncodeToString(sum[:]))
+	}
+
 	return dst, nil
 }
 
@@ -79,6 +94,8 @@ func (dst *ResourceTypeResource) ConvertFrom(src v1.DataModelInterface) error {
 		Capabilities:      to.SliceOfPtrs(dm.Properties.Capabilities...),
 		DefaultAPIVersion: dm.Properties.DefaultAPIVersion,
 		Description:       dm.Properties.Description,
+		Icon:              dm.Properties.Icon,
+		IconHash:          dm.Properties.IconHash,
 	}
 
 	return nil

--- a/pkg/ucp/api/v20231001preview/resourcetype_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/resourcetype_conversion_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v20231001preview
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"testing"
 
@@ -114,6 +116,110 @@ func Test_ResourceType_DataModelToVersioned(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_ResourceType_Icon_VersionedToDataModel(t *testing.T) {
+	const svg = `<svg xmlns="http://www.w3.org/2000/svg"></svg>`
+	sum := sha256.Sum256([]byte(svg))
+	expectedHash := hex.EncodeToString(sum[:])
+
+	t.Run("icon present is stored verbatim and hashed server-side", func(t *testing.T) {
+		versioned := &ResourceTypeResource{
+			ID:   to.Ptr("/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test/resourceTypes/testResources"),
+			Name: to.Ptr("testResources"),
+			Properties: &ResourceTypeProperties{
+				Icon: to.Ptr(svg),
+			},
+		}
+
+		dm, err := versioned.ConvertTo()
+		require.NoError(t, err)
+
+		rt := dm.(*datamodel.ResourceType)
+		require.NotNil(t, rt.Properties.Icon)
+		require.Equal(t, svg, *rt.Properties.Icon)
+		require.NotNil(t, rt.Properties.IconHash)
+		require.Equal(t, expectedHash, *rt.Properties.IconHash)
+	})
+
+	t.Run("no icon leaves icon and hash unset", func(t *testing.T) {
+		versioned := &ResourceTypeResource{
+			ID:         to.Ptr("/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test/resourceTypes/testResources"),
+			Name:       to.Ptr("testResources"),
+			Properties: &ResourceTypeProperties{},
+		}
+
+		dm, err := versioned.ConvertTo()
+		require.NoError(t, err)
+
+		rt := dm.(*datamodel.ResourceType)
+		require.Nil(t, rt.Properties.Icon)
+		require.Nil(t, rt.Properties.IconHash)
+	})
+}
+
+func Test_ResourceType_ConvertTo_RejectsInvalidIcon(t *testing.T) {
+	tests := []struct {
+		name    string
+		icon    string
+		wantErr string
+	}{
+		{
+			name:    "not svg",
+			icon:    "<html><body/></html>",
+			wantErr: "invalid icon",
+		},
+		{
+			name:    "script element",
+			icon:    `<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`,
+			wantErr: "invalid icon",
+		},
+		{
+			name:    "event handler",
+			icon:    `<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"/>`,
+			wantErr: "invalid icon",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			versioned := &ResourceTypeResource{
+				ID:   to.Ptr("/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test/resourceTypes/testResources"),
+				Name: to.Ptr("testResources"),
+				Properties: &ResourceTypeProperties{
+					Icon: to.Ptr(tc.icon),
+				},
+			}
+			_, err := versioned.ConvertTo()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func Test_ResourceType_Icon_DataModelToVersioned(t *testing.T) {
+	dm := &datamodel.ResourceType{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:   "/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test/resourceTypes/testResources",
+				Name: "testResources",
+				Type: datamodel.ResourceTypeResourceType,
+			},
+		},
+		Properties: datamodel.ResourceTypeProperties{
+			Capabilities: []string{},
+			Icon:         to.Ptr(`<svg/>`),
+			IconHash:     to.Ptr("abc123"),
+		},
+	}
+
+	versioned := &ResourceTypeResource{}
+	err := versioned.ConvertFrom(dm)
+	require.NoError(t, err)
+
+	require.NotNil(t, versioned.Properties.Icon)
+	require.Equal(t, `<svg/>`, *versioned.Properties.Icon)
+	require.NotNil(t, versioned.Properties.IconHash)
+	require.Equal(t, "abc123", *versioned.Properties.IconHash)
 }
 
 func Test_validateCapability(t *testing.T) {

--- a/pkg/ucp/api/v20231001preview/zz_generated_models.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_models.go
@@ -667,6 +667,12 @@ type ResourceProviderSummaryResourceType struct {
 
 	// Description of the resource type.
 	Description *string
+
+	// The verbatim SVG icon content associated with the resource type, carried as a UTF-8 string.
+	Icon *string
+
+	// The SHA-256 hash of the icon's SVG bytes, computed by the control plane.
+	IconHash *string
 }
 
 // ResourceTypeProperties - The properties of a resource type.
@@ -679,6 +685,13 @@ type ResourceTypeProperties struct {
 
 	// Description of the resource type.
 	Description *string
+
+	// The verbatim SVG file content of the icon associated with the resource type, carried as a UTF-8 string. Set by 'rad resource-type
+	// create --icon <path>'.
+	Icon *string
+
+	// READ-ONLY; The SHA-256 hash of the icon's SVG bytes. Computed by the control plane and used to content-address the icon.
+	IconHash *string
 
 	// READ-ONLY; The status of the asynchronous operation.
 	ProvisioningState *ProvisioningState

--- a/pkg/ucp/api/v20231001preview/zz_generated_models_serde.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_models_serde.go
@@ -1680,6 +1680,8 @@ func (r ResourceProviderSummaryResourceType) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "capabilities", r.Capabilities)
 	populate(objectMap, "defaultApiVersion", r.DefaultAPIVersion)
 	populate(objectMap, "description", r.Description)
+	populate(objectMap, "icon", r.Icon)
+	populate(objectMap, "iconHash", r.IconHash)
 	return json.Marshal(objectMap)
 }
 
@@ -1704,6 +1706,12 @@ func (r *ResourceProviderSummaryResourceType) UnmarshalJSON(data []byte) error {
 		case "description":
 			err = unpopulate(val, "Description", &r.Description)
 			delete(rawMsg, key)
+		case "icon":
+			err = unpopulate(val, "Icon", &r.Icon)
+			delete(rawMsg, key)
+		case "iconHash":
+			err = unpopulate(val, "IconHash", &r.IconHash)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", r, err)
@@ -1718,6 +1726,8 @@ func (r ResourceTypeProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "capabilities", r.Capabilities)
 	populate(objectMap, "defaultApiVersion", r.DefaultAPIVersion)
 	populate(objectMap, "description", r.Description)
+	populate(objectMap, "icon", r.Icon)
+	populate(objectMap, "iconHash", r.IconHash)
 	populate(objectMap, "provisioningState", r.ProvisioningState)
 	return json.Marshal(objectMap)
 }
@@ -1739,6 +1749,12 @@ func (r *ResourceTypeProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "description":
 			err = unpopulate(val, "Description", &r.Description)
+			delete(rawMsg, key)
+		case "icon":
+			err = unpopulate(val, "Icon", &r.Icon)
+			delete(rawMsg, key)
+		case "iconHash":
+			err = unpopulate(val, "IconHash", &r.IconHash)
 			delete(rawMsg, key)
 		case "provisioningState":
 			err = unpopulate(val, "ProvisioningState", &r.ProvisioningState)

--- a/pkg/ucp/api/v20231001preview/zz_generated_options.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_options.go
@@ -241,7 +241,8 @@ type ResourceProvidersClientGetOptions struct {
 // ResourceProvidersClientGetProviderSummaryOptions contains the optional parameters for the ResourceProvidersClient.GetProviderSummary
 // method.
 type ResourceProvidersClientGetProviderSummaryOptions struct {
-	// placeholder for future optional parameters
+	// When true, resource type icon bytes are included in the response. When false or omitted, only the icon hash is returned.
+	IncludeIcons *bool
 }
 
 // ResourceProvidersClientListOptions contains the optional parameters for the ResourceProvidersClient.NewListPager method.
@@ -266,6 +267,11 @@ type ResourceTypesClientBeginCreateOrUpdateOptions struct {
 type ResourceTypesClientBeginDeleteOptions struct {
 	// Resumes the long-running operation from the provided token.
 	ResumeToken string
+}
+
+// ResourceTypesClientGetIconOptions contains the optional parameters for the ResourceTypesClient.GetIcon method.
+type ResourceTypesClientGetIconOptions struct {
+	// placeholder for future optional parameters
 }
 
 // ResourceTypesClientGetOptions contains the optional parameters for the ResourceTypesClient.Get method.

--- a/pkg/ucp/api/v20231001preview/zz_generated_resourceproviders_client.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_resourceproviders_client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -249,7 +250,7 @@ func (client *ResourceProvidersClient) GetProviderSummary(ctx context.Context, p
 }
 
 // getProviderSummaryCreateRequest creates the GetProviderSummary request.
-func (client *ResourceProvidersClient) getProviderSummaryCreateRequest(ctx context.Context, planeName string, resourceProviderName string, _ *ResourceProvidersClientGetProviderSummaryOptions) (*policy.Request, error) {
+func (client *ResourceProvidersClient) getProviderSummaryCreateRequest(ctx context.Context, planeName string, resourceProviderName string, options *ResourceProvidersClientGetProviderSummaryOptions) (*policy.Request, error) {
 	urlPath := "/planes/radius/{planeName}/providers/{resourceProviderName}"
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
@@ -265,6 +266,9 @@ func (client *ResourceProvidersClient) getProviderSummaryCreateRequest(ctx conte
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("api-version", version20231001Preview)
+	if options != nil && options.IncludeIcons != nil {
+		reqQP.Set("includeIcons", strconv.FormatBool(*options.IncludeIcons))
+	}
 	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil

--- a/pkg/ucp/api/v20231001preview/zz_generated_resourcetypes_client.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_resourcetypes_client.go
@@ -237,6 +237,77 @@ func (client *ResourceTypesClient) getHandleResponse(resp *http.Response) (Resou
 	return result, nil
 }
 
+// GetIcon - Get the icon bytes stored for the specified resource type, addressed by the SHA-256 hash of those bytes. Returns
+// the verbatim SVG file content with Content-Type: image/svg+xml and an immutable Cache-Control. If the hash does not match
+// the stored icon, or the resource type has no icon, returns 404.
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - planeName - The plane name.
+//   - resourceProviderName - The resource provider name. This is also the resource provider namespace. Example: 'Applications.Datastores'.
+//   - resourceTypeName - The resource type name.
+//   - hashParam - The SHA-256 hash of the icon's SVG bytes, as a lowercase hex string.
+//   - options - ResourceTypesClientGetIconOptions contains the optional parameters for the ResourceTypesClient.GetIcon method.
+func (client *ResourceTypesClient) GetIcon(ctx context.Context, planeName string, resourceProviderName string, resourceTypeName string, hashParam string, options *ResourceTypesClientGetIconOptions) (ResourceTypesClientGetIconResponse, error) {
+	var err error
+	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ResourceTypesClient.GetIcon")
+	req, err := client.getIconCreateRequest(ctx, planeName, resourceProviderName, resourceTypeName, hashParam, options)
+	if err != nil {
+		return ResourceTypesClientGetIconResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return ResourceTypesClientGetIconResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
+		err = runtime.NewResponseError(httpResp)
+		return ResourceTypesClientGetIconResponse{}, err
+	}
+	resp, err := client.getIconHandleResponse(httpResp)
+	return resp, err
+}
+
+// getIconCreateRequest creates the GetIcon request.
+func (client *ResourceTypesClient) getIconCreateRequest(ctx context.Context, planeName string, resourceProviderName string, resourceTypeName string, hashParam string, _ *ResourceTypesClientGetIconOptions) (*policy.Request, error) {
+	urlPath := "/planes/radius/{planeName}/providers/System.Resources/resourceproviders/{resourceProviderName}/resourcetypes/{resourceTypeName}/icons/{hash}"
+	if planeName == "" {
+		return nil, errors.New("parameter planeName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+	if resourceProviderName == "" {
+		return nil, errors.New("parameter resourceProviderName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{resourceProviderName}", url.PathEscape(resourceProviderName))
+	if resourceTypeName == "" {
+		return nil, errors.New("parameter resourceTypeName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{resourceTypeName}", url.PathEscape(resourceTypeName))
+	if hashParam == "" {
+		return nil, errors.New("parameter hashParam cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{hash}", url.PathEscape(hashParam))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", version20231001Preview)
+	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+	runtime.SkipBodyDownload(req)
+	req.Raw().Header["Accept"] = []string{"image/svg+xml"}
+	return req, nil
+}
+
+// getIconHandleResponse handles the GetIcon response.
+func (client *ResourceTypesClient) getIconHandleResponse(resp *http.Response) (ResourceTypesClientGetIconResponse, error) {
+	result := ResourceTypesClientGetIconResponse{Body: resp.Body}
+	if val := resp.Header.Get("cache-control"); val != "" {
+		result.CacheControl = &val
+	}
+	if val := resp.Header.Get("content-type"); val != "" {
+		result.ContentType = &val
+	}
+	return result, nil
+}
+
 // NewListPager - List resource types.
 //   - planeName - The plane name.
 //   - resourceProviderName - The resource provider name. This is also the resource provider namespace. Example: 'Applications.Datastores'.

--- a/pkg/ucp/api/v20231001preview/zz_generated_responses.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_responses.go
@@ -3,6 +3,8 @@
 
 package v20231001preview
 
+import "io"
+
 // APIVersionsClientCreateOrUpdateResponse contains the response from method APIVersionsClient.BeginCreateOrUpdate.
 type APIVersionsClientCreateOrUpdateResponse struct {
 	// The resource type for defining an API version of a resource type supported by the containing resource provider.
@@ -273,6 +275,18 @@ type ResourceTypesClientCreateOrUpdateResponse struct {
 // ResourceTypesClientDeleteResponse contains the response from method ResourceTypesClient.BeginDelete.
 type ResourceTypesClientDeleteResponse struct {
 	// placeholder for future response values
+}
+
+// ResourceTypesClientGetIconResponse contains the response from method ResourceTypesClient.GetIcon.
+type ResourceTypesClientGetIconResponse struct {
+	// Body contains the streaming response.
+	Body io.ReadCloser
+
+	// Caching hint. Icon bytes are content-addressed by SHA-256 and safe to cache immutably.
+	CacheControl *string
+
+	// MIME type of the icon bytes.
+	ContentType *string
 }
 
 // ResourceTypesClientGetResponse contains the response from method ResourceTypesClient.Get.

--- a/pkg/ucp/backend/controller/resourceproviders/resourcetype_put.go
+++ b/pkg/ucp/backend/controller/resourceproviders/resourcetype_put.go
@@ -81,6 +81,8 @@ func (c *ResourceTypePutController) updateSummary(id resources.ID, resourceType 
 		resourceTypeEntry.Capabilities = resourceType.Properties.Capabilities
 		resourceTypeEntry.DefaultAPIVersion = resourceType.Properties.DefaultAPIVersion
 		resourceTypeEntry.Description = resourceType.Properties.Description
+		resourceTypeEntry.Icon = resourceType.Properties.Icon
+		resourceTypeEntry.IconHash = resourceType.Properties.IconHash
 		summary.Properties.ResourceTypes[resourceTypeName] = resourceTypeEntry
 		return nil
 	}

--- a/pkg/ucp/datamodel/icon_validation.go
+++ b/pkg/ucp/datamodel/icon_validation.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datamodel
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// MaxIconSizeBytes is the maximum accepted size of a resource type icon per
+// NFR-002 of spec 003 (Resource Type Icons): 32 KiB.
+const MaxIconSizeBytes = 32 * 1024
+
+// ValidateIcon enforces the resource-type icon contract from FR-005 (CLI-side)
+// and FR-005a (server-side) of spec 003. The rules are:
+//
+//   - non-empty
+//   - size <= MaxIconSizeBytes
+//   - well-formed XML
+//   - root element is <svg>
+//   - no <script> elements
+//   - no on* event-handler attributes
+//   - no <foreignObject> elements
+//   - href / xlink:href values are either data: URLs or intra-document fragments (starting with '#')
+//
+// Bytes that pass validation are stored verbatim — the caller must not
+// re-encode or normalize them, so that FR-010's SHA-256 iconHash content-addresses
+// exactly what the author published.
+func ValidateIcon(icon []byte) error {
+	if len(icon) == 0 {
+		return fmt.Errorf("icon is empty")
+	}
+	if len(icon) > MaxIconSizeBytes {
+		return fmt.Errorf("icon is %d bytes, which exceeds the %d byte limit", len(icon), MaxIconSizeBytes)
+	}
+
+	decoder := xml.NewDecoder(bytes.NewReader(icon))
+
+	sawRoot := false
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("icon is not well-formed XML: %w", err)
+		}
+
+		start, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+
+		local := start.Name.Local
+		if !sawRoot {
+			if !strings.EqualFold(local, "svg") {
+				return fmt.Errorf("icon root element is <%s>, expected <svg>", local)
+			}
+			sawRoot = true
+		}
+
+		if strings.EqualFold(local, "script") {
+			return fmt.Errorf("icon contains a <script> element, which is not allowed")
+		}
+		if strings.EqualFold(local, "foreignObject") {
+			return fmt.Errorf("icon contains a <foreignObject> element, which is not allowed")
+		}
+
+		for _, attr := range start.Attr {
+			name := attr.Name.Local
+			if strings.HasPrefix(strings.ToLower(name), "on") {
+				return fmt.Errorf("icon <%s> element has event-handler attribute %q, which is not allowed", local, name)
+			}
+			if strings.EqualFold(name, "href") {
+				if err := validateHrefValue(local, attr.Value); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	if !sawRoot {
+		return fmt.Errorf("icon does not contain an <svg> root element")
+	}
+	return nil
+}
+
+// validateHrefValue rejects href / xlink:href values that would let an SVG
+// pull an external resource. Fragment references (#foo) and data: URLs are
+// the only accepted forms.
+func validateHrefValue(elementName, value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	if strings.HasPrefix(trimmed, "#") {
+		return nil
+	}
+	if strings.HasPrefix(strings.ToLower(trimmed), "data:") {
+		return nil
+	}
+	return fmt.Errorf("icon <%s> element references external resource %q via href; only data: URLs and intra-document fragments are allowed", elementName, value)
+}

--- a/pkg/ucp/datamodel/icon_validation_test.go
+++ b/pkg/ucp/datamodel/icon_validation_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datamodel
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateIcon(t *testing.T) {
+	tests := []struct {
+		name    string
+		icon    string
+		wantErr string
+	}{
+		{
+			name: "valid minimal svg",
+			icon: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="red"/></svg>`,
+		},
+		{
+			name: "valid svg with xml declaration",
+			icon: `<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>`,
+		},
+		{
+			name: "valid svg with fragment href",
+			icon: `<svg xmlns="http://www.w3.org/2000/svg"><use href="#glyph"/></svg>`,
+		},
+		{
+			name: "valid svg with data uri href",
+			icon: `<svg xmlns="http://www.w3.org/2000/svg"><image href="data:image/png;base64,iVBORw0KGgo="/></svg>`,
+		},
+		{
+			name:    "empty",
+			icon:    "",
+			wantErr: "icon is empty",
+		},
+		{
+			name:    "not xml",
+			icon:    "not an svg",
+			wantErr: "does not contain an <svg>",
+		},
+		{
+			name:    "malformed xml",
+			icon:    "<svg><rect>",
+			wantErr: "well-formed XML",
+		},
+		{
+			name:    "wrong root element",
+			icon:    `<html><body/></html>`,
+			wantErr: "root element is <html>",
+		},
+		{
+			name:    "script element",
+			icon:    `<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`,
+			wantErr: "<script>",
+		},
+		{
+			name:    "onclick attribute",
+			icon:    `<svg xmlns="http://www.w3.org/2000/svg"><rect onclick="alert(1)"/></svg>`,
+			wantErr: "event-handler attribute",
+		},
+		{
+			name:    "onload attribute on root",
+			icon:    `<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"/>`,
+			wantErr: "event-handler attribute",
+		},
+		{
+			name:    "foreignObject element",
+			icon:    `<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div/></foreignObject></svg>`,
+			wantErr: "<foreignObject>",
+		},
+		{
+			name:    "external href",
+			icon:    `<svg xmlns="http://www.w3.org/2000/svg"><image href="https://example.com/x.png"/></svg>`,
+			wantErr: "references external resource",
+		},
+		{
+			name:    "external xlink href",
+			icon:    `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><image xlink:href="https://example.com/x.png"/></svg>`,
+			wantErr: "references external resource",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateIcon([]byte(tc.icon))
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestValidateIcon_SizeLimit(t *testing.T) {
+	// Body is padded with comment content so the SVG remains well-formed while
+	// pushing the total byte count past MaxIconSizeBytes.
+	prefix := `<svg xmlns="http://www.w3.org/2000/svg"><!--`
+	suffix := `--></svg>`
+	padding := strings.Repeat("x", MaxIconSizeBytes-len(prefix)-len(suffix)+1)
+	oversized := prefix + padding + suffix
+	require.Greater(t, len(oversized), MaxIconSizeBytes)
+
+	err := ValidateIcon([]byte(oversized))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds")
+}

--- a/pkg/ucp/datamodel/resourceprovidersummary.go
+++ b/pkg/ucp/datamodel/resourceprovidersummary.go
@@ -78,6 +78,12 @@ type ResourceProviderSummaryPropertiesResourceType struct {
 	//Description of the resource type.
 	Description *string `json:"description,omitempty"`
 
+	// Icon is the verbatim SVG icon content associated with the resource type.
+	Icon *string `json:"icon,omitempty"`
+
+	// IconHash is the SHA-256 hash of the icon's SVG bytes, computed by the control plane.
+	IconHash *string `json:"iconHash,omitempty"`
+
 	// APIVersions is the list of API versions available for the resource type.
 	APIVersions map[string]ResourceProviderSummaryPropertiesAPIVersion `json:"apiVersions,omitempty"`
 }

--- a/pkg/ucp/datamodel/resourcetype.go
+++ b/pkg/ucp/datamodel/resourcetype.go
@@ -49,4 +49,10 @@ type ResourceTypeProperties struct {
 
 	// Description of the resource type.
 	Description *string `json:"description,omitempty"`
+
+	// Icon is the verbatim SVG file content associated with the resource type, carried as a UTF-8 string.
+	Icon *string `json:"icon,omitempty"`
+
+	// IconHash is the SHA-256 hash of the icon's SVG bytes, computed by the control plane.
+	IconHash *string `json:"iconHash,omitempty"`
 }

--- a/pkg/ucp/frontend/controller/resourceproviders/geticon.go
+++ b/pkg/ucp/frontend/controller/resourceproviders/geticon.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceproviders
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/radius-project/radius/pkg/armrpc/frontend/controller"
+	armrpc_rest "github.com/radius-project/radius/pkg/armrpc/rest"
+	"github.com/radius-project/radius/pkg/components/database"
+	"github.com/radius-project/radius/pkg/ucp/datamodel"
+	"github.com/radius-project/radius/pkg/ucp/resources"
+)
+
+var _ controller.Controller = (*GetIcon)(nil)
+
+// GetIcon is the controller implementation to get a resource type's icon by hash.
+type GetIcon struct {
+	controller.Operation[*datamodel.ResourceType, datamodel.ResourceType]
+}
+
+// NewGetIcon creates a new GetIcon controller.
+func NewGetIcon(opts controller.Options) (controller.Controller, error) {
+	return &GetIcon{
+		Operation: controller.NewOperation(opts, controller.ResourceOptions[datamodel.ResourceType]{}),
+	}, nil
+}
+
+// Run executes the GetIcon operation.
+func (r *GetIcon) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
+	// Extract path parameters from chi. The route is:
+	// /planes/radius/{planeName}/providers/System.Resources/resourceproviders/{resourceProviderName}/resourcetypes/{resourceTypeName}/icons/{hash}
+	planeName := chi.URLParam(req, "planeName")
+	rpName := chi.URLParam(req, "resourceProviderName")
+	rtName := chi.URLParam(req, "resourceTypeName")
+	hash := chi.URLParam(req, "hash")
+
+	if planeName == "" || rpName == "" || rtName == "" || hash == "" {
+		return armrpc_rest.NewBadRequestResponse("invalid icon path"), nil
+	}
+
+	rtPath := fmt.Sprintf("/planes/radius/%s/providers/System.Resources/resourceProviders/%s/resourceTypes/%s", planeName, rpName, rtName)
+	id, err := resources.Parse(rtPath)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := r.DatabaseClient().Get(ctx, id.String())
+	if err != nil {
+		var notFound *database.ErrNotFound
+		if errors.As(err, &notFound) {
+			return armrpc_rest.NewNotFoundResponse(id), nil
+		}
+		return nil, err
+	}
+
+	rt := &datamodel.ResourceType{}
+	if err := result.As(rt); err != nil {
+		return nil, err
+	}
+
+	// Verify the hash matches what is stored
+	if rt.Properties.IconHash == nil || rt.Properties.Icon == nil {
+		return armrpc_rest.NewNotFoundResponseWithCause(id, "resource type has no icon"), nil
+	}
+	if *rt.Properties.IconHash != hash {
+		return armrpc_rest.NewNotFoundResponseWithCause(id, fmt.Sprintf("icon with hash %q was not found", hash)), nil
+	}
+
+	// Return the verbatim SVG bytes with the correct content type (FR-018)
+	return &iconResponse{content: *rt.Properties.Icon}, nil
+}
+
+type iconResponse struct {
+	content string
+}
+
+func (r *iconResponse) Apply(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
+	w.Header().Set("Content-Type", "image/svg+xml; charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write([]byte(r.content))
+	return err
+}

--- a/pkg/ucp/frontend/controller/resourceproviders/geticon.go
+++ b/pkg/ucp/frontend/controller/resourceproviders/geticon.go
@@ -96,6 +96,13 @@ type iconResponse struct {
 func (r *iconResponse) Apply(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
 	w.Header().Set("Content-Type", "image/svg+xml; charset=utf-8")
 	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	// Defense in depth: ValidateIcon already rejects <script>, on* handlers,
+	// <foreignObject>, and external href references before storage. These
+	// headers harden the response against MIME-sniffing and neutralize any
+	// residual active content if a client (e.g. a browser) navigates to the
+	// icon URL top-level rather than embedding it via <img>.
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox")
 	w.WriteHeader(http.StatusOK)
 	_, err := w.Write([]byte(r.content))
 	return err

--- a/pkg/ucp/frontend/controller/resourceproviders/geticon_test.go
+++ b/pkg/ucp/frontend/controller/resourceproviders/geticon_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceproviders
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	armrpc_controller "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
+	armrpc_rest "github.com/radius-project/radius/pkg/armrpc/rest"
+	"github.com/radius-project/radius/pkg/components/database"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/datamodel"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+const (
+	testIconPlaneName        = "local"
+	testIconResourceProvider = "MyCompany.Resources"
+	testIconResourceType     = "testResources"
+	testIconSVG              = `<svg xmlns="http://www.w3.org/2000/svg"><circle/></svg>`
+	testIconHash             = "6c4b7fa177f3ee83b7f81769f55048a2be419ebf024f5784b07b00198f0984c1"
+	testIconResourceTypeID   = "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/resourceTypes/testResources"
+)
+
+func newIconRequest(t *testing.T, hash string) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, "http://ucp/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/System.Resources/resourceproviders/MyCompany.Resources/resourcetypes/testResources/icons/"+hash, nil)
+	require.NoError(t, err)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("planeName", testIconPlaneName)
+	rctx.URLParams.Add("resourceProviderName", testIconResourceProvider)
+	rctx.URLParams.Add("resourceTypeName", testIconResourceType)
+	rctx.URLParams.Add("hash", hash)
+
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+func newGetIconController(t *testing.T) (*GetIcon, *database.MockClient) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	mockDB := database.NewMockClient(ctrl)
+
+	c, err := NewGetIcon(armrpc_controller.Options{DatabaseClient: mockDB})
+	require.NoError(t, err)
+
+	return c.(*GetIcon), mockDB
+}
+
+func TestGetIcon_Success(t *testing.T) {
+	ctrl, mockDB := newGetIconController(t)
+
+	rt := &datamodel.ResourceType{
+		Properties: datamodel.ResourceTypeProperties{
+			Icon:     to.Ptr(testIconSVG),
+			IconHash: to.Ptr(testIconHash),
+		},
+	}
+	mockDB.EXPECT().Get(gomock.Any(), testIconResourceTypeID).Return(&database.Object{Data: rt}, nil)
+
+	req := newIconRequest(t, testIconHash)
+	resp, err := ctrl.Run(context.Background(), nil, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, resp.Apply(context.Background(), rec, req))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "image/svg+xml; charset=utf-8", rec.Header().Get("Content-Type"))
+	require.Equal(t, "public, max-age=31536000, immutable", rec.Header().Get("Cache-Control"))
+	require.Equal(t, testIconSVG, rec.Body.String())
+}
+
+func TestGetIcon_HashMismatch(t *testing.T) {
+	ctrl, mockDB := newGetIconController(t)
+
+	rt := &datamodel.ResourceType{
+		Properties: datamodel.ResourceTypeProperties{
+			Icon:     to.Ptr(testIconSVG),
+			IconHash: to.Ptr(testIconHash),
+		},
+	}
+	mockDB.EXPECT().Get(gomock.Any(), testIconResourceTypeID).Return(&database.Object{Data: rt}, nil)
+
+	req := newIconRequest(t, "deadbeef")
+	resp, err := ctrl.Run(context.Background(), nil, req)
+	require.NoError(t, err)
+
+	notFound, ok := resp.(*armrpc_rest.NotFoundResponse)
+	require.True(t, ok, "expected NotFoundResponse, got %T", resp)
+	require.Equal(t, v1.CodeNotFound, notFound.Body.Error.Code)
+	require.Contains(t, notFound.Body.Error.Message, `icon with hash "deadbeef" was not found`)
+}
+
+func TestGetIcon_NoIcon(t *testing.T) {
+	tests := []struct {
+		name string
+		icon *string
+		hash *string
+	}{
+		{name: "both nil", icon: nil, hash: nil},
+		{name: "icon nil", icon: nil, hash: to.Ptr(testIconHash)},
+		{name: "hash nil", icon: to.Ptr(testIconSVG), hash: nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl, mockDB := newGetIconController(t)
+
+			rt := &datamodel.ResourceType{
+				Properties: datamodel.ResourceTypeProperties{
+					Icon:     tc.icon,
+					IconHash: tc.hash,
+				},
+			}
+			mockDB.EXPECT().Get(gomock.Any(), testIconResourceTypeID).Return(&database.Object{Data: rt}, nil)
+
+			req := newIconRequest(t, testIconHash)
+			resp, err := ctrl.Run(context.Background(), nil, req)
+			require.NoError(t, err)
+
+			notFound, ok := resp.(*armrpc_rest.NotFoundResponse)
+			require.True(t, ok, "expected NotFoundResponse, got %T", resp)
+			require.Contains(t, notFound.Body.Error.Message, "resource type has no icon")
+		})
+	}
+}
+
+func TestGetIcon_ResourceTypeNotFound(t *testing.T) {
+	ctrl, mockDB := newGetIconController(t)
+
+	mockDB.EXPECT().Get(gomock.Any(), testIconResourceTypeID).Return(nil, &database.ErrNotFound{ID: testIconResourceTypeID})
+
+	req := newIconRequest(t, testIconHash)
+	resp, err := ctrl.Run(context.Background(), nil, req)
+	require.NoError(t, err)
+
+	notFound, ok := resp.(*armrpc_rest.NotFoundResponse)
+	require.True(t, ok, "expected NotFoundResponse, got %T", resp)
+	require.Equal(t, v1.CodeNotFound, notFound.Body.Error.Code)
+	// The plain NotFoundResponse (no cause) is used when the resource type itself
+	// doesn't exist, so the message should NOT contain the "resource type has no icon"
+	// or "icon with hash" causes we produce when the resource does exist.
+	require.NotContains(t, notFound.Body.Error.Message, "resource type has no icon")
+	require.NotContains(t, notFound.Body.Error.Message, "icon with hash")
+}

--- a/pkg/ucp/frontend/controller/resourceproviders/geticon_test.go
+++ b/pkg/ucp/frontend/controller/resourceproviders/geticon_test.go
@@ -91,6 +91,8 @@ func TestGetIcon_Success(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, "image/svg+xml; charset=utf-8", rec.Header().Get("Content-Type"))
 	require.Equal(t, "public, max-age=31536000, immutable", rec.Header().Get("Cache-Control"))
+	require.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+	require.Equal(t, "default-src 'none'; style-src 'unsafe-inline'; sandbox", rec.Header().Get("Content-Security-Policy"))
 	require.Equal(t, testIconSVG, rec.Body.String())
 }
 

--- a/pkg/ucp/frontend/controller/resourceproviders/getresourceprovidersummary.go
+++ b/pkg/ucp/frontend/controller/resourceproviders/getresourceprovidersummary.go
@@ -83,12 +83,19 @@ func (r *GetResourceProviderSummary) Run(ctx context.Context, w http.ResponseWri
 		return nil, err
 	}
 
-	response, err := r.createResponse(ctx, result)
+	response, err := r.createResponse(ctx, result, includeIcons(req))
 	if err != nil {
 		return nil, err
 	}
 
 	return armrpc_rest.NewOKResponse(response), nil
+}
+
+// includeIcons reports whether the caller opted into icon bytes via the
+// includeIcons=true query parameter. Absent or any other value means false, so
+// the response carries icon hashes only (FR-015 of the resource-type icons spec).
+func includeIcons(req *http.Request) bool {
+	return strings.EqualFold(req.URL.Query().Get("includeIcons"), "true")
 }
 
 func (r *GetResourceProviderSummary) extractScopeAndName(relativePath string) (resources.ID, string, error) {
@@ -117,13 +124,23 @@ func (r *GetResourceProviderSummary) extractScopeAndName(relativePath string) (r
 	return scope, name, nil
 }
 
-func (r *GetResourceProviderSummary) createResponse(ctx context.Context, result *database.Object) (any, error) {
+func (r *GetResourceProviderSummary) createResponse(ctx context.Context, result *database.Object, includeIcons bool) (any, error) {
 	serviceCtx := v1.ARMRequestContextFromContext(ctx)
 
 	summary := datamodel.ResourceProviderSummary{}
 	err := result.As(&summary)
 	if err != nil {
 		return nil, err
+	}
+
+	// Icon bytes are only returned when the caller opts in with includeIcons=true.
+	// The icon hash is always retained so consumers can content-address the icon
+	// via the icon endpoint (FR-015).
+	if !includeIcons {
+		for name, resourceType := range summary.Properties.ResourceTypes {
+			resourceType.Icon = nil
+			summary.Properties.ResourceTypes[name] = resourceType
+		}
 	}
 
 	return converter.ResourceProviderSummaryDataModelToVersioned(&summary, serviceCtx.APIVersion)

--- a/pkg/ucp/frontend/controller/resourceproviders/getresourceprovidersummary_test.go
+++ b/pkg/ucp/frontend/controller/resourceproviders/getresourceprovidersummary_test.go
@@ -2,6 +2,8 @@ package resourceproviders
 
 import (
 	"errors"
+	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/ucp/resources"
@@ -60,6 +62,27 @@ func TestExtractScopeAndName(t *testing.T) {
 
 			require.Equal(t, tt.expectedScope, scope, "expected scope %v, got %v", tt.expectedScope, scope)
 			require.Equal(t, tt.expectedName, name, "expected name %v, got %v", tt.expectedName, name)
+		})
+	}
+}
+
+func TestIncludeIcons(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawQuery string
+		expected bool
+	}{
+		{name: "true opts in", rawQuery: "includeIcons=true", expected: true},
+		{name: "case-insensitive true", rawQuery: "includeIcons=TRUE", expected: true},
+		{name: "explicit false", rawQuery: "includeIcons=false", expected: false},
+		{name: "unrecognized value", rawQuery: "includeIcons=1", expected: false},
+		{name: "absent parameter", rawQuery: "", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &http.Request{URL: &url.URL{RawQuery: tt.rawQuery}}
+			require.Equal(t, tt.expected, includeIcons(req))
 		})
 	}
 }

--- a/pkg/ucp/frontend/radius/routes.go
+++ b/pkg/ucp/frontend/radius/routes.go
@@ -130,6 +130,10 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 											r.With(apiValidator).Delete("/", capture(apiVersionDeleteHandler(ctx, ctrlOptions)))
 										})
 									})
+
+									r.Route("/icons", func(r chi.Router) {
+										r.Get("/{hash}", capture(resourceTypeIconGetHandler(ctx, ctrlOptions)))
+									})
 								})
 							})
 						})
@@ -333,6 +337,12 @@ func apiVersionPutHandler(ctx context.Context, ctrlOptions controller.Options) (
 func apiVersionDeleteHandler(ctx context.Context, ctrlOptions controller.Options) (http.HandlerFunc, error) {
 	return server.CreateHandler(ctx, datamodel.APIVersionResourceType, v1.OperationDelete, ctrlOptions, func(opts controller.Options) (controller.Controller, error) {
 		return defaultoperation.NewDefaultAsyncDelete(opts, apiVersionResourceOptions)
+	})
+}
+
+func resourceTypeIconGetHandler(ctx context.Context, ctrlOptions controller.Options) (http.HandlerFunc, error) {
+	return server.CreateHandler(ctx, datamodel.ResourceTypeResourceType, v1.OperationGet, ctrlOptions, func(opts controller.Options) (controller.Controller, error) {
+		return resourceproviders_ctrl.NewGetIcon(opts)
 	})
 }
 

--- a/specs/003-resource-type-icons/plan.md
+++ b/specs/003-resource-type-icons/plan.md
@@ -1,0 +1,287 @@
+# Implementation Plan: Resource Type Icons (Spec #003)
+
+Companion to [spec.md](./spec.md). Groups the spec's functional requirements into
+PR-sized slices so each slice is coherent and mergeable on its own. FR/NFR ids
+reference the numbered requirements in `spec.md`.
+
+## Slice status at a glance
+
+| Slice | Scope | Status |
+|---|---|---|
+| 1 | Wire contract + inline endpoint | In progress on branch `azlinks_pr` |
+| 2 | Default icon + FR-011 substitution | Not started |
+| 3 | Full `--icon` grammar | Not started |
+| 4 | Built-in `Applications.Core/*` icons | Not started |
+| 5 | `rad app graph` + rendering integration | Not started |
+| 6 | CI enforcement | Not started |
+
+## Slice 1 — Wire contract + inline endpoint
+
+**Delivers:** `--icon` flag, server-side hashing, `iconHash` on responses,
+opt-in inline bytes, content-addressed icon endpoint, and SVG/size validation
+on both the CLI and the control plane.
+
+**FRs covered:** FR-003, FR-004, FR-005, FR-005a, FR-010, FR-012, FR-014,
+FR-015, FR-018, NFR-001, NFR-002, NFR-003, NFR-004.
+
+**FRs partially covered:**
+
+- FR-002 — bare `--icon <path>` only, plus a multi-type guard error.
+- FR-011 — `iconHash` is surfaced on responses; default substitution is Slice 2.
+
+**Key file changes on the branch:**
+
+- [typespec/UCP/resourceproviders.tsp](../../typespec/UCP/resourceproviders.tsp) — adds `icon` and `iconHash` to `ResourceTypeProperties` and `ResourceProviderSummaryResourceType`, and the `includeIcons` query param on the summary GET.
+- [pkg/ucp/datamodel/icon_validation.go](../../pkg/ucp/datamodel/icon_validation.go) — shared `ValidateIcon` implementing FR-005 / FR-005a with a 32 KiB size cap (NFR-002).
+- [pkg/ucp/api/v20231001preview/resourcetype_conversion.go](../../pkg/ucp/api/v20231001preview/resourcetype_conversion.go) — server-side validation + SHA-256 in `ConvertTo`.
+- [pkg/ucp/backend/controller/resourceproviders/resourcetype_put.go](../../pkg/ucp/backend/controller/resourceproviders/resourcetype_put.go) — copies `icon`/`iconHash` onto the summary entry.
+- [pkg/ucp/frontend/controller/resourceproviders/getresourceprovidersummary.go](../../pkg/ucp/frontend/controller/resourceproviders/getresourceprovidersummary.go) — honors `includeIcons` query param.
+- [pkg/ucp/frontend/controller/resourceproviders/geticon.go](../../pkg/ucp/frontend/controller/resourceproviders/geticon.go) and [pkg/ucp/frontend/radius/routes.go](../../pkg/ucp/frontend/radius/routes.go) — FR-018 endpoint.
+- [pkg/cli/cmd/resourcetype/create/create.go](../../pkg/cli/cmd/resourcetype/create/create.go) and [pkg/cli/manifest/registermanifest.go](../../pkg/cli/manifest/registermanifest.go) — `--icon` flag, byte read, CLI-side validation, embedding.
+
+**Still to add inside this slice before merging:** (none required — deferred items are listed in later slices)
+
+## Slice 2 — Default icon + FR-011 substitution
+
+**Delivers:** every registered type has a resolvable `iconHash`, even when the
+manifest arrives without an `icon` field.
+
+**FRs covered:** FR-001, FR-006, FR-011 (fully).
+
+**Changes:**
+
+- Ship a canonical default SVG in the Radius product repository and `go:embed` it into the control plane.
+- In the resource-type PUT path, if `icon` is nil after conversion, substitute the default's bytes + hash before storing.
+- Build fails loudly if the embedded default is missing or fails validation.
+
+## Slice 3 — Full `--icon` grammar
+
+**Delivers:** the named form and repeatable flag; strict-mode YAML decoder.
+
+**FRs covered:** FR-002 (fully), FR-002a, FR-002b (fully), FR-002c, FR-010a.
+
+**Changes:**
+
+- Make `--icon` a repeatable `StringSlice`; parse each value as either `<typeName>=<path>` or bare `<path>`.
+- Enforce per-type resolution rules; error on duplicate targeting, ambiguous args, non-matching typeName.
+- Switch the manifest YAML decoder to known-fields mode so `icon:` under a type is a hard error.
+
+## Slice 4 — Built-in `Applications.Core/*` icons
+
+**Delivers:** every built-in type ships with its own distinct custom icon.
+
+**FRs covered:** FR-007, FR-008, FR-009. Success criterion: SC-003.
+
+**Changes:**
+
+- Add SVG assets for `environments`, `applications`, `containers`, `gateways`, `secretStores`, `extenders`.
+- Regenerate `deploy/manifest/built-in-providers/{dev,self-hosted}/` through the icon-embedding flow.
+- Wire a build-time mapping (`Makefile` or generator) so the icon-to-type association is explicit, not filename-inferred.
+
+## Slice 5 — `rad app graph` + rendering integration
+
+**Delivers:** graph responses carry `iconHash` per node; the dashboard can
+consume them.
+
+**FRs covered:** FR-013, FR-016, FR-017, FR-019, NFR-005 (renderer-side).
+
+**Changes in this repo:**
+
+- Extend the `getGraph` response to include `iconHash` per node.
+- Add an `includeIcons` query param that returns an `icons` map deduped by hash (FR-013).
+- Add `--include-icons` to `rad app graph`.
+
+**Changes in the dashboard repo (separate PR):** consume `iconHash` and either
+use inline bytes or fetch them via FR-018.
+
+## Slice 6 — CI enforcement
+
+**Delivers:** malformed / oversized / non-SVG icons are rejected in CI.
+
+**FRs covered:** FR-020. Success criterion: SC-005.
+
+**Changes:**
+
+- CI job that validates every referenced icon file plus the default icon against NFR-001 and NFR-002.
+
+## What Slice 1 delivers today (functional summary)
+
+- `rad resource-type create <typeName> --from-file <yaml> --icon <path.svg>` reads the SVG and sends its verbatim UTF-8 bytes as `ResourceTypeProperties.icon`.
+- Multi-type YAML combined with a bare `--icon` fails with an actionable CLI error.
+- The server computes `iconHash` (SHA-256 of the bytes) during conversion and stores both `icon` and `iconHash`.
+- The provider summary API returns `iconHash` for every type by default; add `?includeIcons=true` to also inline the bytes.
+- `GET /planes/radius/{plane}/providers/System.Resources/resourceProviders/{namespace}/resourceTypes/{type}/icons/{hash}` returns the raw SVG bytes with `Content-Type: image/svg+xml; charset=utf-8` and a long-lived `Cache-Control`.
+
+Explicitly **not** on the branch yet: default icon, SVG/size validation on
+either side, named `--icon <typeName>=<path>` form, YAML strict-mode for the
+`icon:` key, built-in `Applications.Core/*` icons, graph endpoint changes,
+`rad app graph --include-icons`, CI validation, and the FR-018 `ETag` header.
+
+## Manual verification — Slice 1
+
+Copy the block below into a test ticket.
+
+````markdown
+## Manual verification — Slice 1 (icons wire contract + inline endpoint)
+
+### Preconditions
+
+- Local debug stack running: `make debug-start` (UCP listens on `localhost:9000`).
+- `./drad` built at the repo root (produced by `make debug-start`).
+- `curl`, `jq`, `python3`, and `shasum` (or `sha256sum`) available.
+
+### 1. Prepare fixtures
+
+```bash
+cat > /tmp/rt.yaml <<'YAML'
+namespace: MyCompany.Resources
+types:
+  testResources:
+    description: This is a test resource type.
+    apiVersions:
+      "2025-01-01-preview":
+        schema: {}
+YAML
+
+cat > /tmp/icon.svg <<'SVG'
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="red"/></svg>
+SVG
+
+cat > /tmp/rt-multi.yaml <<'YAML'
+namespace: MyCompany.Multi
+types:
+  a:
+    apiVersions: { "2025-01-01-preview": { schema: {} } }
+  b:
+    apiVersions: { "2025-01-01-preview": { schema: {} } }
+YAML
+```
+
+### 2. Register a type with an icon (FR-004, FR-010, FR-012)
+
+```bash
+./drad resource-type create testResources -f /tmp/rt.yaml --icon /tmp/icon.svg
+```
+
+**Expected:** `MyCompany.Resources/testResources created`.
+
+### 3. Verify the hash is deterministic and server-computed (FR-010)
+
+```bash
+EXPECTED_HASH=$(shasum -a 256 /tmp/icon.svg | awk '{print $1}')
+ACTUAL_HASH=$(curl -s "http://localhost:9000/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/MyCompany.Resources" \
+  | jq -r '.properties.resourceTypes.testResources.iconHash')
+echo "expected=$EXPECTED_HASH"
+echo "actual  =$ACTUAL_HASH"
+[ "$EXPECTED_HASH" = "$ACTUAL_HASH" ] && echo "match" || echo "mismatch"
+```
+
+**Expected:** `match` — the server's `iconHash` equals SHA-256 of the SVG file bytes.
+
+### 4. Default response omits bytes; opt-in returns them (FR-015)
+
+```bash
+# Default: no bytes, only hash
+curl -s "http://localhost:9000/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/MyCompany.Resources" \
+  | jq '.properties.resourceTypes.testResources | {has_icon: (.icon != null), iconHash}'
+
+# Opt-in: bytes inlined
+curl -s "http://localhost:9000/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/MyCompany.Resources?includeIcons=true" \
+  | jq '.properties.resourceTypes.testResources | {icon,iconHash}'
+```
+
+**Expected:**
+
+- Default call → `{"has_icon": false, "iconHash": "<hash>"}`.
+- `includeIcons=true` call → both `icon` (the SVG string) and `iconHash` populated.
+
+### 5. Fetch bytes via the content-addressed endpoint (FR-018)
+
+```bash
+HASH=$(curl -s "http://localhost:9000/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/MyCompany.Resources" \
+  | jq -r '.properties.resourceTypes.testResources.iconHash')
+
+curl -i "http://localhost:9000/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/System.Resources/resourceproviders/MyCompany.Resources/resourcetypes/testResources/icons/$HASH"
+```
+
+**Expected:**
+
+- `HTTP/1.1 200 OK`
+- `Content-Type: image/svg+xml; charset=utf-8`
+- `Cache-Control: public, max-age=31536000, immutable`
+- Body equals the exact contents of `/tmp/icon.svg`.
+
+### 6. Wrong hash returns 404 (FR-018 stale-hash case)
+
+```bash
+curl -i "http://localhost:9000/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/System.Resources/resourceproviders/MyCompany.Resources/resourcetypes/testResources/icons/deadbeefdeadbeef"
+```
+
+**Expected:** `HTTP/1.1 404 Not Found` with a JSON error body.
+
+### 7. Multi-type YAML with bare `--icon` is rejected (FR-002b, partial)
+
+```bash
+./drad resource-type create -f /tmp/rt-multi.yaml --icon /tmp/icon.svg
+```
+
+**Expected:** non-zero exit, error message telling the author to specify a
+single type name (currently `rad resource-type create <typeName> --from-file <file> --icon <path>`).
+
+### 8. CLI rejects non-SVG icon (FR-005, NFR-001)
+
+```bash
+cat > /tmp/bad.svg <<'HTML'
+<html><body>not an svg</body></html>
+HTML
+
+./drad resource-type create testResources -f /tmp/rt.yaml --icon /tmp/bad.svg
+```
+
+**Expected:** non-zero exit, error message containing `invalid icon file` and
+`root element is <html>, expected <svg>`. Nothing is sent to the control plane.
+
+### 9. CLI rejects oversized icon (FR-005, NFR-002)
+
+```bash
+python3 -c "print('<svg xmlns=\"http://www.w3.org/2000/svg\">' + 'x' * 33000 + '</svg>')" > /tmp/big.svg
+
+./drad resource-type create testResources -f /tmp/rt.yaml --icon /tmp/big.svg
+```
+
+**Expected:** non-zero exit, error message containing `exceeds the 32768 byte limit`.
+
+### 10. Server rejects malicious SVG (FR-005a)
+
+Even if the CLI check is bypassed (for example a caller hitting the wire API
+directly), the server rejects dangerous SVG bytes.
+
+```bash
+cat > /tmp/scripty.svg <<'SVG'
+<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>
+SVG
+
+./drad resource-type create testResources -f /tmp/rt.yaml --icon /tmp/scripty.svg
+```
+
+**Expected:** non-zero exit. The failure is raised by the CLI validator here;
+in a bypass scenario the control plane returns `HTTP 400` with an
+`invalid icon` message.
+
+### 11. Type without an icon has no `iconHash` today (Slice 2 will fix)
+
+```bash
+./drad resource-type create testResources -f /tmp/rt.yaml
+curl -s "http://localhost:9000/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/MyCompany.Resources" \
+  | jq '.properties.resourceTypes.testResources | {icon, iconHash}'
+```
+
+**Expected (Slice 1):** `iconHash` is `null` / absent.
+**Expected once Slice 2 lands:** `iconHash` equals the default icon's hash.
+
+### Cleanup
+
+```bash
+rm -f /tmp/rt.yaml /tmp/rt-multi.yaml /tmp/icon.svg /tmp/bad.svg /tmp/big.svg /tmp/scripty.svg
+```
+````

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2023-10-01-preview/openapi.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2023-10-01-preview/openapi.json
@@ -1422,6 +1422,13 @@
             "type": "string",
             "maxLength": 63,
             "pattern": "^([A-Za-z]([-A-Za-z0-9]*[A-Za-z0-9]))\\.([A-Za-z]([-A-Za-z0-9]*[A-Za-z0-9]))?$"
+          },
+          {
+            "name": "includeIcons",
+            "in": "query",
+            "description": "When true, resource type icon bytes are included in the response. When false or omitted, only the icon hash is returned.",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {
@@ -2539,6 +2546,84 @@
           "final-state-via": "location"
         },
         "x-ms-long-running-operation": true
+      }
+    },
+    "/planes/radius/{planeName}/providers/System.Resources/resourceproviders/{resourceProviderName}/resourcetypes/{resourceTypeName}/icons/{hash}": {
+      "get": {
+        "operationId": "ResourceTypes_GetIcon",
+        "tags": [
+          "ResourceTypes"
+        ],
+        "description": "Get the icon bytes stored for the specified resource type, addressed by the SHA-256 hash of those bytes. Returns the verbatim SVG file content with Content-Type: image/svg+xml and an immutable Cache-Control. If the hash does not match the stored icon, or the resource type has no icon, returns 404.",
+        "produces": [
+          "image/svg+xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "planeName",
+            "in": "path",
+            "description": "The plane name.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[A-Za-z]([-A-Za-z0-9]*[A-Za-z0-9])?$"
+          },
+          {
+            "name": "resourceProviderName",
+            "in": "path",
+            "description": "The resource provider name. This is also the resource provider namespace. Example: 'Applications.Datastores'.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^([A-Za-z]([-A-Za-z0-9]*[A-Za-z0-9]))\\.([A-Za-z]([-A-Za-z0-9]*[A-Za-z0-9]))?$"
+          },
+          {
+            "name": "resourceTypeName",
+            "in": "path",
+            "description": "The resource type name.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^([A-Za-z]([-A-Za-z0-9]*[A-Za-z0-9]))$"
+          },
+          {
+            "name": "hash",
+            "in": "path",
+            "description": "The SHA-256 hash of the icon's SVG bytes, as a lowercase hex string.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The response body for fetching a resource type's icon bytes.",
+            "schema": {
+              "type": "file"
+            },
+            "headers": {
+              "cache-control": {
+                "type": "string",
+                "description": "Caching hint. Icon bytes are content-addressed by SHA-256 and safe to cache immutably.",
+                "enum": [
+                  "public, max-age=31536000, immutable"
+                ],
+                "x-ms-enum": {
+                  "modelAsString": false
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
       }
     },
     "/planes/radius/{planeName}/resourcegroups": {
@@ -3993,10 +4078,32 @@
         "description": {
           "type": "string",
           "description": "Description of the resource type."
+        },
+        "icon": {
+          "type": "string",
+          "description": "The verbatim SVG icon content associated with the resource type, carried as a UTF-8 string."
+        },
+        "iconHash": {
+          "type": "string",
+          "description": "The SHA-256 hash of the icon's SVG bytes, computed by the control plane."
         }
       },
       "required": [
         "apiVersions"
+      ]
+    },
+    "ResourceTypeIconResponse": {
+      "type": "object",
+      "description": "The response body for fetching a resource type's icon bytes.",
+      "properties": {
+        "body": {
+          "type": "string",
+          "format": "byte",
+          "description": "The verbatim SVG file content stored for the resource type."
+        }
+      },
+      "required": [
+        "body"
       ]
     },
     "ResourceTypeNameString": {
@@ -4028,6 +4135,15 @@
         "description": {
           "type": "string",
           "description": "Description of the resource type."
+        },
+        "icon": {
+          "type": "string",
+          "description": "The verbatim SVG file content of the icon associated with the resource type, carried as a UTF-8 string. Set by 'rad resource-type create --icon <path>'."
+        },
+        "iconHash": {
+          "type": "string",
+          "description": "The SHA-256 hash of the icon's SVG bytes. Computed by the control plane and used to content-address the icon.",
+          "readOnly": true
         }
       }
     },

--- a/typespec/UCP/resourceproviders.tsp
+++ b/typespec/UCP/resourceproviders.tsp
@@ -105,6 +105,13 @@ model ResourceTypeProperties {
 
   @doc("Description of the resource type.")
   description?: string;
+
+  @doc("The verbatim SVG file content of the icon associated with the resource type, carried as a UTF-8 string. Set by 'rad resource-type create --icon <path>'.")
+  icon?: string;
+
+  @doc("The SHA-256 hash of the icon's SVG bytes. Computed by the control plane and used to content-address the icon.")
+  @visibility(Lifecycle.Read)
+  iconHash?: string;
 }
 
 @doc("The resource type for defining an API version of a resource type supported by the containing resource provider.")
@@ -189,6 +196,12 @@ model ResourceProviderSummaryResourceType {
 
   @doc("Description of the resource type.")
   description?: string;
+
+  @doc("The verbatim SVG icon content associated with the resource type, carried as a UTF-8 string.")
+  icon?: string;
+
+  @doc("The SHA-256 hash of the icon's SVG bytes, computed by the control plane.")
+  iconHash?: string;
 }
 
 @doc("The configuration of a resource type API version.")
@@ -294,7 +307,30 @@ interface ResourceProviders {
     @path
     @segment("providers")
     resourceProviderName: ResourceProviderNamespaceString,
+
+    @doc("When true, resource type icon bytes are included in the response. When false or omitted, only the icon hash is returned.")
+    @query
+    includeIcons?: boolean,
   ): ArmResponse<ResourceProviderSummary> | ErrorResponse;
+}
+
+@doc("The response body for fetching a resource type's icon bytes.")
+model ResourceTypeIconResponse {
+  @doc("HTTP status code.")
+  @statusCode
+  statusCode: 200;
+
+  @doc("MIME type of the icon bytes.")
+  @header
+  contentType: "image/svg+xml";
+
+  @doc("Caching hint. Icon bytes are content-addressed by SHA-256 and safe to cache immutably.")
+  @header("cache-control")
+  cacheControl: "public, max-age=31536000, immutable";
+
+  @doc("The verbatim SVG file content stored for the resource type.")
+  @body
+  body: bytes;
 }
 
 @route("/planes")
@@ -327,6 +363,17 @@ interface ResourceTypes {
     ResourceTypeResource,
     ResourceTypeBaseParameters<ResourceTypeResource>
   >;
+
+  @doc("Get the icon bytes stored for the specified resource type, addressed by the SHA-256 hash of those bytes. Returns the verbatim SVG file content with Content-Type: image/svg+xml and an immutable Cache-Control. If the hash does not match the stored icon, or the resource type has no icon, returns 404.")
+  @get
+  getIcon(
+    ...ResourceTypeBaseParameters<ResourceTypeResource>,
+
+    @doc("The SHA-256 hash of the icon's SVG bytes, as a lowercase hex string.")
+    @path
+    @segment("icons")
+    hash: string,
+  ): ResourceTypeIconResponse | ErrorResponse;
 }
 
 @route("/planes")


### PR DESCRIPTION
# Description

This PR implements the core infrastructure for Resource Type Icons (Spec #003), enabling resource type authors to associate SVG icons with their types during registration. The icons are stored directly in the control plane and content-addressed via SHA-256 hashes.


## Testing

### Setup fixtures

```bash
cat > /tmp/rt.yaml <<'YAML'
namespace: MyCompany.Resources
types:
  testResources:
    description: This is a test resource type.
    apiVersions:
      "2025-01-01-preview":
        schema: {}
YAML

cat > /tmp/rt-multi.yaml <<'YAML'
namespace: MyCompany.Multi
types:
  a: { apiVersions: { "2025-01-01-preview": { schema: {} } } }
  b: { apiVersions: { "2025-01-01-preview": { schema: {} } } }
YAML

cat > /tmp/icon.svg <<'SVG'
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="red"/></svg>
SVG

cat > /tmp/bad-root.svg <<'HTML'
<html><body>not an svg</body></html>
HTML

cat > /tmp/scripty.svg <<'SVG'
<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>
SVG

cat > /tmp/onload.svg <<'SVG'
<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"/>
SVG

cat > /tmp/foreignobj.svg <<'SVG'
<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div/></foreignObject></svg>
SVG

cat > /tmp/external-href.svg <<'SVG'
<svg xmlns="http://www.w3.org/2000/svg"><image href="https://example.com/x.png"/></svg>
SVG

python3 -c "print('<svg xmlns=\"http://www.w3.org/2000/svg\">' + 'x' * 33000 + '</svg>')" > /tmp/big.svg
```

### Happy path

```bash
# 1. Register with icon (FR-004, FR-010, FR-012)
./drad resource-type create testResources -f /tmp/rt.yaml --icon /tmp/icon.svg

# 2. Verify server-computed hash matches SHA-256 of the file (FR-010)
EXPECTED=$(shasum -a 256 /tmp/icon.svg | awk '{print $1}')
ACTUAL=$(curl -s "http://localhost:9000/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/MyCompany.Resources" \
  | jq -r '.properties.resourceTypes.testResources.iconHash')
echo "expected=$EXPECTED actual=$ACTUAL"
[ "$EXPECTED" = "$ACTUAL" ] && echo "MATCH" || echo "MISMATCH"

# 3. Default response has hash only (FR-015 default)
curl -s "http://localhost:9000/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/MyCompany.Resources" \
  | jq '.properties.resourceTypes.testResources | {has_icon: (.icon != null), iconHash}'

# 4. includeIcons=true inlines the bytes (FR-015 opt-in)
curl -s "http://localhost:9000/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/MyCompany.Resources?includeIcons=true" \
  | jq '.properties.resourceTypes.testResources | {icon,iconHash}'

# 5. FR-018 icon endpoint returns verbatim SVG bytes
HASH=$(curl -s "http://localhost:9000/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/MyCompany.Resources" \
  | jq -r '.properties.resourceTypes.testResources.iconHash')
curl -i "http://localhost:9000/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/System.Resources/resourceproviders/MyCompany.Resources/resourcetypes/testResources/icons/$HASH"

# 6. Stale/unknown hash returns 404 (FR-018)
curl -i "http://localhost:9000/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/System.Resources/resourceproviders/MyCompany.Resources/resourcetypes/testResources/icons/deadbeef"
```

### CLI validation (FR-005, FR-002b)

```bash
# 7. Multi-type YAML + bare --icon → CLI error (FR-002b partial)
./drad resource-type create -f /tmp/rt-multi.yaml --icon /tmp/icon.svg

# 8. Non-SVG root element rejected (NFR-001)
./drad resource-type create testResources -f /tmp/rt.yaml --icon /tmp/bad-root.svg

# 9. Oversized icon rejected (NFR-002)
./drad resource-type create testResources -f /tmp/rt.yaml --icon /tmp/big.svg

# 10. <script> rejected (FR-005a)
./drad resource-type create testResources -f /tmp/rt.yaml --icon /tmp/scripty.svg

# 11. on* event handler rejected (FR-005a)
./drad resource-type create testResources -f /tmp/rt.yaml --icon /tmp/onload.svg

# 12. <foreignObject> rejected (FR-005a)
./drad resource-type create testResources -f /tmp/rt.yaml --icon /tmp/foreignobj.svg

# 13. External href rejected (FR-005a)
./drad resource-type create testResources -f /tmp/rt.yaml --icon /tmp/external-href.svg

# 14. Missing icon file rejected
./drad resource-type create testResources -f /tmp/rt.yaml --icon /tmp/does-not-exist.svg  

```
## Type of change

<!--
Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.
If you are making a bug fix or functionality change to Radius and do not have an associated issue link, please create one now. 
-->
- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
- This pull request is a design document and only includes files in the eng/design-notes directory.

<!-- Please update the following to link the associated issue. This is required for some kinds of changes (see above). -->
Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
