### PR TITLE
chore(ci): use install scripts and parallel workflows

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -139,14 +139,12 @@ jobs:
         # Pinned version + checksums live in build/tools.mk (GOLANGCI_LINT_VERSION).
         run: make install-golangci-lint
 
-      - name: Install Go tools
+      - name: Install Delve (dlv)
         # controller-gen, mockgen, and gotestsum are managed as Go tool dependencies
         # (the 'tool' directives in go.mod) and run via `go tool`, so they need no
         # separate install. dlv (Delve) is used by the process-debugging workflow
-        # (make debug-*).
-        run: |
-          DLV_VER="v1.26.3"
-          go install "github.com/go-delve/delve/cmd/dlv@${DLV_VER}"
+        # (make debug-*). Version pinned in build/tools.mk (DLV_VERSION).
+        run: make install-dlv
 
       - name: Install yq
         # Required by Bicep type generation to parse YAML defaults.

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -186,26 +186,32 @@ jobs:
           DOCKER_REGISTRY: ${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}
           DOCKER_TAG_VERSION: ${{ steps.gen-id.outputs.REL_VERSION }}
 
-      - name: Upload rad CLI binary
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: radius_test_cli
-          path: ./dist/linux_amd64/release/rad
-          if-no-files-found: error
+      # Upload the three build artifacts concurrently. Each targets a distinct
+      # artifact name and source path, so they are independent; running them as a
+      # parallel group overlaps the small rad CLI and Bicep-types uploads with the
+      # much larger container-image upload. The implicit wait at the end of the
+      # group ensures all three uploads finish before the job completes.
+      - parallel:
+          - name: Upload rad CLI binary
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+            with:
+              name: radius_test_cli
+              path: ./dist/linux_amd64/release/rad
+              if-no-files-found: error
 
-      - name: Upload container image artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: radius_test_images
-          path: ./dist/images
-          if-no-files-found: error
+          - name: Upload container image artifacts
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+            with:
+              name: radius_test_images
+              path: ./dist/images
+              if-no-files-found: error
 
-      - name: Upload Radius Bicep types artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: radius_test_bicep_types
-          path: ./hack/bicep-types-radius/generated
-          if-no-files-found: error
+          - name: Upload Radius Bicep types artifacts
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+            with:
+              name: radius_test_bicep_types
+              path: ./hack/bicep-types-radius/generated
+              if-no-files-found: error
 
   tests:
     name: Run ${{ matrix.name }} functional tests
@@ -283,24 +289,29 @@ jobs:
       # "build" job and shared with every matrix leg. Downloading them here avoids
       # recompiling the source and reinstalling the Node/yq toolchain in each leg.
       # They land in the same paths a local build would produce, so the remaining
-      # steps are unchanged.
-      - name: Download rad CLI binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: radius_test_cli
-          path: ./dist/linux_amd64/release
+      # steps are unchanged. The three artifacts have distinct names and paths, so
+      # they download concurrently as a parallel group: the small rad CLI and
+      # Bicep-types downloads overlap with the larger container-image download. The
+      # implicit wait at the end of the group ensures all three are present before
+      # the local registry and Bicep publishing steps run.
+      - parallel:
+          - name: Download rad CLI binary
+            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+            with:
+              name: radius_test_cli
+              path: ./dist/linux_amd64/release
 
-      - name: Download container image artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: radius_test_images
-          path: ./dist/images
+          - name: Download container image artifacts
+            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+            with:
+              name: radius_test_images
+              path: ./dist/images
 
-      - name: Download Radius Bicep types artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: radius_test_bicep_types
-          path: ./hack/bicep-types-radius/generated
+          - name: Download Radius Bicep types artifacts
+            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+            with:
+              name: radius_test_bicep_types
+              path: ./hack/bicep-types-radius/generated
 
       - name: Create a secure local registry
         id: create-local-registry

--- a/.github/workflows/validate-bicep.yaml
+++ b/.github/workflows/validate-bicep.yaml
@@ -85,16 +85,24 @@ jobs:
           mkdir tmp-radius-bicep-extension
           mkdir tmp-testresources-bicep-extension
 
-      - name: Publish bicep types
-        run: |
-          bicep publish-extension ./hack/bicep-types-radius/generated/index.json --target ./tmp-radius-bicep-extension/radius.tgz --force
+      # The two publish-extension commands are independent: they write to separate
+      # output files (tmp-radius-bicep-extension/radius.tgz and
+      # tmp-testresources-bicep-extension/testresources.tgz, both created above).
+      # Running them as a parallel group overlaps the slow `go run` compile of the
+      # testresources publisher with the Bicep publish. The implicit wait at the
+      # end of the group ensures both finish before bicepconfig.json is modified.
+      - parallel:
+          - name: Publish bicep types
+            run: |
+              bicep publish-extension ./hack/bicep-types-radius/generated/index.json --target ./tmp-radius-bicep-extension/radius.tgz --force
 
-      - name: Publish testresources extension
-        run: |
-          go run ./cmd/rad/main.go bicep publish-extension -f ./test/functional-portable/dynamicrp/noncloud/resources/testdata/testresourcetypes.yaml --target ./tmp-testresources-bicep-extension/testresources.tgz --force
+          - name: Publish testresources extension
+            run: |
+              go run ./cmd/rad/main.go bicep publish-extension -f ./test/functional-portable/dynamicrp/noncloud/resources/testdata/testresourcetypes.yaml --target ./tmp-testresources-bicep-extension/testresources.tgz --force
 
       - name: Install jq
-        run: sudo apt-get install -y jq
+        # Pinned version + checksums live in build/tools.mk (JQ_VERSION).
+        run: make install-jq
 
       - name: Modify bicepconfig.json
         run: |

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -4,11 +4,6 @@
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/"
     },
-    "terraform": {
-      "type": "stdio",
-      "command": "docker",
-      "args": ["run", "-i", "--rm", "hashicorp/terraform-mcp-server:0.4.0"]
-    },
     "gopls": {
       "type": "stdio",
       "command": "gopls",

--- a/build/debug.mk
+++ b/build/debug.mk
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#    
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
@@ -116,7 +116,7 @@ debug-check-prereqs: ## Check if all required tools are installed for debugging
 		echo ""; \
 		echo "Installation instructions:"; \
 		echo "  go: https://golang.org/doc/install"; \
-		echo "  dlv: go install github.com/go-delve/delve/cmd/dlv@latest"; \
+		echo "  dlv: make install-dlv"; \
 		echo "  k3d: https://k3d.io/v5.6.0/#installation"; \
 		echo "  kubectl: https://kubernetes.io/docs/tasks/tools/"; \
 		echo "  terraform: https://learn.hashicorp.com/tutorials/terraform/install-cli"; \

--- a/build/resource-types.mk
+++ b/build/resource-types.mk
@@ -77,7 +77,7 @@ update-resource-types: ## Bump resource-types-contrib to latest and sync manifes
 sync-resource-types: ## Copy manifest files listed in defaults.yaml from the pinned resource-types-contrib version
 	@# Verify required tools are available before making any changes.
 	@command -v yq >/dev/null 2>&1 || { echo "ERROR: yq is required but not found. Install via: make install-yq"; exit 1; }
-	@command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required but not found. Install via: brew install jq (macOS) or apt-get install jq (Linux)"; exit 1; }
+	@command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required but not found. Install via: make install-jq"; exit 1; }
 	@echo "Syncing default resource types from resource-types-contrib..."
 	@# Resolve the module's local cache directory from the version pinned in
 	@# go.mod. "go mod download -json" outputs JSON with a "Dir" field pointing

--- a/build/scripts/install-bicep.sh
+++ b/build/scripts/install-bicep.sh
@@ -60,7 +60,10 @@ gh_curl() {
     if [ -n "${GITHUB_TOKEN:-}" ]; then
         headers+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
     fi
-    curl --proto '=https' --tlsv1.2 "${headers[@]}" "$@"
+    # --retry rides out transient failures (timeouts and HTTP 408/429/5xx such as
+    # the 504 gateway timeouts GitHub's release CDN returns intermittently) with
+    # exponential backoff, while still failing fast on 404s (a wrong version).
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused "${headers[@]}" "$@"
 }
 
 detect_os() {

--- a/build/scripts/install-dapr.sh
+++ b/build/scripts/install-dapr.sh
@@ -57,7 +57,10 @@ gh_curl() {
     if [ -n "${GITHUB_TOKEN:-}" ]; then
         headers+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
     fi
-    curl --proto '=https' --tlsv1.2 "${headers[@]}" "$@"
+    # --retry rides out transient failures (timeouts and HTTP 408/429/5xx such as
+    # the 504 gateway timeouts GitHub's release CDN returns intermittently) with
+    # exponential backoff, while still failing fast on 404s (a wrong version).
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused "${headers[@]}" "$@"
 }
 
 detect_os() {

--- a/build/scripts/install-dlv.sh
+++ b/build/scripts/install-dlv.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Installs Delve (the 'dlv' debugger) for the current platform using 'go install'.
+# Unlike the other install-*.sh scripts, Delve publishes no prebuilt release
+# binaries (its GitHub releases contain only source archives), so it is built
+# from source with the Go toolchain. Module integrity is guaranteed by the Go
+# checksum database (the 'go install <module>@<version>' verification against
+# sum.golang.org), so there are no per-platform SHA-256 checksums to pin. Under
+# GitHub Actions the Go bin dir is added to the job PATH so later steps can run
+# dlv.
+#
+# The pinned version is normally provided by build/tools.mk through the
+# environment. When it is not supplied it defaults to the latest release.
+#
+# Usage: install-dlv.sh [install_dir]
+#
+# Environment (all optional):
+#   DLV_VERSION       Module version, e.g. v1.27.0. Empty (or 'latest') selects
+#                     the latest release.
+#   DLV_INSTALL_DIR   Install directory for the 'dlv' binary. Default: Go's own
+#                     install target ($(go env GOBIN), else $(go env GOPATH)/bin).
+
+readonly MODULE="github.com/go-delve/delve/cmd/dlv"
+
+log() { echo "[install-dlv] $*" >&2; }
+fail() {
+    echo "[install-dlv] ERROR: $*" >&2
+    exit 1
+}
+
+main() {
+    local install_dir version
+
+    command -v go >/dev/null 2>&1 || fail "go is required but was not found"
+
+    # Normalize the requested version: strip whitespace, treat empty as 'latest'.
+    version="${DLV_VERSION:-}"
+    version="${version//[[:space:]]/}"
+    [ -n "$version" ] || version="latest"
+
+    # Determine where 'go install' places the binary so we can force that location,
+    # add it to PATH, and run an already-installed check. GOBIN wins when set,
+    # otherwise Go uses GOPATH/bin.
+    install_dir="${1:-${DLV_INSTALL_DIR:-}}"
+    if [ -z "$install_dir" ]; then
+        install_dir="$(go env GOBIN)"
+        [ -n "$install_dir" ] || install_dir="$(go env GOPATH)/bin"
+    fi
+
+    # Skip if the exact pinned version is already installed. 'dlv version' prints a
+    # line like 'Version: 1.27.0'; compare against the tag without a leading 'v'.
+    if [ "$version" != "latest" ] && command -v dlv >/dev/null 2>&1 \
+        && dlv version 2>/dev/null | grep -q "Version: ${version#v}$"; then
+        log "dlv ${version} already installed: $(command -v dlv)"
+        return 0
+    fi
+
+    log "installing dlv ${version} via go install (${MODULE}@${version})..."
+    GOBIN="$install_dir" go install "${MODULE}@${version}" \
+        || fail "go install ${MODULE}@${version} failed"
+
+    "${install_dir}/dlv" version >/dev/null 2>&1 \
+        || fail "installed dlv failed to run (${install_dir}/dlv)"
+    log "installed dlv ${version} to ${install_dir}/dlv"
+
+    # Make dlv available to later GitHub Actions steps.
+    if [ -n "${GITHUB_PATH:-}" ]; then
+        echo "$install_dir" >> "$GITHUB_PATH"
+    fi
+}
+
+main "$@"

--- a/build/scripts/install-golangci-lint.sh
+++ b/build/scripts/install-golangci-lint.sh
@@ -60,7 +60,10 @@ gh_curl() {
     if [ -n "${GITHUB_TOKEN:-}" ]; then
         headers+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
     fi
-    curl --proto '=https' --tlsv1.2 "${headers[@]}" "$@"
+    # --retry rides out transient failures (timeouts and HTTP 408/429/5xx such as
+    # the 504 gateway timeouts GitHub's release CDN returns intermittently) with
+    # exponential backoff, while still failing fast on 404s (a wrong version).
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused "${headers[@]}" "$@"
 }
 
 detect_os() {

--- a/build/scripts/install-helm.sh
+++ b/build/scripts/install-helm.sh
@@ -50,7 +50,10 @@ cleanup() {
 # curl wrapper: enforces HTTPS + TLS 1.2 and sets a User-Agent. get.helm.sh is a
 # public CDN, so no authentication is required.
 helm_curl() {
-    curl --proto '=https' --tlsv1.2 -H "User-Agent: helm-installer" "$@"
+    # --retry rides out transient failures (timeouts and HTTP 408/429/5xx such as
+    # 504 gateway timeouts) with exponential backoff, while still failing fast on
+    # 404s (a wrong version).
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused -H "User-Agent: helm-installer" "$@"
 }
 
 detect_os() {

--- a/build/scripts/install-jq.sh
+++ b/build/scripts/install-jq.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Installs the jq JSON processor into a user-owned directory (no sudo) for the
+# current platform. Works on linux and darwin, amd64 and arm64, for both CI and
+# local development; under GitHub Actions the install dir is added to the job
+# PATH so later steps can run jq.
+#
+# jq is published as a single per-platform binary on jqlang/jq's GitHub releases,
+# whose release tags are 'jq-<version>' (e.g. jq-1.8.2) and whose darwin assets
+# are named 'macos'. The pinned version and per-platform SHA-256 checksums are
+# normally provided by build/tools.mk through the environment. The script is
+# generic, so when a value is not supplied it is resolved at runtime:
+#   * empty JQ_VERSION              -> the latest published release
+#   * missing checksum for platform -> read from the release's own 'sha256sum.txt'
+#
+# Usage: install-jq.sh [install_dir]
+#
+# Environment (all optional):
+#   JQ_VERSION                Release version, e.g. 1.8.2 (the bare 'jq-1.8.2' tag
+#                             is also accepted). Empty selects the latest release.
+#   JQ_CHECKSUM_<OS>_<ARCH>   SHA-256 for that platform (e.g.
+#                             JQ_CHECKSUM_LINUX_AMD64). Empty fetches it from the
+#                             release's 'sha256sum.txt' file.
+#   JQ_INSTALL_DIR            Install directory. Default: $HOME/.local/bin.
+#   GITHUB_TOKEN              If set, authenticates GitHub requests (higher rate
+#                             limits; required for private repositories).
+
+readonly REPO="jqlang/jq"
+readonly RELEASES_URL="https://github.com/${REPO}/releases"
+
+log() { echo "[install-jq] $*" >&2; }
+fail() {
+    echo "[install-jq] ERROR: $*" >&2
+    exit 1
+}
+
+# Temporary working directory for downloads, removed on exit. Uses an explicit
+# 'if' (not '&&') so the function returns 0 when WORKDIR is unset; otherwise the
+# failing test would become the EXIT trap's status and abort an otherwise
+# successful run, e.g. the early return when the tool is already installed.
+WORKDIR=""
+cleanup() {
+    if [ -n "${WORKDIR:-}" ] && [ -d "${WORKDIR}" ]; then
+        rm -rf "${WORKDIR}"
+    fi
+}
+
+# curl wrapper for GitHub requests: enforces HTTPS + TLS 1.2, sets a User-Agent,
+# and adds an Authorization header when GITHUB_TOKEN is set (raises API rate
+# limits and allows private repositories). curl drops the Authorization header on
+# cross-host redirects, so the token is not sent to the download CDN. The array is
+# seeded with the User-Agent so it is never empty -- expanding an empty array
+# under 'set -u' is an error on bash 3.2 (macOS).
+gh_curl() {
+    local headers=(-H "User-Agent: jq-installer")
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        headers+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+    fi
+    # --retry rides out transient failures (timeouts and HTTP 408/429/5xx such as
+    # the 504 gateway timeouts GitHub's release CDN returns intermittently) with
+    # exponential backoff, while still failing fast on 404s (a wrong version).
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused "${headers[@]}" "$@"
+}
+
+detect_os() {
+    case "$(uname -s)" in
+        Linux) echo "linux" ;;
+        Darwin) echo "darwin" ;;
+        *) fail "unsupported OS '$(uname -s)' (supported: Linux, Darwin)" ;;
+    esac
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64 | amd64) echo "amd64" ;;
+        aarch64 | arm64) echo "arm64" ;;
+        *) fail "unsupported architecture '$(uname -m)' (supported: amd64, arm64)" ;;
+    esac
+}
+
+# Resolve the latest release version by following the /releases/latest redirect
+# and stripping the 'jq-' tag prefix. Avoids the GitHub API (no token, no rate
+# limit).
+resolve_latest_version() {
+    local effective_url tag
+    effective_url="$(gh_curl -fsSLI -o /dev/null -w '%{url_effective}' "${RELEASES_URL}/latest")" \
+        || fail "could not resolve the latest jq version"
+    tag="${effective_url##*/tag/}"
+    printf '%s\n' "${tag#jq-}"
+}
+
+# Print the SHA-256 of an asset, read from the release's own 'sha256sum.txt'
+# (standard 'sha256sum' format: '<sha256>  <asset>').
+checksum_from_release() {
+    local version="$1" asset="$2"
+    gh_curl -fsSL "${RELEASES_URL}/download/jq-${version}/sha256sum.txt" -o "${WORKDIR}/sha256sum.txt" \
+        || fail "could not download sha256sum.txt for jq-${version}"
+    awk -v a="$asset" '$2 == a { print $1 }' "${WORKDIR}/sha256sum.txt"
+}
+
+verify_checksum() {
+    local expected="$1" file="$2"
+    if command -v sha256sum >/dev/null 2>&1; then
+        echo "${expected}  ${file}" | sha256sum -c - >/dev/null
+    elif command -v shasum >/dev/null 2>&1; then
+        echo "${expected}  ${file}" | shasum -a 256 -c - >/dev/null
+    else
+        fail "neither sha256sum nor shasum is available for checksum verification"
+    fi
+}
+
+main() {
+    local install_dir os arch platform asset_os asset version checksum
+
+    command -v curl >/dev/null 2>&1 || fail "curl is required but was not found"
+
+    install_dir="${1:-${JQ_INSTALL_DIR:-}}"
+    [ -n "$install_dir" ] || install_dir="${HOME}/.local/bin"
+
+    os="$(detect_os)"
+    arch="$(detect_arch)"
+    platform="${os}_${arch}"
+
+    # jq names its darwin assets 'macos' (e.g. jq-macos-arm64); linux stays 'linux'.
+    case "$os" in
+        darwin) asset_os="macos" ;;
+        *) asset_os="$os" ;;
+    esac
+    asset="jq-${asset_os}-${arch}"
+
+    # Normalize the requested version: strip whitespace and any leading 'jq-' tag
+    # prefix, and treat empty as the latest release.
+    version="${JQ_VERSION:-}"
+    version="${version//[[:space:]]/}"
+    version="${version#jq-}"
+    if [ -z "$version" ]; then
+        log "resolving latest jq version..."
+        version="$(resolve_latest_version)"
+    fi
+    [ -n "$version" ] || fail "could not determine the jq version to install"
+
+    if command -v jq >/dev/null 2>&1 && jq --version 2>/dev/null | grep -q "^jq-${version}$"; then
+        log "jq ${version} already installed: $(command -v jq)"
+        return 0
+    fi
+
+    WORKDIR="$(mktemp -d)"
+
+    # Expected checksum: prefer the value supplied for this platform, otherwise
+    # read it from the release's own published checksums.
+    case "$platform" in
+        linux_amd64) checksum="${JQ_CHECKSUM_LINUX_AMD64:-}" ;;
+        linux_arm64) checksum="${JQ_CHECKSUM_LINUX_ARM64:-}" ;;
+        darwin_amd64) checksum="${JQ_CHECKSUM_DARWIN_AMD64:-}" ;;
+        darwin_arm64) checksum="${JQ_CHECKSUM_DARWIN_ARM64:-}" ;;
+        *) checksum="" ;;
+    esac
+    if [ -z "$checksum" ]; then
+        log "no checksum supplied for ${platform}; reading it from the jq-${version} release..."
+        checksum="$(checksum_from_release "$version" "$asset")"
+    fi
+    [ -n "$checksum" ] || fail "could not determine the SHA-256 checksum for ${asset} jq-${version}"
+
+    log "downloading ${asset} jq-${version}..."
+    gh_curl -fsSL "${RELEASES_URL}/download/jq-${version}/${asset}" -o "${WORKDIR}/jq" \
+        || fail "could not download ${asset} jq-${version}"
+    verify_checksum "$checksum" "${WORKDIR}/jq"
+    chmod 0755 "${WORKDIR}/jq"
+
+    mkdir -p "$install_dir"
+    mv "${WORKDIR}/jq" "${install_dir}/jq"
+    "${install_dir}/jq" --version >/dev/null 2>&1 \
+        || fail "installed jq failed to run (${install_dir}/jq)"
+    log "installed jq ${version} to ${install_dir}/jq"
+
+    # Make jq available to later GitHub Actions steps.
+    if [ -n "${GITHUB_PATH:-}" ]; then
+        echo "$install_dir" >> "$GITHUB_PATH"
+    fi
+}
+
+trap cleanup EXIT
+main "$@"

--- a/build/scripts/install-k3d.sh
+++ b/build/scripts/install-k3d.sh
@@ -57,7 +57,10 @@ gh_curl() {
     if [ -n "${GITHUB_TOKEN:-}" ]; then
         headers+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
     fi
-    curl --proto '=https' --tlsv1.2 "${headers[@]}" "$@"
+    # --retry rides out transient failures (timeouts and HTTP 408/429/5xx such as
+    # the 504 gateway timeouts GitHub's release CDN returns intermittently) with
+    # exponential backoff, while still failing fast on 404s (a wrong version).
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused "${headers[@]}" "$@"
 }
 
 detect_os() {

--- a/build/scripts/install-kind.sh
+++ b/build/scripts/install-kind.sh
@@ -56,7 +56,10 @@ gh_curl() {
     if [ -n "${GITHUB_TOKEN:-}" ]; then
         headers+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
     fi
-    curl --proto '=https' --tlsv1.2 "${headers[@]}" "$@"
+    # --retry rides out transient failures (timeouts and HTTP 408/429/5xx such as
+    # the 504 gateway timeouts GitHub's release CDN returns intermittently) with
+    # exponential backoff, while still failing fast on 404s (a wrong version).
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused "${headers[@]}" "$@"
 }
 
 detect_os() {

--- a/build/scripts/install-kubectl.sh
+++ b/build/scripts/install-kubectl.sh
@@ -47,7 +47,10 @@ cleanup() {
 # curl wrapper: enforces HTTPS + TLS 1.2 and sets a User-Agent. dl.k8s.io is a
 # public CDN, so no authentication is required.
 dl_curl() {
-    curl --proto '=https' --tlsv1.2 -H "User-Agent: kubectl-installer" "$@"
+    # --retry rides out transient failures (timeouts and HTTP 408/429/5xx such as
+    # 504 gateway timeouts) with exponential backoff, while still failing fast on
+    # 404s (a wrong version).
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused -H "User-Agent: kubectl-installer" "$@"
 }
 
 detect_os() {

--- a/build/scripts/install-oras.sh
+++ b/build/scripts/install-oras.sh
@@ -57,7 +57,10 @@ gh_curl() {
     if [ -n "${GITHUB_TOKEN:-}" ]; then
         headers+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
     fi
-    curl --proto '=https' --tlsv1.2 "${headers[@]}" "$@"
+    # --retry rides out transient failures (timeouts and HTTP 408/429/5xx such as
+    # the 504 gateway timeouts GitHub's release CDN returns intermittently) with
+    # exponential backoff, while still failing fast on 404s (a wrong version).
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused "${headers[@]}" "$@"
 }
 
 detect_os() {

--- a/build/scripts/install-shellcheck.sh
+++ b/build/scripts/install-shellcheck.sh
@@ -59,7 +59,10 @@ gh_curl() {
     if [ -n "${GITHUB_TOKEN:-}" ]; then
         headers+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
     fi
-    curl --proto '=https' --tlsv1.2 "${headers[@]}" "$@"
+    # --retry rides out transient failures (timeouts and HTTP 408/429/5xx such as
+    # the 504 gateway timeouts GitHub's release CDN returns intermittently) with
+    # exponential backoff, while still failing fast on 404s (a wrong version).
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused "${headers[@]}" "$@"
 }
 
 detect_os() {

--- a/build/scripts/install-stern.sh
+++ b/build/scripts/install-stern.sh
@@ -57,7 +57,10 @@ gh_curl() {
     if [ -n "${GITHUB_TOKEN:-}" ]; then
         headers+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
     fi
-    curl --proto '=https' --tlsv1.2 "${headers[@]}" "$@"
+    # --retry rides out transient failures (timeouts and HTTP 408/429/5xx such as
+    # the 504 gateway timeouts GitHub's release CDN returns intermittently) with
+    # exponential backoff, while still failing fast on 404s (a wrong version).
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused "${headers[@]}" "$@"
 }
 
 detect_os() {

--- a/build/scripts/install-terraform.sh
+++ b/build/scripts/install-terraform.sh
@@ -51,7 +51,10 @@ cleanup() {
 # curl wrapper: enforces HTTPS + TLS 1.2 and sets a User-Agent.
 # releases.hashicorp.com is a public CDN, so no authentication is required.
 tf_curl() {
-    curl --proto '=https' --tlsv1.2 -H "User-Agent: terraform-installer" "$@"
+    # --retry rides out transient failures (timeouts and HTTP 408/429/5xx such as
+    # 504 gateway timeouts) with exponential backoff, while still failing fast on
+    # 404s (a wrong version).
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused -H "User-Agent: terraform-installer" "$@"
 }
 
 detect_os() {

--- a/build/scripts/install-yq.sh
+++ b/build/scripts/install-yq.sh
@@ -55,7 +55,10 @@ gh_curl() {
     if [ -n "${GITHUB_TOKEN:-}" ]; then
         headers+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
     fi
-    curl --proto '=https' --tlsv1.2 "${headers[@]}" "$@"
+    # --retry rides out transient failures (timeouts and HTTP 408/429/5xx such as
+    # the 504 gateway timeouts GitHub's release CDN returns intermittently) with
+    # exponential backoff, while still failing fast on 404s (a wrong version).
+    curl --proto '=https' --tlsv1.2 --retry 5 --retry-connrefused "${headers[@]}" "$@"
 }
 
 detect_os() {

--- a/build/scripts/start-radius.sh
+++ b/build/scripts/start-radius.sh
@@ -69,7 +69,7 @@ check_prerequisites() {
   local advisory_msgs=()
 
   # Required tools
-  command -v dlv >/dev/null 2>&1 || missing_tools+=("dlv -> go install github.com/go-delve/delve/cmd/dlv@latest")
+  command -v dlv >/dev/null 2>&1 || missing_tools+=("dlv -> make install-dlv")
   command -v go >/dev/null 2>&1 || missing_tools+=("go -> https://golang.org/doc/install")
   command -v k3d >/dev/null 2>&1 || missing_tools+=("k3d -> https://k3d.io/")
   command -v kubectl >/dev/null 2>&1 || missing_tools+=("kubectl -> https://kubernetes.io/docs/tasks/tools/")

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -278,3 +278,40 @@ install-shellcheck: ## Install the pinned ShellCheck into a user-owned bin dir (
 		SHELLCHECK_CHECKSUM_DARWIN_ARM64="$(SHELLCHECK_CHECKSUM_DARWIN_ARM64)" \
 		SHELLCHECK_INSTALL_DIR="$(SHELLCHECK_INSTALL_DIR)" \
 		./build/scripts/install-shellcheck.sh
+
+# jq (command-line JSON processor) - pinned version and per-platform SHA-256
+# checksums consumed by build/scripts/install-jq.sh. jq is published as a single
+# per-platform binary on jqlang/jq's GitHub releases (release tags are
+# 'jq-<version>', and darwin assets are named 'macos'). The script is generic:
+# clear JQ_VERSION to install the latest release, and clear a checksum to have it
+# read from the release's own 'sha256sum.txt' file. Keep the checksums in sync
+# when bumping JQ_VERSION.
+JQ_VERSION ?= 1.8.2
+JQ_CHECKSUM_LINUX_AMD64 ?= b1c22172dd303f3be49e935aa56aa48a8b7a46e0bc838b4997d3bb451495870f
+JQ_CHECKSUM_LINUX_ARM64 ?= 8b85c817833814ddca00a144c33705546355afccf0cf39b188f3cdb48b852309
+JQ_CHECKSUM_DARWIN_AMD64 ?= e94b266e3c26690550006abe63152b782280f4e14374accdf04cbde844f00bc0
+JQ_CHECKSUM_DARWIN_ARM64 ?= 2d75340ba57a4b4b4c8708a21c2dc8e958a48aaa8bba13b27f77f6e4c0eca07e
+
+.PHONY: install-jq
+install-jq: ## Install the pinned jq JSON processor into a user-owned bin dir (no sudo).
+	@JQ_VERSION="$(JQ_VERSION)" \
+		JQ_CHECKSUM_LINUX_AMD64="$(JQ_CHECKSUM_LINUX_AMD64)" \
+		JQ_CHECKSUM_LINUX_ARM64="$(JQ_CHECKSUM_LINUX_ARM64)" \
+		JQ_CHECKSUM_DARWIN_AMD64="$(JQ_CHECKSUM_DARWIN_AMD64)" \
+		JQ_CHECKSUM_DARWIN_ARM64="$(JQ_CHECKSUM_DARWIN_ARM64)" \
+		JQ_INSTALL_DIR="$(JQ_INSTALL_DIR)" \
+		./build/scripts/install-jq.sh
+
+# Delve (the 'dlv' Go debugger) - pinned module version consumed by
+# build/scripts/install-dlv.sh. Delve publishes no prebuilt binaries, so it is
+# installed with 'go install' and its integrity is guaranteed by the Go checksum
+# database; there are no per-platform SHA-256 checksums to pin. Clear DLV_VERSION
+# to install the latest release. Used by the process-debugging workflow (make
+# debug-*).
+DLV_VERSION ?= v1.27.0
+
+.PHONY: install-dlv
+install-dlv: ## Install the pinned Delve (dlv) Go debugger via 'go install'.
+	@DLV_VERSION="$(DLV_VERSION)" \
+		DLV_INSTALL_DIR="$(DLV_INSTALL_DIR)" \
+		./build/scripts/install-dlv.sh

--- a/docs/contributing/contributing-code/contributing-code-debugging/radius-os-processes-debugging.md
+++ b/docs/contributing/contributing-code/contributing-code-debugging/radius-os-processes-debugging.md
@@ -27,7 +27,7 @@ In addition to the base environment, debugging requires these tools. `make debug
 ```bash
 brew install go kubectl k3d terraform postgresql
 brew install --cask docker
-go install github.com/go-delve/delve/cmd/dlv@latest
+make install-dlv
 echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
 ```
 
@@ -43,7 +43,7 @@ echo 'export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"' >> ~/.bashrc && source
 sudo apt update && sudo apt install -y kubectl postgresql-client docker.io
 
 # Delve and k3d
-go install github.com/go-delve/delve/cmd/dlv@latest
+make install-dlv
 wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 
 # Terraform

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.10.0",
   "devDependencies": {
     "markdown-table-formatter": "1.7.0",
     "markdownlint-cli2": "0.23.0",


### PR DESCRIPTION
# Description

This PR updates CI/tooling setup to use shared pinned installers and faster independent workflow steps.

- Adds `make install-jq` and `make install-dlv` targets backed by `build/scripts/install-jq.sh` and `build/scripts/install-dlv.sh`.
- Replaces inline `jq` and `dlv` installs in workflows with the new make targets.
- Runs independent workflow work in parallel where applicable, including functional-test artifact uploads/downloads and Bicep validation publish steps.
- Updates prerequisite messages to point contributors at the new make targets.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: N/A

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable