### PR TITLE
ci(aws-irsa): switch long-running tests to federated identity

### DIFF
--- a/.github/scripts/manage-radius-installation.sh
+++ b/.github/scripts/manage-radius-installation.sh
@@ -22,7 +22,7 @@
 # This script detects the installed Radius control plane version on the
 # connected Kubernetes cluster and takes appropriate action:
 # - If not installed: runs rad install kubernetes
-# - If same version as CLI: skips installation (no action needed)
+# - If same version as CLI: reconciles required chart values when needed
 # - If different version: attempts rad upgrade kubernetes
 # ============================================================================
 
@@ -158,6 +158,65 @@ save_skip_resources_list() {
     fi
 }
 
+aws_irsa_token_volumes_enabled() {
+    local -a deployments=(ucp applications-rp dynamic-rp)
+    local deployment volume_name
+
+    for deployment in "${deployments[@]}"; do
+        if ! volume_name=$(
+            kubectl get deployment "${deployment}" -n radius-system \
+                -o jsonpath='{.spec.template.spec.volumes[?(@.name=="aws-iam-token")].name}'
+        ); then
+            echo "Error: Failed to inspect deployment ${deployment} for AWS IRSA configuration." >&2
+            return 2
+        fi
+
+        if [[ "${volume_name}" != "aws-iam-token" ]]; then
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+upgrade_radius() {
+    rad upgrade kubernetes \
+        --set global.azureWorkloadIdentity.enabled=true \
+        --set global.aws.irsa.enabled=true \
+        --set database.enabled=false \
+        "$@"
+}
+
+reconcile_required_chart_values() {
+    local irsa_status=0
+    aws_irsa_token_volumes_enabled || irsa_status=$?
+
+    if [[ ${irsa_status} -eq 0 ]]; then
+        echo "Required Radius chart values are already configured."
+        return 0
+    fi
+
+    if [[ ${irsa_status} -ne 1 ]]; then
+        return 1
+    fi
+
+    echo "AWS IRSA is not enabled on the current Radius installation. Reconciling chart values..."
+    # The upgrade preflight rejects a same-version target. We already established
+    # that this is an installed, matching-version control plane, so skip preflight
+    # for this one-time Helm value reconciliation.
+    if ! upgrade_radius --skip-preflight; then
+        echo "Error: Failed to reconcile required Radius chart values." >&2
+        return 1
+    fi
+
+    if ! aws_irsa_token_volumes_enabled; then
+        echo "Error: AWS IRSA token volumes are still missing after reconciliation." >&2
+        return 1
+    fi
+
+    echo "Required Radius chart values reconciled successfully."
+}
+
 # Install Radius on the cluster
 install_radius() {
     echo "Installing Radius..."
@@ -237,7 +296,11 @@ main() {
         install_radius
     elif [[ "${cp_version}" == "${cli_version}" ]]; then
         echo ""
-        echo "Radius control plane version matches CLI version (${cli_version}). Skipping install/upgrade."
+        echo "Radius control plane version matches CLI version (${cli_version})."
+
+        if ! reconcile_required_chart_values; then
+            exit 1
+        fi
 
         # Verify resource types with retry for transient failures.
         local check_result=0
@@ -278,10 +341,7 @@ main() {
         # - global.azureWorkloadIdentity.enabled defaults to false and is required for Azure WI auth in this workflow.
         # - global.aws.irsa.enabled defaults to false and is required for AWS IRSA auth in this workflow.
         # https://github.com/radius-project/radius/issues/11218
-        if ! rad upgrade kubernetes \
-            --set global.azureWorkloadIdentity.enabled=true \
-            --set global.aws.irsa.enabled=true \
-            --set database.enabled=false; then
+        if ! upgrade_radius; then
             echo ""
             echo "============================================================================"
             echo "ERROR: Radius upgrade failed"
@@ -300,4 +360,6 @@ main() {
     echo "============================================================================"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/.github/scripts/manage-radius-installation.sh
+++ b/.github/scripts/manage-radius-installation.sh
@@ -163,6 +163,7 @@ install_radius() {
     echo "Installing Radius..."
     if ! rad install kubernetes \
         --set global.azureWorkloadIdentity.enabled=true \
+        --set global.aws.irsa.enabled=true \
         --set database.enabled=false; then
         echo ""
         echo "============================================================================"
@@ -275,9 +276,11 @@ main() {
         # NOTE: Helm upgrades do not automatically reuse values from the previous release.
         # We must re-apply critical chart values or they will reset to chart defaults.
         # - global.azureWorkloadIdentity.enabled defaults to false and is required for Azure WI auth in this workflow.
+        # - global.aws.irsa.enabled defaults to false and is required for AWS IRSA auth in this workflow.
         # https://github.com/radius-project/radius/issues/11218
         if ! rad upgrade kubernetes \
             --set global.azureWorkloadIdentity.enabled=true \
+            --set global.aws.irsa.enabled=true \
             --set database.enabled=false; then
             echo ""
             echo "============================================================================"

--- a/.github/scripts/manage-radius-installation_test.sh
+++ b/.github/scripts/manage-radius-installation_test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_contains() {
+    local actual="$1"
+    local expected="$2"
+
+    [[ "${actual}" == *"${expected}"* ]] || fail "expected '${actual}' to contain '${expected}'"
+}
+
+run_matching_version_case() (
+    local initial_irsa_state="$1"
+    local expect_upgrade="$2"
+    local irsa_enabled="${initial_irsa_state}"
+    local upgrade_args=""
+    local work_dir
+    work_dir="$(mktemp -d)"
+    trap 'rm -rf "${work_dir}"' EXIT
+
+    # The production script is checked separately; this test sources it dynamically.
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/manage-radius-installation.sh"
+
+    # shellcheck disable=SC2329 # Invoked indirectly by the sourced script.
+    rad() {
+        if [[ "$1" == "version" ]]; then
+            printf 'RELEASE\n0.60.0\nSTATUS VERSION\nReady 0.60.0\n'
+        elif [[ "$1 $2" == "workspace create" ]]; then
+            return 0
+        elif [[ "$1 $2" == "resource-provider list" ]]; then
+            echo "Applications.Core"
+        elif [[ "$1 $2" == "upgrade kubernetes" ]]; then
+            upgrade_args="$*"
+            irsa_enabled="true"
+        else
+            fail "unexpected rad invocation: $*"
+        fi
+    }
+
+    # shellcheck disable=SC2329 # Invoked indirectly by the sourced script.
+    kubectl() {
+        if [[ "$1 $2" == "get deployment" ]]; then
+            if [[ "${irsa_enabled}" == "error" ]]; then
+                return 1
+            fi
+            if [[ "${irsa_enabled}" == "true" ]]; then
+                printf 'aws-iam-token'
+            fi
+        elif [[ "$1 $2" == "get resources.ucp.dev" ]]; then
+            echo "resource-id"
+        else
+            fail "unexpected kubectl invocation: $*"
+        fi
+    }
+
+    cd "${work_dir}"
+
+    if [[ "${irsa_enabled}" == "error" ]]; then
+        if (main); then
+            fail "expected deployment inspection failure to stop reconciliation"
+        fi
+        return 0
+    fi
+
+    main
+
+    if [[ "${expect_upgrade}" == "true" ]]; then
+        [[ -n "${upgrade_args}" ]] || fail "expected matching-version reconciliation to run"
+        assert_contains "${upgrade_args}" "--skip-preflight"
+        assert_contains "${upgrade_args}" "global.azureWorkloadIdentity.enabled=true"
+        assert_contains "${upgrade_args}" "global.aws.irsa.enabled=true"
+        assert_contains "${upgrade_args}" "database.enabled=false"
+    elif [[ -n "${upgrade_args}" ]]; then
+        fail "did not expect an upgrade when IRSA was already enabled: ${upgrade_args}"
+    fi
+
+    [[ -s skip-delete-resources-list.txt ]] || fail "expected the skip-resources list to be saved"
+)
+
+run_matching_version_case "false" "true"
+run_matching_version_case "true" "false"
+run_matching_version_case "error" "false"
+
+echo "manage-radius-installation tests passed"

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -754,7 +754,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ secrets.AWS_GH_ACTIONS_ROLE }}
-          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          role-session-name: ${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Install KinD

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -281,8 +281,7 @@ jobs:
           AZURE_SP_TESTS_APPID: ${{ secrets.AZURE_SP_TESTS_APPID }}
           AZURE_SP_TESTS_TENANTID: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
           FUNCTEST_AWS_ACCOUNT_ID: ${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}
-          FUNCTEST_AWS_ACCESS_KEY_ID: ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }}
-          FUNCTEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.FUNCTEST_AWS_SECRET_ACCESS_KEY }}
+          FUNC_TEST_RAD_IRSA_ROLE: ${{ secrets.FUNC_TEST_RAD_IRSA_ROLE }}
         run: |
           set -x
 
@@ -307,8 +306,12 @@ jobs:
 
           echo "*** Configuring AWS provider ***"
           rad env update "${RADIUS_TEST_ENVIRONMENT_NAME}" --aws-region "${AWS_REGION}" --aws-account-id "${FUNCTEST_AWS_ACCOUNT_ID}"
-          rad credential register aws access-key \
-            --access-key-id "${FUNCTEST_AWS_ACCESS_KEY_ID}" --secret-access-key "${FUNCTEST_AWS_SECRET_ACCESS_KEY}"
+          # Register AWS credentials using IRSA (IAM Roles for Service Accounts).
+          # The Radius pods on the AKS cluster assume this role via their
+          # projected service account tokens (workload identity), so no static
+          # access keys are stored in the control plane.
+          rad credential register aws irsa \
+            --iam-role "${FUNC_TEST_RAD_IRSA_ROLE}"
 
       - name: Log radius installation status (failure)
         if: failure()
@@ -373,6 +376,18 @@ jobs:
         env:
           RELEASE_DIR: ${{ steps.checkout-release-codebase.outputs.release-dir }}
 
+      - name: Configure AWS credentials using assumed role
+        # The test verification code constructs an AWS Cloud Control client via
+        # the default credential chain to check and clean up AWS resources. Use
+        # federated OIDC to assume a role instead of static access keys; the
+        # action exports short-lived AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY /
+        # AWS_SESSION_TOKEN into the environment for the test step below.
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          role-to-assume: ${{ secrets.AWS_GH_ACTIONS_ROLE }}
+          role-session-name: ${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Run functional tests
         timeout-minutes: 120
         env:
@@ -380,8 +395,6 @@ jobs:
           UNIQUE_ID: ${{ steps.gen-id.outputs.UNIQUE_ID }}
           TEST_TIMEOUT: ${{ env.FUNCTIONALTEST_TIMEOUT }}
           RADIUS_CONTAINER_LOG_PATH: ${{ github.workspace }}/${{ env.RADIUS_CONTAINER_LOG_BASE }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.FUNCTEST_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ env.AWS_REGION }}
           AWS_ACCOUNT_ID: ${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}
           RADIUS_SAMPLES_REPO_ROOT: ${{ github.workspace }}/samples

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -386,6 +386,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_GH_ACTIONS_ROLE }}
           role-session-name: ${{ github.run_id }}
+          role-duration-seconds: 5400
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Run functional tests

--- a/.github/workflows/purge-aws-test-resources.yaml
+++ b/.github/workflows/purge-aws-test-resources.yaml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
+      id-token: write # Required for requesting the OIDC JWT to assume the AWS role
       contents: read
       issues: write # Required to create an issue when the scheduled run fails
     steps:
@@ -49,8 +50,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
-          aws-access-key-id: ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.FUNCTEST_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_GH_ACTIONS_ROLE }}
+          role-session-name: ${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Delete old AWS resources

--- a/build/test.mk
+++ b/build/test.mk
@@ -47,8 +47,12 @@ GOTEST_OPTS ?=
 GOTEST_TOOL ?= go tool gotestsum $(GOTESTSUM_OPTS) --
 
 .PHONY: test
-test: test-get-envtools test-helm ## Runs unit tests, excluding kubernetes controller tests
+test: test-get-envtools test-helm test-manage-radius-installation ## Runs unit tests, excluding kubernetes controller tests
 	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" CGO_ENABLED=1 $(GOTEST_TOOL) ./pkg/... $(GOTEST_OPTS)
+
+.PHONY: test-manage-radius-installation
+test-manage-radius-installation: ## Tests Radius installation lifecycle reconciliation
+	@bash ./.github/scripts/manage-radius-installation_test.sh
 
 .PHONY: test-compile
 test-compile: test-get-envtools ## Compiles all tests without running them

--- a/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
+++ b/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
@@ -155,47 +155,17 @@ The identities are carried in repository secrets rather than in the workflow fil
 | `AZURE_SP_TESTS_APPID` + `AZURE_SP_TESTS_TENANTID` | both the runner (`azure/login`) and the Radius pods (workload identity) | GitHub OIDC and AKS OIDC -> AAD app federated credentials |
 | `FUNCTEST_AWS_ACCOUNT_ID`                          | the AWS account id passed to `rad env update` (not a credential)        | -                                                         |
 
-#### Point the AWS IRSA role at the LRT cluster
+#### Provision the AWS identities
 
-`FUNC_TEST_RAD_IRSA_ROLE` is shared with `functional-test-cloud.yaml`, which runs on a KinD cluster whose OIDC issuer is an Azure-blob issuer. The LRT runs on a pre-provisioned AKS cluster with a *different* OIDC issuer, so the role's trust policy must also trust that issuer. Register the AKS issuer as an IAM OIDC provider and append a trust statement for the three Radius service accounts. Run this once, when the LRT cluster is created or rotated:
+The AWS identity resources are owned by the [`radius-project/wellknown`](https://github.com/radius-project/wellknown) Terraform layers. Do not create OIDC providers or edit role trust policies manually because a later Terraform apply will overwrite that drift.
 
-```bash
-export AWS_ACCOUNT_ID="<test-account-id>"            # = FUNCTEST_AWS_ACCOUNT_ID
-export AKS_CLUSTER_NAME="<LRT_AKS_CLUSTER_NAME>"     # = vars.LRT_AKS_CLUSTER_NAME
-export AKS_RESOURCE_GROUP="<LRT_AKS_RESOURCE_GROUP>" # = vars.LRT_AKS_RESOURCE_GROUP
-IRSA_ROLE_NAME="$(basename "<FUNC_TEST_RAD_IRSA_ROLE-arn>")"
+Apply the layers in order whenever the LRT cluster is created or rotated:
 
-# 1. Fetch the AKS OIDC issuer and register it as an IAM OIDC provider (skip if it already exists).
-AKS_OIDC_ISSUER="$(az aks show -n "$AKS_CLUSTER_NAME" -g "$AKS_RESOURCE_GROUP" --query 'oidcIssuerProfile.issuerUrl' -o tsv)"
-ISSUER_HOST="$(echo "$AKS_OIDC_ISSUER" | sed -e 's~^https://~~' -e 's~/.*$~~')"
-THUMBPRINT="$(echo | openssl s_client -servername "$ISSUER_HOST" -connect "${ISSUER_HOST}:443" \
-  | openssl x509 -fingerprint -sha1 -noout | cut -d= -f2 | tr -d ':' | tr 'A-F' 'a-f')"
-aws iam create-open-id-connect-provider --url "$AKS_OIDC_ISSUER" \
-  --client-id-list "sts.amazonaws.com" --thumbprint-list "$THUMBPRINT"
+1. `modules/20-functional-tests` publishes `workload_identity_issuers`, containing both the blob-hosted KinD issuer and the managed AKS issuer, plus the Radius service-account subjects.
+2. [`modules/21-functional-tests-aws`](https://github.com/radius-project/wellknown/tree/main/modules/21-functional-tests-aws) creates or reuses an IAM OIDC provider for each issuer. It creates the IRSA role trusted by every issuer and the GitHub Actions role trusted by the Radius repository.
+3. `modules/30-functional-tests-github` publishes the resulting role ARNs as `FUNC_TEST_RAD_IRSA_ROLE` and `AWS_GH_ACTIONS_ROLE`.
 
-# 2. Append a trust statement for the Radius service accounts on the AKS issuer.
-OIDC_PROVIDER="${AKS_OIDC_ISSUER#https://}"
-aws iam get-role --role-name "$IRSA_ROLE_NAME" --query 'Role.AssumeRolePolicyDocument' > trust.json
-cat > aks-statement.json <<EOF
-{
-  "Effect": "Allow",
-  "Principal": { "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER}" },
-  "Action": "sts:AssumeRoleWithWebIdentity",
-  "Condition": { "StringEquals": {
-    "${OIDC_PROVIDER}:aud": "sts.amazonaws.com",
-    "${OIDC_PROVIDER}:sub": [
-      "system:serviceaccount:radius-system:ucp",
-      "system:serviceaccount:radius-system:applications-rp",
-      "system:serviceaccount:radius-system:dynamic-rp"
-    ]
-  } }
-}
-EOF
-jq '.Statement += [input]' trust.json aks-statement.json > trust-updated.json
-aws iam update-assume-role-policy --role-name "$IRSA_ROLE_NAME" --policy-document file://trust-updated.json
-```
-
-`AWS_GH_ACTIONS_ROLE` needs no cluster-specific change, but because the LRT is triggered on a schedule its OIDC subject is `repo:radius-project/radius:ref:refs/heads/main`; confirm the role's trust `sub` condition matches (widen it if it was scoped only to pull requests) and that its `MaxSessionDuration` is at least the 60-minute functional-test window.
+The GitHub Actions role allows 5400-second sessions, and the LRT workflow requests that duration to leave headroom over the 60-minute functional-test window. Its generated subject patterns include branch refs, so the scheduled `main` run uses `repo:radius-project/radius:ref:refs/heads/main` without a separate trust-policy edit.
 
 ## Verification
 
@@ -209,4 +179,5 @@ aws iam update-assume-role-policy --role-name "$IRSA_ROLE_NAME" --policy-documen
 - **You changed the `rad` CLI.** Copy the rebuilt `rad` to your path (or set `RAD_PATH` for Codelens) so the tests use your new binary.
 - **Environment variables seem ignored.** Restart VS Code or your editor so newly set variables take effect.
 - **Many tests fail immediately.** Confirm the Kubernetes namespace in use is `default`.
+- **LRT AWS tests fail with `AccessDenied` on `AssumeRoleWithWebIdentity`.** Confirm the latest `modules/20-functional-tests`, `modules/21-functional-tests-aws`, and `modules/30-functional-tests-github` layers from `radius-project/wellknown` were applied in order. Verify the AKS issuer appears in the AWS layer's `oidc_issuers` output and the current `FUNC_TEST_RAD_IRSA_ROLE` secret matches its `irsa_role_arn` output.
 - **A special test group is skipped or fails during setup.** Confirm that you met the isolated-cluster requirements in [Run a special test group](#run-a-special-test-group).

--- a/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
+++ b/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
@@ -4,7 +4,7 @@
 
 Functional tests (also called end-to-end tests) interact with real hosting environments (Kubernetes), deploy real applications and resources, and cover realistic user scenarios. They verify, for example, that a Radius Environment can be created successfully and that the Bicep templates of sample applications can be deployed to it. This page is for contributors validating a change against a real cluster; for the full set of test tiers and when to run each, start at the [test matrix overview](./README.md).
 
-The tests live under `./test/functional-portable`. They use product functionality — the Radius CLI configuration and your local KubeConfig — to detect settings, so the local setup resembles a real user scenario.
+The tests live under `./test/functional-portable`. They use product functionality - the Radius CLI configuration and your local KubeConfig - to detect settings, so the local setup resembles a real user scenario.
 
 ## Prerequisites
 
@@ -138,6 +138,64 @@ These tests run automatically for every PR via the `functional-test-noncloud.yam
 - For each group of tests: creates a Kubernetes cluster, installs the build, runs the tests, and deletes any cloud resources that were created.
 
 Separate scheduled jobs (`purge-azure-test-resources.yaml` and `purge-aws-test-resources.yaml`) delete cloud resources left behind when a run is cancelled or times out.
+
+### Cloud credentials in CI (federated identity)
+
+The cloud CI workflows - `functional-test-cloud.yaml`, the long-running test `long-running-azure.yaml` ("LRT"), and the two scheduled purge jobs - authenticate to Azure and AWS with **federated identity only**. No static cloud secrets (service-principal passwords or AWS access keys) are stored in GitHub; every credential is a short-lived token minted from an OIDC trust. Two distinct trusts are in play:
+
+- **Runner -> cloud.** The GitHub Actions runner gets tokens from GitHub's OIDC provider (`token.actions.githubusercontent.com`), and `azure/login` / `aws-actions/configure-aws-credentials` exchange them for short-lived credentials that the test and purge code use to verify and delete cloud resources. Every such job sets `permissions: id-token: write`.
+- **Radius control plane -> cloud.** The Radius pods (service accounts `ucp`, `applications-rp`, and `dynamic-rp` in `radius-system`) assume a cloud identity through the *cluster's own* OIDC issuer - Azure Workload Identity on Azure, IRSA on AWS - using a projected service-account token (audience `sts.amazonaws.com` for AWS). Radius reads the target identity from the credential registered with `rad credential register azure wi` and `rad credential register aws irsa`; enabling it requires installing the chart with `--set global.azureWorkloadIdentity.enabled=true` and `--set global.aws.irsa.enabled=true` (the LRT does this in [`.github/scripts/manage-radius-installation.sh`](../../../../.github/scripts/manage-radius-installation.sh)).
+
+The identities are carried in repository secrets rather than in the workflow files:
+
+| Secret                                             | Assumed by                                                              | Trust                                                     |
+|----------------------------------------------------|-------------------------------------------------------------------------|-----------------------------------------------------------|
+| `AWS_GH_ACTIONS_ROLE`                              | the runner, via `configure-aws-credentials`                             | GitHub OIDC -> IAM role                                   |
+| `FUNC_TEST_RAD_IRSA_ROLE`                          | the Radius pods, via IRSA                                               | cluster OIDC issuer -> IAM role                           |
+| `AZURE_SP_TESTS_APPID` + `AZURE_SP_TESTS_TENANTID` | both the runner (`azure/login`) and the Radius pods (workload identity) | GitHub OIDC and AKS OIDC -> AAD app federated credentials |
+| `FUNCTEST_AWS_ACCOUNT_ID`                          | the AWS account id passed to `rad env update` (not a credential)        | -                                                         |
+
+#### Point the AWS IRSA role at the LRT cluster
+
+`FUNC_TEST_RAD_IRSA_ROLE` is shared with `functional-test-cloud.yaml`, which runs on a KinD cluster whose OIDC issuer is an Azure-blob issuer. The LRT runs on a pre-provisioned AKS cluster with a *different* OIDC issuer, so the role's trust policy must also trust that issuer. Register the AKS issuer as an IAM OIDC provider and append a trust statement for the three Radius service accounts. Run this once, when the LRT cluster is created or rotated:
+
+```bash
+export AWS_ACCOUNT_ID="<test-account-id>"            # = FUNCTEST_AWS_ACCOUNT_ID
+export AKS_CLUSTER_NAME="<LRT_AKS_CLUSTER_NAME>"     # = vars.LRT_AKS_CLUSTER_NAME
+export AKS_RESOURCE_GROUP="<LRT_AKS_RESOURCE_GROUP>" # = vars.LRT_AKS_RESOURCE_GROUP
+IRSA_ROLE_NAME="$(basename "<FUNC_TEST_RAD_IRSA_ROLE-arn>")"
+
+# 1. Fetch the AKS OIDC issuer and register it as an IAM OIDC provider (skip if it already exists).
+AKS_OIDC_ISSUER="$(az aks show -n "$AKS_CLUSTER_NAME" -g "$AKS_RESOURCE_GROUP" --query 'oidcIssuerProfile.issuerUrl' -o tsv)"
+ISSUER_HOST="$(echo "$AKS_OIDC_ISSUER" | sed -e 's~^https://~~' -e 's~/.*$~~')"
+THUMBPRINT="$(echo | openssl s_client -servername "$ISSUER_HOST" -connect "${ISSUER_HOST}:443" \
+  | openssl x509 -fingerprint -sha1 -noout | cut -d= -f2 | tr -d ':' | tr 'A-F' 'a-f')"
+aws iam create-open-id-connect-provider --url "$AKS_OIDC_ISSUER" \
+  --client-id-list "sts.amazonaws.com" --thumbprint-list "$THUMBPRINT"
+
+# 2. Append a trust statement for the Radius service accounts on the AKS issuer.
+OIDC_PROVIDER="${AKS_OIDC_ISSUER#https://}"
+aws iam get-role --role-name "$IRSA_ROLE_NAME" --query 'Role.AssumeRolePolicyDocument' > trust.json
+cat > aks-statement.json <<EOF
+{
+  "Effect": "Allow",
+  "Principal": { "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER}" },
+  "Action": "sts:AssumeRoleWithWebIdentity",
+  "Condition": { "StringEquals": {
+    "${OIDC_PROVIDER}:aud": "sts.amazonaws.com",
+    "${OIDC_PROVIDER}:sub": [
+      "system:serviceaccount:radius-system:ucp",
+      "system:serviceaccount:radius-system:applications-rp",
+      "system:serviceaccount:radius-system:dynamic-rp"
+    ]
+  } }
+}
+EOF
+jq '.Statement += [input]' trust.json aks-statement.json > trust-updated.json
+aws iam update-assume-role-policy --role-name "$IRSA_ROLE_NAME" --policy-document file://trust-updated.json
+```
+
+`AWS_GH_ACTIONS_ROLE` needs no cluster-specific change, but because the LRT is triggered on a schedule its OIDC subject is `repo:radius-project/radius:ref:refs/heads/main`; confirm the role's trust `sub` condition matches (widen it if it was scoped only to pull requests) and that its `MaxSessionDuration` is at least the 60-minute functional-test window.
 
 ## Verification
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on [radius-project/wellknown#117](https://github.com/radius-project/wellknown/pull/117).** That PR must be merged first — do not merge this PR until it lands.

# Description

Completes the AWS portion of #8889 by switching the cloud CI workflows from static AWS access keys to **federated identity** (GitHub OIDC + AWS IRSA). The Azure half was already migrated in #9072; this change removes the remaining static AWS credentials from the long-running and cloud functional tests and their scheduled purge job.

Two distinct OIDC trusts are now in play:

- **Runner → cloud.** The GitHub Actions runner exchanges a GitHub OIDC token for a short-lived AWS role via `aws-actions/configure-aws-credentials`; the test-verification and purge code use those credentials to inspect and delete AWS resources.
- **Radius control plane → cloud.** The Radius pods assume an AWS IAM role through the cluster's OIDC issuer (IRSA) using projected service-account tokens, so no static keys are stored in the control plane.

### Changes

- **`.github/workflows/long-running-azure.yaml`** — Replace `FUNCTEST_AWS_ACCESS_KEY_ID` / `FUNCTEST_AWS_SECRET_ACCESS_KEY` with `rad credential register aws irsa --iam-role "${FUNC_TEST_RAD_IRSA_ROLE}"`, and add a "Configure AWS credentials using assumed role" step so the test-verification code assumes a role via OIDC instead of using static keys.
- **`.github/workflows/purge-aws-test-resources.yaml`** — Switch the purge job to `role-to-assume` OIDC federated identity and add `id-token: write` permission.
- **`.github/workflows/functional-test-cloud.yaml`** — Use `${{ github.run_id }}` as the role session name.
- **`.github/scripts/manage-radius-installation.sh`** — Enable AWS IRSA on install and upgrade with `--set global.aws.irsa.enabled=true` (mirrors the existing Azure Workload Identity flag).
- **`docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md`** — Document the federated-identity model for cloud CI: the secrets table, the one-time IAM trust setup that points `FUNC_TEST_RAD_IRSA_ROLE` at the LRT AKS cluster's OIDC issuer, and troubleshooting for `AssumeRoleWithWebIdentity` `AccessDenied` failures.

No product code changes — this is CI/test infrastructure and contributor documentation only.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #8889

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
