### PR TITLE
fix(ci): stabilize long-running Azure tests

### DIFF
--- a/.github/scripts/cleanup-long-running-cluster.sh
+++ b/.github/scripts/cleanup-long-running-cluster.sh
@@ -16,9 +16,30 @@
 # limitations under the License.
 # ------------------------------------------------------------
 
-set -e
+set -euo pipefail
 
 SKIP_RESOURCE_FILE="${1:-}"
+readonly RESOURCE_DELETE_BATCH_SIZE=100
+declare -a resource_delete_batch=()
+
+delete_resource_batch() {
+    if (( ${#resource_delete_batch[@]} == 0 )); then
+        return
+    fi
+
+    echo "deleting ${#resource_delete_batch[@]} resources.ucp.dev entries"
+    kubectl delete resources.ucp.dev "${resource_delete_batch[@]}" \
+        -n radius-system --ignore-not-found=true --wait=false
+    resource_delete_batch=()
+}
+
+queue_resource_deletion() {
+    resource_delete_batch+=("$1")
+    if (( ${#resource_delete_batch[@]} >= RESOURCE_DELETE_BATCH_SIZE )); then
+        delete_resource_batch
+    fi
+}
+
 echo "cleaning up long-running cluster on Azure"
 echo "Using skip-resource-list from: $SKIP_RESOURCE_FILE"
 
@@ -54,8 +75,7 @@ if kubectl get crd resources.ucp.dev >/dev/null 2>&1; then
             if grep -F -x -q -- "$r" "$SKIP_RESOURCE_FILE"; then
                 echo "skip deletion: $r (found in skip-resource-list $SKIP_RESOURCE_FILE)"
             else
-                echo "deleting resource: $r"
-                kubectl delete resources.ucp.dev "$r" -n radius-system --ignore-not-found=true --wait=false
+                queue_resource_deletion "$r"
             fi
             continue
         fi
@@ -64,12 +84,12 @@ if kubectl get crd resources.ucp.dev >/dev/null 2>&1; then
         # Non-scope resources (resource.*) may include system-critical entries
         # that must not be deleted without a valid skip list.
         if [[ $r == scope.* ]]; then
-            echo "deleting resource: $r (no skip list, scope entry)"
-            kubectl delete resources.ucp.dev "$r" -n radius-system --ignore-not-found=true --wait=false
+            queue_resource_deletion "$r"
         else
             echo "skip deletion: $r (no skip list available, preserving non-scope resource)"
         fi
     done
+    delete_resource_batch
 fi
 
 # Delete all test namespaces.

--- a/.github/scripts/release-aci-quota.sh
+++ b/.github/scripts/release-aci-quota.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly ACI_API_VERSION="2024-11-01-preview"
+
+usage() {
+    echo "Usage: $0 <subscription-id> <resource-group>"
+}
+
+if (( $# != 2 )); then
+    usage >&2
+    exit 1
+fi
+
+readonly SUBSCRIPTION_ID="$1"
+readonly RESOURCE_GROUP="$2"
+
+if ! az group show \
+    --subscription "${SUBSCRIPTION_ID}" \
+    --name "${RESOURCE_GROUP}" \
+    --output none; then
+    echo "Warning: resource group ${RESOURCE_GROUP} is unavailable; skipping ACI cleanup." >&2
+    exit 0
+fi
+
+if ! aci_rows=$(az resource list \
+    --subscription "${SUBSCRIPTION_ID}" \
+    --resource-group "${RESOURCE_GROUP}" \
+    --query "[?starts_with(type, 'Microsoft.ContainerInstance/')].[id,type]" \
+    --output tsv); then
+    echo "Warning: failed to list Azure Container Instances resources in ${RESOURCE_GROUP}." >&2
+    exit 0
+fi
+
+if [[ -z "${aci_rows}" ]]; then
+    echo "No Azure Container Instances resources in ${RESOURCE_GROUP}."
+    exit 0
+fi
+
+declare -a ngroup_ids=()
+declare -a remaining_aci_ids=()
+
+while IFS=$'\t' read -r id type; do
+    [[ -z "${id}" ]] && continue
+
+    if [[ "${type,,}" == "microsoft.containerinstance/ngroups" ]]; then
+        ngroup_ids+=("${id}")
+    else
+        remaining_aci_ids+=("${id}")
+    fi
+done <<< "${aci_rows}"
+
+delete_resources() {
+    local resource_kind="$1"
+    shift
+
+    if (( $# == 0 )); then
+        return
+    fi
+
+    echo "Deleting ${resource_kind} from ${RESOURCE_GROUP}:"
+    printf '  %s\n' "$@"
+
+    local id
+    for id in "$@"; do
+        (
+            if ! az resource delete \
+                --subscription "${SUBSCRIPTION_ID}" \
+                --ids "${id}" \
+                --api-version "${ACI_API_VERSION}" \
+                --verbose; then
+                echo "Warning: failed to delete ${id}." >&2
+            fi
+        ) &
+    done
+    wait
+}
+
+# nGroups hold the container scale-set quota and reference the profiles, so the
+# two resource classes must be deleted in this order.
+delete_resources "ACI nGroups" "${ngroup_ids[@]}"
+delete_resources "remaining ACI resources" "${remaining_aci_ids[@]}"

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -1136,51 +1136,9 @@ jobs:
         env:
           AZURE_SUBSCRIPTIONID_TESTS: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
         run: |
-          # The regional Azure Container Instances 'StandardCores' quota is shared
-          # across all concurrent cloud functional-test runs and is the bottleneck
-          # behind Test_ACI (deploys fail with ContainerGroupQuotaReached). The
-          # resource group is deleted with --no-wait below because the full delete is
-          # slow for gateways/VNets (see #12044), so its ACI resources would otherwise
-          # linger for minutes and keep holding quota that other runs need. Delete the
-          # ACI resources synchronously here to release the quota promptly. Best-effort:
-          # the resource group delete and the purge workflow still clean up the rest.
-          set -uo pipefail
-          sub="${AZURE_SUBSCRIPTIONID_TESTS}"
-          rg="${AZURE_TEST_RESOURCE_GROUP}"
-          # Radius creates the ACI nGroups/containerGroupProfiles with this API version
-          # (pkg/sdk/v20241101preview). Delete with it explicitly: a plain delete lets
-          # ARM pick the provider's latest advertised version (e.g. 2026-06-01-preview),
-          # which the RP rejects ("api-version not supported"), leaving the nGroups -
-          # and therefore the whole resource group - undeletable.
-          aci_api_version="2024-11-01-preview"
-          if ! az group show --subscription "${sub}" --name "${rg}" >/dev/null 2>&1; then
-            echo "Resource group ${rg} not found; nothing to release."
-            exit 0
-          fi
-          aci_ids=$(az resource list \
-            --subscription "${sub}" \
-            --resource-group "${rg}" \
-            --query "[?starts_with(type, 'Microsoft.ContainerInstance/')].id" \
-            --output tsv 2>/dev/null || true)
-          if [ -z "${aci_ids}" ]; then
-            echo "No Azure Container Instances resources in ${rg}."
-            exit 0
-          fi
-          echo "Releasing ACI quota by deleting:"
-          echo "${aci_ids}"
-          # nGroups (container scale sets) back the quota-holding container groups, so
-          # delete them first (in parallel) and wait, then delete the remaining ACI
-          # resources (profiles). Parallelizing keeps the synchronous teardown short
-          # while preserving the nGroups-before-profiles order (nGroups reference the
-          # profiles).
-          for id in $(echo "${aci_ids}" | grep -i '/nGroups/' || true); do
-            az resource delete --subscription "${sub}" --ids "${id}" --api-version "${aci_api_version}" --verbose || true &
-          done
-          wait
-          for id in $(echo "${aci_ids}" | grep -iv '/nGroups/' || true); do
-            az resource delete --subscription "${sub}" --ids "${id}" --api-version "${aci_api_version}" --verbose || true &
-          done
-          wait
+          ./.github/scripts/release-aci-quota.sh \
+            "${AZURE_SUBSCRIPTIONID_TESTS}" \
+            "${AZURE_TEST_RESOURCE_GROUP}"
 
       - name: Delete azure resource group - ${{ env.AZURE_TEST_RESOURCE_GROUP }}
         if: always()

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -399,7 +399,7 @@ jobs:
           # This RE2 expression matches every test name except the exact Test_ACI
           # name, keeping the long-running suite aligned with that mitigation until
           # a release contains it. See #12044, #12163, and #12247.
-          GOTEST_OPTS: "-run=^(Test_ACI.+|Test_AC[^I].*|Test_A[^C].*|Test_[^A].*|Test[^_].*|Tes[^t].*|Te[^s].*|T[^e].*|[^T].*|T|Te|Tes|Test|Test_|Test_A|Test_AC)$"
+          GOTEST_OPTS: "-run='^(Test_ACI.+|Test_AC[^I].*|Test_A[^C].*|Test_[^A].*|Test[^_].*|Tes[^t].*|Te[^s].*|T[^e].*|[^T].*|T|Te|Tes|Test|Test_|Test_A|Test_AC)$'"
         working-directory: ${{ steps.checkout-release-codebase.outputs.release-dir }}
         run: |
           set -euo pipefail

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -396,9 +396,10 @@ jobs:
           GIT_HTTP_PASSWORD: ${{ env.GIT_HTTP_PASSWORD }}
           FUNCTEST_PREPROVISIONED_RESOURCE_JSON: ${{ secrets.FUNCTEST_PREPROVISIONED_RESOURCE_JSON }}
           # The released v0.59 test code predates main's temporary Test_ACI skip.
-          # Keep the long-running suite aligned with that mitigation until a release
-          # contains it. See #12044, #12163, and #12247.
-          GOTEST_OPTS: "-skip=^Test_ACI$"
+          # This RE2 expression matches every test name except the exact Test_ACI
+          # name, keeping the long-running suite aligned with that mitigation until
+          # a release contains it. See #12044, #12163, and #12247.
+          GOTEST_OPTS: "-run=^(Test_ACI.+|Test_AC[^I].*|Test_A[^C].*|Test_[^A].*|Test[^_].*|Tes[^t].*|Te[^s].*|T[^e].*|[^T].*|T|Te|Tes|Test|Test_|Test_A|Test_AC)$"
         working-directory: ${{ steps.checkout-release-codebase.outputs.release-dir }}
         run: |
           set -euo pipefail

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -94,7 +94,7 @@ jobs:
     if: github.repository == vars.RADIUS_REPOSITORY
     name: Run functional tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    timeout-minutes: 210
     permissions:
       id-token: write # Required for requesting the JWT
       contents: read # Required for actions/checkout
@@ -374,6 +374,7 @@ jobs:
           RELEASE_DIR: ${{ steps.checkout-release-codebase.outputs.release-dir }}
 
       - name: Run functional tests
+        timeout-minutes: 120
         env:
           AZURE_TEST_RESOURCE_GROUP: ${{ steps.gen-id.outputs.AZURE_TEST_RESOURCE_GROUP }}
           UNIQUE_ID: ${{ steps.gen-id.outputs.UNIQUE_ID }}
@@ -394,6 +395,10 @@ jobs:
           GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
           GIT_HTTP_PASSWORD: ${{ env.GIT_HTTP_PASSWORD }}
           FUNCTEST_PREPROVISIONED_RESOURCE_JSON: ${{ secrets.FUNCTEST_PREPROVISIONED_RESOURCE_JSON }}
+          # The released v0.59 test code predates main's temporary Test_ACI skip.
+          # Keep the long-running suite aligned with that mitigation until a release
+          # contains it. See #12044, #12163, and #12247.
+          GOTEST_OPTS: "-skip=^Test_ACI$"
         working-directory: ${{ steps.checkout-release-codebase.outputs.release-dir }}
         run: |
           set -euo pipefail
@@ -420,7 +425,11 @@ jobs:
           export AZURE_MSSQL_USERNAME="$(echo "${PREPROVISIONED_JSON}" | jq -er '.AZURE_MSSQL_USERNAME')"
           export AZURE_MSSQL_PASSWORD="$(echo "${PREPROVISIONED_JSON}" | jq -er '.AZURE_MSSQL_PASSWORD')"
 
-          make test-functional-all
+          # Run quota-dependent suites first so cloud failures leave enough time for
+          # diagnostics and cleanup. These two targets cover the same suites as
+          # test-functional-all without rerunning the Kubernetes aggregate target.
+          make test-functional-all-cloud
+          make test-functional-all-noncloud
 
       - name: Collect Pod details
         if: always()
@@ -463,6 +472,16 @@ jobs:
           tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
 
+      - name: Release ACI quota before async resource group delete
+        if: always()
+        env:
+          AZURE_SUBSCRIPTIONID_TESTS: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
+          AZURE_TEST_RESOURCE_GROUP: ${{ steps.gen-id.outputs.AZURE_TEST_RESOURCE_GROUP }}
+        run: |
+          ./.github/scripts/release-aci-quota.sh \
+            "${AZURE_SUBSCRIPTIONID_TESTS}" \
+            "${AZURE_TEST_RESOURCE_GROUP}"
+
       - name: Delete azure resource group - ${{ steps.gen-id.outputs.AZURE_TEST_RESOURCE_GROUP }}
         if: always()
         env:
@@ -496,22 +515,26 @@ jobs:
           ./.github/scripts/cleanup-long-running-cluster.sh skip-delete-resources-list.txt
 
   report-failure:
-    if: failure() && github.repository == vars.RADIUS_REPOSITORY && github.event_name == 'schedule'
-    name: Report test failure
+    if: |
+      always() &&
+      (needs.tests.result == 'failure' || needs.tests.result == 'cancelled') &&
+      github.repository == vars.RADIUS_REPOSITORY &&
+      github.event_name == 'schedule'
+    name: Report unsuccessful test run
     needs: [tests]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       issues: write # Required to create an issue when the scheduled run fails
     steps:
-      - name: Create failure issue for failing long running test run
+      - name: Create issue for unsuccessful long running test run
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |
             github.rest.issues.create({
               ...context.repo,
-              title: `Scheduled long running test failed - Run ID: ${context.runId}`,
+              title: `Scheduled long running test did not complete successfully - Run ID: ${context.runId}`,
               labels: ['test-failure'],
-              body: `## Bug information \n\nThis issue is automatically generated if the scheduled long running test fails. The Radius long running test operates on a schedule of once per day. It's important to understand that the test may fail due to workflow infrastructure issues, like network problems, rather than the flakiness of the test itself. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
+              body: `## Bug information \n\nThis issue is automatically generated if the scheduled long running test fails or is cancelled. The Radius long running test operates on a schedule of once per day. It's important to understand that the test may fail due to workflow infrastructure issues, like network problems, rather than the flakiness of the test itself. For further investigation, visit [the workflow run](${process.env.ACTION_LINK}).`
             })


### PR DESCRIPTION
# Description

Scheduled long-running Azure tests have failed or timed out since June 18 because the released v0.59 `Test_ACI` consumes the subscription's shared Container Scale Set quota while asynchronous resource-group deletion can leave quota-holding ACI nGroups behind.

This change:

- skips the already-disabled ACI test when running release-tag test code and runs quota-dependent suites first
- separates the functional-test timeout from job cleanup headroom and reports timed-out scheduled runs
- adds a reusable ACI quota-release script that deletes nGroups before profiles with the required API version
- reuses the quota-release path in both Azure cloud workflows
- batches long-running cluster resource cleanup in groups of 100 instead of issuing one Kubernetes API call per resource

Related: #12044, #12163, #12247

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: N/A

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable

## Validation

- `actionlint` on the changed workflows
- repository-pinned `shellcheck` and `bash -n` on the changed scripts
- Make dry run confirming the ACI skip reaches all functional-test commands
- mocked ACI deletion-order check and 100/100/5 cluster cleanup batching check
- `git diff --check`