### PR TITLE
Release v0.60.0-rc1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,9 +1,11 @@
 supported:
+  - channel: '0.60'
+    version: 'v0.60.0-rc1'
   - channel: '0.59'
     version: 'v0.59.0'
+deprecated:
   - channel: '0.58'
     version: 'v0.58.0'
-deprecated:
   - channel: '0.57'
     version: 'v0.57.1'
   - channel: '0.56'


### PR DESCRIPTION
## Description

Updates `versions.yaml` to start the v0.60.0 release cycle by adding `v0.60.0-rc1` as a supported version.

- Adds channel `0.60` / version `v0.60.0-rc1` to the top of `supported`
- Keeps channel `0.59` supported
- Moves channel `0.58` from `supported` to `deprecated`

This is Step 4 of the [RC release process](https://github.com/radius-project/radius/blob/main/docs/contributing/contributing-releases/README.md#step-4-update-versionsyaml). Only one new untagged version (`v0.60.0-rc1`) is present in `supported`, as required by `release.yaml`.

## Type of change

- This pull request is part of the release process.

Once merged, the [Release Radius](https://github.com/radius-project/radius/actions/workflows/release.yaml) workflow will create the `release/0.60` branch and push the `v0.60.0-rc1` tag automatically.