### PR TITLE
refactor: improve ARM request context handling

### DIFF
--- a/pkg/armrpc/api/v1/armrequestcontext.go
+++ b/pkg/armrpc/api/v1/armrequestcontext.go
@@ -180,36 +180,39 @@ type ARMRequestContext struct {
 // FromARMRequest extracts proxy request headers from http.Request.
 func FromARMRequest(r *http.Request, pathBase, location string) (*ARMRequestContext, error) {
 	log := ucplog.FromContextOrDiscard(r.Context())
-	refererUri := r.Header.Get(RefererHeader)
-	refererURL, err := url.Parse(refererUri)
-	if refererUri == "" || err != nil {
-		refererURL = r.URL
+	requestPathBase := pathBase
+	if requestPathBase == "" {
+		requestPathBase = ParsePathBase(r.URL.Path)
 	}
-
-	if pathBase == "" {
-		pathBase = ParsePathBase(refererURL.Path)
-	}
-	path := strings.TrimPrefix(refererURL.Path, pathBase)
-	rID, err := resources.ParseByMethod(path, r.Method)
-	if err != nil {
-		log.V(ucplog.LevelDebug).Info(fmt.Sprintf("URL was not a valid resource id: %v", refererURL.Path))
+	requestPath := strings.TrimPrefix(r.URL.Path, requestPathBase)
+	rID, resourceIDErr := resources.ParseByMethod(requestPath, r.Method)
+	if resourceIDErr != nil {
+		log.V(ucplog.LevelDebug).Info(fmt.Sprintf("URL was not a valid resource id: %v", r.URL.Path))
 		// do not stop extracting headers. handler needs to care invalid resource id.
 	}
 
-	// Radius (like ARM) uses the Referer header to recover the original resource path when a request
-	// has been proxied or its URL path was case-normalized, so a well-formed Referer normally refers
-	// to the same resource as the request URL, differing only by casing or path base. Keep the two
-	// consistent: if a well-formed Referer refers to a different resource than the request URL, use
-	// the URL so the resource id used for storage, scope, and downstream routing matches the request
-	// path.
-	if refererUri != "" && err == nil {
-		// Strip the URL's own path base before comparing: a proxied request can carry a routing
-		// prefix on the URL that the Referer does not, and that prefix is not a resource difference.
-		urlPath := strings.TrimPrefix(r.URL.Path, ParsePathBase(r.URL.Path))
-		if urlID, urlErr := resources.ParseByMethod(urlPath, r.Method); urlErr == nil && !strings.EqualFold(rID.String(), urlID.String()) {
-			log.Info("Referer header refers to a different resource than the request URL; using the request URL.",
-				"refererResourceID", rID.String(), "urlResourceID", urlID.String())
-			rID = urlID
+	// Radius (like ARM) uses the Referer header to recover original resource ID casing after a
+	// request has been proxied or its URL path was case-normalized. The request URL remains the
+	// authoritative source of identity: only use the Referer ID when both IDs identify the same
+	// resource.
+	refererURI := r.Header.Get(RefererHeader)
+	if refererURI != "" && resourceIDErr == nil {
+		refererURL, refererURLErr := url.Parse(refererURI)
+		if refererURLErr == nil {
+			refererPathBase := pathBase
+			if refererPathBase == "" {
+				refererPathBase = ParsePathBase(refererURL.Path)
+			}
+			refererPath := strings.TrimPrefix(refererURL.Path, refererPathBase)
+			refererID, refererIDErr := resources.ParseByMethod(refererPath, r.Method)
+			if refererIDErr == nil {
+				if resources.IDEquals(rID, refererID) {
+					rID = refererID
+				} else {
+					log.Info("Referer header refers to a different resource than the request URL; using the request URL.",
+						"refererResourceID", refererID.String(), "urlResourceID", rID.String())
+				}
+			}
 		}
 	}
 

--- a/pkg/armrpc/api/v1/armrequestcontext_test.go
+++ b/pkg/armrpc/api/v1/armrequestcontext_test.go
@@ -89,6 +89,7 @@ func TestFromARMRequest_PrefersURLWhenRefererResourceDiffers(t *testing.T) {
 	// at a different resource is ignored in favor of the request URL.
 	cases := []struct {
 		desc       string
+		method     string
 		urlPath    string
 		referer    string
 		expectedID string
@@ -106,10 +107,29 @@ func TestFromARMRequest_PrefersURLWhenRefererResourceDiffers(t *testing.T) {
 			expectedID: "/planes/radius/local/resourceGroups/group-a/providers/Applications.Core/environments/Env0",
 		},
 		{
-			desc:       "referer for a different resource uses url",
+			desc:       "delete with referer for a different resource uses url",
+			method:     http.MethodDelete,
 			urlPath:    "/planes/radius/local/resourcegroups/group-b/providers/Applications.Core/environments/env0",
 			referer:    "http://localhost/planes/radius/local/resourceGroups/group-a/providers/Applications.Core/environments/env0",
 			expectedID: "/planes/radius/local/resourcegroups/group-b/providers/Applications.Core/environments/env0",
+		},
+		{
+			desc:       "malformed referer uses url",
+			urlPath:    "/planes/radius/local/resourcegroups/group-b/providers/Applications.Core/environments/env0",
+			referer:    "://invalid",
+			expectedID: "/planes/radius/local/resourcegroups/group-b/providers/Applications.Core/environments/env0",
+		},
+		{
+			desc:       "referer without resource id uses url",
+			urlPath:    "/planes/radius/local/resourcegroups/group-b/providers/Applications.Core/environments/env0",
+			referer:    "http://localhost",
+			expectedID: "/planes/radius/local/resourcegroups/group-b/providers/Applications.Core/environments/env0",
+		},
+		{
+			desc:       "invalid url does not use referer resource id",
+			urlPath:    "/planes/radius/local/resourcegroups/group-b/providers/Applications.Core//environments/env0",
+			referer:    "http://localhost/planes/radius/local/resourceGroups/group-a/providers/Applications.Core/environments/env0",
+			expectedID: "",
 		},
 		{
 			// A proxied request can carry a routing prefix on the URL (e.g. a downstream id) that the
@@ -124,7 +144,12 @@ func TestFromARMRequest_PrefersURLWhenRefererResourceDiffers(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.desc, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, tt.urlPath, nil)
+			method := tt.method
+			if method == "" {
+				method = http.MethodGet
+			}
+
+			req := httptest.NewRequest(method, tt.urlPath, nil)
 			if tt.referer != "" {
 				req.Header.Set(RefererHeader, tt.referer)
 			}

--- a/pkg/ucp/frontend/controller/radius/proxy.go
+++ b/pkg/ucp/frontend/controller/radius/proxy.go
@@ -105,6 +105,11 @@ func (p *ProxyController) Run(ctx context.Context, w http.ResponseWriter, req *h
 	requestCtx := v1.ARMRequestContextFromContext(ctx)
 	id := requestCtx.ResourceID
 	relativePath := middleware.GetRelativePath(p.Options().PathBase, requestCtx.OriginalURL.Path)
+	if id.IsEmpty() {
+		message := "the request URL does not contain a valid resource ID"
+		response := v1.ErrorResponse{Error: &v1.ErrorDetails{Code: v1.CodeInvalid, Message: message}}
+		return armrpc_rest.NewBadRequestARMResponse(response), nil
+	}
 
 	apiVersion := requestCtx.APIVersion
 	if apiVersion == "" {

--- a/pkg/ucp/frontend/controller/radius/proxy_test.go
+++ b/pkg/ucp/frontend/controller/radius/proxy_test.go
@@ -118,6 +118,30 @@ func Test_Run(t *testing.T) {
 		},
 	}
 
+	t.Run("failure (invalid resource ID)", func(t *testing.T) {
+		p, _, _, _, _ := createController(t)
+
+		svcContext := &v1.ARMRequestContext{
+			APIVersion: apiVersion,
+		}
+		ctx := testcontext.New(t)
+		ctx = v1.WithARMRequestContext(ctx, svcContext)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Test//my-resource?api-version="+apiVersion, nil)
+
+		expected := rest.NewBadRequestARMResponse(v1.ErrorResponse{
+			Error: &v1.ErrorDetails{
+				Code:    v1.CodeInvalid,
+				Message: "the request URL does not contain a valid resource ID",
+			},
+		})
+
+		response, err := p.Run(ctx, w, req.WithContext(ctx))
+		require.NoError(t, err)
+		require.Equal(t, expected, response)
+	})
+
 	t.Run("success (non-tracked)", func(t *testing.T) {
 		p, databaseClient, _, roundTripper, _ := createController(t)
 


### PR DESCRIPTION
## Summary

Improves ARM request context parsing so resource IDs are consistently derived from the request URL while retaining original casing when equivalent request metadata is available. Requests without a valid resource ID now receive a clear bad-request response before downstream processing.

## Reason for change

Keep resource ID handling predictable across proxy hops and URL normalization. This avoids inconsistent behavior when optional `Referer` metadata is absent, malformed, or describes a different path.

## How to test

```console
go test ./pkg/armrpc/... ./pkg/ucp/frontend/... ./pkg/dynamicrp/frontend -count=1
```

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `pkg/armrpc/api/v1/armrequestcontext.go` | Derives resource identity from the request URL and uses equivalent `Referer` metadata only to preserve casing. |
| `pkg/armrpc/api/v1/armrequestcontext_test.go` | Adds coverage for casing, path bases, malformed metadata, differing paths, and invalid URLs. |
| `pkg/ucp/frontend/controller/radius/proxy.go` | Returns a bad-request response when the request context has no valid resource ID. |
| `pkg/ucp/frontend/controller/radius/proxy_test.go` | Verifies invalid resource IDs are rejected before downstream processing. |