### PR TITLE
handle x-radius-sensitive in static graph

### DIFF
--- a/eng/design-notes/security/2026-07-sensitive-fields-in-app-graph.md
+++ b/eng/design-notes/security/2026-07-sensitive-fields-in-app-graph.md
@@ -1,0 +1,215 @@
+# Sensitive Fields in the Application Graph
+
+Status: Draft
+Author: (fill in)
+Date: 2026-07-15
+
+## Problem statement
+
+Resource-type schemas can mark individual properties as sensitive via the
+`x-radius-sensitive: true` annotation (see
+[`bicep-tools/pkg/manifest/manifest.go`](../../../bicep-tools/pkg/manifest/manifest.go)
+and [`pkg/schema/annotations.go`](../../../pkg/schema/annotations.go)). Radius
+encrypts those values at rest and redacts them from the LIST/GET API
+responses that dynamic-rp serves. However, we need to confirm and codify how
+those redacted values appear in the **application graph** (the
+`Radius.Core/applications/getGraph@2025-08-01-preview` response) and answer a
+disambiguation question the current wire contract cannot answer:
+
+> When a graph consumer sees `"password": null` in a resource's `properties`
+> map, is that because the property was **never set** by the user, or because
+> it **was set but redacted** for security?
+
+Both cases produce identical JSON today, which makes it impossible for a
+downstream consumer (CLI text renderer, browser extension, third-party
+tooling) to render "[REDACTED]" correctly and equally impossible to tell a
+platform engineer "this field is empty, please set it" without risk of that
+being a security surprise.
+
+## What exists today
+
+### 1. Schema-declared sensitive paths
+
+- `x-radius-sensitive: true` on a property (or on an array's `items` /
+  `additionalProperties`) marks that path as sensitive.
+- [`schema.ExtractSensitiveFieldPaths`](../../../pkg/schema/annotations.go)
+  walks the OpenAPI schema and returns dot-notation paths, e.g.:
+  - `credentials.password`
+  - `secrets[*].value`
+  - `config[*]`
+- Handles object properties, array items, and additionalProperties (maps).
+
+### 2. Redaction happens at the read boundary
+
+The dynamic-rp read paths all fetch sensitive paths from the schema and pass
+them to [`schema.RedactFields`](../../../pkg/schema/annotations.go), which
+walks the data and sets each matching leaf to `nil` — which the autorest
+serializer emits as JSON `null`:
+
+- LIST: [`pkg/dynamicrp/frontend/listresources.go`](../../../pkg/dynamicrp/frontend/listresources.go) (`ListResourcesWithRedaction`).
+- GET: [`pkg/dynamicrp/frontend/getresource.go`](../../../pkg/dynamicrp/frontend/getresource.go).
+- Encryption filter: [`pkg/dynamicrp/frontend/encryptionfilter.go`](../../../pkg/dynamicrp/frontend/encryptionfilter.go).
+- Backend controller: [`pkg/portableresources/backend/controller/createorupdateresource.go`](../../../pkg/portableresources/backend/controller/createorupdateresource.go).
+
+Core-RP resource types (containers, gateways, environments, applications) do
+not inline secrets in their LIST responses at all — secrets live behind
+dedicated `/listSecrets` endpoints. So the graph never sees a raw secret
+value for core-RP types.
+
+### 3. How the graph consumes this
+
+The graph pipeline in
+[`pkg/corerp/frontend/controller/applications/graph_util.go`](../../../pkg/corerp/frontend/controller/applications/graph_util.go)
+calls the ARM LIST endpoint per resource type, then hands the already-redacted
+property bag to `getResourceTypeSpecificProperties`, which copies it verbatim
+(minus `provisioningState`, `connections`, `status`) into the graph node's
+`properties` map. The doc comment on `getResourceTypeSpecificProperties`
+records the contract: it depends on upstream LIST handlers having redacted
+secrets first.
+
+Net effect: **on the happy path the graph is free of raw
+`x-radius-sensitive` values today**, but only implicitly, via LIST redaction.
+The graph layer itself performs no schema-based redaction as a safety net.
+
+## The disambiguation problem
+
+The current wire contract is:
+
+| Case                                    | JSON wire form         |
+| --------------------------------------- | ---------------------- |
+| Property never set                      | `"foo": null` (or key absent) |
+| Property set but marked sensitive       | `"foo": null`          |
+| Property set to a non-nil value         | `"foo": <the value>`   |
+
+The two `null` cases are indistinguishable from the wire. A consumer cannot
+choose between rendering "not configured" and "[REDACTED]" without a
+side-channel signal.
+
+### Why not a sentinel string?
+
+- `"foo": "[REDACTED]"` works only for string properties. For int, bool,
+  object, or array properties, `"[REDACTED]"` breaks the wire type and any
+  strict-schema client (TypeScript, autorest) rejects the response.
+- Type-aware sentinels (`"[REDACTED]"` for strings, `null` for everything
+  else) make the redaction asymmetric — consumers still have to special-case
+  and still can't tell "null number: unset or redacted?".
+
+### Why not a wrapper envelope?
+
+- Replacing every sensitive value with `{"$redacted": true}` is uniform but
+  breaks the wire type for every property, regardless of kind. Strict-schema
+  clients reject it universally.
+
+### Why not schema-based disambiguation?
+
+Every consumer could fetch the resource-type schema, look at whether the
+path is `x-radius-sensitive`, and render accordingly. Zero wire change,
+architecturally cleanest. Downsides:
+
+- Every consumer (CLI, browser extension, external tooling) needs schema
+  fetch logic and a per-`(namespace, typeName, apiVersion)` schema cache.
+- One extra UCP call per distinct type per consumer session.
+- Consumers written before the annotation existed can't opt in.
+
+## Recommended solution: `redactedPaths` sidecar
+
+Add an optional `redactedPaths: string[]` field to each
+`ApplicationGraphResource` in the v20250801preview response. It enumerates
+the dot-notation paths whose values have been redacted for security in the
+current response.
+
+### Wire example
+
+```json
+{
+  "id": "/planes/radius/local/.../mySqlDatabases/db",
+  "type": "Radius.Data/mySqlDatabases",
+  "properties": {
+    "host": "db.example.com",
+    "port": 3306,
+    "username": "admin",
+    "password": null,
+    "readReplica": null
+  },
+  "redactedPaths": ["password"]
+}
+```
+
+### Consumer disambiguation rules
+
+- Path listed in `redactedPaths` → **was set, hidden for security** → render
+  "[REDACTED]" (or type-appropriate placeholder) in the UI.
+- Path absent from `redactedPaths` and value is `null` → **unset**.
+- Path absent from `redactedPaths` and value is present → real value.
+
+### Why this works
+
+- **Wire-safe.** No property-value type changes. Existing clients that don't
+  know about `redactedPaths` simply ignore the extra field.
+- **Type-agnostic.** Works uniformly for string, int, bool, object, array
+  properties — the value is still `null`, the sidecar is the signal.
+- **No consumer schema fetch.** Consumers get the disambiguation signal
+  in-band with the graph response.
+- **Cheap to compute.** The LIST redaction path already knows the sensitive
+  path list per API version (it fetched them from the schema to do the
+  nil-out). It publishes that list on each returned record; the graph layer
+  copies it through, same way it copies `properties`.
+- **Backwards compatible.** Additive on the v20250801preview surface. The
+  legacy v20231001preview surface stays unchanged.
+
+### Optional refinement: shared map
+
+If the same sensitive-path list is repeated across many nodes of the same
+type, we could dedupe to a top-level
+
+```
+"redactedPaths": {
+  "Radius.Data/mySqlDatabases": ["password"],
+  "Radius.Security/secrets":    ["data[*]"]
+}
+```
+
+on the `ApplicationGraphResponse`. Slightly less wire but every consumer
+needs the type→paths lookup. Per-resource is simpler to consume and rarely
+larger in practice.
+
+## Belt-and-suspenders: redact at the graph layer too
+
+Independent of how we render redacted values, we should call
+`schema.RedactFields` inside `getResourceTypeSpecificProperties` even though
+LIST already redacts. Rationale:
+
+- The graph layer's contract today ("LIST is the redaction boundary")
+  depends on every upstream LIST handler getting redaction right.
+- A second call at the graph layer costs one schema-cache lookup plus one
+  map walk per node, and it guarantees the graph itself cannot leak a
+  sensitive value even if a LIST handler misses.
+- The `redactedPaths` sidecar is computed as a natural byproduct of that
+  call, so the two changes ship together.
+
+## Rejected alternatives (summary)
+
+| Option                                              | Verdict                                                  |
+| --------------------------------------------------- | -------------------------------------------------------- |
+| Keep only `null`, no signal                         | Blocks the disambiguation the user needs.                |
+| `"[REDACTED]"` sentinel for all types               | Breaks wire type for int/bool/object/array.              |
+| Type-aware sentinel                                 | Still ambiguous for non-strings; asymmetric render.      |
+| Envelope wrapper `{"$redacted": true}`              | Breaks wire type universally.                            |
+| Schema-based disambiguation                         | Cleanest architecturally; requires every consumer to fetch and cache schemas. Viable as a follow-up. |
+| **`redactedPaths` sidecar** (recommendation)        | **Wire-safe, type-agnostic, zero schema fetch on the consumer.** |
+
+## Follow-ups / open questions
+
+1. **Should `redactedPaths` live on each resource or on the response?** —
+   Draft assumes per-resource. Response-level dedupe is a possible refinement
+   if size matters.
+2. **Encoding for paths inside `additionalProperties` / arrays** — reuse the
+   same `[*]` and `[N]` grammar already produced by
+   `ExtractSensitiveFieldPaths`; no new syntax needed.
+3. **CLI rendering** — once the sidecar ships, `rad app graph`'s text
+   renderer and the browser extension should show `[REDACTED]` for listed
+   paths. Both are consumer-side and not blocked by the wire change.
+4. **Do we redact core-RP inline containers today?** — Core-RP LIST does not
+   inline secrets (they're behind `/listSecrets`). The doc contract on
+   `getResourceTypeSpecificProperties` should be revisited if any core-RP
+   type ever starts inlining sensitive data.

--- a/eng/design-notes/security/2026-07-static-graph-sensitive-redaction.md
+++ b/eng/design-notes/security/2026-07-static-graph-sensitive-redaction.md
@@ -45,7 +45,7 @@ Bicep's `@secure()` decorator applies to both string and object parameters and c
 }
 ```
 
-Both types are treated identically as sensitive sources — the redaction contract does not distinguish scalar from structured secrets, and mixing the two rules would let a `secureObject` field like `credentialsBlob.password` flow through the graph unredacted. This mirrors how [pkg/recipes/driver/bicep/bicep.go](../../../pkg/recipes/driver/bicep/bicep.go) treats `securestring` / `secureobject` outputs identically for recipe-response secret routing.
+Both types are treated identically as sensitive sources — the redaction contract does not distinguish scalar from structured secrets, and treating them differently would let a `secureObject` field like `credentialsBlob.password` flow through the graph without being nulled. This mirrors how [pkg/recipes/driver/bicep/bicep.go](../../../pkg/recipes/driver/bicep/bicep.go) treats `securestring` / `secureobject` outputs identically for recipe-response secret routing.
 
 Any resource property value that draws from a secure param appears in the compiled template as an ARM expression referencing `parameters('name')` — either directly, e.g. `"password": "[parameters('adminPassword')]"`, or nested inside another function, e.g. `"connectionString": "[format('server=x;pwd={0}', parameters('adminPassword'))]"`, or via property access on a secureObject, e.g. `"clientId": "[parameters('credentialsBlob').clientId]"`.
 
@@ -84,7 +84,7 @@ sasToken
 - Applies to keys in maps at every depth, including inside arrays' object items.
 - The value is set to `nil` regardless of its type (string, object, number, array).
 
-**False-positive tolerance.** Occasionally a legitimate non-sensitive property will collide (e.g. a hypothetical `password` field on a rate-limiter config that stores the number of password attempts). We accept that risk. The list is short, curated, and conservative; a false positive redacts one graph cell but never leaks a real secret. The alternative — no naming rule — would let hard-coded plaintext secrets flow through unredacted.
+**False-positive tolerance.** Occasionally a legitimate non-sensitive property will collide (e.g. a hypothetical `password` field on a rate-limiter config that stores the number of password attempts). We accept that risk. The list is short, curated, and conservative; a false positive redacts one graph cell but never leaks a real secret. The alternative — no naming rule — would let hard-coded plaintext secrets flow through as-is.
 
 ### Order
 

--- a/eng/design-notes/security/2026-07-static-graph-sensitive-redaction.md
+++ b/eng/design-notes/security/2026-07-static-graph-sensitive-redaction.md
@@ -7,158 +7,193 @@ Companion to: [2026-07-sensitive-fields-in-app-graph.md](./2026-07-sensitive-fie
 
 ## Scope
 
-- **Namespace:** `Radius.*` only (types authored under `Applications.Core/*` are out of scope).
-- **API version:** the `Radius.Core/applications/getGraph@2025-08-01-preview` response shape (the type this static graph produces). The static graph itself does **not** call any API — it is built entirely from the compiled Bicep template. The API-version qualifier applies only to the response model it targets.
-- **In scope:** the static (modeled) graph produced by `rad app graph <app.bicep>` — [pkg/cli/graph/modeled.go](../../../pkg/cli/graph/modeled.go).
-- **Out of scope:** `Applications.Core/*`, older API versions (`v20231001preview` and predecessors), the runtime graph handler (see [Why the runtime graph needs no change](#why-the-runtime-graph-needs-no-change)), and any server-side redaction code.
+- **In scope:** the static (modeled) graph produced by `rad app graph <app.bicep>` — [pkg/cli/graph/modeled.go](../../../pkg/cli/graph/modeled.go). No API calls, no control plane. Static graph is Bicep-side only.
+- **Out of scope:** the runtime graph (see [Why the runtime graph needs no change](#why-the-runtime-graph-needs-no-change)), `Applications.Core/*` handlers, older API versions, all server-side redaction code.
 
 ## Deliverable
 
 Two changes shipped together:
 
-1. **Populate `ApplicationGraphResource.Properties` on every static-graph node.** The field exists on the response model but is left `nil` today; this effort starts populating it from the compiled Bicep resource body, using the same drop-list (`provisioningState`, `connections`, `status`) the runtime graph applies in `getResourceTypeSpecificProperties`.
-2. **Redact `x-radius-sensitive` paths in that newly-populated `Properties` bag** using the schema information carried by the Bicep extension `types.tgz` for each resource type.
+1. **Populate `ApplicationGraphResource.Properties` on every static-graph node.** The field exists on the response model ([pkg/corerp/api/v20250801preview/zz_generated_models.go](../../../pkg/corerp/api/v20250801preview/zz_generated_models.go)) but is left `nil` today. Populate it from the compiled Bicep resource body, minus the runtime keys the graph itself surfaces first-class (`provisioningState`, `connections`, `status`) — matching the runtime graph's `getResourceTypeSpecificProperties`.
+2. **Null out sensitive values in that newly-populated `Properties` bag** using two simple rules:
+   - **Rule A — Secure-parameter tracing.** Values that come from a Bicep `@secure() param` are marked in the compiled ARM JSON via `parameters.<name>.type == "secureString"` (scalar secrets) or `"secureObject"` (structured secrets). Any property value that references such a parameter — directly, nested inside an expression, or via field access on a secureObject — is nulled.
+   - **Rule B — Name-based blocklist.** Any property whose key (case-insensitive, at any nesting depth) matches a well-known secret name is nulled — regardless of source.
 
-Redaction is only meaningful once (1) is done — the whole point of populating `Properties` is that operators want to see resource-specific configuration in the graph, and sensitive properties must be nulled out along that path. The two ship as one unit; there is no intermediate state where properties are populated but not redacted.
-
-## Problem statement
-
-The static graph is built entirely client-side from the compiled ARM JSON of a Bicep file — no control-plane calls, no APIs. Today `buildModeledResource` in [pkg/cli/graph/modeled.go](../../../pkg/cli/graph/modeled.go) does not populate `ApplicationGraphResource.Properties` at all; the field is left `nil`. As a result the static graph shows resource identity, connections, and dependencies but not the resource-specific configuration operators actually need in the diff view.
-
-The desired behavior is:
-
-> Populate `Properties` per resource — matching the shape of the runtime graph — **and** null out any property marked `x-radius-sensitive` in the resource type's schema.
-
-Because the static graph is offline, we cannot look up the schema over the network at graph-build time.
+Redaction is only meaningful once population is done; the two ship as one change.
 
 ## Why the runtime graph needs no change
 
-Two-layer guarantee already in place:
+The runtime graph already relies on two-layer redaction upstream:
 
-1. **Write path redacts at rest.** `dynamicrp` encrypts sensitive fields on create/update; the record's `Properties` bag is stored with sensitive keys already `null`. Both `GetResourceWithRedaction` ([pkg/dynamicrp/frontend/getresource.go:71-77](../../../pkg/dynamicrp/frontend/getresource.go)) and `ListResourcesWithRedaction` ([pkg/dynamicrp/frontend/listresources.go:76-82](../../../pkg/dynamicrp/frontend/listresources.go)) fast-path `Succeeded` resources for this reason.
+1. **Write path redacts at rest.** `dynamicrp` encrypts `x-radius-sensitive` fields on create/update; storage carries them already-nulled. Both `GetResourceWithRedaction` ([pkg/dynamicrp/frontend/getresource.go](../../../pkg/dynamicrp/frontend/getresource.go)) and `ListResourcesWithRedaction` ([pkg/dynamicrp/frontend/listresources.go](../../../pkg/dynamicrp/frontend/listresources.go)) fast-path `Succeeded` resources for this reason.
 2. **Read path redacts explicitly for non-`Succeeded`.** Both controllers call `schema.RedactFields(resource.Properties, sensitiveFieldPaths)` for `Updating` / `Accepted` / `Failed` states.
 
-The runtime graph calls those LIST endpoints via `listAllResourcesByApplication` / `listAllResourcesByEnvironment`, then copies the already-redacted properties into `ApplicationGraphResource.Properties` at [pkg/corerp/frontend/controller/applications/graph_util.go:328](../../../pkg/corerp/frontend/controller/applications/graph_util.go). No additional graph-layer redaction is needed for the runtime path.
+The runtime graph's `Properties` bag is populated from those redacted LIST responses at [pkg/corerp/frontend/controller/applications/graph_util.go:328](../../../pkg/corerp/frontend/controller/applications/graph_util.go). No additional graph-layer redaction is needed and none is added here.
 
-## Approach: read `x-radius-sensitive` from the local Bicep extension cache
+## Approach
 
-Every Bicep extension declared at the top of an `app.bicep` (`extension radius`, `extension aws`, `extension myprovider`, etc.) is packaged as a `types.tgz` archive containing two files:
+### Rule A — Secure-parameter tracing
 
-```text
-index.json    # { "resources": { "Namespace/Type@Version": { "$ref": "types.json#/N" }, ... }, "settings": { ... } }
-types.json    # the full type registry with "sensitive": true on marked properties
+Bicep's `@secure()` decorator applies to both string and object parameters and compiles to two ARM types:
+
+```json
+{
+  "parameters": {
+    "adminPassword":    { "type": "secureString" },   // @secure() param adminPassword string
+    "credentialsBlob":  { "type": "secureObject" }    // @secure() param credentialsBlob object
+  }
+}
 ```
 
-The `"sensitive": true` marker is emitted by [bicep-tools/pkg/converter/converter.go](../../../bicep-tools/pkg/converter/converter.go) directly from the `x-radius-sensitive` annotation in the source YAML manifest. Same source of truth `dynamic-rp` uses server-side.
+Both types are treated identically as sensitive sources — the redaction contract does not distinguish scalar from structured secrets, and mixing the two rules would let a `secureObject` field like `credentialsBlob.password` flow through the graph unredacted. This mirrors how [pkg/recipes/driver/bicep/bicep.go](../../../pkg/recipes/driver/bicep/bicep.go) treats `securestring` / `secureobject` outputs identically for recipe-response secret routing.
 
-The Bicep CLI resolves each extension into a content-addressed local cache under `~/.bicep/`:
+Any resource property value that draws from a secure param appears in the compiled template as an ARM expression referencing `parameters('name')` — either directly, e.g. `"password": "[parameters('adminPassword')]"`, or nested inside another function, e.g. `"connectionString": "[format('server=x;pwd={0}', parameters('adminPassword'))]"`, or via property access on a secureObject, e.g. `"clientId": "[parameters('credentialsBlob').clientId]"`.
+
+**Algorithm.** Extract the set `secureParams = { name | template.parameters[name].type ∈ {"secureString","secureObject"} }` (case-insensitive on the type). When populating a resource's `Properties`, walk recursively; for each **string** leaf value:
+
+- If the string is an ARM expression (`^\[.*\]$`) that contains a `parameters('<name>')` reference where `<name> ∈ secureParams`, null the value.
+
+The match is intentionally coarse: a single sensitive substring nulls the entire value. Trying to redact a substring inside a `format(...)` expression would produce a partially-decoded value the user cannot interpret; nil is the safer signal.
+
+**What this does NOT catch:**
+
+- Sensitive values that are literal strings hard-coded in the Bicep source. Rule B is the backstop for this — the naming heuristic catches values named `password` / `apiKey` / etc. even when the author bypassed `@secure()`.
+- Values assigned via `output` chaining across module boundaries. Modules aren't in scope for the static graph today; when they are, this rule extends naturally by walking the module's own parameter table.
+
+### Rule B — Name-based blocklist
+
+Regardless of where the value came from, if the **property key** (case-insensitive) matches one of the well-known secret names below, its value is set to `nil`. Applied at every nesting depth inside the `Properties` bag.
+
+**Blocklist:**
 
 ```text
-~/.bicep/local/sha256_<hash>/types.tgz    # local files (../out/x.tgz)
-~/.bicep/br/<registry-path>/**/types.tgz  # OCI-resolved (br:registry/name:tag)
+password
+connectionString
+apiKey
+secret
+token
+privateKey
+sasToken
 ```
 
-Because `bicep build` is invoked as one of the first steps of `runModeled` (in [pkg/cli/cmd/app/graph/graph.go](../../../pkg/cli/cmd/app/graph/graph.go)), the cache is populated for every extension referenced by the app **before** the static graph is built. This gives us schema-driven redaction without a UCP call.
+**Why these specifically.** Every entry is either universally understood as sensitive (industry consensus, e.g. `password`, `privateKey`) or appears verbatim as a property key on multiple existing Radius resource types (`connectionString`, `sasToken`). The list intentionally excludes generic names like `key`, `data`, or `config` that are frequently used for non-sensitive purposes.
+
+**Match rules:**
+
+- Case-insensitive exact match on the key. `"Password"`, `"password"`, `"PASSWORD"` all match; `"passwordHash"` does not.
+- Applies to keys in maps at every depth, including inside arrays' object items.
+- The value is set to `nil` regardless of its type (string, object, number, array).
+
+**False-positive tolerance.** Occasionally a legitimate non-sensitive property will collide (e.g. a hypothetical `password` field on a rate-limiter config that stores the number of password attempts). We accept that risk. The list is short, curated, and conservative; a false positive redacts one graph cell but never leaks a real secret. The alternative — no naming rule — would let hard-coded plaintext secrets flow through unredacted.
+
+### Order
+
+Both rules run on the same in-place walk. A cell that matches either rule is nulled; the rules are OR-composed, not sequential.
+
+### DiffHash
+
+`DiffHash` is computed over the **authored** properties (pre-redaction), matching the runtime graph. Rationale: the hash exists to detect authored changes; nulling sensitive values before hashing would make the hash stable across secret rotations, which is the wrong signal for the diff-detection use case. The hash itself is one-way and does not surface plaintext.
 
 ## Design
 
-### New package: `pkg/cli/bicep/extensions`
+### Changes to [pkg/cli/graph/modeled.go](../../../pkg/cli/graph/modeled.go)
 
-Single public interface:
+1. **`BuildModeledGraph`** keeps its existing `(template map[string]any)` signature — no context, no resolver, no injected dependencies. All state comes from the template itself.
+2. New unexported helper `sensitiveParamNames(template) map[string]struct{}` returns the set of parameter names declared as `secureString` or `secureObject` (case-insensitive on the type).
+3. `buildModeledResource` accepts the param set, calls new `resolveGraphProperties(authored, secureParams)` which:
+   - Clones the authored map minus the runtime keys.
+   - Walks the clone recursively, applying Rules A and B to each leaf value.
+   - Returns the redacted clone (or `nil` if the input was empty).
+4. Two small unexported helpers:
+   - `containsSecureParamReference(value string, secureParams map[string]struct{}) bool` — literal substring check for `parameters('name')` occurrences, robust to whitespace variants seen in real Bicep output.
+   - `isSensitiveKey(key string) bool` — case-insensitive membership check against the blocklist.
 
-```go
-// SensitivePathResolver resolves the dot-notation paths of properties marked
-// `x-radius-sensitive` for a fully-qualified Bicep resource type, e.g.
-// "Radius.Data/sqlServerDatabases@2025-08-01-preview".
-type SensitivePathResolver interface {
-    Resolve(ctx context.Context, typeAndVersion string) ([]string, error)
-}
-```
+### No changes required to callers
 
-Returned paths use the same dot-notation format as [pkg/schema/annotations.go](../../../pkg/schema/annotations.go) so the caller can hand them straight to `schema.RedactFields` — the same function the runtime path uses.
+`BuildModeledGraph`'s signature is unchanged, so [pkg/cli/cmd/app/graph/graph.go](../../../pkg/cli/cmd/app/graph/graph.go) and all existing tests continue to work without edits.
 
-### `CacheResolver`
+### Testing
 
-The default production implementation:
+All offline, no I/O, no fake schemas:
 
-1. **Locate** the Bicep cache root. Default `~/.bicep/`; overridable for tests.
-2. **On first call in a graph build**, walk `~/.bicep/local/**/types.tgz` and `~/.bicep/br/**/types.tgz` and build an in-memory index `type@version → (tgz path, $ref)`. One walk per graph build; results memoized.
-3. **Resolve one type**:
-   - Look up `type@version` in the index. If missing → cache-refetch fallback (below).
-   - Load and cache `types.json` from the target tgz.
-   - Follow the `$ref` (e.g., `types.json#/18`) to the type definition.
-   - Recursively walk `properties`, collecting dot-paths for every property whose target type carries `"sensitive": true`. Includes nested objects and array items.
-4. **Return** `([]string, nil)` on success, or `ErrTypeNotFound` on miss.
-
-### Cache-refetch fallback
-
-Per the requirement *"if for some reason the cache location is wrong or misses a type, I want the code to fetch the extension again"*:
-
-- On the first `ErrTypeNotFound` for a given `BuildModeledGraph` invocation, call `bicep restore --force <app.bicep>` via the existing `bicep.Interface.Call` helper the CLI already uses to shell out to Bicep. This re-resolves and re-downloads every extension declared in the file's `bicepconfig.json` scope.
-- Rescan the cache after `bicep restore` completes. If the type is now indexed, use it. If still not indexed → surface `ErrTypeNotFound`.
-- The refetch is attempted **at most once per graph build**, gated by a `sync.Once`, so a bicepconfig-level misconfiguration cannot trigger a fetch storm.
-
-### Failure semantics — fail-closed on Properties, never fail the graph
-
-Per the requirement *"if this fails for some reason, I want it to just stick to what we display for static graph today and not bring in resource-specific properties"*:
-
-For each resource in `buildModeledResource`:
-
-```text
-paths, err := resolver.Resolve(ctx, typeAndVersion)
-switch {
-case err == nil:
-    Properties = redact(bicepProperties, paths)   // populated + redacted
-case errors.Is(err, ErrTypeNotFound):
-    Properties = nil                              // fall back to today's shape
-    logOnce(warning, "no cached schema for %s")
-default:
-    Properties = nil                              // any other resolver error
-    logOnce(warning, "sensitive-path resolution failed for %s: %v")
-}
-```
-
-The graph itself — ID, name, type, connections, output resources, diff hash, icon hash — is always emitted. Redaction failure never fails the command. This preserves the "static graph works everywhere" invariant.
-
-### Changes to `pkg/cli/graph/modeled.go`
-
-1. **Preserve the API version.** [`stripAPIVersion`](../../../pkg/cli/graph/modeled.go) currently discards the `@version` suffix. The graph builder needs the fully-qualified `type@version` string to key into the cache. Introduce a small helper `splitTypeAndVersion(t string) (typeName, version, fullKey string)` and store the full key alongside the stripped type on the working entry.
-2. **Widen `BuildModeledGraph`.** New signature:
-
-   ```go
-   func BuildModeledGraph(
-       ctx context.Context,
-       template map[string]any,
-       resolver extensions.SensitivePathResolver,
-   ) (*corerpv20250801preview.ApplicationGraphResponse, error)
-   ```
-
-   The single caller in [pkg/cli/cmd/app/graph/graph.go](../../../pkg/cli/cmd/app/graph/graph.go) constructs a `CacheResolver` (with the workspace-defined bicep interface for the refetch path) and passes it through. Test callers use a fake resolver — no I/O.
-3. **Populate `Properties`.** In `buildModeledResource`, after `ComputeDiffHash`, build a `Properties` bag from the raw Bicep properties minus the same set of keys the runtime graph drops (`provisioningState`, `connections`, `status`) — matching `existingKeys` in [pkg/corerp/frontend/controller/applications/graph_util.go](../../../pkg/corerp/frontend/controller/applications/graph_util.go). Apply the resolver + `schema.RedactFields`. On resolver failure, leave `Properties` `nil`.
-
-### Order of operations for `DiffHash`
-
-`DiffHash` is computed over the **authored** properties (pre-redaction), matching the runtime side. Rationale: the hash exists to detect authored changes; nulling sensitive values before hashing would make the hash stable across secret rotations, which is the wrong signal for the diff-detection use case. The hash itself is one-way and does not surface plaintext.
-
-## Testing
-
-All offline, no I/O to the real `~/.bicep`:
-
-- **Unit tests for `CacheResolver`** with a temp-dir cache seeded from synthetic `types.tgz` files built at test time (Go's `archive/tar` + `compress/gzip`). Covers happy path, cache miss with successful refetch (mocked `bicep restore` writes a new tgz), and cache miss with failed refetch.
-- **Unit tests for `BuildModeledGraph`** with an in-memory `SensitivePathResolver` fake. Covers: populated + redacted, `ErrTypeNotFound` → nil Properties, other error → nil Properties, `existingKeys` drops, and the graph itself renders regardless.
-- **One end-to-end test** that seeds a temp Bicep cache dir with a small synthetic tgz declaring a `x-radius-sensitive: true` property and asserts the full pipeline connects.
+- **Rule A**: secure-param tracing with direct `[parameters('x')]`, nested inside `format(...)`, mixed with non-secure params (nulls the whole value), and unreferenced secure params (no-op).
+- **Rule B**: each blocklisted name at top level, nested inside an object, inside an array item, and case variants (`Password`, `PASSWORD`).
+- **Population**: runtime keys (`provisioningState`/`connections`/`status`) dropped; empty properties → empty `Properties` map; missing properties → `nil` `Properties`.
+- **DiffHash**: identical for two graphs of the same app where one has secure params and one doesn't (redaction happens after `ComputeDiffHash`).
 
 ## What this design deliberately does not do
 
-- **No `redactedPaths` sidecar** on the wire response. Redaction is expressed as plain `null` per user directive; consumers cannot distinguish "unset" from "redacted" — that is accepted for now.
-- **No `bicepconfig.json` parsing.** The compiled ARM JSON already lists every type actually used in the app; there is no need to enumerate declared extensions.
-- **No UCP call.** Ever.
-- **No changes to the runtime graph** — already redacted upstream.
-- **No changes to `Applications.Core/*` or older API versions.**
+- **No Bicep type registry / `types.tgz` parsing.** Considered and rejected — see [Alternatives considered](#alternatives-considered) below.
+- **No `redactedProperties` list** on the wire response — tracked as a future enhancement; redaction is expressed as plain `null` in this milestone. See [Future enhancements](#future-enhancements).
+- **No `bicepconfig.json` parsing.**
+- **No UCP calls, no filesystem I/O, no network.** Pure template inspection.
+- **No changes to the runtime graph handler**, `Applications.Core/*`, or older API versions.
+
+## Alternatives considered
+
+### Alternative 1: Bicep extension type-registry parsing (rejected)
+
+The `x-radius-sensitive` annotation authored in a resource-type YAML manifest is preserved end-to-end into the Bicep type registry that ships alongside each extension:
+
+```text
+~/.bicep/local/sha256_<hash>/types.tgz    # extensions resolved from a local ../out/x.tgz
+~/.bicep/br/<registry-path>/**/types.tgz  # extensions resolved from an OCI registry (br:host/name:tag)
+```
+
+Each `types.tgz` contains two files: an `index.json` that maps `Namespace/Type@Version → $ref` and a `types.json` that carries the resolved type nodes with `"sensitive": true` markers on the individual properties (see [bicep-tools/pkg/converter/converter.go](../../../bicep-tools/pkg/converter/converter.go) — the converter that emits those markers from the source YAML).
+
+The rejected approach would have added a `pkg/cli/bicep/extensions` package with:
+
+- A cache walker that scans `~/.bicep/**/types.tgz`, indexes types by fully-qualified name, and lazy-loads `types.json` per archive.
+- A tree walker over each type's `ObjectType → outer body → inner properties` structure to compute the dot-notation path list of sensitive properties (`credentials.password`, `secrets[*].value`, etc.) using the same encoding `pkg/schema.RedactFields` accepts.
+- A refetch fallback that runs `bicep restore --force` at most once per graph build when the cache lacked a requested type.
+- Fail-closed semantics: `Properties = nil` when the resolver could not decide.
+
+**Why we rejected it.** Three reasons, in decreasing weight:
+
+1. **Redundant with `@secure()`.** Any resource property authored with `x-radius-sensitive` is expected to be assigned only from a `@secure()` Bicep parameter — that is the documented authoring pattern in [docs/architecture/extensibility.md](../../../docs/architecture/extensibility.md). **Bicep itself warns when a sensitive-typed property is assigned a plaintext literal**, pushing authors toward `@secure()` naturally. So the secure-param tracing rule (Rule A) already catches every value the extension approach would have caught, without needing the schema.
+2. **Complexity budget.** The abandoned approach required ~600 LOC across a new package (`resolver.go`, `cache_resolver.go`, `walker.go`, three test files), one integration point in `pkg/cli/graph`, one integration point in `pkg/cli/cmd/app/graph`, plus a refetch loop that itself has failure modes. The two-rule approach lives in one file, ~120 LOC. Every line saved is a line that cannot regress.
+3. **Offline / cache-consistency footguns.** The refetch fallback existed because a fresh cache can miss a type the current app.bicep declares. Getting `bicep restore --force` to leave the cache in a state that a second walk of the same directory would find the type is not obvious across OS variants, filesystem casing, and OCI-vs-local resolution paths. Adding this complexity to protect a case that Rule A already covers was not worth it.
+
+**The kept git ref.** The full implementation of the abandoned approach lives on branch [`x-radius-senstive-graph-extn-walkthrough`](https://github.com/radius-project/radius/tree/x-radius-senstive-graph-extn-walkthrough) for reference — walker, resolver, cache scanner, refetch loop, and tests are all there. If a future need forces us to reconsider (e.g., an extension author who bypasses `@secure()` intentionally and Bicep changes its warning policy), that branch is the starting point.
+
+### Alternative 2: UCP schema fetch at graph-build time (rejected)
+
+We considered having the static graph call the same `pkg/schema.GetSensitiveFieldPaths` helper the runtime redaction path uses, contacting UCP to fetch each resource type's schema. Rejected because it violates the "static graph works offline" invariant — the graph is often built in CI, in a workflow that runs before the target cluster exists.
+
+## Future enhancements
+
+### Emit a per-resource `redactedProperties` list on the graph response (deferred)
+
+With redaction expressed as plain `null`, downstream consumers cannot distinguish two states:
+
+- **Unset** — the author never assigned a value to this property.
+- **Redacted** — the author assigned a value that this design nulled out.
+
+Both serialize as `"password": null`. A dashboard rendering the graph today has no way to display "🔒 redacted" vs. "—" (empty), and diff tooling cannot tell the two apart when comparing two graphs.
+
+**Sketch of the proposal.** Add a `redactedProperties: []string` field to `ApplicationGraphResource` in the `2025-08-01-preview` model. When [`resolveGraphProperties`](../../../pkg/cli/graph/modeled.go) nulls a value, append its dot-notation path (matching the format `schema.RedactFields` uses — `credentials.password`, `secrets[*].value`, etc.) to that list on the emitted node. The redacted `Properties` map continues to serialize as `null` for each entry so the wire is backward-compatible; the new field is additive and always non-nil (empty when nothing was redacted).
+
+**Why deferred.**
+
+- Requires a schema/TypeSpec change on `Radius.Core/applications` at `2025-08-01-preview`, which the current milestone is trying to keep additive-free.
+- No consumer today needs the disambiguation. Adding the field now would be speculative; adding it when a real client asks for it means we get to shape the field around the actual use case (list of paths vs. structured entries with a reason code, etc.).
+- The runtime graph would want the same field for symmetry, which pulls the change into the shared response type and the runtime handler — out of scope for the static-graph milestone.
+
+Tracked in [radius-project/radius#12451](https://github.com/radius-project/radius/issues/12451).
+
+## Why the two-rule approach is sufficient
+
+The design leans on three facts that make Rule A + Rule B a practically complete redactor for the static graph:
+
+1. **Bicep already gates the sensitive-authoring path.** A resource property declared `x-radius-sensitive` in its type manifest surfaces in Bicep's type system with the equivalent of `@secure()`. Bicep raises a compile-time warning (and in some future versions, an error) when an author hard-codes a literal value into that property, pushing every legitimate assignment through a `@secure() param`. Rule A catches those.
+2. **Name-based redaction is the safety net for authors who bypass `@secure()`.** Even if Bicep's warning is ignored or the author uses a non-annotated type with an obviously-sensitive property name, Rule B catches the common cases (`password`, `connectionString`, etc.). The list is short, curated, and universally understood.
+3. **The runtime graph is protected by the server, not us.** Any leakage of `x-radius-sensitive` at runtime is a server bug ([pkg/dynamicrp/frontend/getresource.go](../../../pkg/dynamicrp/frontend/getresource.go), [pkg/dynamicrp/frontend/listresources.go](../../../pkg/dynamicrp/frontend/listresources.go)), not something the CLI needs to compensate for.
+
+Together, the two rules cover the observable static-graph attack surface with a much smaller design and a much shorter path to first review.
 
 ## Files touched
 
-- New: `pkg/cli/bicep/extensions/resolver.go`, `pkg/cli/bicep/extensions/cache_resolver.go`, corresponding `_test.go`.
-- Modified: `pkg/cli/graph/modeled.go` (widen `BuildModeledGraph`, preserve API version, populate + redact `Properties`), `pkg/cli/graph/modeled_test.go` (fake resolver).
-- Modified: `pkg/cli/cmd/app/graph/graph.go` (construct + pass the resolver).
-- No changes to `pkg/corerp/frontend/controller/applications/**`, `pkg/dynamicrp/**`, or any API-generated code.
+- Modified: [pkg/cli/graph/modeled.go](../../../pkg/cli/graph/modeled.go) — populate + redact Properties.
+- Modified: [pkg/cli/graph/modeled_test.go](../../../pkg/cli/graph/modeled_test.go) — new cases for the two rules and population.
+- No new files. No changes to any server-side code, CLI wiring, or API-generated code.

--- a/eng/design-notes/security/2026-07-static-graph-sensitive-redaction.md
+++ b/eng/design-notes/security/2026-07-static-graph-sensitive-redaction.md
@@ -1,0 +1,164 @@
+# Static-Graph Sensitive-Field Redaction
+
+Status: Proposed
+Author: (fill in)
+Date: 2026-07-15
+Companion to: [2026-07-sensitive-fields-in-app-graph.md](./2026-07-sensitive-fields-in-app-graph.md)
+
+## Scope
+
+- **Namespace:** `Radius.*` only (types authored under `Applications.Core/*` are out of scope).
+- **API version:** the `Radius.Core/applications/getGraph@2025-08-01-preview` response shape (the type this static graph produces). The static graph itself does **not** call any API — it is built entirely from the compiled Bicep template. The API-version qualifier applies only to the response model it targets.
+- **In scope:** the static (modeled) graph produced by `rad app graph <app.bicep>` — [pkg/cli/graph/modeled.go](../../../pkg/cli/graph/modeled.go).
+- **Out of scope:** `Applications.Core/*`, older API versions (`v20231001preview` and predecessors), the runtime graph handler (see [Why the runtime graph needs no change](#why-the-runtime-graph-needs-no-change)), and any server-side redaction code.
+
+## Deliverable
+
+Two changes shipped together:
+
+1. **Populate `ApplicationGraphResource.Properties` on every static-graph node.** The field exists on the response model but is left `nil` today; this effort starts populating it from the compiled Bicep resource body, using the same drop-list (`provisioningState`, `connections`, `status`) the runtime graph applies in `getResourceTypeSpecificProperties`.
+2. **Redact `x-radius-sensitive` paths in that newly-populated `Properties` bag** using the schema information carried by the Bicep extension `types.tgz` for each resource type.
+
+Redaction is only meaningful once (1) is done — the whole point of populating `Properties` is that operators want to see resource-specific configuration in the graph, and sensitive properties must be nulled out along that path. The two ship as one unit; there is no intermediate state where properties are populated but not redacted.
+
+## Problem statement
+
+The static graph is built entirely client-side from the compiled ARM JSON of a Bicep file — no control-plane calls, no APIs. Today `buildModeledResource` in [pkg/cli/graph/modeled.go](../../../pkg/cli/graph/modeled.go) does not populate `ApplicationGraphResource.Properties` at all; the field is left `nil`. As a result the static graph shows resource identity, connections, and dependencies but not the resource-specific configuration operators actually need in the diff view.
+
+The desired behavior is:
+
+> Populate `Properties` per resource — matching the shape of the runtime graph — **and** null out any property marked `x-radius-sensitive` in the resource type's schema.
+
+Because the static graph is offline, we cannot look up the schema over the network at graph-build time.
+
+## Why the runtime graph needs no change
+
+Two-layer guarantee already in place:
+
+1. **Write path redacts at rest.** `dynamicrp` encrypts sensitive fields on create/update; the record's `Properties` bag is stored with sensitive keys already `null`. Both `GetResourceWithRedaction` ([pkg/dynamicrp/frontend/getresource.go:71-77](../../../pkg/dynamicrp/frontend/getresource.go)) and `ListResourcesWithRedaction` ([pkg/dynamicrp/frontend/listresources.go:76-82](../../../pkg/dynamicrp/frontend/listresources.go)) fast-path `Succeeded` resources for this reason.
+2. **Read path redacts explicitly for non-`Succeeded`.** Both controllers call `schema.RedactFields(resource.Properties, sensitiveFieldPaths)` for `Updating` / `Accepted` / `Failed` states.
+
+The runtime graph calls those LIST endpoints via `listAllResourcesByApplication` / `listAllResourcesByEnvironment`, then copies the already-redacted properties into `ApplicationGraphResource.Properties` at [pkg/corerp/frontend/controller/applications/graph_util.go:328](../../../pkg/corerp/frontend/controller/applications/graph_util.go). No additional graph-layer redaction is needed for the runtime path.
+
+## Approach: read `x-radius-sensitive` from the local Bicep extension cache
+
+Every Bicep extension declared at the top of an `app.bicep` (`extension radius`, `extension aws`, `extension myprovider`, etc.) is packaged as a `types.tgz` archive containing two files:
+
+```text
+index.json    # { "resources": { "Namespace/Type@Version": { "$ref": "types.json#/N" }, ... }, "settings": { ... } }
+types.json    # the full type registry with "sensitive": true on marked properties
+```
+
+The `"sensitive": true` marker is emitted by [bicep-tools/pkg/converter/converter.go](../../../bicep-tools/pkg/converter/converter.go) directly from the `x-radius-sensitive` annotation in the source YAML manifest. Same source of truth `dynamic-rp` uses server-side.
+
+The Bicep CLI resolves each extension into a content-addressed local cache under `~/.bicep/`:
+
+```text
+~/.bicep/local/sha256_<hash>/types.tgz    # local files (../out/x.tgz)
+~/.bicep/br/<registry-path>/**/types.tgz  # OCI-resolved (br:registry/name:tag)
+```
+
+Because `bicep build` is invoked as one of the first steps of `runModeled` (in [pkg/cli/cmd/app/graph/graph.go](../../../pkg/cli/cmd/app/graph/graph.go)), the cache is populated for every extension referenced by the app **before** the static graph is built. This gives us schema-driven redaction without a UCP call.
+
+## Design
+
+### New package: `pkg/cli/bicep/extensions`
+
+Single public interface:
+
+```go
+// SensitivePathResolver resolves the dot-notation paths of properties marked
+// `x-radius-sensitive` for a fully-qualified Bicep resource type, e.g.
+// "Radius.Data/sqlServerDatabases@2025-08-01-preview".
+type SensitivePathResolver interface {
+    Resolve(ctx context.Context, typeAndVersion string) ([]string, error)
+}
+```
+
+Returned paths use the same dot-notation format as [pkg/schema/annotations.go](../../../pkg/schema/annotations.go) so the caller can hand them straight to `schema.RedactFields` — the same function the runtime path uses.
+
+### `CacheResolver`
+
+The default production implementation:
+
+1. **Locate** the Bicep cache root. Default `~/.bicep/`; overridable for tests.
+2. **On first call in a graph build**, walk `~/.bicep/local/**/types.tgz` and `~/.bicep/br/**/types.tgz` and build an in-memory index `type@version → (tgz path, $ref)`. One walk per graph build; results memoized.
+3. **Resolve one type**:
+   - Look up `type@version` in the index. If missing → cache-refetch fallback (below).
+   - Load and cache `types.json` from the target tgz.
+   - Follow the `$ref` (e.g., `types.json#/18`) to the type definition.
+   - Recursively walk `properties`, collecting dot-paths for every property whose target type carries `"sensitive": true`. Includes nested objects and array items.
+4. **Return** `([]string, nil)` on success, or `ErrTypeNotFound` on miss.
+
+### Cache-refetch fallback
+
+Per the requirement *"if for some reason the cache location is wrong or misses a type, I want the code to fetch the extension again"*:
+
+- On the first `ErrTypeNotFound` for a given `BuildModeledGraph` invocation, call `bicep restore --force <app.bicep>` via the existing `bicep.Interface.Call` helper the CLI already uses to shell out to Bicep. This re-resolves and re-downloads every extension declared in the file's `bicepconfig.json` scope.
+- Rescan the cache after `bicep restore` completes. If the type is now indexed, use it. If still not indexed → surface `ErrTypeNotFound`.
+- The refetch is attempted **at most once per graph build**, gated by a `sync.Once`, so a bicepconfig-level misconfiguration cannot trigger a fetch storm.
+
+### Failure semantics — fail-closed on Properties, never fail the graph
+
+Per the requirement *"if this fails for some reason, I want it to just stick to what we display for static graph today and not bring in resource-specific properties"*:
+
+For each resource in `buildModeledResource`:
+
+```text
+paths, err := resolver.Resolve(ctx, typeAndVersion)
+switch {
+case err == nil:
+    Properties = redact(bicepProperties, paths)   // populated + redacted
+case errors.Is(err, ErrTypeNotFound):
+    Properties = nil                              // fall back to today's shape
+    logOnce(warning, "no cached schema for %s")
+default:
+    Properties = nil                              // any other resolver error
+    logOnce(warning, "sensitive-path resolution failed for %s: %v")
+}
+```
+
+The graph itself — ID, name, type, connections, output resources, diff hash, icon hash — is always emitted. Redaction failure never fails the command. This preserves the "static graph works everywhere" invariant.
+
+### Changes to `pkg/cli/graph/modeled.go`
+
+1. **Preserve the API version.** [`stripAPIVersion`](../../../pkg/cli/graph/modeled.go) currently discards the `@version` suffix. The graph builder needs the fully-qualified `type@version` string to key into the cache. Introduce a small helper `splitTypeAndVersion(t string) (typeName, version, fullKey string)` and store the full key alongside the stripped type on the working entry.
+2. **Widen `BuildModeledGraph`.** New signature:
+
+   ```go
+   func BuildModeledGraph(
+       ctx context.Context,
+       template map[string]any,
+       resolver extensions.SensitivePathResolver,
+   ) (*corerpv20250801preview.ApplicationGraphResponse, error)
+   ```
+
+   The single caller in [pkg/cli/cmd/app/graph/graph.go](../../../pkg/cli/cmd/app/graph/graph.go) constructs a `CacheResolver` (with the workspace-defined bicep interface for the refetch path) and passes it through. Test callers use a fake resolver — no I/O.
+3. **Populate `Properties`.** In `buildModeledResource`, after `ComputeDiffHash`, build a `Properties` bag from the raw Bicep properties minus the same set of keys the runtime graph drops (`provisioningState`, `connections`, `status`) — matching `existingKeys` in [pkg/corerp/frontend/controller/applications/graph_util.go](../../../pkg/corerp/frontend/controller/applications/graph_util.go). Apply the resolver + `schema.RedactFields`. On resolver failure, leave `Properties` `nil`.
+
+### Order of operations for `DiffHash`
+
+`DiffHash` is computed over the **authored** properties (pre-redaction), matching the runtime side. Rationale: the hash exists to detect authored changes; nulling sensitive values before hashing would make the hash stable across secret rotations, which is the wrong signal for the diff-detection use case. The hash itself is one-way and does not surface plaintext.
+
+## Testing
+
+All offline, no I/O to the real `~/.bicep`:
+
+- **Unit tests for `CacheResolver`** with a temp-dir cache seeded from synthetic `types.tgz` files built at test time (Go's `archive/tar` + `compress/gzip`). Covers happy path, cache miss with successful refetch (mocked `bicep restore` writes a new tgz), and cache miss with failed refetch.
+- **Unit tests for `BuildModeledGraph`** with an in-memory `SensitivePathResolver` fake. Covers: populated + redacted, `ErrTypeNotFound` → nil Properties, other error → nil Properties, `existingKeys` drops, and the graph itself renders regardless.
+- **One end-to-end test** that seeds a temp Bicep cache dir with a small synthetic tgz declaring a `x-radius-sensitive: true` property and asserts the full pipeline connects.
+
+## What this design deliberately does not do
+
+- **No `redactedPaths` sidecar** on the wire response. Redaction is expressed as plain `null` per user directive; consumers cannot distinguish "unset" from "redacted" — that is accepted for now.
+- **No `bicepconfig.json` parsing.** The compiled ARM JSON already lists every type actually used in the app; there is no need to enumerate declared extensions.
+- **No UCP call.** Ever.
+- **No changes to the runtime graph** — already redacted upstream.
+- **No changes to `Applications.Core/*` or older API versions.**
+
+## Files touched
+
+- New: `pkg/cli/bicep/extensions/resolver.go`, `pkg/cli/bicep/extensions/cache_resolver.go`, corresponding `_test.go`.
+- Modified: `pkg/cli/graph/modeled.go` (widen `BuildModeledGraph`, preserve API version, populate + redact `Properties`), `pkg/cli/graph/modeled_test.go` (fake resolver).
+- Modified: `pkg/cli/cmd/app/graph/graph.go` (construct + pass the resolver).
+- No changes to `pkg/corerp/frontend/controller/applications/**`, `pkg/dynamicrp/**`, or any API-generated code.

--- a/pkg/cli/graph/modeled.go
+++ b/pkg/cli/graph/modeled.go
@@ -37,7 +37,70 @@ const (
 	applicationsResourceType = "Applications.Core/applications"
 	environmentsResourceType = "Applications.Core/environments"
 	recipePacksResourceType  = "Radius.Core/recipePacks"
+
+	// secureStringParameterType and secureObjectParameterType are the
+	// two ARM parameter types Bicep emits for `@secure()` parameter
+	// declarations (respectively for `string` and `object` bases).
+	// Values that reference such a parameter via `parameters('name')`
+	// — including nested inside larger ARM expressions or the result of
+	// dotted property access on a secureObject — are treated as sensitive
+	// on the static graph and nulled in the emitted Properties bag. Both
+	// types are handled uniformly because the redaction contract does
+	// not distinguish scalar from structured secrets. See
+	// eng/design-notes/security/2026-07-static-graph-sensitive-redaction.md.
+	secureStringParameterType = "secureString"
+	secureObjectParameterType = "secureObject"
 )
+
+// dropOnGraph lists top-level property keys that are stripped from the
+// resource-specific Properties bag before it is written into an
+// ApplicationGraphResource. Mirrors the runtime graph's `existingKeys`
+// in pkg/corerp/frontend/controller/applications/graph_util.go so the
+// static and runtime graphs surface the same shape:
+//
+//   - "provisioningState" and "connections" are already first-class
+//     fields on the resource; keeping duplicates in Properties would
+//     confuse diff tooling.
+//   - "status" is dropped in its entirety on the runtime side because
+//     status subtrees may include computed values that carry secrets
+//     (connection strings, endpoints). The same rule applies here to
+//     keep the two graphs comparable, even though the static graph's
+//     status is always empty in practice.
+var dropOnGraph = map[string]struct{}{
+	"provisioningState": {},
+	"connections":       {},
+	"status":            {},
+}
+
+// sensitiveKeyBlocklist enumerates property names whose values are
+// unconditionally nulled in the static graph's Properties bag,
+// regardless of how the value was assigned in the source Bicep. The
+// list is short, curated, and case-insensitive; it complements the
+// secureString parameter tracing (which only catches values threaded
+// through `@secure()` parameters) by catching hard-coded literals and
+// values whose provenance the static graph cannot trace.
+//
+// See eng/design-notes/security/2026-07-static-graph-sensitive-redaction.md
+// for the rationale on inclusion. New entries should be added
+// conservatively: a false positive redacts one graph cell, but the
+// list is not the place to litigate ambiguously-named properties like
+// "key" or "config".
+var sensitiveKeyBlocklist = map[string]struct{}{
+	"password":         {},
+	"connectionstring": {},
+	"apikey":           {},
+	"secret":           {},
+	"token":            {},
+	"privatekey":       {},
+	"sastoken":         {},
+}
+
+// armExpressionPattern matches an ARM template expression — any value
+// bracketed in `[...]`. Used as a cheap filter before running the more
+// specific secureString-parameter substring check; ordinary string
+// literals cannot reference a parameter, so this early-out avoids
+// pointless work on the majority of property values.
+var armExpressionPattern = regexp.MustCompile(`^\[.*\]$`)
 
 // resourceIDExpression matches an ARM template resourceId() expression
 // produced by `bicep build` for Radius resource references, e.g.
@@ -52,18 +115,36 @@ var resourceIDExpression = regexp.MustCompile(`^\[resourceId\(([^)]*)\)\]$`)
 // BuildModeledGraph parses an ARM JSON template (typically the output of
 // `bicep build` on an application's app.bicep) and returns the corresponding
 // modeled application graph. The graph contains application resources,
-// their connections and dependsOn relationships, and a stable diff hash for
-// each resource. It does not contain output resources or runtime status —
-// those are only available for planned and deployed graphs.
+// their connections and dependsOn relationships, resource-specific
+// authored properties (with sensitive values nulled), and a stable diff
+// hash for each resource. It does not contain output resources or
+// runtime status — those are only available for planned and deployed
+// graphs.
+//
+// Sensitive values are redacted using two rules applied to every
+// property in the emitted Properties bag:
+//
+//  1. Values that reference a Bicep `@secure() param` (surfaced in the
+//     compiled template as `parameters.<name>.type == "secureString"`
+//     for scalar and `"secureObject"` for structured secrets) are
+//     nulled.
+//  2. Values whose property key case-insensitively matches a well-known
+//     secret name (`password`, `connectionString`, `apiKey`, etc.) are
+//     nulled regardless of source.
+//
+// See eng/design-notes/security/2026-07-static-graph-sensitive-redaction.md
+// for the full contract.
 func BuildModeledGraph(template map[string]any) (*corerpv20250801preview.ApplicationGraphResponse, error) {
 	rawResources := collectResources(template["resources"])
 	if rawResources == nil {
 		return emptyGraph(), nil
 	}
 
+	secureParams := sensitiveParamNames(template)
+
 	graphResources := make([]*corerpv20250801preview.ApplicationGraphResource, 0, len(rawResources))
 	for _, entry := range rawResources {
-		resource, err := buildModeledResource(entry)
+		resource, err := buildModeledResource(entry, secureParams)
 		if err != nil {
 			return nil, err
 		}
@@ -76,6 +157,36 @@ func BuildModeledGraph(template map[string]any) (*corerpv20250801preview.Applica
 	graph := &corerpv20250801preview.ApplicationGraphResponse{Resources: graphResources}
 	addInboundConnections(graph)
 	return graph, nil
+}
+
+// sensitiveParamNames returns the set of parameter names declared with
+// a secure ARM type in the compiled template. Bicep emits
+// `secureString` for `@secure() param foo string` and `secureObject`
+// for `@secure() param foo object`; both are treated as sensitive
+// sources for the value-tracing rule. Comparison is case-insensitive
+// to survive ARM's occasional case-normalization of type names (the
+// bicep recipe driver applies the same case-insensitive rule for
+// symmetry — see pkg/recipes/driver/bicep/bicep.go:isSecureARMOutputType).
+// Returns an empty map when the template has no parameters or the
+// parameters block is malformed — downstream callers use
+// `_, ok := secureParams[name]` and are safe on nil / empty maps.
+func sensitiveParamNames(template map[string]any) map[string]struct{} {
+	out := map[string]struct{}{}
+	params, ok := template["parameters"].(map[string]any)
+	if !ok {
+		return out
+	}
+	for name, raw := range params {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		t, _ := entry["type"].(string)
+		if strings.EqualFold(t, secureStringParameterType) || strings.EqualFold(t, secureObjectParameterType) {
+			out[name] = struct{}{}
+		}
+	}
+	return out
 }
 
 // collectResources normalizes the "resources" section of an ARM JSON
@@ -244,7 +355,13 @@ func stringAt(m map[string]any, key string) string {
 // not appear as graph nodes (Radius applications and environments are
 // containers rather than graph members, and recipe packs are catalog
 // resources defined only in Radius.Core that hold reusable recipes).
-func buildModeledResource(entry map[string]any) (*corerpv20250801preview.ApplicationGraphResource, error) {
+//
+// The resource-specific Properties bag is populated from the entry's
+// authored properties (minus the well-known runtime keys enumerated in
+// dropOnGraph) and then walked to null out any value that either
+// references a secureString parameter or is stored under a sensitive
+// property name (see resolveGraphProperties).
+func buildModeledResource(entry map[string]any, secureParams map[string]struct{}) (*corerpv20250801preview.ApplicationGraphResource, error) {
 	resourceType, _ := entry["type"].(string)
 	name, _ := entry["name"].(string)
 	if resourceType == "" || name == "" {
@@ -260,6 +377,11 @@ func buildModeledResource(entry map[string]any) (*corerpv20250801preview.Applica
 	rawDependsOn, _ := entry["dependsOn"].([]any)
 	dependsOn := resolveDependsOn(rawDependsOn)
 
+	// DiffHash is computed over the authored properties (pre-redaction)
+	// so the hash detects authored changes — including changes to
+	// sensitive values that never leave the local machine. The hash
+	// itself is one-way and does not surface plaintext. See the design
+	// note's `DiffHash` section.
 	hash, err := ComputeDiffHash(properties, dependsOn...)
 	if err != nil {
 		return nil, fmt.Errorf("compute diffHash for %s/%s: %w", resourceType, name, err)
@@ -273,7 +395,139 @@ func buildModeledResource(entry map[string]any) (*corerpv20250801preview.Applica
 		Connections:       outboundConnections(properties),
 		OutputResources:   []*corerpv20250801preview.ApplicationGraphOutputResource{},
 		DiffHash:          to.Ptr(hash),
+		Properties:        resolveGraphProperties(properties, secureParams),
 	}, nil
+}
+
+// resolveGraphProperties returns the redacted, resource-specific
+// Properties bag suitable for embedding in ApplicationGraphResource. It
+// clones the authored map (so the caller retains its original,
+// pre-redaction copy for ComputeDiffHash and connection extraction),
+// drops the graph-level top-level keys enumerated in dropOnGraph, then
+// walks the clone applying the secureString-tracing and name-blocklist
+// rules to every leaf.
+//
+// Returns nil for a nil or empty input so the emitted graph node omits
+// the Properties field entirely rather than serializing an empty map —
+// this preserves the pre-population wire shape for resources that
+// authored nothing.
+func resolveGraphProperties(authoredProperties map[string]any, secureParams map[string]struct{}) map[string]any {
+	if len(authoredProperties) == 0 {
+		return nil
+	}
+	clonedProperties := make(map[string]any, len(authoredProperties))
+	for k, v := range authoredProperties {
+		if _, drop := dropOnGraph[k]; drop {
+			continue
+		}
+		clonedProperties[k] = deepCloneValue(v)
+	}
+	if len(clonedProperties) == 0 {
+		return nil
+	}
+	redactSensitive(clonedProperties, secureParams)
+	return clonedProperties
+}
+
+// redactSensitive walks m recursively, nulling any value that either
+// (a) is stored under a case-insensitively sensitive property name, or
+// (b) is a string containing a `parameters('<secure>')` reference to a
+// declared secureString parameter. The two rules are OR-composed: a
+// cell matching either is nulled. Recurses into nested map values and
+// array items; leaf primitives are checked only for the string-based
+// rule via their containing key's blocklist match.
+func redactSensitive(m map[string]any, secureParams map[string]struct{}) {
+	for key, val := range m {
+		if isSensitiveKey(key) {
+			m[key] = nil
+			continue
+		}
+		m[key] = redactValue(val, secureParams)
+	}
+}
+
+// redactValue applies the secureString-tracing rule to leaf strings
+// and recurses into nested maps and array items. Non-string leaves are
+// returned unchanged; the name-blocklist rule is applied by the
+// containing map's key check in redactSensitive, so it does not need
+// to travel through the value dispatcher.
+func redactValue(v any, secureParams map[string]struct{}) any {
+	switch typed := v.(type) {
+	case string:
+		if containsSecureParamReference(typed, secureParams) {
+			return nil
+		}
+		return typed
+	case map[string]any:
+		redactSensitive(typed, secureParams)
+		return typed
+	case []any:
+		for i, item := range typed {
+			typed[i] = redactValue(item, secureParams)
+		}
+		return typed
+	default:
+		return v
+	}
+}
+
+// containsSecureParamReference reports whether s is an ARM expression
+// that references any of the given secureString parameters. The check
+// is intentionally coarse: a single sensitive substring nulls the
+// entire value. Trying to redact a substring inside a `format(...)`
+// expression would produce a partially-decoded value the user cannot
+// interpret; nil is the safer signal.
+//
+// Whitespace tolerance: Bicep normally emits `parameters('name')` with
+// no whitespace, but the check accepts a small amount of internal
+// whitespace around the argument to survive hand-authored ARM JSON.
+func containsSecureParamReference(s string, secureParams map[string]struct{}) bool {
+	if len(secureParams) == 0 || !armExpressionPattern.MatchString(s) {
+		return false
+	}
+	for name := range secureParams {
+		// Match both single- and double-quote forms; ARM canonically
+		// emits single-quoted string literals but hand-authored ARM
+		// JSON in the wild uses either.
+		if strings.Contains(s, "parameters('"+name+"')") || strings.Contains(s, `parameters("`+name+`")`) {
+			return true
+		}
+	}
+	return false
+}
+
+// isSensitiveKey reports whether the property key case-insensitively
+// matches an entry in sensitiveKeyBlocklist. Exact match —
+// `passwordHash` does not match `password`.
+func isSensitiveKey(key string) bool {
+	_, ok := sensitiveKeyBlocklist[strings.ToLower(key)]
+	return ok
+}
+
+// deepCloneValue returns a shallow-recursive copy of v that is safe to
+// mutate without touching the caller's original data structure. Only
+// containers (maps and slices) need cloning; primitive leaves are
+// value-copied by assignment. This matters because redactSensitive
+// mutates its input in place and the authored properties are also
+// consumed by ComputeDiffHash — which must observe the pre-redaction
+// values.
+func deepCloneValue(v any) any {
+	switch typed := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for k, vv := range typed {
+			out[k] = deepCloneValue(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(typed))
+		for i, item := range typed {
+			out[i] = deepCloneValue(item)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 // outboundConnections extracts the resource's `connections` map and emits

--- a/pkg/cli/graph/modeled_test.go
+++ b/pkg/cli/graph/modeled_test.go
@@ -234,3 +234,467 @@ func findResource(t *testing.T, g *corerpv20250801preview.ApplicationGraphRespon
 	t.Fatalf("resource %q not found", name)
 	return nil
 }
+
+// TestBuildModeledGraph_PopulatesPropertiesAndDropsRuntimeKeys covers the
+// baseline population contract: authored properties flow into the
+// emitted graph node minus the runtime keys (provisioningState,
+// connections, status) that the graph surfaces first-class. Matches
+// the runtime graph's getResourceTypeSpecificProperties behavior so the
+// two graphs compare cleanly.
+func TestBuildModeledGraph_PopulatesPropertiesAndDropsRuntimeKeys(t *testing.T) {
+	t.Parallel()
+
+	template := map[string]any{
+		"resources": []any{
+			map[string]any{
+				"type": "Radius.Data/postgreSqlDatabases",
+				"name": "db",
+				"properties": map[string]any{
+					"database":          "app",
+					"username":          "admin",
+					"provisioningState": "Succeeded",
+					"status":            map[string]any{"foo": "bar"},
+					"connections":       map[string]any{},
+				},
+			},
+		},
+	}
+
+	graph, err := BuildModeledGraph(template)
+	require.NoError(t, err)
+	require.Len(t, graph.Resources, 1)
+	props := graph.Resources[0].Properties
+	require.NotNil(t, props)
+	require.Equal(t, "app", props["database"])
+	require.Equal(t, "admin", props["username"])
+	require.NotContains(t, props, "provisioningState")
+	require.NotContains(t, props, "status")
+	require.NotContains(t, props, "connections")
+}
+
+// TestBuildModeledGraph_NilPropertiesWhenAuthoredIsEmpty preserves the
+// pre-population wire shape for resources that don't author anything:
+// Properties stays nil rather than serializing as `{}`. Guards against
+// noise in graph diffs when a resource genuinely has no inputs.
+func TestBuildModeledGraph_NilPropertiesWhenAuthoredIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	template := map[string]any{
+		"resources": []any{
+			map[string]any{
+				"type":       "Applications.Core/containers",
+				"name":       "empty",
+				"properties": map[string]any{},
+			},
+		},
+	}
+
+	graph, err := BuildModeledGraph(template)
+	require.NoError(t, err)
+	require.Nil(t, graph.Resources[0].Properties)
+}
+
+// TestBuildModeledGraph_SecureStringDirectReference is the base case
+// for rule A: a property value that is exactly `[parameters('name')]`
+// where the referenced parameter is `secureString` gets nulled, while a
+// sibling property that references a non-secure parameter is preserved.
+func TestBuildModeledGraph_SecureStringDirectReference(t *testing.T) {
+	t.Parallel()
+
+	template := map[string]any{
+		"parameters": map[string]any{
+			"pw":     map[string]any{"type": "secureString"},
+			"region": map[string]any{"type": "string"},
+		},
+		"resources": []any{
+			map[string]any{
+				"type": "Radius.Data/postgreSqlDatabases",
+				"name": "db",
+				"properties": map[string]any{
+					"credentials": "[parameters('pw')]",
+					"region":      "[parameters('region')]",
+				},
+			},
+		},
+	}
+
+	graph, err := BuildModeledGraph(template)
+	require.NoError(t, err)
+	props := graph.Resources[0].Properties
+	require.Nil(t, props["credentials"], "secureString-derived value must be nulled")
+	require.Equal(t, "[parameters('region')]", props["region"])
+}
+
+// TestBuildModeledGraph_SecureStringNestedInsideExpression covers the
+// coarse-match half of rule A: even when the secure parameter is
+// embedded inside a larger expression (format/concat/etc), the whole
+// resulting value is nulled. Trying to redact a substring inside the
+// expression would produce an interpretable but broken value; nil is
+// the safer signal.
+func TestBuildModeledGraph_SecureStringNestedInsideExpression(t *testing.T) {
+	t.Parallel()
+
+	template := map[string]any{
+		"parameters": map[string]any{
+			"dbPassword": map[string]any{"type": "secureString"},
+		},
+		"resources": []any{
+			map[string]any{
+				"type": "Radius.Data/postgreSqlDatabases",
+				"name": "db",
+				"properties": map[string]any{
+					"connectionURL": "[format('postgres://admin:{0}@host/db', parameters('dbPassword'))]",
+				},
+			},
+		},
+	}
+
+	graph, err := BuildModeledGraph(template)
+	require.NoError(t, err)
+	require.Nil(t, graph.Resources[0].Properties["connectionURL"])
+}
+
+// TestBuildModeledGraph_SecureStringInNestedObjectAndArray verifies the
+// walker descends into nested objects and array items when applying
+// rule A. Common in real Bicep — credentials often nest inside
+// `properties.auth.credentials.password` or similar.
+func TestBuildModeledGraph_SecureStringInNestedObjectAndArray(t *testing.T) {
+	t.Parallel()
+
+	template := map[string]any{
+		"parameters": map[string]any{
+			"apiToken": map[string]any{"type": "secureString"},
+		},
+		"resources": []any{
+			map[string]any{
+				"type": "Custom.Provider/thing",
+				"name": "x",
+				"properties": map[string]any{
+					"auth": map[string]any{
+						"headers": []any{
+							map[string]any{
+								"name":  "Authorization",
+								"value": "[format('Bearer {0}', parameters('apiToken'))]",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	graph, err := BuildModeledGraph(template)
+	require.NoError(t, err)
+	auth := graph.Resources[0].Properties["auth"].(map[string]any)
+	headers := auth["headers"].([]any)
+	header0 := headers[0].(map[string]any)
+	require.Equal(t, "Authorization", header0["name"])
+	require.Nil(t, header0["value"], "secureString-derived value in array item must be nulled")
+}
+
+// TestBuildModeledGraph_SecureObjectReferenceAndFieldAccess covers the
+// secureObject half of rule A: a `@secure() param blob object` compiles
+// to `type: "secureObject"` in the ARM template. Whether the whole
+// object is passed through (`[parameters('blob')]`) or a specific field
+// is projected (`[parameters('blob').clientId]`), both must be nulled
+// because the resulting value derives from a secret source. Mirrors the
+// recipe driver's treatment of securestring / secureobject as
+// equivalent for output sensitivity — see
+// pkg/recipes/driver/bicep/bicep.go:isSecureARMOutputType.
+func TestBuildModeledGraph_SecureObjectReferenceAndFieldAccess(t *testing.T) {
+	t.Parallel()
+
+	template := map[string]any{
+		"parameters": map[string]any{
+			"credentialsBlob": map[string]any{"type": "secureObject"},
+		},
+		"resources": []any{
+			map[string]any{
+				"type": "Custom.Provider/thing",
+				"name": "x",
+				"properties": map[string]any{
+					"credentials":  "[parameters('credentialsBlob')]",
+					"clientId":     "[parameters('credentialsBlob').clientId]",
+					"clientSecret": "[parameters('credentialsBlob').clientSecret]",
+					"tenantId":     "static-value",
+				},
+			},
+		},
+	}
+
+	graph, err := BuildModeledGraph(template)
+	require.NoError(t, err)
+	props := graph.Resources[0].Properties
+	require.Nil(t, props["credentials"], "whole secureObject reference must be nulled")
+	require.Nil(t, props["clientId"], "field access on secureObject must be nulled")
+	require.Nil(t, props["clientSecret"], "field access on secureObject must be nulled")
+	require.Equal(t, "static-value", props["tenantId"], "non-secure values must pass through")
+}
+
+// TestBuildModeledGraph_NameBlocklistTopLevelAndNested covers rule B
+// across every blocklisted key at both top level and one level deep.
+// Case variants of the same name (Password / PASSWORD / password) all
+// match — locking in the case-insensitivity contract.
+func TestBuildModeledGraph_NameBlocklistTopLevelAndNested(t *testing.T) {
+	t.Parallel()
+
+	template := map[string]any{
+		"resources": []any{
+			map[string]any{
+				"type": "Custom.Thing/instance",
+				"name": "x",
+				"properties": map[string]any{
+					"password":         "hunter2",
+					"Password":         "hunter2",
+					"PASSWORD":         "hunter2",
+					"connectionString": "server=x;pwd=y",
+					"apiKey":           "k",
+					"secret":           "s",
+					"token":            "t",
+					"privateKey":       "----BEGIN...",
+					"sasToken":         "sv=2020",
+					"database":         "app",
+					"nested": map[string]any{
+						"password": "still-secret",
+						"public":   "ok",
+					},
+				},
+			},
+		},
+	}
+
+	graph, err := BuildModeledGraph(template)
+	require.NoError(t, err)
+	props := graph.Resources[0].Properties
+	require.Nil(t, props["password"])
+	require.Nil(t, props["Password"])
+	require.Nil(t, props["PASSWORD"])
+	require.Nil(t, props["connectionString"])
+	require.Nil(t, props["apiKey"])
+	require.Nil(t, props["secret"])
+	require.Nil(t, props["token"])
+	require.Nil(t, props["privateKey"])
+	require.Nil(t, props["sasToken"])
+	require.Equal(t, "app", props["database"])
+
+	nested := props["nested"].(map[string]any)
+	require.Nil(t, nested["password"], "blocklist must apply at every nesting depth")
+	require.Equal(t, "ok", nested["public"])
+}
+
+// TestBuildModeledGraph_NameBlocklistIsExactMatch guards against
+// over-eager matching. `passwordHash`, `apiKeyPolicy`, and
+// `connectionStringTemplate` are legitimate non-sensitive keys in real
+// Radius resource types and must not be redacted.
+func TestBuildModeledGraph_NameBlocklistIsExactMatch(t *testing.T) {
+	t.Parallel()
+
+	template := map[string]any{
+		"resources": []any{
+			map[string]any{
+				"type": "Custom.Thing/instance",
+				"name": "x",
+				"properties": map[string]any{
+					"passwordHash":             "argon2-hash",
+					"apiKeyPolicy":             "rotate",
+					"connectionStringTemplate": "server={0}",
+				},
+			},
+		},
+	}
+
+	graph, err := BuildModeledGraph(template)
+	require.NoError(t, err)
+	props := graph.Resources[0].Properties
+	require.Equal(t, "argon2-hash", props["passwordHash"])
+	require.Equal(t, "rotate", props["apiKeyPolicy"])
+	require.Equal(t, "server={0}", props["connectionStringTemplate"])
+}
+
+// TestBuildModeledGraph_NameBlocklistNullsAnyValueType exercises the
+// "regardless of value type" half of rule B. A blocklisted key holding
+// an object or number gets nulled just as thoroughly as one holding a
+// string, because the graph consumer must never see the concrete value.
+func TestBuildModeledGraph_NameBlocklistNullsAnyValueType(t *testing.T) {
+	t.Parallel()
+
+	template := map[string]any{
+		"resources": []any{
+			map[string]any{
+				"type": "Custom.Thing/instance",
+				"name": "x",
+				"properties": map[string]any{
+					"secret": map[string]any{"raw": []byte("bin")},
+					"token":  1234,
+				},
+			},
+		},
+	}
+
+	graph, err := BuildModeledGraph(template)
+	require.NoError(t, err)
+	props := graph.Resources[0].Properties
+	require.Nil(t, props["secret"])
+	require.Nil(t, props["token"])
+}
+
+// TestBuildModeledGraph_DiffHashIndependentOfRedaction pins the design
+// note's claim that DiffHash is computed over authored properties
+// pre-redaction: two graphs of the same authored app, one with a
+// secure-param declaration and one without, must share the same
+// DiffHash. Otherwise diff tooling would flap every time the
+// sensitivity marker changed without a real content change.
+func TestBuildModeledGraph_DiffHashIndependentOfRedaction(t *testing.T) {
+	t.Parallel()
+
+	baseResource := map[string]any{
+		"type": "Radius.Data/postgreSqlDatabases",
+		"name": "db",
+		"properties": map[string]any{
+			"database": "app",
+			"password": "[parameters('pw')]",
+		},
+	}
+
+	withSecure := map[string]any{
+		"parameters": map[string]any{"pw": map[string]any{"type": "secureString"}},
+		"resources":  []any{baseResource},
+	}
+	withoutSecure := map[string]any{
+		"parameters": map[string]any{"pw": map[string]any{"type": "string"}},
+		"resources":  []any{baseResource},
+	}
+
+	g1, err := BuildModeledGraph(withSecure)
+	require.NoError(t, err)
+	g2, err := BuildModeledGraph(withoutSecure)
+	require.NoError(t, err)
+
+	require.Equal(t, *g1.Resources[0].DiffHash, *g2.Resources[0].DiffHash,
+		"DiffHash must be computed pre-redaction so schema-only changes do not flap the hash")
+
+	// And confirm the visible Properties actually differ (rule B still
+	// nulls `password` in both, but the secure-param one would null a
+	// hypothetical differently-named property).
+	require.Nil(t, g1.Resources[0].Properties["password"], "rule B nulls password by name")
+	require.Nil(t, g2.Resources[0].Properties["password"], "rule B nulls password by name even without secure param")
+}
+
+// TestBuildModeledGraph_AuthoredMapNotMutated confirms the internal
+// clone contract: the caller's input template survives untouched even
+// after redaction runs on the emitted Properties bag. Enforced because
+// ComputeDiffHash reads the same authored map and must not see redacted
+// values.
+func TestBuildModeledGraph_AuthoredMapNotMutated(t *testing.T) {
+	t.Parallel()
+
+	authored := map[string]any{
+		"database": "app",
+		"password": "hunter2",
+		"nested":   map[string]any{"secret": "kept"},
+	}
+	template := map[string]any{
+		"resources": []any{
+			map[string]any{
+				"type":       "Custom.Thing/instance",
+				"name":       "x",
+				"properties": authored,
+			},
+		},
+	}
+
+	graph, err := BuildModeledGraph(template)
+	require.NoError(t, err)
+	// Graph copy is redacted...
+	require.Nil(t, graph.Resources[0].Properties["password"])
+	require.Nil(t, graph.Resources[0].Properties["nested"].(map[string]any)["secret"])
+	// ...but the caller's original map is intact.
+	require.Equal(t, "hunter2", authored["password"])
+	require.Equal(t, "kept", authored["nested"].(map[string]any)["secret"])
+}
+
+// TestSensitiveParamNames covers the compiled-template scanner in
+// isolation: only string-typed `secureString` entries are surfaced;
+// malformed or missing parameter blocks return an empty set without
+// error so downstream lookups (`_, ok := set[name]`) are safe.
+func TestSensitiveParamNames(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		template map[string]any
+		want     []string
+	}{
+		{
+			name:     "no parameters block",
+			template: map[string]any{},
+			want:     nil,
+		},
+		{
+			name: "mixed types",
+			template: map[string]any{
+				"parameters": map[string]any{
+					"pw":     map[string]any{"type": "secureString"},
+					"region": map[string]any{"type": "string"},
+					"other":  map[string]any{"type": "int"},
+					"caps":   map[string]any{"type": "SecureString"},
+					"blob":   map[string]any{"type": "secureObject"},
+					"blob2":  map[string]any{"type": "SECUREOBJECT"},
+				},
+			},
+			want: []string{"blob", "blob2", "caps", "pw"},
+		},
+		{
+			name: "malformed entries ignored",
+			template: map[string]any{
+				"parameters": map[string]any{
+					"pw":  map[string]any{"type": "secureString"},
+					"bad": "not-a-map",
+				},
+			},
+			want: []string{"pw"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sensitiveParamNames(tc.template)
+			gotKeys := make([]string, 0, len(got))
+			for k := range got {
+				gotKeys = append(gotKeys, k)
+			}
+			require.ElementsMatch(t, tc.want, gotKeys)
+		})
+	}
+}
+
+// TestContainsSecureParamReference exercises the substring matcher
+// directly across the shapes real Bicep output can produce: direct
+// references, format() wrappers, single vs double quotes, and
+// non-expression strings that must never match.
+func TestContainsSecureParamReference(t *testing.T) {
+	t.Parallel()
+
+	secureParams := map[string]struct{}{"pw": {}, "apiKey": {}}
+	cases := []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{"direct single quote", "[parameters('pw')]", true},
+		{"direct double quote", `[parameters("pw")]`, true},
+		{"nested format", "[format('user:{0}', parameters('pw'))]", true},
+		{"other secure param", "[parameters('apiKey')]", true},
+		{"non-secure param name", "[parameters('region')]", false},
+		{"plain string literal", "hunter2", false},
+		{"non-expression that happens to contain the substring",
+			"parameters('pw')", false},
+		{"empty", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, containsSecureParamReference(tc.s, secureParams))
+		})
+	}
+}

--- a/pkg/cli/graph/modeled_test.go
+++ b/pkg/cli/graph/modeled_test.go
@@ -614,9 +614,10 @@ func TestBuildModeledGraph_AuthoredMapNotMutated(t *testing.T) {
 }
 
 // TestSensitiveParamNames covers the compiled-template scanner in
-// isolation: only string-typed `secureString` entries are surfaced;
-// malformed or missing parameter blocks return an empty set without
-// error so downstream lookups (`_, ok := set[name]`) are safe.
+// isolation: only `secureString` and `secureObject` entries are surfaced
+// (case-insensitively); malformed or missing parameter blocks return an
+// empty set without error so downstream lookups (`_, ok := set[name]`)
+// are safe.
 func TestSensitiveParamNames(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION

## Summary

Populates the properties block on every node of the static application graph (rad app graph app.bicep), and nulls values considered sensitive so they never appear as plaintext in the graph JSON.

Before → after
Before this branch, rad app graph app.bicep produced nodes with identity, connections, diffHash — but no per-resource properties. Operators saw the shape of an app but not what each resource was configured with.

After this branch, each node carries a properties bag copied from the compiled Bicep template, with sensitive values replaced by null


The graph JSON emits redacted values as bare null, which is indistinguishable from "author never set this property." A per-node redactedProperties: []string field is filed as a follow-up: [radius-project/radius#12451]

## Reason for change

<!--
Explain why this change is needed. If it addresses a GitHub issue, link it
below so it is automatically closed when this PR merges (optional).
-->

Fixes #12316

## How to test

```
namespace: Demo.Test
types:
  widgets:
    description: |
      A tiny made-up resource type used to demonstrate how `x-radius-sensitive`
      flows through Bicep type generation and appears (or doesn't) in the
      compiled ARM/Bicep JSON.
    apiVersions:
      '2025-01-01-preview':
        schema:
          type: object
          properties:
            environment:
              type: string
              description: The Radius Environment ID.
            application:
              type: string
              description: The Radius Application ID.
            plainPassword:
              type: string
              description: A password field WITHOUT the sensitive marker.
            securePassword:
              type: string
              x-radius-sensitive: true
              description: A password field WITH the sensitive marker.
            nested:
              type: object
              description: Nested object containing a sensitive property.
              properties:
                apiKey:
                  type: string
                  x-radius-sensitive: true
                  description: A nested sensitive property.
          required: [environment]

```

```
extension demo

param environment string

// Case A: pass a secure parameter into the sensitive property (idiomatic).
@secure()
param securePasswordParam string

// Case B: pass a NON-secure parameter into the sensitive property.
param plainStringParam string = 'not-secret-really'

resource w1 'Demo.Test/widgets@2025-01-01-preview' = {
  name: 'w1'
  properties: {
    environment: environment
    plainPassword: plainStringParam        // non-sensitive property, non-secure value: OK
    securePassword: securePasswordParam    // sensitive property, secure value: OK
    nested: {
      apiKey: securePasswordParam          // nested sensitive property, secure value: OK
    }
  }
}

resource w2 'Demo.Test/widgets@2025-01-01-preview' = {
  name: 'w2'
  properties: {
    environment: environment
    // Case C: hard-coded literal into a sensitive property -> should trigger
    //   use-secure-value-for-secure-inputs lint warning.
    securePassword: 'hunter2-literal'
    nested: {
      apiKey: plainStringParam             // non-secure param into sensitive prop -> also warns
    }
  }
}

```

```
(drad is debug binary)
drad app graph /Users/nithya/radius/my-radius-recipes/deploy/secret-demo/demo.bicep 


app-graph.json:

{
  "resources": [
    {
      "connections": [],
      "diffHash": "sha256:0ab9d8cca7df854f68e8168b483970eaa8938dbd0325f00947a82ceefdebe9c5",
      "id": "/planes/radius/local/resourcegroups/default/providers/Demo.Test/widgets/w1",
      "name": "w1",
      "outputResources": [],
      "properties": {
        "environment": "[parameters('environment')]",
        "nested": {
          "apiKey": null
        },
        "plainPassword": "[parameters('plainStringParam')]",
        "securePassword": null
      },
      "provisioningState": "NotSpecified",
      "type": "Demo.Test/widgets"
    },
    {
      "connections": [],
      "diffHash": "sha256:1a26aa393d2d8be7b49aab787efa74a86d845bc95482903065611088e9e55ce4",
      "id": "/planes/radius/local/resourcegroups/default/providers/Demo.Test/widgets/w2",
      "name": "w2",
      "outputResources": [],
      "properties": {
        "environment": "[parameters('environment')]",
        "nested": {
          "apiKey": null
        },
        "securePassword": "hunter2-literal"
      },
      "provisioningState": "NotSpecified",
      "type": "Demo.Test/widgets"
    }
  ]
}

```

<!-- Describe the steps a reviewer can take to verify these changes. -->

