### PR TITLE
Upd `rad env upd` to work with `RADIUS_PREVIEW` env variable

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -391,20 +391,8 @@ func initSubCommands() {
 
 	legacyEnvUpdateCmd, _ := env_update.NewCommand(framework)
 	previewEnvUpdateCmd, _ := env_update_preview.NewCommand(framework)
-	envUpdateCmd := previewEnvUpdateCmd
-	envUpdateCmd.Flags().Bool("preview", false, "Use the Radius.Core preview implementation for environment update.")
-	previewRunE := envUpdateCmd.RunE
-	envUpdateCmd.RunE = func(cmd *cobra.Command, args []string) error {
-		usePreview, err := cmd.Flags().GetBool("preview")
-		if err != nil {
-			return err
-		}
-		if usePreview {
-			return previewRunE(cmd, args)
-		}
-		return legacyEnvUpdateCmd.RunE(cmd, args)
-	}
-	envCmd.AddCommand(envUpdateCmd)
+	wirePreviewSubcommandPreviewBase(previewEnvUpdateCmd, legacyEnvUpdateCmd.RunE, "Use the Radius.Core preview implementation for environment update")
+	envCmd.AddCommand(previewEnvUpdateCmd)
 
 	workspaceCreateCmd, _ := workspace_create.NewCommand(framework)
 	previewWorkspaceCreateCmd, _ := workspace_create_preview.NewCommand(framework)
@@ -529,22 +517,70 @@ func getRootSpanName() string {
 // The preview behavior can also be activated by setting the RADIUS_PREVIEW environment variable to "true" (case-insensitive).
 // The --preview flag takes precedence over the environment variable.
 func wirePreviewSubcommand(cmd *cobra.Command, previewCmd *cobra.Command) {
-	cmd.Flags().Bool("preview", false, "Use the Radius.Core preview implementation (can also be set via RADIUS_PREVIEW=true)")
+	cmd.Flags().Bool("preview", false, withPreviewEnvVarNote("Use the Radius.Core preview implementation"))
 
 	legacyRun := cmd.RunE
 	previewRun := previewCmd.RunE
 
 	cmd.RunE = func(c *cobra.Command, args []string) error {
-		usePreview, err := c.Flags().GetBool("preview")
+		usePreview, err := resolveUsePreview(c)
 		if err != nil {
 			return err
-		}
-		if !c.Flags().Changed("preview") {
-			usePreview = strings.EqualFold(os.Getenv("RADIUS_PREVIEW"), "true")
 		}
 		if usePreview {
 			return previewRun(c, args)
 		}
 		return legacyRun(c, args)
 	}
+}
+
+// wirePreviewSubcommandPreviewBase wires a subcommand whose preview implementation carries
+// flags that the legacy implementation lacks (e.g. env update's --recipe-packs), so the
+// preview command must be used as the base to expose those flags. The legacy runner is
+// invoked as a fallback. Like wirePreviewSubcommand, preview is activated by the --preview
+// flag or the RADIUS_PREVIEW environment variable, with the flag taking precedence.
+func wirePreviewSubcommandPreviewBase(previewCmd *cobra.Command, legacyRunE func(*cobra.Command, []string) error, previewFlagUsage string) {
+	previewCmd.Flags().Bool("preview", false, withPreviewEnvVarNote(previewFlagUsage))
+
+	previewRun := previewCmd.RunE
+
+	previewCmd.RunE = func(c *cobra.Command, args []string) error {
+		usePreview, err := resolveUsePreview(c)
+		if err != nil {
+			return err
+		}
+		if usePreview {
+			return previewRun(c, args)
+		}
+		return legacyRunE(c, args)
+	}
+}
+
+// resolveUsePreview reports whether a command should use its preview implementation.
+// It returns true when the --preview flag is explicitly set to true, or when the flag is
+// unset and the RADIUS_PREVIEW environment variable is "true" (case-insensitive). The
+// --preview flag takes precedence over the environment variable.
+func resolveUsePreview(cmd *cobra.Command) (bool, error) {
+	usePreview, err := cmd.Flags().GetBool("preview")
+	if err != nil {
+		return false, err
+	}
+	if !cmd.Flags().Changed("preview") {
+		usePreview = strings.EqualFold(os.Getenv("RADIUS_PREVIEW"), "true")
+	}
+	return usePreview, nil
+}
+
+// previewEnvVarNote documents that the RADIUS_PREVIEW environment variable also activates
+// preview mode. It is appended to --preview flag usage strings by withPreviewEnvVarNote.
+const previewEnvVarNote = "can also be set via RADIUS_PREVIEW=true"
+
+// withPreviewEnvVarNote ensures a --preview flag usage string mentions that RADIUS_PREVIEW
+// also activates preview, so --help stays accurate. The note is appended unless the usage
+// already references RADIUS_PREVIEW, avoiding a double-append when a caller includes it.
+func withPreviewEnvVarNote(usage string) string {
+	if strings.Contains(usage, "RADIUS_PREVIEW") {
+		return usage
+	}
+	return usage + " (" + previewEnvVarNote + ")"
 }

--- a/cmd/rad/cmd/root_test.go
+++ b/cmd/rad/cmd/root_test.go
@@ -209,3 +209,105 @@ func Test_wirePreviewSubcommand(t *testing.T) {
 		require.False(t, previewCalled, "preview runner should not have been called")
 	})
 }
+
+func Test_withPreviewEnvVarNote(t *testing.T) {
+	t.Run("appends the RADIUS_PREVIEW note when absent", func(t *testing.T) {
+		got := withPreviewEnvVarNote("Use the Radius.Core preview implementation for environment update")
+		require.Equal(t, "Use the Radius.Core preview implementation for environment update (can also be set via RADIUS_PREVIEW=true)", got)
+	})
+
+	t.Run("does not double-append when the note is already present", func(t *testing.T) {
+		usage := "Use the Radius.Core preview implementation (can also be set via RADIUS_PREVIEW=true)"
+		require.Equal(t, usage, withPreviewEnvVarNote(usage))
+	})
+
+	t.Run("preview-base wiring exposes a --preview flag mentioning RADIUS_PREVIEW", func(t *testing.T) {
+		previewCmd := &cobra.Command{
+			Use:  "test",
+			RunE: func(cmd *cobra.Command, args []string) error { return nil },
+		}
+		wirePreviewSubcommandPreviewBase(previewCmd, func(cmd *cobra.Command, args []string) error { return nil }, "Use the preview implementation")
+
+		flag := previewCmd.Flags().Lookup("preview")
+		require.NotNil(t, flag)
+		require.Contains(t, flag.Usage, "RADIUS_PREVIEW")
+	})
+}
+
+func Test_wirePreviewSubcommandPreviewBase(t *testing.T) {
+	// newCmds builds a preview command (the base) plus a legacy runner, wired together via
+	// wirePreviewSubcommandPreviewBase. The returned pointers report which runner executed.
+	newCmds := func(legacyCalled, previewCalled *bool) *cobra.Command {
+		previewCmd := &cobra.Command{
+			Use:  "test",
+			RunE: func(cmd *cobra.Command, args []string) error { *previewCalled = true; return nil },
+		}
+		legacyRunE := func(cmd *cobra.Command, args []string) error { *legacyCalled = true; return nil }
+		wirePreviewSubcommandPreviewBase(previewCmd, legacyRunE, "Use the preview implementation.")
+		return previewCmd
+	}
+
+	t.Run("routes to legacy runner when --preview is not set", func(t *testing.T) {
+		legacyCalled, previewCalled := false, false
+		cmd := newCmds(&legacyCalled, &previewCalled)
+
+		cmd.SetArgs([]string{})
+		require.NoError(t, cmd.Execute())
+		require.True(t, legacyCalled, "legacy runner should have been called")
+		require.False(t, previewCalled, "preview runner should not have been called")
+	})
+
+	t.Run("routes to preview runner when --preview is set", func(t *testing.T) {
+		legacyCalled, previewCalled := false, false
+		cmd := newCmds(&legacyCalled, &previewCalled)
+
+		cmd.SetArgs([]string{"--preview"})
+		require.NoError(t, cmd.Execute())
+		require.False(t, legacyCalled, "legacy runner should not have been called")
+		require.True(t, previewCalled, "preview runner should have been called")
+	})
+
+	t.Run("routes to preview runner when RADIUS_PREVIEW=true", func(t *testing.T) {
+		legacyCalled, previewCalled := false, false
+		cmd := newCmds(&legacyCalled, &previewCalled)
+
+		t.Setenv("RADIUS_PREVIEW", "true")
+		cmd.SetArgs([]string{})
+		require.NoError(t, cmd.Execute())
+		require.False(t, legacyCalled, "legacy runner should not have been called")
+		require.True(t, previewCalled, "preview runner should have been called")
+	})
+
+	t.Run("routes to preview runner when RADIUS_PREVIEW=True (case-insensitive)", func(t *testing.T) {
+		legacyCalled, previewCalled := false, false
+		cmd := newCmds(&legacyCalled, &previewCalled)
+
+		t.Setenv("RADIUS_PREVIEW", "True")
+		cmd.SetArgs([]string{})
+		require.NoError(t, cmd.Execute())
+		require.False(t, legacyCalled, "legacy runner should not have been called")
+		require.True(t, previewCalled, "preview runner should have been called")
+	})
+
+	t.Run("uses --preview=false to override RADIUS_PREVIEW=true", func(t *testing.T) {
+		legacyCalled, previewCalled := false, false
+		cmd := newCmds(&legacyCalled, &previewCalled)
+
+		t.Setenv("RADIUS_PREVIEW", "true")
+		cmd.SetArgs([]string{"--preview=false"})
+		require.NoError(t, cmd.Execute())
+		require.True(t, legacyCalled, "legacy runner should have been called")
+		require.False(t, previewCalled, "preview runner should not have been called")
+	})
+
+	t.Run("routes to legacy runner when RADIUS_PREVIEW is not true", func(t *testing.T) {
+		legacyCalled, previewCalled := false, false
+		cmd := newCmds(&legacyCalled, &previewCalled)
+
+		t.Setenv("RADIUS_PREVIEW", "false")
+		cmd.SetArgs([]string{})
+		require.NoError(t, cmd.Execute())
+		require.True(t, legacyCalled, "legacy runner should have been called")
+		require.False(t, previewCalled, "preview runner should not have been called")
+	})
+}


### PR DESCRIPTION
# Description

 `rad env update ` was the only preview-capable command that didn't honor  RADIUS_PREVIEW=true  — it required the explicit  --preview  flag. Without it,  RADIUS_PREVIEW=true rad env update ...  fell through to the legacy  Applications.Core  path and failed with "environment does not exist" for  Radius.Core  environments.

Root cause: Every other preview command is wired via  wirePreviewSubcommand , which activates preview on  --preview  or  RADIUS_PREVIEW=true .  env update  was hand-wired instead, because its preview implementation exposes flags the legacy command lacks ( --recipe-packs ,  --clear-kubernetes ,  --kubernetes-namespace ), so the preview command was set to be the cobra base. 

Fix: Extracted the shared preview-decision logic into  resolveUsePreview , added  wirePreviewSubcommandPreviewBase  for commands whose preview implementation carries extra flags, and rewired  env update  through it.  env update  now activates preview via either  --preview  or  RADIUS_PREVIEW=true , consistent with all other commands.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius.

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
