### PR TITLE
static-graph dependency edges

### DIFF
--- a/docs/architecture/application-graph.md
+++ b/docs/architecture/application-graph.md
@@ -206,6 +206,47 @@ The `findSourceResource()` helper supports three resolution strategies:
    resource name)
 3. Fallback to the raw string (marked as `ErrInvalidSource`)
 
+#### Edge Sources and `Kind`
+
+Every edge on the `Radius.Core/2025-08-01-preview` wire carries a `kind`
+discriminator (`ApplicationGraphConnection.kind`, values `Connection` or
+`Dependency`). Two sources feed it:
+
+- **`properties.connections`** — author-declared. Every edge emitted from
+  this source is tagged `Kind: Connection`.
+- **`dependsOn`** — implicit dependencies inferred from Bicep's compiled
+  `dependsOn` list. Every edge emitted from this source is tagged `Kind:
+  Dependency`. When the same `(source, target)` pair is signaled by both
+  the connections block and `dependsOn`, **Connection wins** — exactly
+  one edge is emitted, tagged `Connection`.
+
+Today the two producers differ in which sources they consume:
+
+- **Server-side runtime handler**
+  (`pkg/corerp/frontend/controller/applications/v20250801preview/graph_util.go`)
+  — sees only `properties.connections` (deployed resources do not carry
+  Bicep's `dependsOn`). Every edge it emits is `Kind: Connection`.
+  Applications.Core (stable) is unchanged and does not carry `kind` on
+  the wire.
+- **CLI static-graph builder** (`rad app graph app.bicep`,
+  [`pkg/cli/graph/modeled.go`](../../pkg/cli/graph/modeled.go)) — also
+  reads Bicep's `dependsOn`, so it emits both `Kind: Connection` and
+  `Kind: Dependency` edges. Templates that reference another resource
+  only via `secretKeyRef` (no `properties.connections` block) still
+  surface an implicit dependency edge.
+
+Both producers share the same extraction primitive
+([`pkg/graph/edges/`](../../pkg/graph/edges/)): exclusion of
+control-plane types (`Radius.Core/applications`, `Radius.Core/environments`,
+`Radius.Core/recipePacks`, plus the legacy `Applications.Core/applications`
+and `Applications.Core/environments`), Connection-wins de-duplication, and
+reciprocal `Outbound`/`Inbound` mirroring. Excluded types are neither
+graph nodes nor edge targets. Phase 2 will bring `Kind: Dependency` to
+the server by adding an optional `dependsOnEdges` field to
+`GetGraphRequest` — callers who ran `bicep build` locally send the
+compiled dependency list, and the server merges it into the graph
+through the same primitive.
+
 #### Breadth-First Expansion
 
 The algorithm starts with resources known to be in the application and
@@ -245,6 +286,7 @@ classDiagram
     class ApplicationGraphConnection {
         +id: string
         +direction: Direction
+        +kind: ConnectionKind
     }
     class ApplicationGraphOutputResource {
         +id: string
@@ -256,15 +298,24 @@ classDiagram
         Outbound
         Inbound
     }
+    class ConnectionKind {
+        <<enum>>
+        Connection
+        Dependency
+    }
 
     ApplicationGraphResponse "1" --> "*" ApplicationGraphResource : resources
     ApplicationGraphResource "1" --> "*" ApplicationGraphConnection : connections
     ApplicationGraphResource "1" --> "*" ApplicationGraphOutputResource : outputResources
     ApplicationGraphConnection --> Direction : direction
+    ApplicationGraphConnection --> ConnectionKind : kind
 ```
 
 The types are defined in TypeSpec at `typespec/Radius.Core/applications.tsp`
-and generated into `pkg/corerp/api/v20231001preview/`.
+and generated into `pkg/corerp/api/v20231001preview/` (stable Applications.Core)
+and `pkg/corerp/api/v20250801preview/` (Radius.Core preview). The `kind`
+field and the `ConnectionKind` enum only exist on the Radius.Core preview
+surface; the stable Applications.Core wire is unchanged.
 
 ## CLI Display
 
@@ -333,7 +384,7 @@ RP handler based on the registered resource provider.
 | HTTP Method | `POST` |
 | URL | `{rootScope}/providers/Radius.Core/applications/{name}/getGraph?api-version=2025-08-01-preview` |
 | Request Body | `GetGraphRequest` — `{ "includeIcons": false }` (both the object and the field are optional; missing or empty bodies resolve to `false`) |
-| Response | `ApplicationGraphResponse` (200 OK) — same resources/connections/output-resources as the stable version, plus per-node `iconHash` and (when `includeIcons: true`) a top-level `icons` map from hash to verbatim SVG bytes |
+| Response | `ApplicationGraphResponse` (200 OK) — same resources/connections/output-resources as the stable version, plus per-node `iconHash` and (when `includeIcons: true`) a top-level `icons` map from hash to verbatim SVG bytes. Every `ApplicationGraphConnection` also carries a `kind` discriminator (`Connection` or `Dependency`) not present on the Applications.Core wire; see [Edge Sources and Kind](#edge-sources-and-kind). |
 
 ## Radius.Core Preview: Icon Enrichment
 

--- a/hack/bicep-types-radius/generated/index.json
+++ b/hack/bicep-types-radius/generated/index.json
@@ -64,19 +64,19 @@
       "$ref": "radius/radius.compute/2025-08-01-preview/types.json#/225"
     },
     "Radius.Core/applications@2025-08-01-preview": {
-      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/67"
+      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/70"
     },
     "Radius.Core/bicepSettings@2025-08-01-preview": {
-      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/100"
+      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/103"
     },
     "Radius.Core/environments@2025-08-01-preview": {
-      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/134"
+      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/137"
     },
     "Radius.Core/recipePacks@2025-08-01-preview": {
-      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/168"
+      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/171"
     },
     "Radius.Core/terraformSettings@2025-08-01-preview": {
-      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/206"
+      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/209"
     },
     "Radius.Data/mongoDatabases@2025-08-01-preview": {
       "$ref": "radius/radius.data/2025-08-01-preview/types.json#/19"

--- a/hack/bicep-types-radius/generated/radius/radius.core/2025-08-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/radius/radius.core/2025-08-01-preview/types.json
@@ -617,14 +617,14 @@
     "properties": {
       "resources": {
         "type": {
-          "$ref": "#/64"
+          "$ref": "#/67"
         },
         "flags": 1,
         "description": "The resources in the application graph."
       },
       "icons": {
         "type": {
-          "$ref": "#/65"
+          "$ref": "#/68"
         },
         "flags": 0,
         "description": "Map from iconHash to the verbatim SVG UTF-8 bytes for every icon referenced by any resource in this response. Populated only when the request specifies `includeIcons: true`."
@@ -665,7 +665,7 @@
       },
       "connections": {
         "type": {
-          "$ref": "#/61"
+          "$ref": "#/64"
         },
         "flags": 1,
         "description": "The connections between resources in the application graph."
@@ -693,7 +693,7 @@
       },
       "properties": {
         "type": {
-          "$ref": "#/63"
+          "$ref": "#/66"
         },
         "flags": 0,
         "description": "Resource-type-specific properties of the resource as returned by its resource provider. The shape of this map varies by `type` (e.g. a `Radius.Compute/containers` resource exposes different keys than `Radius.Datastores/redisCaches` or any user-defined resource type) and matches the `properties` returned by that resource's GET response. Top-level keys already surfaced as first-class fields on this model (`provisioningState`, `connections`) are omitted. The whole `status` object is also omitted because it may contain computed values that include sensitive data (for example, connection strings); the redundant `status.outputResources` list is surfaced via the dedicated `outputResources` field instead. Use `diffHash` rather than a byte-wise compare of this map to detect change."
@@ -757,6 +757,13 @@
         },
         "flags": 1,
         "description": "The direction of the connection. 'Outbound' indicates this connection specifies the ID of the destination and 'Inbound' indicates indicates this connection specifies the ID of the source."
+      },
+      "kind": {
+        "type": {
+          "$ref": "#/63"
+        },
+        "flags": 1,
+        "description": "Discriminator identifying the origin of this edge. 'Connection' edges are author-declared entries under properties.connections. 'Dependency' edges are implicit dependencies derived from Bicep's dependsOn list (static graph only in Phase 1). Every emitted edge carries a kind."
       }
     }
   },
@@ -780,6 +787,25 @@
     ]
   },
   {
+    "$type": "StringLiteralType",
+    "value": "Connection"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Dependency"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/61"
+      },
+      {
+        "$ref": "#/62"
+      }
+    ]
+  },
+  {
     "$type": "ArrayType",
     "itemType": {
       "$ref": "#/57"
@@ -793,7 +819,7 @@
     "name": "Record",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/62"
+      "$ref": "#/65"
     }
   },
   {
@@ -836,7 +862,7 @@
     "functions": {
       "getGraph": {
         "type": {
-          "$ref": "#/66"
+          "$ref": "#/69"
         },
         "description": "getGraph"
       }
@@ -886,15 +912,6 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/70"
-      },
-      {
-        "$ref": "#/71"
-      },
-      {
-        "$ref": "#/72"
-      },
-      {
         "$ref": "#/73"
       },
       {
@@ -908,6 +925,15 @@
       },
       {
         "$ref": "#/77"
+      },
+      {
+        "$ref": "#/78"
+      },
+      {
+        "$ref": "#/79"
+      },
+      {
+        "$ref": "#/80"
       }
     ]
   },
@@ -923,7 +949,7 @@
     "properties": {
       "authenticationMethod": {
         "type": {
-          "$ref": "#/84"
+          "$ref": "#/87"
         },
         "flags": 0,
         "description": "The authentication method to use. Supported values: BasicAuth, AzureWI, AwsIrsa."
@@ -974,13 +1000,13 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/81"
+        "$ref": "#/84"
       },
       {
-        "$ref": "#/82"
+        "$ref": "#/85"
       },
       {
-        "$ref": "#/83"
+        "$ref": "#/86"
       }
     ]
   },
@@ -989,7 +1015,7 @@
     "name": "Record",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/80"
+      "$ref": "#/83"
     }
   },
   {
@@ -998,21 +1024,21 @@
     "properties": {
       "provisioningState": {
         "type": {
-          "$ref": "#/95"
+          "$ref": "#/98"
         },
         "flags": 2,
         "description": "The status of the asynchronous operation."
       },
       "referencedBy": {
         "type": {
-          "$ref": "#/96"
+          "$ref": "#/99"
         },
         "flags": 2,
         "description": "Environments that reference this Bicep configuration."
       },
       "registryAuthentications": {
         "type": {
-          "$ref": "#/97"
+          "$ref": "#/100"
         },
         "flags": 0,
         "description": "Authentication configuration for private Bicep registries, keyed by registry hostname (e.g. 'corp.acr.io'). The Bicep driver looks up credentials by the host parsed from the recipe template path."
@@ -1055,15 +1081,6 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/87"
-      },
-      {
-        "$ref": "#/88"
-      },
-      {
-        "$ref": "#/89"
-      },
-      {
         "$ref": "#/90"
       },
       {
@@ -1077,6 +1094,15 @@
       },
       {
         "$ref": "#/94"
+      },
+      {
+        "$ref": "#/95"
+      },
+      {
+        "$ref": "#/96"
+      },
+      {
+        "$ref": "#/97"
       }
     ]
   },
@@ -1091,7 +1117,7 @@
     "name": "Record",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/80"
+      "$ref": "#/83"
     }
   },
   {
@@ -1122,49 +1148,49 @@
       },
       "type": {
         "type": {
-          "$ref": "#/68"
+          "$ref": "#/71"
         },
         "flags": 10,
         "description": "The resource type"
       },
       "apiVersion": {
         "type": {
-          "$ref": "#/69"
+          "$ref": "#/72"
         },
         "flags": 10,
         "description": "The resource api version"
       },
       "provisioningState": {
         "type": {
-          "$ref": "#/78"
+          "$ref": "#/81"
         },
         "flags": 2,
         "description": "The status of the asynchronous operation."
       },
       "referencedBy": {
         "type": {
-          "$ref": "#/79"
+          "$ref": "#/82"
         },
         "flags": 2,
         "description": "Environments that reference this Bicep configuration."
       },
       "registryAuthentications": {
         "type": {
-          "$ref": "#/85"
+          "$ref": "#/88"
         },
         "flags": 2,
         "description": "Authentication configuration for private Bicep registries, keyed by registry hostname (e.g. 'corp.acr.io'). The Bicep driver looks up credentials by the host parsed from the recipe template path."
       },
       "properties": {
         "type": {
-          "$ref": "#/86"
+          "$ref": "#/89"
         },
         "flags": 1,
         "description": "The resource-specific properties for this resource."
       },
       "tags": {
         "type": {
-          "$ref": "#/98"
+          "$ref": "#/101"
         },
         "flags": 0,
         "description": "Resource tags."
@@ -1189,7 +1215,7 @@
     "$type": "ResourceType",
     "name": "Radius.Core/bicepSettings@2025-08-01-preview",
     "body": {
-      "$ref": "#/99"
+      "$ref": "#/102"
     },
     "readableScopes": 0,
     "writableScopes": 0,
@@ -1239,15 +1265,6 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/103"
-      },
-      {
-        "$ref": "#/104"
-      },
-      {
-        "$ref": "#/105"
-      },
-      {
         "$ref": "#/106"
       },
       {
@@ -1261,6 +1278,15 @@
       },
       {
         "$ref": "#/110"
+      },
+      {
+        "$ref": "#/111"
+      },
+      {
+        "$ref": "#/112"
+      },
+      {
+        "$ref": "#/113"
       }
     ]
   },
@@ -1275,7 +1301,7 @@
     "name": "RecipeParameterValue",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/62"
+      "$ref": "#/65"
     }
   },
   {
@@ -1283,7 +1309,7 @@
     "name": "Record",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/113"
+      "$ref": "#/116"
     }
   },
   {
@@ -1292,21 +1318,21 @@
     "properties": {
       "azure": {
         "type": {
-          "$ref": "#/116"
+          "$ref": "#/119"
         },
         "flags": 0,
         "description": "The Azure cloud provider configuration."
       },
       "kubernetes": {
         "type": {
-          "$ref": "#/117"
+          "$ref": "#/120"
         },
         "flags": 0,
         "description": "The Kubernetes provider configuration."
       },
       "aws": {
         "type": {
-          "$ref": "#/118"
+          "$ref": "#/121"
         },
         "flags": 0,
         "description": "The AWS cloud provider configuration."
@@ -1379,28 +1405,28 @@
     "properties": {
       "provisioningState": {
         "type": {
-          "$ref": "#/128"
+          "$ref": "#/131"
         },
         "flags": 2,
         "description": "The status of the asynchronous operation."
       },
       "recipePacks": {
         "type": {
-          "$ref": "#/129"
+          "$ref": "#/132"
         },
         "flags": 0,
         "description": "List of Recipe Pack resource IDs linked to this environment."
       },
       "recipeParameters": {
         "type": {
-          "$ref": "#/131"
+          "$ref": "#/134"
         },
         "flags": 0,
         "description": "Recipe specific parameters that apply to all resources of a given type in this environment."
       },
       "providers": {
         "type": {
-          "$ref": "#/115"
+          "$ref": "#/118"
         },
         "flags": 0,
         "description": "Cloud provider configuration for the environment."
@@ -1464,15 +1490,6 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/120"
-      },
-      {
-        "$ref": "#/121"
-      },
-      {
-        "$ref": "#/122"
-      },
-      {
         "$ref": "#/123"
       },
       {
@@ -1486,6 +1503,15 @@
       },
       {
         "$ref": "#/127"
+      },
+      {
+        "$ref": "#/128"
+      },
+      {
+        "$ref": "#/129"
+      },
+      {
+        "$ref": "#/130"
       }
     ]
   },
@@ -1500,7 +1526,7 @@
     "name": "RecipeParameterValue",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/62"
+      "$ref": "#/65"
     }
   },
   {
@@ -1508,7 +1534,7 @@
     "name": "Record",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/130"
+      "$ref": "#/133"
     }
   },
   {
@@ -1539,42 +1565,42 @@
       },
       "type": {
         "type": {
-          "$ref": "#/101"
+          "$ref": "#/104"
         },
         "flags": 10,
         "description": "The resource type"
       },
       "apiVersion": {
         "type": {
-          "$ref": "#/102"
+          "$ref": "#/105"
         },
         "flags": 10,
         "description": "The resource api version"
       },
       "provisioningState": {
         "type": {
-          "$ref": "#/111"
+          "$ref": "#/114"
         },
         "flags": 2,
         "description": "The status of the asynchronous operation."
       },
       "recipePacks": {
         "type": {
-          "$ref": "#/112"
+          "$ref": "#/115"
         },
         "flags": 2,
         "description": "List of Recipe Pack resource IDs linked to this environment."
       },
       "recipeParameters": {
         "type": {
-          "$ref": "#/114"
+          "$ref": "#/117"
         },
         "flags": 2,
         "description": "Recipe specific parameters that apply to all resources of a given type in this environment."
       },
       "providers": {
         "type": {
-          "$ref": "#/115"
+          "$ref": "#/118"
         },
         "flags": 2,
         "description": "Cloud provider configuration for the environment."
@@ -1602,14 +1628,14 @@
       },
       "properties": {
         "type": {
-          "$ref": "#/119"
+          "$ref": "#/122"
         },
         "flags": 1,
         "description": "The resource-specific properties for this resource."
       },
       "tags": {
         "type": {
-          "$ref": "#/132"
+          "$ref": "#/135"
         },
         "flags": 0,
         "description": "Resource tags."
@@ -1634,7 +1660,7 @@
     "$type": "ResourceType",
     "name": "Radius.Core/environments@2025-08-01-preview",
     "body": {
-      "$ref": "#/133"
+      "$ref": "#/136"
     },
     "readableScopes": 0,
     "writableScopes": 0,
@@ -1684,15 +1710,6 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/137"
-      },
-      {
-        "$ref": "#/138"
-      },
-      {
-        "$ref": "#/139"
-      },
-      {
         "$ref": "#/140"
       },
       {
@@ -1706,6 +1723,15 @@
       },
       {
         "$ref": "#/144"
+      },
+      {
+        "$ref": "#/145"
+      },
+      {
+        "$ref": "#/146"
+      },
+      {
+        "$ref": "#/147"
       }
     ]
   },
@@ -1721,7 +1747,7 @@
     "properties": {
       "kind": {
         "type": {
-          "$ref": "#/150"
+          "$ref": "#/153"
         },
         "flags": 1,
         "description": "The type of recipe (e.g., Terraform, Bicep)"
@@ -1742,14 +1768,14 @@
       },
       "parameters": {
         "type": {
-          "$ref": "#/151"
+          "$ref": "#/154"
         },
         "flags": 0,
         "description": "Parameters to pass to the recipe"
       },
       "outputs": {
         "type": {
-          "$ref": "#/152"
+          "$ref": "#/155"
         },
         "flags": 0,
         "description": "Maps the module's outputs onto the resource type's properties, for recipes that point directly at a Bicep or Terraform module. Each entry's value is either a string (the module output name for a non-secret property) or, under the reserved `secrets` key, a nested object mapping secret property names to module output names. A `secrets` entry always routes its module output to the resource's secret outputs regardless of how the module classified it (for example an AVM module's `primaryConnectionString`). Example: `{ host: 'name', secrets: { connectionString: 'primaryConnectionString' } }`."
@@ -1768,10 +1794,10 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/148"
+        "$ref": "#/151"
       },
       {
-        "$ref": "#/149"
+        "$ref": "#/152"
       }
     ]
   },
@@ -1780,7 +1806,7 @@
     "name": "Record",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/62"
+      "$ref": "#/65"
     }
   },
   {
@@ -1788,7 +1814,7 @@
     "name": "Record",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/62"
+      "$ref": "#/65"
     }
   },
   {
@@ -1796,7 +1822,7 @@
     "name": "Record",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/147"
+      "$ref": "#/150"
     }
   },
   {
@@ -1805,21 +1831,21 @@
     "properties": {
       "provisioningState": {
         "type": {
-          "$ref": "#/163"
+          "$ref": "#/166"
         },
         "flags": 2,
         "description": "The status of the asynchronous operation"
       },
       "referencedBy": {
         "type": {
-          "$ref": "#/164"
+          "$ref": "#/167"
         },
         "flags": 2,
         "description": "List of environment IDs that reference this recipe pack"
       },
       "recipes": {
         "type": {
-          "$ref": "#/165"
+          "$ref": "#/168"
         },
         "flags": 1,
         "description": "Map of resource types to their recipe configurations"
@@ -1862,15 +1888,6 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/155"
-      },
-      {
-        "$ref": "#/156"
-      },
-      {
-        "$ref": "#/157"
-      },
-      {
         "$ref": "#/158"
       },
       {
@@ -1884,6 +1901,15 @@
       },
       {
         "$ref": "#/162"
+      },
+      {
+        "$ref": "#/163"
+      },
+      {
+        "$ref": "#/164"
+      },
+      {
+        "$ref": "#/165"
       }
     ]
   },
@@ -1898,7 +1924,7 @@
     "name": "Record",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/147"
+      "$ref": "#/150"
     }
   },
   {
@@ -1929,49 +1955,49 @@
       },
       "type": {
         "type": {
-          "$ref": "#/135"
+          "$ref": "#/138"
         },
         "flags": 10,
         "description": "The resource type"
       },
       "apiVersion": {
         "type": {
-          "$ref": "#/136"
+          "$ref": "#/139"
         },
         "flags": 10,
         "description": "The resource api version"
       },
       "provisioningState": {
         "type": {
-          "$ref": "#/145"
+          "$ref": "#/148"
         },
         "flags": 2,
         "description": "The status of the asynchronous operation"
       },
       "referencedBy": {
         "type": {
-          "$ref": "#/146"
+          "$ref": "#/149"
         },
         "flags": 2,
         "description": "List of environment IDs that reference this recipe pack"
       },
       "recipes": {
         "type": {
-          "$ref": "#/153"
+          "$ref": "#/156"
         },
         "flags": 2,
         "description": "Map of resource types to their recipe configurations"
       },
       "properties": {
         "type": {
-          "$ref": "#/154"
+          "$ref": "#/157"
         },
         "flags": 1,
         "description": "The resource-specific properties for this resource."
       },
       "tags": {
         "type": {
-          "$ref": "#/166"
+          "$ref": "#/169"
         },
         "flags": 0,
         "description": "Resource tags."
@@ -1996,7 +2022,7 @@
     "$type": "ResourceType",
     "name": "Radius.Core/recipePacks@2025-08-01-preview",
     "body": {
-      "$ref": "#/167"
+      "$ref": "#/170"
     },
     "readableScopes": 0,
     "writableScopes": 0,
@@ -2046,15 +2072,6 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/171"
-      },
-      {
-        "$ref": "#/172"
-      },
-      {
-        "$ref": "#/173"
-      },
-      {
         "$ref": "#/174"
       },
       {
@@ -2068,6 +2085,15 @@
       },
       {
         "$ref": "#/178"
+      },
+      {
+        "$ref": "#/179"
+      },
+      {
+        "$ref": "#/180"
+      },
+      {
+        "$ref": "#/181"
       }
     ]
   },
@@ -2083,14 +2109,14 @@
     "properties": {
       "providerInstallation": {
         "type": {
-          "$ref": "#/182"
+          "$ref": "#/185"
         },
         "flags": 0,
         "description": "Provider installation configuration. Specifies the location of providers via network mirrors or direct downloads."
       },
       "credentials": {
         "type": {
-          "$ref": "#/190"
+          "$ref": "#/193"
         },
         "flags": 0,
         "description": "Credentials for authenticating to private Terraform registries (HTTP-based, e.g. app.terraform.io). Map of registry hostname to credential configuration. Rendered as native `credentials \"hostname\" {}` blocks in the generated .terraformrc. Note: this is for Terraform CLI registry auth (HTTP), not for Git-based module sources; Git auth is a separate mechanism."
@@ -2103,14 +2129,14 @@
     "properties": {
       "networkMirror": {
         "type": {
-          "$ref": "#/183"
+          "$ref": "#/186"
         },
         "flags": 0,
         "description": "Network mirror configuration for downloading providers."
       },
       "direct": {
         "type": {
-          "$ref": "#/186"
+          "$ref": "#/189"
         },
         "flags": 0,
         "description": "Direct provider installation configuration."
@@ -2130,14 +2156,14 @@
       },
       "include": {
         "type": {
-          "$ref": "#/184"
+          "$ref": "#/187"
         },
         "flags": 0,
         "description": "Provider address patterns to include from this mirror."
       },
       "exclude": {
         "type": {
-          "$ref": "#/185"
+          "$ref": "#/188"
         },
         "flags": 0,
         "description": "Provider address patterns to exclude from this mirror."
@@ -2162,14 +2188,14 @@
     "properties": {
       "include": {
         "type": {
-          "$ref": "#/187"
+          "$ref": "#/190"
         },
         "flags": 0,
         "description": "Provider address patterns to include for direct installation."
       },
       "exclude": {
         "type": {
-          "$ref": "#/188"
+          "$ref": "#/191"
         },
         "flags": 0,
         "description": "Provider address patterns to exclude from direct installation."
@@ -2206,7 +2232,7 @@
     "name": "Record",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/189"
+      "$ref": "#/192"
     }
   },
   {
@@ -2223,28 +2249,28 @@
     "properties": {
       "provisioningState": {
         "type": {
-          "$ref": "#/201"
+          "$ref": "#/204"
         },
         "flags": 2,
         "description": "The status of the asynchronous operation."
       },
       "referencedBy": {
         "type": {
-          "$ref": "#/202"
+          "$ref": "#/205"
         },
         "flags": 2,
         "description": "Environments that reference this Terraform configuration."
       },
       "terraformrc": {
         "type": {
-          "$ref": "#/181"
+          "$ref": "#/184"
         },
         "flags": 0,
         "description": "Terraform CLI configuration file settings. Maps directly to the Terraform CLI configuration file (.terraformrc)."
       },
       "env": {
         "type": {
-          "$ref": "#/203"
+          "$ref": "#/206"
         },
         "flags": 0,
         "description": "Environment variables injected during Terraform recipe execution."
@@ -2287,15 +2313,6 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/193"
-      },
-      {
-        "$ref": "#/194"
-      },
-      {
-        "$ref": "#/195"
-      },
-      {
         "$ref": "#/196"
       },
       {
@@ -2309,6 +2326,15 @@
       },
       {
         "$ref": "#/200"
+      },
+      {
+        "$ref": "#/201"
+      },
+      {
+        "$ref": "#/202"
+      },
+      {
+        "$ref": "#/203"
       }
     ]
   },
@@ -2354,56 +2380,56 @@
       },
       "type": {
         "type": {
-          "$ref": "#/169"
+          "$ref": "#/172"
         },
         "flags": 10,
         "description": "The resource type"
       },
       "apiVersion": {
         "type": {
-          "$ref": "#/170"
+          "$ref": "#/173"
         },
         "flags": 10,
         "description": "The resource api version"
       },
       "provisioningState": {
         "type": {
-          "$ref": "#/179"
+          "$ref": "#/182"
         },
         "flags": 2,
         "description": "The status of the asynchronous operation."
       },
       "referencedBy": {
         "type": {
-          "$ref": "#/180"
+          "$ref": "#/183"
         },
         "flags": 2,
         "description": "Environments that reference this Terraform configuration."
       },
       "terraformrc": {
         "type": {
-          "$ref": "#/181"
+          "$ref": "#/184"
         },
         "flags": 2,
         "description": "Terraform CLI configuration file settings. Maps directly to the Terraform CLI configuration file (.terraformrc)."
       },
       "env": {
         "type": {
-          "$ref": "#/191"
+          "$ref": "#/194"
         },
         "flags": 2,
         "description": "Environment variables injected during Terraform recipe execution."
       },
       "properties": {
         "type": {
-          "$ref": "#/192"
+          "$ref": "#/195"
         },
         "flags": 1,
         "description": "The resource-specific properties for this resource."
       },
       "tags": {
         "type": {
-          "$ref": "#/204"
+          "$ref": "#/207"
         },
         "flags": 0,
         "description": "Resource tags."
@@ -2428,7 +2454,7 @@
     "$type": "ResourceType",
     "name": "Radius.Core/terraformSettings@2025-08-01-preview",
     "body": {
-      "$ref": "#/205"
+      "$ref": "#/208"
     },
     "readableScopes": 0,
     "writableScopes": 0,

--- a/pkg/cli/graph/modeled.go
+++ b/pkg/cli/graph/modeled.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	corerpv20250801preview "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	"github.com/radius-project/radius/pkg/graph/edges"
 	"github.com/radius-project/radius/pkg/to"
 
 	productmanifest "github.com/radius-project/radius/deploy/manifest"
@@ -154,6 +155,7 @@ func BuildModeledGraph(template map[string]any, includeIcons bool) (*corerpv2025
 	secureParams := sensitiveParamNames(template)
 
 	graphResources := make([]*corerpv20250801preview.ApplicationGraphResource, 0, len(rawResources))
+	extractInputs := make([]edges.Resource, 0, len(rawResources))
 	for _, entry := range rawResources {
 		resource, err := buildModeledResource(entry, secureParams)
 		if err != nil {
@@ -163,14 +165,58 @@ func BuildModeledGraph(template map[string]any, includeIcons bool) (*corerpv2025
 			continue
 		}
 		graphResources = append(graphResources, resource)
+
+		// Feed the pure-Go extractor with pre-resolved canonical IDs.
+		// The static graph is the only Kind: Dependency producer today
+		// (Bicep dependsOn). Runtime dependency edges arrive via
+		// caller-supplied dependsOnEdges on GetGraphRequest in Phase 2.
+		properties, _ := entry["properties"].(map[string]any)
+		rawDependsOn, _ := entry["dependsOn"].([]any)
+		extractInputs = append(extractInputs, edges.Resource{
+			ID:          to.String(resource.ID),
+			Type:        to.String(resource.Type),
+			Connections: resolveConnectionSources(properties),
+			DependsOn:   resolveDependsOn(rawDependsOn),
+		})
 	}
 
 	graph := &corerpv20250801preview.ApplicationGraphResponse{Resources: graphResources}
-	addInboundConnections(graph)
+	applyEdges(graph, edges.ExtractEdges(extractInputs, excludeResourceTypes))
 	if includeIcons {
 		graph.Icons = collectStaticGraphIcons(graphResources)
 	}
 	return graph, nil
+}
+
+// applyEdges attaches each Edge returned by the extractor to the
+// Connections slice of the resource that owns it (Source for Outbound,
+// Target for Inbound). ExtractEdges returns entries sorted
+// deterministically, so the resulting Connections slices are ordered
+// stably across runs. Excluded resources are already absent from
+// graph.Resources (buildModeledResource returns nil for them), so byID
+// lookups for excluded owners silently drop mirror edges — the extractor
+// also refuses to emit edges whose target type is excluded.
+func applyEdges(graph *corerpv20250801preview.ApplicationGraphResponse, extracted []edges.Edge) {
+	if graph == nil || len(extracted) == 0 {
+		return
+	}
+	byID := make(map[string]*corerpv20250801preview.ApplicationGraphResource, len(graph.Resources))
+	for _, r := range graph.Resources {
+		if r != nil && r.ID != nil {
+			byID[*r.ID] = r
+		}
+	}
+	for _, e := range extracted {
+		owner, ok := byID[e.Owner()]
+		if !ok {
+			continue
+		}
+		owner.Connections = append(owner.Connections, &corerpv20250801preview.ApplicationGraphConnection{
+			ID:        to.Ptr(e.Peer()),
+			Direction: to.Ptr(corerpv20250801preview.Direction(e.Direction)),
+			Kind:      to.Ptr(corerpv20250801preview.ConnectionKind(e.Kind)),
+		})
+	}
 }
 
 // sensitiveParamNames returns the set of parameter names declared with
@@ -462,7 +508,7 @@ func buildModeledResource(entry map[string]any, secureParams map[string]struct{}
 		Name:              to.Ptr(name),
 		Type:              to.Ptr(resourceType),
 		ProvisioningState: to.Ptr(string(v1.ProvisioningStateNotSpecified)),
-		Connections:       outboundConnections(properties),
+		Connections:       []*corerpv20250801preview.ApplicationGraphConnection{},
 		OutputResources:   []*corerpv20250801preview.ApplicationGraphOutputResource{},
 		DiffHash:          to.Ptr(hash),
 		IconHash:          resolveIconHash(resourceType),
@@ -601,19 +647,20 @@ func deepCloneValue(v any) any {
 	}
 }
 
-// outboundConnections extracts the resource's `connections` map and emits
-// one outbound graph edge per entry whose source can be resolved to a
-// Radius resource ID.
-func outboundConnections(properties map[string]any) []*corerpv20250801preview.ApplicationGraphConnection {
+// resolveConnectionSources walks the resource's properties.connections
+// map and returns each entry's `source` after resolving it from an ARM
+// [resourceId(...)] expression to a fully-qualified Radius resource ID.
+// Unresolvable sources are dropped; the caller sees a Connections
+// slice of pre-resolved canonical IDs suitable for edges.ExtractEdges.
+func resolveConnectionSources(properties map[string]any) []string {
 	if properties == nil {
-		return []*corerpv20250801preview.ApplicationGraphConnection{}
+		return nil
 	}
 	connections, ok := properties["connections"].(map[string]any)
 	if !ok {
-		return []*corerpv20250801preview.ApplicationGraphConnection{}
+		return nil
 	}
-
-	result := make([]*corerpv20250801preview.ApplicationGraphConnection, 0, len(connections))
+	out := make([]string, 0, len(connections))
 	for _, raw := range connections {
 		entry, ok := raw.(map[string]any)
 		if !ok {
@@ -624,47 +671,17 @@ func outboundConnections(properties map[string]any) []*corerpv20250801preview.Ap
 		if resolved == "" {
 			continue
 		}
-		result = append(result, &corerpv20250801preview.ApplicationGraphConnection{
-			ID:        to.Ptr(resolved),
-			Direction: to.Ptr(corerpv20250801preview.DirectionOutbound),
-		})
+		out = append(out, resolved)
 	}
-	return result
+	return out
 }
 
-// addInboundConnections walks every outbound edge in the graph and inserts
-// the reciprocal inbound edge on the destination resource so each resource
-// surfaces both sides of its relationships.
-func addInboundConnections(graph *corerpv20250801preview.ApplicationGraphResponse) {
-	byID := make(map[string]*corerpv20250801preview.ApplicationGraphResource, len(graph.Resources))
-	for _, r := range graph.Resources {
-		if r != nil && r.ID != nil {
-			byID[*r.ID] = r
-		}
-	}
-
-	for _, src := range graph.Resources {
-		if src == nil || src.ID == nil {
-			continue
-		}
-		for _, conn := range src.Connections {
-			if conn == nil || conn.ID == nil || conn.Direction == nil {
-				continue
-			}
-			if *conn.Direction != corerpv20250801preview.DirectionOutbound {
-				continue
-			}
-			dest, ok := byID[*conn.ID]
-			if !ok {
-				continue
-			}
-			dest.Connections = append(dest.Connections, &corerpv20250801preview.ApplicationGraphConnection{
-				ID:        src.ID,
-				Direction: to.Ptr(corerpv20250801preview.DirectionInbound),
-			})
-		}
-	}
-}
+// outboundConnections and addInboundConnections have been superseded by
+// the pkg/graph/edges shared extractor. BuildModeledGraph now feeds
+// []edges.Resource into edges.ExtractEdges and hands the result to
+// applyEdges, which handles both properties.connections and Bicep
+// dependsOn as edge sources with Connection-wins de-duplication and
+// reciprocal mirroring.
 
 // resolveDependsOn resolves each ARM expression in an ARM JSON dependsOn
 // list to a fully-qualified Radius resource ID. Unresolvable entries are

--- a/pkg/cli/graph/modeled_test.go
+++ b/pkg/cli/graph/modeled_test.go
@@ -204,6 +204,117 @@ func TestBuildModeledGraph_InboundConnectionsAreReciprocal(t *testing.T) {
 	)
 }
 
+// TestBuildModeledGraph_ConnectionWinsOverDependencyOnRabbitMQShape locks
+// in SC-001 (specs/004-graph-dependency-edges/spec.md): when a resource
+// has BOTH a properties.connections block targeting another resource AND
+// a dependsOn entry naming the same target, the static graph emits
+// exactly ONE edge tagged Kind: Connection. Connection wins.
+func TestBuildModeledGraph_ConnectionWinsOverDependencyOnRabbitMQShape(t *testing.T) {
+	t.Parallel()
+
+	template := map[string]any{
+		"languageVersion": "2.0",
+		"resources": map[string]any{
+			"rabbitmq": map[string]any{
+				"type": "Radius.Messaging/rabbitMQ@2025-08-01-preview",
+				"properties": map[string]any{
+					"name": "rabbitmq",
+					"properties": map[string]any{
+						"queue": "jobs",
+					},
+				},
+			},
+			"consumer": map[string]any{
+				"type": "Radius.Compute/containers@2025-08-01-preview",
+				"properties": map[string]any{
+					"name": "consumer",
+					"properties": map[string]any{
+						// Author-declared connection to rabbitmq.
+						"connections": map[string]any{
+							"rabbitmq": map[string]any{
+								"source": "[reference('rabbitmq').id]",
+							},
+						},
+					},
+				},
+				// dependsOn also names rabbitmq, so both edge sources
+				// signal the same (consumer, rabbitmq) pair. Connection
+				// wins.
+				"dependsOn": []any{"rabbitmq"},
+			},
+		},
+	}
+
+	graph, err := BuildModeledGraph(template, false)
+	require.NoError(t, err)
+	require.Len(t, graph.Resources, 2)
+
+	consumer := findResource(t, graph, "consumer")
+	require.Len(t, consumer.Connections, 1, "consumer must have exactly one outbound edge (Connection wins over Dependency)")
+	require.Equal(t, corerpv20250801preview.DirectionOutbound, *consumer.Connections[0].Direction)
+	require.NotNil(t, consumer.Connections[0].Kind, "kind must be populated on every emitted edge")
+	require.Equal(t, corerpv20250801preview.ConnectionKindConnection, *consumer.Connections[0].Kind,
+		"same-pair Connection + Dependency must resolve to Connection")
+
+	rabbitmq := findResource(t, graph, "rabbitmq")
+	require.Len(t, rabbitmq.Connections, 1)
+	require.Equal(t, corerpv20250801preview.DirectionInbound, *rabbitmq.Connections[0].Direction)
+	require.NotNil(t, rabbitmq.Connections[0].Kind)
+	require.Equal(t, corerpv20250801preview.ConnectionKindConnection, *rabbitmq.Connections[0].Kind,
+		"mirrored inbound must preserve the winning Kind")
+}
+
+// TestBuildModeledGraph_DependencyEdgeSurfacesWithoutConnectionsBlock
+// locks in SC-002: a resource that references another via dependsOn
+// only (no properties.connections block) still surfaces an implicit
+// edge, tagged Kind: Dependency.
+func TestBuildModeledGraph_DependencyEdgeSurfacesWithoutConnectionsBlock(t *testing.T) {
+	t.Parallel()
+
+	template := map[string]any{
+		"languageVersion": "2.0",
+		"resources": map[string]any{
+			"rabbitmq": map[string]any{
+				"type": "Radius.Messaging/rabbitMQ@2025-08-01-preview",
+				"properties": map[string]any{
+					"name": "rabbitmq",
+					"properties": map[string]any{
+						"queue": "jobs",
+					},
+				},
+			},
+			"consumer": map[string]any{
+				"type": "Radius.Compute/containers@2025-08-01-preview",
+				"properties": map[string]any{
+					"name": "consumer",
+					// No connections block. dependsOn is the only edge
+					// source; the extractor tags it Kind: Dependency.
+					"properties": map[string]any{},
+				},
+				"dependsOn": []any{"rabbitmq"},
+			},
+		},
+	}
+
+	graph, err := BuildModeledGraph(template, false)
+	require.NoError(t, err)
+	require.Len(t, graph.Resources, 2)
+
+	consumer := findResource(t, graph, "consumer")
+	require.Len(t, consumer.Connections, 1)
+	require.Equal(t, corerpv20250801preview.DirectionOutbound, *consumer.Connections[0].Direction)
+	require.NotNil(t, consumer.Connections[0].Kind)
+	require.Equal(t, corerpv20250801preview.ConnectionKindDependency, *consumer.Connections[0].Kind,
+		"dependsOn-only edge must be tagged Dependency")
+
+	rabbitmq := findResource(t, graph, "rabbitmq")
+	require.Len(t, rabbitmq.Connections, 1, "mirrored inbound must be emitted on the target")
+	require.Equal(t, corerpv20250801preview.DirectionInbound, *rabbitmq.Connections[0].Direction)
+	require.NotNil(t, rabbitmq.Connections[0].Kind)
+	require.Equal(t, corerpv20250801preview.ConnectionKindDependency, *rabbitmq.Connections[0].Kind,
+		"mirrored inbound must preserve the source Kind")
+}
+
 func TestBuildModeledGraph_DropsUnresolvableConnections(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/corerp/api/v20250801preview/zz_generated_constants.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_constants.go
@@ -43,6 +43,26 @@ func PossibleBicepAuthenticationMethodValues() []BicepAuthenticationMethod {
 	}
 }
 
+// ConnectionKind - The origin of a connection: 'Connection' for author-declared entries in properties.connections, 'Dependency'
+// for implicit entries derived from Bicep's dependsOn list.
+type ConnectionKind string
+
+const (
+	// ConnectionKindConnection - The edge was declared by the author in properties.connections.
+	ConnectionKindConnection ConnectionKind = "Connection"
+	// ConnectionKindDependency - The edge was inferred from a Bicep dependsOn entry (implicit dependency). Not emitted by the
+	// runtime graph in Phase 1 — runtime dependency extraction is Phase 2.
+	ConnectionKindDependency ConnectionKind = "Dependency"
+)
+
+// PossibleConnectionKindValues returns the possible values for the ConnectionKind const type.
+func PossibleConnectionKindValues() []ConnectionKind {
+	return []ConnectionKind{
+		ConnectionKindConnection,
+		ConnectionKindDependency,
+	}
+}
+
 // CreatedByType - The kind of entity that created the resource.
 type CreatedByType string
 

--- a/pkg/corerp/api/v20250801preview/zz_generated_models.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_models.go
@@ -13,6 +13,11 @@ type ApplicationGraphConnection struct {
 
 	// REQUIRED; The resource ID
 	ID *string
+
+	// REQUIRED; Discriminator identifying the origin of this edge. 'Connection' edges are author-declared entries under properties.connections.
+	// 'Dependency' edges are implicit dependencies derived from Bicep's dependsOn list (static graph only in Phase 1). Every
+	// emitted edge carries a kind.
+	Kind *ConnectionKind
 }
 
 // ApplicationGraphOutputResource - Describes an output resource that comprises an application graph resource.

--- a/pkg/corerp/api/v20250801preview/zz_generated_models_serde.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_models_serde.go
@@ -17,6 +17,7 @@ func (a ApplicationGraphConnection) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "direction", a.Direction)
 	populate(objectMap, "id", a.ID)
+	populate(objectMap, "kind", a.Kind)
 	return json.Marshal(objectMap)
 }
 
@@ -34,6 +35,9 @@ func (a *ApplicationGraphConnection) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "id":
 			err = unpopulate(val, "ID", &a.ID)
+			delete(rawMsg, key)
+		case "kind":
+			err = unpopulate(val, "Kind", &a.Kind)
 			delete(rawMsg, key)
 		}
 		if err != nil {

--- a/pkg/corerp/frontend/controller/applications/v20250801preview/graph_util.go
+++ b/pkg/corerp/frontend/controller/applications/v20250801preview/graph_util.go
@@ -447,6 +447,12 @@ func computeGraph(applicationResources []generated.GenericResource, environmentR
 				connectionInbound := corerpv20250801preview.ApplicationGraphConnection{
 					ID:        new(id),
 					Direction: to.Ptr(corerpv20250801preview.DirectionInbound), //Direction is set with respect to Resource defining this connection
+					// Every edge produced by the runtime graph is a Connection
+					// in Phase 1. Dependency edges are surfaced only on the
+					// static graph (Bicep dependsOn); runtime dependency
+					// extraction is Phase 2 and arrives via caller-supplied
+					// dependsOnEdges on GetGraphRequest.
+					Kind: to.Ptr(corerpv20250801preview.ConnectionKindConnection),
 				}
 				connectionsByDestination[otherID] = append(connectionsByDestination[otherID], connectionInbound)
 			} else {
@@ -755,6 +761,10 @@ func resolveConnections(resource generated.GenericResource, jsonRefPath string, 
 			entries = append(entries, &corerpv20250801preview.ApplicationGraphConnection{
 				ID:        new(sourceID),
 				Direction: new(dir),
+				// Every edge produced by the runtime graph is Kind:
+				// Connection in Phase 1 (see companion inbound-emission
+				// site above).
+				Kind: to.Ptr(corerpv20250801preview.ConnectionKindConnection),
 			})
 		}
 	}

--- a/pkg/graph/edges/doc.go
+++ b/pkg/graph/edges/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edges

--- a/pkg/graph/edges/edges.go
+++ b/pkg/graph/edges/edges.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edges
+
+import "sort"
+
+// Edge kind constants. Values match the ConnectionKind enum on the
+// Radius.Core/2025-08-01-preview wire model; keeping them as untyped
+// strings here avoids importing the generated API package into this
+// otherwise dependency-free package. Callers convert Edge.Kind into the
+// generated ConnectionKind pointer when materializing the wire model.
+const (
+	// KindConnection tags edges derived from a resource's
+	// properties.connections block (author-declared).
+	KindConnection = "Connection"
+
+	// KindDependency tags edges derived from a resource's dependsOn
+	// list (implicit, inferred from Bicep's compiled template or the
+	// caller-supplied dependsOnEdges on the runtime GetGraphRequest
+	// wire).
+	KindDependency = "Dependency"
+)
+
+// Edge direction constants. Values match the Direction enum on the
+// Radius.Core/2025-08-01-preview wire model.
+const (
+	// DirectionOutbound identifies the source resource's view of an
+	// edge: "I depend on / connect to Target".
+	DirectionOutbound = "Outbound"
+
+	// DirectionInbound identifies the target resource's view of the
+	// same edge: "Source depends on / connects to me". Every outbound
+	// edge is mirrored by an inbound edge on the target with the same
+	// Kind.
+	DirectionInbound = "Inbound"
+)
+
+// Resource is a graph-eligible Radius resource as seen by the edge
+// extractor. Callers convert their own representation (ARM JSON entry,
+// stored resource record, etc.) into this shape before calling
+// ExtractEdges.
+//
+// Both Connections and DependsOn hold pre-resolved canonical Radius
+// resource IDs. Callers own the resolution: the static caller parses
+// ARM "[resourceId('T','N')]" expressions before calling the
+// extractor; the runtime caller (Phase 2) receives already-resolved
+// IDs from stored properties and from caller-supplied dependsOnEdges
+// on the GetGraphRequest wire. Keeping the primitive free of ARM /
+// storage / HTTP concerns is what makes it callable from both
+// contexts.
+type Resource struct {
+	// ID is the canonical Radius resource ID
+	// ("/planes/radius/local/resourcegroups/…/providers/{ns}/{type}/{name}").
+	ID string
+
+	// Type is the Radius resource type ("Radius.Compute/containers").
+	Type string
+
+	// Connections is the list of canonical Radius resource IDs this
+	// resource author-declared under properties.connections[*].source.
+	// Each entry produces a Kind=Connection edge (subject to exclusion
+	// and de-duplication). Duplicates are collapsed silently.
+	Connections []string
+
+	// DependsOn is the list of canonical Radius resource IDs the
+	// resource declares as build-time dependencies. Each entry not
+	// already covered by Connections produces a Kind=Dependency edge.
+	// The static caller populates this from resolveDependsOn on the
+	// ARM template's dependsOn array. The runtime caller populates it
+	// from caller-supplied dependsOnEdges on the GetGraphRequest wire.
+	DependsOn []string
+}
+
+// Edge is a single directed edge in the application graph.
+//
+// Source and Target describe the fixed orientation of the underlying
+// edge concept ("Source depends on / connects to Target"). Direction
+// selects which side of that edge this entry describes: an Outbound
+// entry lives on Source's Connections slice; an Inbound entry lives on
+// Target's Connections slice.
+//
+// Use Owner and Peer to translate an Edge into a wire-model
+// ApplicationGraphConnection entry without having to check Direction
+// yourself.
+type Edge struct {
+	// Source is the canonical resource ID of the edge's source node
+	// (the resource that depends on or connects to Target).
+	Source string
+
+	// Target is the canonical resource ID of the edge's target node.
+	Target string
+
+	// Direction is DirectionOutbound or DirectionInbound. Every
+	// outbound edge Source→Target is mirrored by an inbound edge on
+	// Target with the same Kind.
+	Direction string
+
+	// Kind is KindConnection (from properties.connections) or
+	// KindDependency (from DependsOn). Case-sensitive; matches the
+	// wire enum values on Radius.Core/2025-08-01-preview.
+	Kind string
+}
+
+// Owner returns the canonical ID of the resource whose Connections
+// slice owns this Edge entry: Source for an Outbound edge, Target for
+// an Inbound edge.
+func (e Edge) Owner() string {
+	if e.Direction == DirectionInbound {
+		return e.Target
+	}
+	return e.Source
+}
+
+// Peer returns the canonical ID of the other end of the edge — the
+// value stored in the wire entry's `id` field on the owning resource's
+// Connections slice.
+func (e Edge) Peer() string {
+	if e.Direction == DirectionInbound {
+		return e.Source
+	}
+	return e.Target
+}
+
+// ExtractEdges returns the deduplicated, mirrored edge list for the
+// given resources, dropping any edge whose source or target type is
+// present in the excluded set.
+//
+// excluded holds canonical "Namespace/type" strings that MUST NOT
+// appear as graph nodes or edge targets. Callers control membership so
+// the same primitive can be used with different exclusion sets (static
+// vs runtime).
+//
+// The output is sorted deterministically by (Source, Target,
+// Direction, Kind) so callers can compare or diff it.
+//
+// ExtractEdges never returns an error: unresolvable DependsOn entries
+// and edges targeting excluded types are silently dropped. See the
+// spec's edge-cases section for the exhaustive rules.
+//
+// # Callers
+//
+// Two callers consume this primitive today, both by converting their
+// own input into []Resource and interpreting the returned []Edge via
+// Edge.Owner / Edge.Peer when materializing wire entries:
+//
+//   - Static graph builder — [pkg/cli/graph.BuildModeledGraph]. Resolves
+//     ARM "[resourceId('T','N')]" expressions in
+//     properties.connections and dependsOn before calling ExtractEdges.
+//   - Runtime graph handler (Phase 2) —
+//     pkg/corerp/frontend/controller/applications/v20250801preview.
+//     Populates Resource.DependsOn from the caller-supplied
+//     dependsOnEdges field on the GetGraphRequest wire (NOT from a
+//     server-side property scan). Resource.Connections comes from the
+//     resource's stored properties.connections[*].source, which is
+//     already a canonical Radius resource ID at that point. Everything
+//     else — exclusion, Connection-wins de-dup, mirroring — is reused
+//     verbatim.
+//
+// The package intentionally imports nothing from pkg/cli/, pkg/corerp/,
+// or net/http. Verified with `go list -deps ./pkg/graph/edges/...`.
+// Keeping the primitive dependency-free is what makes Phase 2 a wiring
+// change rather than a re-implementation (FR-017..FR-019).
+//
+// Future extensibility: if a second configuration knob becomes
+// necessary (for example, an option to emit diagnostic reasons for
+// dropped edges), promote both arguments into an ExtractOptions
+// struct. Keeping a single positional argument today (Constitution
+// VII, Simplicity Over Cleverness) avoids paying that cost until a
+// real need materializes.
+func ExtractEdges(resources []Resource, excluded map[string]struct{}) []Edge {
+	// Build a canonical-ID → Type map for O(1) target validation.
+	// Every candidate target must resolve to a Resource in this map;
+	// unresolved targets and targets whose type is excluded are
+	// silently dropped.
+	byID := make(map[string]string, len(resources))
+	for i := range resources {
+		byID[resources[i].ID] = resources[i].Type
+	}
+
+	validTarget := func(id string) bool {
+		typ, ok := byID[id]
+		if !ok {
+			return false
+		}
+		_, isExcluded := excluded[typ]
+		return !isExcluded
+	}
+
+	// Collect outbound edges keyed by (source, target) → Kind so that
+	// a Connection recorded first is never downgraded to a Dependency
+	// by a same-pair dependsOn entry (Connection-wins, FR-011). Also
+	// collapses multiple dependsOn tokens targeting the same resource
+	// to one edge (FR-012).
+	type pair struct{ src, tgt string }
+	outbound := make(map[pair]string)
+
+	for _, r := range resources {
+		if _, isExcluded := excluded[r.Type]; isExcluded {
+			continue // excluded types are never sources
+		}
+
+		// Connection edges from author-declared Connections.
+		for _, target := range r.Connections {
+			if !validTarget(target) {
+				continue
+			}
+			// Connection wins: overwrite any pre-existing entry (there
+			// shouldn't be one from Connection, but this makes the
+			// invariant explicit).
+			outbound[pair{r.ID, target}] = KindConnection
+		}
+
+		// Dependency edges from DependsOn. Skip if the pair is already
+		// a Connection (Connection-wins). Collapse duplicate tokens.
+		for _, dep := range r.DependsOn {
+			if !validTarget(dep) {
+				continue
+			}
+			k := pair{r.ID, dep}
+			if _, exists := outbound[k]; exists {
+				continue
+			}
+			outbound[k] = KindDependency
+		}
+	}
+
+	// Emit outbound edges + mirrored inbound edges. Mirroring preserves
+	// Kind per FR-010.
+	out := make([]Edge, 0, len(outbound)*2)
+	for p, kind := range outbound {
+		out = append(out, Edge{
+			Source:    p.src,
+			Target:    p.tgt,
+			Direction: DirectionOutbound,
+			Kind:      kind,
+		})
+		out = append(out, Edge{
+			Source:    p.src,
+			Target:    p.tgt,
+			Direction: DirectionInbound,
+			Kind:      kind,
+		})
+	}
+
+	// Deterministic sort so callers can compare or diff the output.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Source != out[j].Source {
+			return out[i].Source < out[j].Source
+		}
+		if out[i].Target != out[j].Target {
+			return out[i].Target < out[j].Target
+		}
+		if out[i].Direction != out[j].Direction {
+			return out[i].Direction < out[j].Direction
+		}
+		return out[i].Kind < out[j].Kind
+	})
+
+	return out
+}

--- a/pkg/graph/edges/edges_test.go
+++ b/pkg/graph/edges/edges_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edges
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test IDs. Short strings; the extractor is agnostic to their shape as
+// long as they compare equal.
+const (
+	containerAID    = "/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containers/a"
+	containerBID    = "/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containers/b"
+	queueID         = "/planes/radius/local/resourcegroups/default/providers/Radius.Messaging/rabbitMQ/q"
+	appScopeID      = "/planes/radius/local/resourcegroups/default/providers/Radius.Core/applications/scope"
+	unknownID       = "/planes/radius/local/resourcegroups/default/providers/Unknown.Ns/things/x"
+	containerType   = "Radius.Compute/containers"
+	queueType       = "Radius.Messaging/rabbitMQ"
+	appScopeType    = "Radius.Core/applications"
+	radiusCoreScope = "Radius.Core/applications"
+)
+
+// TestExtractEdges is the exhaustive table-driven test for the extractor.
+// Each case sets up a small resource graph, calls ExtractEdges, and
+// asserts on the exact returned edge slice (already sorted
+// deterministically by (Source, Target, Direction, Kind)).
+func TestExtractEdges(t *testing.T) {
+	t.Parallel()
+
+	excluded := map[string]struct{}{
+		radiusCoreScope: {},
+	}
+
+	tests := []struct {
+		name      string
+		resources []Resource
+		excluded  map[string]struct{}
+		want      []Edge
+	}{
+		{
+			name:      "empty input produces empty output",
+			resources: nil,
+			excluded:  excluded,
+			want:      []Edge{},
+		},
+		{
+			name: "single Connection edge produces outbound plus mirrored inbound",
+			resources: []Resource{
+				{
+					ID:          containerAID,
+					Type:        containerType,
+					Connections: []string{queueID},
+				},
+				{ID: queueID, Type: queueType},
+			},
+			excluded: excluded,
+			want: []Edge{
+				{Source: containerAID, Target: queueID, Direction: DirectionInbound, Kind: KindConnection},
+				{Source: containerAID, Target: queueID, Direction: DirectionOutbound, Kind: KindConnection},
+			},
+		},
+		{
+			name: "single Dependency edge produces outbound plus mirrored inbound",
+			resources: []Resource{
+				{
+					ID:        containerAID,
+					Type:      containerType,
+					DependsOn: []string{queueID},
+				},
+				{ID: queueID, Type: queueType},
+			},
+			excluded: excluded,
+			want: []Edge{
+				{Source: containerAID, Target: queueID, Direction: DirectionInbound, Kind: KindDependency},
+				{Source: containerAID, Target: queueID, Direction: DirectionOutbound, Kind: KindDependency},
+			},
+		},
+		{
+			name: "same pair from both sources: Connection wins over Dependency",
+			resources: []Resource{
+				{
+					ID:          containerAID,
+					Type:        containerType,
+					Connections: []string{queueID},
+					DependsOn:   []string{queueID},
+				},
+				{ID: queueID, Type: queueType},
+			},
+			excluded: excluded,
+			want: []Edge{
+				{Source: containerAID, Target: queueID, Direction: DirectionInbound, Kind: KindConnection},
+				{Source: containerAID, Target: queueID, Direction: DirectionOutbound, Kind: KindConnection},
+			},
+		},
+		{
+			name: "multiple dependsOn tokens to same target collapse to one edge",
+			resources: []Resource{
+				{
+					ID:        containerAID,
+					Type:      containerType,
+					DependsOn: []string{queueID, queueID, queueID},
+				},
+				{ID: queueID, Type: queueType},
+			},
+			excluded: excluded,
+			want: []Edge{
+				{Source: containerAID, Target: queueID, Direction: DirectionInbound, Kind: KindDependency},
+				{Source: containerAID, Target: queueID, Direction: DirectionOutbound, Kind: KindDependency},
+			},
+		},
+		{
+			name: "fan-in with mixed kinds preserves each source's kind on the target",
+			resources: []Resource{
+				{
+					ID:          containerAID,
+					Type:        containerType,
+					Connections: []string{queueID},
+				},
+				{
+					ID:        containerBID,
+					Type:      containerType,
+					DependsOn: []string{queueID},
+				},
+				{ID: queueID, Type: queueType},
+			},
+			excluded: excluded,
+			want: []Edge{
+				{Source: containerAID, Target: queueID, Direction: DirectionInbound, Kind: KindConnection},
+				{Source: containerAID, Target: queueID, Direction: DirectionOutbound, Kind: KindConnection},
+				{Source: containerBID, Target: queueID, Direction: DirectionInbound, Kind: KindDependency},
+				{Source: containerBID, Target: queueID, Direction: DirectionOutbound, Kind: KindDependency},
+			},
+		},
+		{
+			name: "edge target of excluded type is dropped (no node, no edge, no mirror)",
+			resources: []Resource{
+				{
+					ID:        containerAID,
+					Type:      containerType,
+					DependsOn: []string{appScopeID},
+				},
+				// Excluded resource is present in the input list.
+				// The extractor must not treat it as a valid target.
+				{ID: appScopeID, Type: appScopeType},
+			},
+			excluded: excluded,
+			want:     []Edge{},
+		},
+		{
+			name: "edge target not in the resource set is dropped",
+			resources: []Resource{
+				{
+					ID:        containerAID,
+					Type:      containerType,
+					DependsOn: []string{unknownID},
+				},
+			},
+			excluded: excluded,
+			want:     []Edge{},
+		},
+		{
+			name: "excluded source emits no edges even if it has connections",
+			resources: []Resource{
+				{
+					ID:          appScopeID,
+					Type:        appScopeType,
+					Connections: []string{queueID},
+				},
+				{ID: queueID, Type: queueType},
+			},
+			excluded: excluded,
+			want:     []Edge{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ExtractEdges(tc.resources, tc.excluded)
+			if got == nil {
+				got = []Edge{}
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestExtractEdges_OwnerPeer verifies the Edge.Owner / Edge.Peer helpers
+// used by callers when materializing wire-model entries.
+func TestExtractEdges_OwnerPeer(t *testing.T) {
+	t.Parallel()
+
+	out := Edge{Source: "a", Target: "b", Direction: DirectionOutbound, Kind: KindConnection}
+	require.Equal(t, "a", out.Owner())
+	require.Equal(t, "b", out.Peer())
+
+	in := Edge{Source: "a", Target: "b", Direction: DirectionInbound, Kind: KindConnection}
+	require.Equal(t, "b", in.Owner())
+	require.Equal(t, "a", in.Peer())
+}
+
+// TestExtractEdges_SortDeterminism confirms the returned edge slice is
+// deterministic across input orderings: shuffling the input resources
+// must not change the output.
+func TestExtractEdges_SortDeterminism(t *testing.T) {
+	t.Parallel()
+
+	base := []Resource{
+		{ID: containerAID, Type: containerType, DependsOn: []string{queueID}},
+		{ID: containerBID, Type: containerType, DependsOn: []string{queueID}},
+		{ID: queueID, Type: queueType},
+	}
+	shuffled := []Resource{base[2], base[0], base[1]}
+
+	require.Equal(t,
+		ExtractEdges(base, nil),
+		ExtractEdges(shuffled, nil),
+	)
+}

--- a/specs/004-graph-dependency-edges/checklists/requirements.md
+++ b/specs/004-graph-dependency-edges/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Application Graph Dependency Edges
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Content Quality items are held to a *pragmatic* standard: this is an internal-engineering spec for a graph-model change, so it names two specific Go source files (`pkg/cli/graph/modeled.go`, `pkg/corerp/frontend/controller/applications/graph_util.go`) and two TypeSpec files as anchor points. That is consistent with the other in-repo specs (e.g. `specs/003-resource-type-icons`), which also name concrete files. It is not a general-audience product spec.
+- Every requirement is verifiable by inspecting the static-graph response for the [`rabbitmq-app`](../../../my-radius-recipes/deploy/edges/rabbitmq-app.bicep) fixture or the existing runtime-graph tests.
+- Phase 2 is intentionally out of scope for this spec; a follow-up spec will cover it once Phase 1 lands.

--- a/specs/004-graph-dependency-edges/contracts/wire-change.md
+++ b/specs/004-graph-dependency-edges/contracts/wire-change.md
@@ -1,0 +1,69 @@
+# Wire-Change Contract — Radius.Core/2025-08-01-preview
+
+**Feature**: [spec.md](../spec.md) · **Plan**: [plan.md](../plan.md) · **Date**: 2026-07-16
+
+This is the exact TypeSpec-source-level change that lands on the `Radius.Core/2025-08-01-preview` API surface. Every downstream artifact (`swagger/`, `pkg/corerp/api/v20250801preview/zz_generated_models.go`, Bicep types) is regenerated from this source via `make generate`.
+
+**Scope constraint (FR-016)**: `Applications.Core` TypeSpec, generated code, and clients are not touched.
+
+## File changed
+
+[typespec/Radius.Core/applications.tsp](../../../typespec/Radius.Core/applications.tsp)
+
+## Diff (added lines)
+
+```typespec
+@doc("The origin of a connection: 'Connection' for author-declared entries in properties.connections, 'Dependency' for implicit entries derived from Bicep's dependsOn list.")
+enum ConnectionKind {
+  @doc("The edge was declared by the author in properties.connections.")
+  Connection,
+
+  @doc("The edge was inferred from a Bicep dependsOn entry (implicit dependency). Not emitted by the runtime graph in Phase 1 — runtime dependency extraction is Phase 2.")
+  Dependency,
+}
+```
+
+And inside `model ApplicationGraphConnection`:
+
+```typespec
+model ApplicationGraphConnection {
+  @doc("The resource ID ")
+  id: string;
+
+  @doc("The direction of the connection. 'Outbound' indicates this connection specifies the ID of the destination and 'Inbound' indicates indicates this connection specifies the ID of the source.")
+  direction: Direction;
+
+  @doc("Discriminator identifying the origin of this edge. Connection edges are author-declared entries under properties.connections. Dependency edges are implicit dependencies derived from Bicep's dependsOn list (static graph only in Phase 1). Every emitted edge carries a kind.")
+  kind: ConnectionKind;
+}
+```
+
+## Compatibility
+
+- `Radius.Core/2025-08-01-preview` is a **preview** version; additive changes are permitted per Constitution IX ("Incremental Adoption & Backward Compatibility") because the surface has not yet been marked stable.
+- `kind` is **required** (not `kind?:`). Making it optional would introduce a producer-less "unset" state (see [research.md](../research.md#r-003--wire-model-for-kind)).
+- Consumers that already parse `Direction` and treat unknown enum members leniently need no change. Consumers that key strictly off the enum shape will need to regenerate their client (dashboard, third-party SDKs).
+
+## Regenerated artifacts
+
+Committed alongside the TypeSpec change, produced by `make generate` at the repository root:
+
+- `swagger/specification/core/resource-manager/Radius.Core/preview/2025-08-01-preview/applications.json` — new `ConnectionKind` schema, new `kind` property on the `ApplicationGraphConnection` schema.
+- `pkg/corerp/api/v20250801preview/zz_generated_models.go` — Go structs regenerated. New `ConnectionKind` type (string alias with two constants) and new `Kind *ConnectionKind` field on `ApplicationGraphConnection`.
+- Bicep type extensions (if the extension consumes this model) — regenerated via the existing Bicep tooling in `bicep-tools/`.
+
+CI enforces that all regenerated files match the current TypeSpec source. The plan includes a task to run `make generate` and commit the diff.
+
+## Handler behavior after regeneration
+
+**Static graph builder** — [`pkg/cli/graph/modeled.go`](../../../pkg/cli/graph/modeled.go): sets `Kind` on every edge. `Connection` for `properties.connections` entries, `Dependency` for `dependsOn` entries. Connection-wins de-dup keeps at most one edge per `(Source, Target)` pair.
+
+**Runtime handler (Radius.Core preview)** — [`pkg/corerp/frontend/controller/applications/v20250801preview/getgraph.go`](../../../pkg/corerp/frontend/controller/applications/v20250801preview/getgraph.go): sets `Kind: Connection` on every emitted edge, unconditionally. Runtime `Dependency` extraction is Phase 2.
+
+**Runtime handler (Applications.Core)** — untouched. Its wire model has no `kind` field.
+
+## Non-goals in this contract
+
+- No changes to `ApplicationGraphResource`, `ApplicationGraphOutputResource`, `Direction`, or `ApplicationGraphResponse`.
+- No new query parameters, headers, or endpoints.
+- No changes to `Applications.Core` (any version).

--- a/specs/004-graph-dependency-edges/data-model.md
+++ b/specs/004-graph-dependency-edges/data-model.md
@@ -1,0 +1,148 @@
+# Phase 1 Data Model — Application Graph Dependency Edges
+
+**Feature**: [spec.md](spec.md) · **Plan**: [plan.md](plan.md) · **Date**: 2026-07-16
+
+Two data models are introduced or modified in Phase 1.
+
+- The **internal Go types** exposed by the new `pkg/graph/edges/` package — pure Go, no ARM syntax, no HTTP.
+- The **wire type** on `Radius.Core/2025-08-01-preview` — one new enum, one new field. See [contracts/wire-change.md](contracts/wire-change.md) for the TypeSpec diff itself.
+
+## `pkg/graph/edges/` — Go types
+
+### `Resource` (input)
+
+```go
+// Resource is a graph-eligible Radius resource as seen by the edge
+// extractor. Callers convert their own representation (ARM JSON entry,
+// stored resource record, etc.) into this shape before calling
+// ExtractEdges.
+type Resource struct {
+    // ID is the canonical Radius resource ID
+    // ("/planes/radius/local/resourcegroups/…/providers/{ns}/{type}/{name}").
+    ID string
+
+    // Type is the Radius resource type ("Radius.Compute/containers").
+    Type string
+
+    // Properties is the resource's authored properties. The extractor
+    // inspects properties["connections"] for author-declared connections.
+    // Other keys are ignored in Phase 1.
+    Properties map[string]any
+
+    // DependsOn is the list of already-resolved canonical Radius resource
+    // IDs the resource declares as build-time dependencies. The static
+    // caller populates this from resolveDependsOn. The runtime caller
+    // passes nil in Phase 1.
+    DependsOn []string
+}
+```
+
+**Validation & invariants**:
+
+- `ID` is required and MUST be a canonical Radius resource ID.
+- `Type` is required.
+- `Properties` may be nil.
+- `DependsOn` entries MUST be canonical resource IDs (not `[resourceId(...)]` expressions, not symbolic names). ARM-form entries are rejected by the caller before invoking `ExtractEdges` — the extractor does not parse ARM syntax (FR-019).
+
+### `Edge` (output)
+
+```go
+// Edge is a single directed edge in the application graph.
+type Edge struct {
+    // Source is the canonical resource ID of the edge's source node.
+    Source string
+
+    // Target is the canonical resource ID of the edge's target node.
+    Target string
+
+    // Direction is "Outbound" or "Inbound".
+    Direction string
+
+    // Kind is "Connection" (from properties.connections) or "Dependency"
+    // (from dependsOn). Case-sensitive, matches the wire enum values on
+    // Radius.Core/2025-08-01-preview.
+    Kind string
+}
+```
+
+**Invariants**:
+
+- Every `Outbound` edge from `A → B` MUST be accompanied by an `Inbound` edge from `A → B` on `B` with the same `Kind` (mirroring, FR-010).
+- No emitted `Edge` has `Source` or `Target` in the exclusion list (FR-002).
+- For any `(Source, Target)` pair on the same source resource, at most one outbound `Edge` is emitted. When both a `Connection` and a `Dependency` would be emitted for the same pair, `Connection` wins (FR-011). The corresponding mirrored inbound entry on `Target` carries the winning `Kind`.
+
+### `ExtractEdges` (public function)
+
+```go
+// ExtractEdges returns the deduplicated, mirrored edge list for the
+// given resources, dropping any edge whose source or target type is
+// present in the excluded set.
+//
+// excluded holds canonical "Namespace/type" strings that MUST NOT
+// appear as graph nodes or edge targets. Callers control membership so
+// the same primitive can be used with different exclusion sets (static
+// vs runtime).
+//
+// The output is sorted deterministically by (Source, Target, Direction,
+// Kind) so callers can compare or diff it.
+//
+// ExtractEdges never returns an error: unresolvable dependsOn entries
+// and edges targeting excluded types are silently dropped (see spec
+// edge cases).
+//
+// Future extensibility: if a second configuration knob becomes
+// necessary (for example, an option to emit diagnostic reasons for
+// dropped edges), promote both arguments into an ExtractOptions struct.
+// Keeping a single positional argument today (Constitution VII) avoids
+// paying that cost until a real need materializes.
+func ExtractEdges(resources []Resource, excluded map[string]struct{}) []Edge
+```
+
+The current exclusion-set membership is defined in the static caller — see FR-005 in the spec. Copying the same map into the runtime caller is Phase 2's opt-in.
+
+## Wire model — `Radius.Core/2025-08-01-preview`
+
+See [contracts/wire-change.md](contracts/wire-change.md) for the exact TypeSpec diff. Summary:
+
+- **New enum** `ConnectionKind` with members `Connection` and `Dependency`.
+- **New required field** `kind: ConnectionKind` on `ApplicationGraphConnection`.
+
+Every existing field on `ApplicationGraphConnection` is unchanged. No fields are added elsewhere on `ApplicationGraphResponse` or `ApplicationGraphResource`.
+
+## Relationships
+
+```mermaid
+classDiagram
+    class Resource {
+        +string ID
+        +string Type
+        +map[string]any Properties
+        +string[] DependsOn
+    }
+
+    class Edge {
+        +string Source
+        +string Target
+        +string Direction
+        +string Kind
+    }
+
+    class ApplicationGraphConnection {
+        +string id
+        +Direction direction
+        +ConnectionKind kind
+    }
+
+    class ApplicationGraphResource {
+        +string id
+        +string type
+        +string name
+        +Array~ApplicationGraphConnection~ connections
+    }
+
+    Resource "1..*" --> "0..*" Edge : ExtractEdges produces
+    Edge ..> ApplicationGraphConnection : converted per API version
+    ApplicationGraphResource "1" *-- "0..*" ApplicationGraphConnection : owns
+```
+
+The `Edge → ApplicationGraphConnection` conversion happens in each API version's converter. Applications.Core converters drop `Kind`; Radius.Core preview converters carry it through.

--- a/specs/004-graph-dependency-edges/plan.md
+++ b/specs/004-graph-dependency-edges/plan.md
@@ -1,0 +1,148 @@
+# Implementation Plan: Application Graph Dependency Edges
+
+**Branch**: `edges` (working name; will rename to `004-graph-dependency-edges` when moved to a feature branch) | **Date**: 2026-07-16 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/004-graph-dependency-edges/spec.md`
+
+**Note**: `.specify/scripts/bash/setup-plan.sh` requires a `NNN-feature-name` branch and refuses to run on `edges`. Artifacts in this directory are created manually against the feature directory recorded in `.specify/feature.json` (`specs/004-graph-dependency-edges`).
+
+## Summary
+
+Phase 1 of a two-phase change to the Radius application graph, scoped to the `Radius.Core/2025-08-01-preview` API surface.
+
+- **Static graph builder** (`pkg/cli/graph/modeled.go`) gains a second edge source: Bicep's compiled `dependsOn` array. Edges are tagged `kind: Connection` (from `properties.connections`) or `kind: Dependency` (from `dependsOn`). Connection wins when both sources signal the same source-target pair.
+- **Exclusion list**: `Radius.Core/applications`, `Radius.Core/environments`, `Radius.Core/recipePacks`, `Applications.Core/applications`, `Applications.Core/environments`. Members are never graph nodes and never edge targets.
+- **Wire model**: `ApplicationGraphConnection` on `Radius.Core/2025-08-01-preview` gains a `kind` field. `Applications.Core` TypeSpec, generated code, handlers, and tests are untouched.
+- **Runtime handler** (Radius.Core preview): sets `kind: Connection` on every edge it emits. `Dependency` edges at runtime are Phase 2.
+- **Shared primitives**: extraction, resolution, exclusion, mirroring, and Connection-wins de-dup live in a new neutral package `pkg/graph/edges/` so Phase 2's runtime dependency scan is a wiring change, not a re-implementation.
+
+## Technical Context
+
+**Language/Version**: Go 1.26.5 (per `go.mod`)
+**Primary Dependencies**: standard library only for the new package (`sort`, `strings`, `strconv`). Consumers already depend on TypeSpec-generated preview models under `pkg/corerp/api/v20250801preview/`.
+**Storage**: N/A (build-time and in-memory operations)
+**Testing**: `go test` with `stretchr/testify` (existing repo convention); table-driven tests in every new/modified file. Regenerated code kept in sync via `make generate`.
+**Target Platform**: Radius control plane (Linux server binary) and `rad` CLI (macOS/Linux/Windows).
+**Project Type**: Single Go module `github.com/radius-project/radius`.
+**Performance Goals**: Static graph must build the `rabbitmq-app` fixture in under 50 ms (informational; not a hard SLO). No new hot-path allocations on the runtime handler.
+**Constraints**: No wire changes to `Applications.Core`. `kind` is additive on `Radius.Core/2025-08-01-preview`, which is still `-preview` so additive change is safe. No new external dependencies.
+**Scale/Scope**: A typical Radius application graph is <100 resources; extraction is O(N × M) where N is resource count and M is average `dependsOn` length. No scaling concerns.
+
+## Constitution Check
+
+*GATE: Passed at plan authoring time. Re-verified after research and data-model artifacts.*
+
+| Principle | Verdict | Note |
+|-----------|---------|------|
+| I. API-First Design | ✅ | Wire change authored in TypeSpec (`typespec/Radius.Core/applications.tsp`); Go models regenerated via `make generate`. |
+| II. Idiomatic Code Standards | ✅ | New package `pkg/graph/edges/` follows `gofmt`, small exported surface, godoc on every exported symbol, table-driven tests. |
+| III. Multi-Cloud Neutrality | N/A | Graph representation is cloud-agnostic; no cloud-specific logic added. |
+| IV. Testing Pyramid Discipline | ✅ | Unit tests for the new package cover: connection extraction, `dependsOn` resolution, exclusion, mirroring, Connection-wins de-dup, symbolic + `resourceId()` forms. Integration coverage via existing `pkg/cli/graph/modeled_test.go` (extended) and preview handler tests. |
+| V. Collaboration-Centric Design | ✅ | Developers see accurate dependency edges; platform engineers get a troubleshooting discriminator (`kind`) they can filter on. |
+| VI. Open Source and Community-First | ✅ | Spec and plan authored in the public repo; commits will carry `Signed-off-by`. |
+| VII. Simplicity Over Cleverness | ✅ | Reuses the existing `resolveDependsOn` helper; new package is a small pure-Go primitive layer with no reflection, no code-gen, no interfaces exceeding the callers' needs. |
+| VIII. Separation of Concerns | ✅ | `pkg/graph/edges/` has no CLI or control-plane imports; callers convert their own inputs into its pure-Go shape. |
+| IX. Incremental Adoption & Backward Compatibility | ✅ | `Applications.Core` is frozen. `Radius.Core/2025-08-01-preview` is not yet stable, so adding a required field on `ApplicationGraphConnection` is safe. |
+| XII / XIII (resource type / recipe standards) | N/A | No resource types or recipes are affected. |
+| XVII. Polyglot Project Coherence | ✅ | TypeSpec is the single source of truth for the wire; Go generated code follows. Dashboard consumers will pick up `kind` when they regenerate their preview model. |
+
+**No violations. Complexity Tracking section is empty.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-graph-dependency-edges/
+├── plan.md              # This file (/speckit.plan output)
+├── spec.md              # /speckit.specify + /speckit.clarify output
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── wire-change.md
+└── checklists/
+    └── requirements.md  # /speckit.specify + /speckit.clarify output
+```
+
+### Source Code (repository root)
+
+New package + edited files, all within the existing single Go module:
+
+```text
+# New — shared extraction primitives
+pkg/graph/edges/
+├── edges.go             # Resource, Edge, ExtractEdges, exclusion list type
+├── edges_test.go        # Table-driven unit tests
+└── doc.go               # Package-level godoc
+
+# Edited — static graph builder consumes the new primitives
+pkg/cli/graph/
+├── modeled.go
+├── modeled_test.go
+
+# Edited — TypeSpec wire change (source of truth)
+typespec/Radius.Core/
+└── applications.tsp     # Add ConnectionKind enum + kind field on ApplicationGraphConnection
+
+# Regenerated — Go models + OpenAPI (via `make generate`)
+pkg/corerp/api/v20250801preview/
+└── zz_generated_models.go   # DO-NOT-EDIT; regenerated
+
+swagger/specification/core/resource-manager/Radius.Core/preview/2025-08-01-preview/
+└── applications.json        # Regenerated from TypeSpec
+
+# Edited — runtime handler for Radius.Core preview sets kind: Connection
+pkg/corerp/frontend/controller/applications/v20250801preview/
+└── getgraph.go              # response conversion sets kind on every edge
+└── getgraph_test.go         # golden updates
+
+# Untouched (explicit non-goal, enforced by FR-016)
+pkg/corerp/frontend/controller/applications/    # Applications.Core internal graph builder
+typespec/Applications.Core/                     # Applications.Core TypeSpec
+
+# Edited — architecture docs
+docs/architecture/application-graph.md
+```
+
+**Structure Decision**: Single Go module; add the new package under `pkg/graph/edges/`. This avoids two anti-patterns: (a) importing CLI code from the control plane if the primitives lived in `pkg/cli/graph/`, and (b) overloading the generic `pkg/algorithm/graph/` package (which is a domain-neutral dependency-graph algorithm library) with Radius-specific exclusion rules.
+
+## Phase 0 — Research
+
+See [research.md](research.md). Summary of resolved unknowns:
+
+1. **`dependsOn` shape after `collectResources` normalization** — always canonical `[resourceId('TYPE','NAME')]` strings after normalization; symbolic-name entries from languageVersion 2.0 are rewritten upstream. Reuse `resolveDependsOn` verbatim.
+2. **Existing `resolveDependsOn` signature and behavior** — returns canonical Radius resource IDs; already used by `DiffHash`. No change needed.
+3. **Wire model shape** — `ApplicationGraphConnection` today has `id` (string) and `direction` (`enum Direction { Outbound, Inbound }`). Adding a required `kind: ConnectionKind` field with `Connection` and `Dependency` members mirrors the `Direction` enum exactly.
+4. **How to regenerate Go from TypeSpec** — `make generate` at the repository root (see `CONTRIBUTING.md`, section "Generated code"). CI enforces that generated files are checked in.
+5. **Where the Applications.Core / Radius.Core preview conversion happens** — the shared internal builder in `pkg/corerp/frontend/controller/applications/graph_util.go` returns an internal representation; each API version's handler (Applications.Core in the parent directory, Radius.Core preview under `v20250801preview/`) converts it to its own wire model. Radius.Core preview conversion is where we set `kind: Connection`. The shared internal builder does not need to change in Phase 1.
+
+## Phase 1 — Design Artifacts
+
+### Data Model — [data-model.md](data-model.md)
+
+Defines the three exported Go entities in `pkg/graph/edges/`:
+
+- `Resource`: `{ ID string; Type string; Properties map[string]any; DependsOn []string }` — pure Go input, no ARM syntax, no HTTP.
+- `Edge`: `{ Source string; Target string; Direction string; Kind string }` — pure Go output.
+- `ExtractEdges(resources []Resource, excluded map[string]struct{}) []Edge` — the public entry point. Plain parameter for the exclusion set today (Constitution VII); promote to a struct if a second knob emerges.
+
+### Contracts — [contracts/wire-change.md](contracts/wire-change.md)
+
+TypeSpec diff on `Radius.Core/2025-08-01-preview`:
+
+- Add `enum ConnectionKind { Connection, Dependency }`.
+- Add `kind: ConnectionKind` to `ApplicationGraphConnection`.
+
+No other API surface is touched. Regenerated Go models and OpenAPI are committed alongside the TypeSpec change.
+
+### Quickstart — [quickstart.md](quickstart.md)
+
+End-to-end verification recipe against the `rabbitmq-app` fixture: `bicep build` → `rad app graph -f rabbitmq-app.json` → assertions on node count, edge count, and `kind` per edge.
+
+### Agent context
+
+No agent-context update required for this feature (no new agent capabilities are introduced).
+
+## Complexity Tracking
+
+Not applicable — no principle violations.

--- a/specs/004-graph-dependency-edges/quickstart.md
+++ b/specs/004-graph-dependency-edges/quickstart.md
@@ -1,0 +1,121 @@
+# Quickstart — Verify Application Graph Dependency Edges (Phase 1)
+
+**Feature**: [spec.md](spec.md) · **Plan**: [plan.md](plan.md) · **Date**: 2026-07-16
+
+End-to-end verification against the `rabbitmq-app` fixture from Story 1 / Story 2 of the spec. Assumes the branch is built locally and `bicep` and `rad` are on `PATH`.
+
+## Prerequisites
+
+1. Radius repo built locally: `make build`.
+2. Bicep CLI installed (`bicep --version`).
+3. Fixtures cloned at `../my-radius-recipes/deploy/edges/` (sibling to this repo — see the spec's plain-text file paths).
+
+## Steps
+
+### 1. Compile the fixture
+
+```bash
+cd ../my-radius-recipes/deploy/edges
+bicep build rabbitmq-app.bicep -o rabbitmq-app.json
+```
+
+Expected: `rabbitmq-app.json` is refreshed. Sanity check that both `dependsOn` blocks and the `connections.rabbitmq.source` expression appear as spec'd in [spec.md § Concrete example](spec.md#concrete-example--rabbitmq-app).
+
+### 2. Build the static graph
+
+```bash
+cd -   # back to the radius repo
+./bin/rad app graph -f ../my-radius-recipes/deploy/edges/rabbitmq-app.json > /tmp/static-graph-rabbit.json
+```
+
+### 3. Assert two graph nodes, zero excluded nodes
+
+```bash
+jq '.resources | length' /tmp/static-graph-rabbit.json
+# Expected: 2
+
+jq -r '.resources[].type' /tmp/static-graph-rabbit.json | sort
+# Expected (exactly, no duplicates):
+#   Radius.Compute/containers
+#   Radius.Messaging/rabbitMQ
+
+# Radius.Core/applications must NOT appear.
+jq -r '.resources[].id' /tmp/static-graph-rabbit.json | grep -c 'Radius.Core/applications'
+# Expected: 0
+```
+
+### 4. Assert exactly one edge between consumer and rabbitmq, tagged Connection
+
+```bash
+# Outbound edge on consumer.
+jq -r '.resources[] | select(.name == "consumer") | .connections[]' /tmp/static-graph-rabbit.json
+# Expected (single entry):
+#   {
+#     "direction": "Outbound",
+#     "id": "/planes/radius/local/resourcegroups/default/providers/Radius.Messaging/rabbitMQ/rabbitmq",
+#     "kind": "Connection"
+#   }
+
+# Mirrored inbound edge on rabbitmq.
+jq -r '.resources[] | select(.name == "rabbitmq") | .connections[]' /tmp/static-graph-rabbit.json
+# Expected (single entry):
+#   {
+#     "direction": "Inbound",
+#     "id": "/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containers/consumer",
+#     "kind": "Connection"
+#   }
+```
+
+Connection wins over the same-pair `Dependency` — this is SC-001.
+
+### 5. Assert `dependsOn: ["app"]` produced no edges
+
+```bash
+# No edge on any node should target Radius.Core/applications/rabbitmq-app.
+jq -r '[.resources[].connections[].id] | map(select(contains("Radius.Core/applications")))' /tmp/static-graph-rabbit.json
+# Expected: []
+```
+
+This is SC-001's exclusion clause + Story 2 case #2.
+
+### 6. Assert a `Dependency`-tagged edge appears when a `connections` block is absent
+
+Create a variant fixture where `consumer` has no `properties.connections` block but still reads `rabbitmq.properties.secrets.name` via `secretKeyRef`. Bicep still emits `dependsOn: ["rabbitmq"]`. Build the static graph and assert:
+
+```bash
+jq -r '.resources[] | select(.name == "consumer") | .connections[]' /tmp/static-graph-rabbit-nodeps.json
+# Expected:
+#   { "direction": "Outbound", "id": "/…/rabbitMQ/rabbitmq", "kind": "Dependency" }
+
+jq -r '.resources[] | select(.name == "rabbitmq") | .connections[]' /tmp/static-graph-rabbit-nodeps.json
+# Expected:
+#   { "direction": "Inbound", "id": "/…/containers/consumer", "kind": "Dependency" }
+```
+
+This is SC-002.
+
+### 7. Confirm runtime graph is unchanged (Applications.Core) and gained `kind: Connection` (Radius.Core preview)
+
+```bash
+# Applications.Core existing test suite — byte-identical goldens.
+go test ./pkg/corerp/frontend/controller/applications/... -count=1
+
+# Radius.Core preview tests — golden files updated to include kind: Connection.
+go test ./pkg/corerp/frontend/controller/applications/v20250801preview/... -count=1
+```
+
+Both green: SC-003.
+
+## What "success" looks like
+
+- The static graph output for `rabbitmq-app` has exactly 2 nodes and exactly 1 edge between them (mirrored on both sides), tagged `Connection`.
+- The variant fixture with no `connections` block has exactly 1 edge tagged `Dependency`.
+- All existing Applications.Core tests pass byte-identical to before.
+- All Radius.Core preview tests pass; their goldens gained `kind: Connection` on every edge.
+
+## Troubleshooting
+
+- **Node count is 3 (still shows `rabbitmq-app`)** → the exclusion list didn't pick up `Radius.Core/applications`. Verify FR-005 membership in [pkg/cli/graph/modeled.go](../../pkg/cli/graph/modeled.go).
+- **Two edges appear between `consumer` and `rabbitmq`** → Connection-wins de-dup is not firing. Verify FR-011 in [`pkg/graph/edges/edges.go`](../../pkg/graph/edges/edges.go).
+- **`kind` is missing on runtime responses** → the Radius.Core preview converter isn't setting it. Verify FR-014 in the v20250801preview handler.
+- **`Applications.Core` test golden files diff** → the shared internal builder in [graph_util.go](../../pkg/corerp/frontend/controller/applications/graph_util.go) changed. It must not (FR-016).

--- a/specs/004-graph-dependency-edges/research.md
+++ b/specs/004-graph-dependency-edges/research.md
@@ -1,0 +1,91 @@
+# Phase 0 Research — Application Graph Dependency Edges
+
+**Feature**: [spec.md](spec.md) · **Plan**: [plan.md](plan.md) · **Date**: 2026-07-16
+
+The plan raised five unknowns. All are resolved from the current codebase — no external research required. Each entry names the decision, the rationale, and the code reference.
+
+## R-001 · Shape of `dependsOn` after `collectResources` normalization
+
+**Decision**: Use `resolveDependsOn` as-is; it returns canonical `[resourceId('TYPE','NAME')]`-derived Radius resource IDs.
+
+**Rationale**: [pkg/cli/graph/modeled.go](../../pkg/cli/graph/modeled.go) already normalizes ARM `languageVersion` 2.0 symbolic-name templates into the classic `[resourceId(...)]` form in `collectResources` / `rewriteSymbolicConnections` / `normalizeSymbolicEntry` before any consumer sees a resource entry. `resolveDependsOn` — the same helper `DiffHash` uses — parses those strings into canonical IDs. The dependency-edge extraction reuses that helper verbatim; no new parser is required.
+
+**Alternatives considered**:
+
+- Rolling a second parser inside the new `pkg/graph/edges/` package. Rejected: duplicates logic already covered by `resolveDependsOn` and doubles the maintenance surface for a well-tested transformation.
+
+## R-002 · Existing `resolveDependsOn` reuse
+
+**Decision**: Keep `resolveDependsOn` in `pkg/cli/graph/`. The new package `pkg/graph/edges/` accepts *already-resolved* canonical IDs and does no ARM parsing.
+
+**Rationale**: FR-018 requires the primitives to be free of ARM template syntax so the future runtime caller (Phase 2) can use them without stubbing ARM helpers. Callers (static and runtime) do their own conversion into the pure-Go `Resource` struct. The static caller resolves `dependsOn` via `resolveDependsOn`; the runtime caller has no `dependsOn` at all in Phase 1 (empty slice).
+
+**Alternatives considered**:
+
+- Move `resolveDependsOn` into `pkg/graph/edges/`. Rejected: it would drag ARM-specific parsing into a neutral package and violate the "no ARM syntax in primitives" rule (FR-019).
+
+## R-003 · Wire model for `kind`
+
+**Decision**: Follow the exact shape of the existing `Direction` enum. Add:
+
+```typespec
+@doc("The origin of a connection: 'Connection' for author-declared entries in properties.connections, 'Dependency' for implicit entries derived from Bicep's dependsOn list.")
+enum ConnectionKind {
+  @doc("The edge was declared by the author in properties.connections.")
+  Connection,
+
+  @doc("The edge was inferred from a Bicep dependsOn entry (implicit dependency).")
+  Dependency,
+}
+```
+
+And on `ApplicationGraphConnection`:
+
+```typespec
+@doc("Discriminator identifying the origin of this edge. Connection edges are author-declared; Dependency edges are implicit dependencies surfaced from Bicep's dependsOn list.")
+kind: ConnectionKind;
+```
+
+**Rationale**: `Direction` is the closest structural analogue already on this model (a required enum discriminator). The naming `ConnectionKind` follows the user's own phrasing ("connection kind") and mirrors the `Direction` pattern (`{ModelName}Kind` alongside the noun-only `Direction`; the alignment is close enough given the reference is already `ApplicationGraphConnection`).
+
+**Alternatives considered**:
+
+- `EdgeKind`. Rejected: the containing model is `ApplicationGraphConnection`, not `ApplicationGraphEdge`, so `EdgeKind` would introduce a noun the wire doesn't use elsewhere.
+- Making `kind` optional (`kind?: ConnectionKind`). Rejected: an "unset kind" state would force every consumer to guard against null; because the runtime handler always emits `kind: Connection` and the static builder always emits either value, an unset state has no producer and would be dead API surface.
+
+## R-004 · How to regenerate Go models from TypeSpec
+
+**Decision**: Run `make generate` at the repository root; commit the regenerated files under `pkg/corerp/api/v20250801preview/zz_generated_models.go` and `swagger/specification/core/resource-manager/Radius.Core/preview/2025-08-01-preview/applications.json`.
+
+**Rationale**: [CONTRIBUTING.md](../../CONTRIBUTING.md) documents `make generate` as the standard regeneration target. CI enforces that generated files are checked in (see [`.github/workflows/`](../../.github/workflows/)).
+
+**Alternatives considered**:
+
+- Hand-editing `zz_generated_models.go`. Rejected — the file is stamped `DO NOT EDIT` and will be overwritten on next generation.
+
+## R-005 · Where Applications.Core vs Radius.Core preview conversion happens
+
+**Decision**: The shared internal graph builder in [pkg/corerp/frontend/controller/applications/graph_util.go](../../pkg/corerp/frontend/controller/applications/graph_util.go) returns an internal representation. Each API version has its own conversion layer:
+
+- Applications.Core (stable): [pkg/corerp/frontend/controller/applications/getgraph.go](../../pkg/corerp/frontend/controller/applications/getgraph.go).
+- Radius.Core preview: [pkg/corerp/frontend/controller/applications/v20250801preview/getgraph.go](../../pkg/corerp/frontend/controller/applications/v20250801preview/getgraph.go).
+
+Only the Radius.Core preview conversion is touched. It sets `kind: Connection` on every edge (the runtime has no `Dependency` edges in Phase 1). The shared internal builder is not modified.
+
+**Rationale**: This surgical placement preserves FR-016 ("`Applications.Core` MUST NOT change"): the shared builder is unchanged, so Applications.Core responses remain byte-identical. Only the Radius.Core preview converter — a file already dedicated to the preview surface — changes.
+
+**Alternatives considered**:
+
+- Adding `kind` on the internal representation and having each API version's converter emit or drop it. Rejected as premature: the internal builder's representation is not part of the wire, and adding a field there just to have Applications.Core drop it later would be dead code. If Phase 2 introduces runtime `Dependency` extraction that both API versions must reason about, we revisit this then; today, only Radius.Core preview needs to know about `kind`.
+
+## R-006 · New package location — `pkg/graph/edges/`
+
+**Decision**: Create a new Radius-domain-neutral package at `pkg/graph/edges/`. Not under `pkg/cli/`, not under `pkg/corerp/`, and not inside the existing `pkg/algorithm/graph/` (which is a generic dependency-graph algorithm library, unrelated to Radius resource-type exclusion rules).
+
+**Rationale**: FR-017 requires that both the CLI (`pkg/cli/graph/`) and the runtime handler (`pkg/corerp/frontend/controller/applications/v20250801preview/`) import the primitives. A neutral top-level package avoids the anti-pattern of `pkg/corerp/` importing from `pkg/cli/`. `pkg/algorithm/graph/` is generic and cloud/Radius-agnostic; overloading it with Radius-specific `Radius.Core/*` exclusion rules would violate separation of concerns (Constitution VIII).
+
+**Alternatives considered**:
+
+- `pkg/cli/graph/`: rejected — makes control-plane import CLI code.
+- `pkg/corerp/graph/`: rejected — makes CLI import control-plane internals.
+- `pkg/algorithm/graph/`: rejected — that package is domain-neutral graph algorithms; Radius resource-type exclusion belongs in a Radius-domain package.

--- a/specs/004-graph-dependency-edges/spec.md
+++ b/specs/004-graph-dependency-edges/spec.md
@@ -1,0 +1,278 @@
+# Feature Specification: Application Graph Dependency Edges
+
+**Feature Branch**: `edges` (in-progress; may be renamed to `004-graph-dependency-edges` at commit time)
+**Created**: 2026-07-16
+**Status**: Draft
+**Input**: User description: "Insert all missing edges (because we have captured only connections so far). Use both `properties.connections` and Bicep-emitted `dependsOn` as edge sources. Exclude Radius.Core control-plane types (`applications`, `environments`, and other authoring-scope resources) from the graph. Apply the same rule to the **static** graph (built from `bicep build` JSON) first, and design it so the runtime deployed graph can reuse the same code path in a follow-up phase. Preserve edge direction — a container `dependsOn` a queue means container →(outbound) queue and queue ←(inbound) container."
+
+## Clarifications
+
+### Session 2026-07-16
+
+- Q: Which API surface receives the changes? → A: Only `Radius.Core/2025-08-01-preview`. `Applications.Core` API versions, handlers, generated code, and tests are out of scope for this feature.
+- Q: Do we need a discriminator on `ApplicationGraphConnection` so consumers can tell an author-declared connection from an implicit dependency? → A: **Yes.** Add a `kind` field to `ApplicationGraphConnection` on the `Radius.Core/2025-08-01-preview` model, with values `Connection` (author-declared, from `properties.connections`) and `Dependency` (implicit, from `dependsOn`). Useful for troubleshooting and for future renderer visual treatment. Applications.Core stays unchanged.
+- Q: How is a source-target pair signaled by **both** `properties.connections` and `dependsOn` reconciled on the wire? → A: **Connection wins.** Emit exactly one edge for the pair, tagged `Connection`. `Dependency` is the fallback tag used only when the pair has no matching `connections` block.
+
+## Purpose
+
+The application graph today under-reports the real dependency structure of an application.
+
+- Edges are emitted only from `properties.connections` (an author-declared block). A container that reads a queue via `secretKeyRef` on the queue's managed secret, but does not declare a `connections` block for it, produces **no edge** in the graph — even though Bicep's `dependsOn` already knows the container depends on the queue.
+- The `Radius.Core/applications` resource shows up as a **graph node** in the static graph because the CLI-side modeled-graph filter only excludes the legacy `Applications.Core` namespace. This clutters the visualization with a control-plane resource that is a **containment scope**, not a graph member.
+
+This feature closes both gaps together. It (1) treats Bicep's compiled `dependsOn` list as a **second edge source** alongside `properties.connections`, tagged with `kind: Dependency` so troubleshooting and renderers can tell it apart, and (2) excludes every `Radius.Core/*` control-plane type — starting with `applications` and `environments` — from graph nodes and from dependency scanning. Both changes land first in the **static** graph (`pkg/cli/graph/modeled.go`), and the extraction is factored so the **runtime** graph handler (`pkg/corerp/frontend/controller/applications/v20250801preview/graph_util.go`) can consume the same primitives in a follow-up phase.
+
+All wire changes are confined to the `Radius.Core/2025-08-01-preview` API surface. `Applications.Core` is untouched.
+
+The visible outcome for the `rabbitmq-app` (../../../my-radius-recipes/deploy/edges/rabbitmq-app.bicep) example: the static graph JSON contains **two nodes** (`consumer`, `rabbitmq`) instead of three. The `consumer` node has one outbound edge to `rabbitmq` tagged `Connection` — the author-declared connection is present and the implicit `dependsOn: ["rabbitmq"]` de-duplicates into it because Connection wins. The queue has the mirrored inbound edge, also tagged `Connection`. Every remaining `dependsOn` entry that targets a `Radius.Core/*` control-plane resource (e.g. `dependsOn: ["app"]`) is dropped along with the node itself.
+
+## System context
+
+Two graph producers, one shared extractor.
+
+```mermaid
+flowchart LR
+    subgraph Author["Author-side (CI, editor, rad app graph)"]
+        Bicep[app.bicep] -->|bicep build| ARM[ARM JSON<br/>resources + dependsOn]
+        ARM --> Static[Static graph builder<br/>pkg/cli/graph/modeled.go]
+    end
+
+    subgraph Server["Server-side (rad app graph on a deployed app)"]
+        API[Radius.Core/applications<br/>getGraph handler] --> Runtime[Runtime graph builder<br/>pkg/corerp/frontend/controller/<br/>applications/v20250801preview/<br/>graph_util.go]
+    end
+
+    subgraph Shared["Shared edge extraction"]
+        Extract[Edge extraction primitives<br/>connections + dependsOn +<br/>exclusion + reciprocal mirroring<br/>+ Connection-wins de-dup]
+    end
+
+    Static --> Extract
+    Runtime -.->|Phase 2| Extract
+    Extract --> Graph[ApplicationGraphResponse<br/>2025-08-01-preview<br/>every edge carries kind]
+```
+
+## Concrete example — rabbitmq-app
+
+The bicep at `rabbitmq-app.bicep` (../../../my-radius-recipes/deploy/edges/rabbitmq-app.bicep) declares three resources: `app` (a `Radius.Core/applications`), `rabbitmq` (a `Radius.Messaging/rabbitMQ`), and `consumer` (a `Radius.Compute/containers`). The consumer resource declares one authored connection to `rabbitmq` and reads the queue's managed secret via `secretKeyRef` on `rabbitmq.properties.secrets.name`.
+
+`bicep build` emits (`rabbitmq-app.json` — ../../../my-radius-recipes/deploy/edges/rabbitmq-app.json):
+
+- `rabbitmq.dependsOn = ["app"]` — the queue depends on the application scope.
+- `consumer.dependsOn = ["app", "rabbitmq"]` — the container depends on the application scope **and** the queue (the queue dependency comes from the `secretKeyRef` and from the `connections.rabbitmq.source: [reference('rabbitmq').id]`).
+- `consumer.properties.connections.rabbitmq.source = "[reference('rabbitmq').id]"` — an author-declared connection.
+
+Today's static graph output (`static-graph-rabbit.json` — ../../../my-radius-recipes/deploy/edges/static-graph-rabbit.json) shows the `app` node as a graph member and only one edge on `consumer` (the connection-block edge, untagged). This feature changes that output to:
+
+| Node                                 | Direction | Target                              | Kind        | Origin                                                                                        |
+| ------------------------------------ | --------- | ----------------------------------- | ----------- | --------------------------------------------------------------------------------------------- |
+| `Radius.Compute/containers/consumer` | Outbound  | `Radius.Messaging/rabbitMQ/rabbitmq` | Connection  | `properties.connections.rabbitmq.source` — `dependsOn: ["rabbitmq"]` de-duplicates in (Connection wins) |
+| `Radius.Messaging/rabbitMQ/rabbitmq` | Inbound   | `Radius.Compute/containers/consumer` | Connection  | mirrored from the outbound edge with the same `kind`                                          |
+| `Radius.Messaging/rabbitMQ/rabbitmq` | Outbound  | (nothing — `app` is excluded)       | —           | `dependsOn: ["app"]` targets an excluded `Radius.Core/*` type                                  |
+
+The `Radius.Core/applications/rabbitmq-app` node is **not present** in the resource list. Two graph nodes remain. Every edge on the wire carries a `kind`.
+
+## Two-phase rollout
+
+**Phase 1 (this spec): static graph + wire change.**
+
+- Wire model: `ApplicationGraphConnection` on `Radius.Core/2025-08-01-preview` gains a `kind` field. `Applications.Core` is unchanged.
+- Static graph builder: emits `Connection` and `Dependency` edges into the new field.
+- Runtime graph handler (Radius.Core preview): sets `kind: Connection` on every edge it emits. No `Dependency` edges yet — the runtime doesn't have `dependsOn`, and Phase 2 will surface them by extending the `GetGraphRequest` wire to accept caller-supplied `dependsOnEdges`.
+- Runtime graph handler (`Applications.Core`): untouched.
+
+**Phase 2 (follow-up, out of scope for this spec): runtime dependency extraction.**
+
+The same extraction primitives — connection resolution, dependency resolution against a resource-ID set, exclusion of `Radius.Core/*` control-plane types, reciprocal mirroring, and Connection-wins de-duplication — are lifted into a shared package the runtime handler consumes. See [Follow-up work](#follow-up-work-phase-2).
+
+## Authoring & consumption flow (Phase 1)
+
+```mermaid
+flowchart TD
+    A[Author writes app.bicep] --> B[bicep build]
+    B --> C[ARM JSON with resources +<br/>connections + dependsOn]
+    C --> D[rad app graph -f template.json<br/>or rad deploy --dry-run]
+    D --> E[Static graph builder]
+    E --> F1[Exclude Radius.Core/*<br/>control-plane types]
+    F1 --> F2[For each remaining resource:]
+    F2 --> G1[Collect Connection edges<br/>from properties.connections]
+    F2 --> G2[Collect Dependency edges<br/>from dependsOn]
+    G2 --> H[Resolve dependsOn tokens →<br/>fully-qualified resource IDs]
+    H --> I[Drop IDs that resolve to<br/>an excluded type or are not<br/>in the resource list]
+    G1 --> J[De-dup on &#40;source, target&#41;:<br/>Connection wins over<br/>Dependency]
+    I --> J
+    J --> K[Mirror each outbound edge<br/>as inbound on the target,<br/>preserving kind]
+    K --> L[ApplicationGraphResponse<br/>Radius.Core/2025-08-01-preview<br/>every edge carries kind]
+```
+
+## User Scenarios *(mandatory)*
+
+### Story 1 — Container-to-managed-resource dependency surfaces without a connections block (Priority: P1)
+
+An application author reads a resource's managed secret via `secretKeyRef` without declaring a `properties.connections` block. Compiling the app and viewing the static graph shows an edge from the consuming container to the managed resource, tagged `kind: Dependency`, so the graph reflects the real deployment order and troubleshooting can tell an implicit dependency apart from an author-declared connection.
+
+**Why this priority**: This is the observed gap driving the feature. Real applications routinely use `secretKeyRef`, `configMapKeyRef`, or embedded `.id` references without a `connections` block; the graph silently omits those edges today and misrepresents dependencies.
+
+**Independent Test**: Compile `rabbitmq-app.bicep` (../../../my-radius-recipes/deploy/edges/rabbitmq-app.bicep) with `bicep build`, run the static-graph builder on the resulting JSON, assert the `consumer` node's outbound edges include exactly one edge to `rabbitmq` tagged `Connection` (Connection wins over the same-pair `Dependency`).
+
+**Acceptance Scenarios**:
+
+1. **Given** an app with a container reading `secretKeyRef: rabbitmq.properties.secrets.name` and no `connections` block on the container, **When** the static graph is built, **Then** the container node has one outbound edge to the queue tagged `Dependency` and the queue has a mirrored inbound edge tagged `Dependency`.
+2. **Given** an app where the container has both a `connections` block to the queue **and** a `dependsOn` on the queue (as `rabbitmq-app.json` — ../../../my-radius-recipes/deploy/edges/rabbitmq-app.json — shows), **When** the static graph is built, **Then** exactly one edge appears between the two nodes tagged `Connection` (Connection wins).
+
+---
+
+### Story 2 — Radius.Core control-plane resources do not appear as graph nodes (Priority: P1)
+
+An application author views the static graph of an app that declares a `Radius.Core/applications` resource for scoping. The `applications` resource does not appear in the graph nodes, and `dependsOn: ["app"]` entries emitted for it by every child do not produce edges.
+
+**Why this priority**: `Radius.Core/applications` is a containment scope, not a runtime graph member. Rendering it as a node clutters the visualization with a resource that has no meaningful "connection" to its children. It's the concrete symptom the user hit first (`rabbitmq-app` showing as a node).
+
+**Independent Test**: Build the static graph for `rabbitmq-app.bicep` (../../../my-radius-recipes/deploy/edges/rabbitmq-app.bicep) and assert (a) `resources` contains exactly two nodes, and (b) neither has an edge — outbound or inbound — whose target is `.../Radius.Core/applications/rabbitmq-app`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Bicep template that declares a `Radius.Core/applications` resource and several member resources whose Bicep source references it via `application: app.id`, **When** the static graph is built, **Then** the `Radius.Core/applications` resource is not present in the `resources` array of the response.
+2. **Given** the same template where every member emits `dependsOn: ["app"]` in the compiled JSON, **When** the static graph is built, **Then** no member emits a `Dependency` edge targeting the `Radius.Core/applications` ID.
+3. **Given** additional `Radius.Core/*` types are added to the exclusion list (per FR-005), **When** the static graph is built for a template containing any of them, **Then** they behave identically to `applications` — no node, no edges.
+
+---
+
+### Story 3 — Runtime graph on Radius.Core preview gains `kind` but stays behavior-equivalent; Applications.Core untouched (Priority: P1)
+
+A deployed application viewed via `rad app graph` (the runtime graph, served by the control plane) continues to render exactly as it does today for existing consumers. The only observable change on `Radius.Core/2025-08-01-preview` is that every emitted edge now carries `kind: Connection`. Applications.Core responses are byte-identical.
+
+**Why this priority**: Phase 1 must not regress the runtime graph. The wire-model change is additive on the Radius.Core preview only, and defaults to `Connection` for every edge the runtime handler emits (the runtime has no `dependsOn` source, so every current edge is a `Connection`).
+
+**Independent Test**: For every existing runtime-graph fixture:
+
+- Applications.Core fixtures: assert byte-identical response to the pre-change golden output.
+- Radius.Core/2025-08-01-preview fixtures: assert the response matches the pre-change golden output except every emitted `connections` entry gains `"kind": "Connection"`.
+
+**Acceptance Scenarios**:
+
+1. **Given** any existing Applications.Core runtime-graph fixture, **When** the handler runs against it after this feature lands, **Then** the emitted response is byte-identical to the pre-change golden file.
+2. **Given** any existing Radius.Core/2025-08-01-preview runtime-graph fixture, **When** the handler runs against it after this feature lands, **Then** the emitted `connections` array is byte-identical to the pre-change output except every entry gains `"kind": "Connection"`.
+3. **Given** a deployed app whose Radius.Core preview runtime response would previously show `Radius.Core/applications` as a node, **When** the handler runs, **Then** the response is unchanged apart from the `kind` addition — runtime `Radius.Core/*` exclusion is a Phase 2 concern.
+
+---
+
+### Story 4 — Shared extraction primitives keep Phase 2 cheap (Priority: P2)
+
+The runtime graph handler (Phase 2) reuses the same connection-resolution, dependency-resolution, exclusion, mirroring, and Connection-wins de-duplication code as the static builder. Adding runtime dependency edges is a wiring change, not a re-implementation.
+
+**Why this priority**: Design-time discipline. Not shipped in Phase 1 but validated by inspection: a code reviewer walking the Phase 1 PR should be able to point to the exported primitives that Phase 2 will call.
+
+**Independent Test**: After Phase 1 lands, the Phase 2 PR adds no new dependency-scan implementation — it only calls the extractor from the runtime handler and switches the exclusion list on.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Phase 1 diff, **When** a reviewer searches for the string-matching and resolution logic, **Then** it lives in an exported package (not inline in `modeled.go`) and every input is a pure Go value already available to the runtime handler (no `*http.Request`, no CLI-only state).
+
+---
+
+### Edge Cases
+
+- **`dependsOn` targets an unresolvable symbolic name** (broken template) → drop the edge silently, do not fail the graph build. Rationale: `bicep build` would have failed already for a real broken template; robustness against synthetic/partial fixtures is cheap.
+- **`dependsOn` targets a Radius.Core type in the exclusion list** → drop the edge (Story 2 case #2).
+- **`properties.connections.<name>.source` targets a Radius.Core type** (author wrote `connections.env = { source: env.id }`) → drop the edge with the same rule; author-declared or not, excluded targets are never rendered.
+- **Same source-target pair is signaled by both a `connections` block and a `dependsOn` entry** → emit exactly one edge tagged `Connection`. Connection wins over Dependency; this is the `rabbitmq-app` case.
+- **Same target appears multiple times in `dependsOn`** → emit exactly one `Dependency` edge.
+- **Same source, same target, both edges via different sources on the same resource (fan-in from A→C=Connection and B→C=Dependency)** → C receives two inbound edges: one from A tagged `Connection`, one from B tagged `Dependency`. Mirroring preserves each source's `kind` because the source-target pair is different (different sources).
+- **`dependsOn` uses the symbolic-name form (languageVersion 2.0)** vs the `[resourceId(...)]` form (languageVersion 1.x) → both must resolve to the same canonical ID via the existing symbol-table normalization in `collectResources`.
+- **Symbolic entry in the exclusion list is referenced by another `dependsOn`** → the reference is dropped after the excluded target is filtered out, not before symbol resolution (so the `["app"]` token in `rabbitmq-app.json` first resolves to `Radius.Core/applications/rabbitmq-app`, then the exclusion rule fires).
+- **A `Radius.Core/*` type that is *not* in the exclusion list** (e.g. a future Radius.Core type intended to be a graph member) → treated as a normal graph node; the exclusion is an explicit allow-list of "control-plane containment scopes," not a wildcard on the namespace. See FR-005.
+- **Environment resource** (`Radius.Core/environments`) authored inside an app template → same treatment as `applications`: excluded as a node and as an edge target.
+
+## Requirements *(mandatory)*
+
+### Exclusion of control-plane types
+
+- **FR-001**: The static graph builder MUST NOT emit a graph node for any resource whose `type` matches an entry in the control-plane-type exclusion list.
+- **FR-002**: The static graph builder MUST NOT emit an edge — `Connection` or `Dependency`, outbound or inbound — whose source or target resolves to a resource of an excluded type.
+- **FR-003**: Recipe-catalog resources currently filtered out by `modeled.go` (`Radius.Core/recipePacks`) MUST remain filtered under the same rule; adding this feature MUST NOT re-introduce them as nodes.
+- **FR-004**: The exclusion list applies before de-duplication and reciprocal-mirroring, so a self-loop or mirror edge never targets an excluded type.
+- **FR-005**: The exclusion list is defined explicitly in code (a Go slice or set of type strings) — it is **not** derived from the `Radius.Core` namespace prefix. Starting membership:
+  - `Applications.Core/applications` — legacy namespace, already filtered.
+  - `Applications.Core/environments` — legacy namespace, already filtered.
+  - `Radius.Core/applications` — new; this is the observed regression.
+  - `Radius.Core/environments` — new.
+  - `Radius.Core/recipePacks` — already filtered.
+
+  Any additional `Radius.Core/*` types added later are added by editing this list, not by wildcard.
+
+### Edge sources
+
+- **FR-006**: `Connection` edges MUST continue to be emitted from `properties.connections[*].source`, with the wire model now carrying an explicit `kind: Connection` on each entry.
+- **FR-007**: `Dependency` edges MUST be emitted from the compiled ARM template's per-resource `dependsOn` array. Every entry is resolved to a fully-qualified Radius resource ID using the same symbol-table + `[resourceId(...)]` resolution `resolveDependsOn` uses today for `DiffHash`.
+- **FR-008**: A `Dependency` edge MUST be dropped when:
+  - it resolves to a type in the exclusion list (FR-002), or
+  - the same source-target pair is already emitted as a `Connection` edge for that resource (Connection-wins de-duplication, FR-011), or
+  - it cannot be resolved to a target that is present in the graph's resource list.
+- **FR-009**: `Dependency` edge resolution MUST handle both ARM languageVersion 1.x (`[resourceId('TYPE','NAME')]` strings) and languageVersion 2.0 (symbolic-name strings) via the existing `collectResources` / symbol-table path.
+- **FR-010**: For every outbound edge, the builder MUST emit a reciprocal inbound edge on the target node with the same `kind`.
+
+### De-duplication
+
+- **FR-011**: When the same source-target pair on the same resource is signaled by both `properties.connections` and `dependsOn`, the builder MUST emit exactly one edge and MUST tag it `Connection`. **Connection wins.** The `Dependency` tag is emitted only when the pair has no matching `connections` block.
+- **FR-012**: Multiple `dependsOn` tokens targeting the same resource MUST collapse to one `Dependency` edge.
+
+### Wire contract
+
+- **FR-013**: `ApplicationGraphConnection` on the `Radius.Core/2025-08-01-preview` TypeSpec MUST gain a `kind` field with values `Connection` (author-declared, from `properties.connections`) and `Dependency` (implicit, from `dependsOn`). The field is required on the response — every emitted edge carries a `kind`. Field name and enum name (working name: `ConnectionKind`) are firmed up during `speckit.plan`.
+- **FR-014**: The `Radius.Core/2025-08-01-preview` runtime graph handler (`pkg/corerp/frontend/controller/applications/v20250801preview/graph_util.go`) MUST set `kind: Connection` on every edge it emits. It does **not** produce `Dependency` edges in Phase 1 — caller-supplied `dependsOnEdges` on `GetGraphRequest` is Phase 2.
+- **FR-015**: The static graph builder MUST set `kind` on every edge — `Connection` or `Dependency` — including mirrored inbound edges.
+- **FR-016**: `Applications.Core` TypeSpec, generated code, handlers, and tests MUST NOT change. The wire change is scoped to `Radius.Core/2025-08-01-preview` only.
+
+### Reuse (Phase 2 preparation)
+
+- **FR-017**: The static graph's dependency-resolution and exclusion logic MUST be implemented as exported primitives in a package callable from both `pkg/cli/graph/` and `pkg/corerp/frontend/controller/applications/v20250801preview/`. No CLI-only state (`http.Request`, `*flag.FlagSet`, `sdk.Connection`) may appear in the primitive signatures. Package location is firmed up during `speckit.plan`.
+- **FR-018**: The primitives' input is a pure Go representation: a list of resources with a canonical ID, `properties`, and a `dependsOn` slice already resolved to canonical IDs. Callers convert their own inputs into this shape.
+- **FR-019**: The primitives MUST NOT reach into ARM template syntax (`[resourceId(...)]`, `[reference(...)]`) — that resolution stays in `modeled.go` for the static caller, and is a no-op for the runtime caller.
+
+### Documentation
+
+- **FR-020**: [docs/architecture/application-graph.md](../../../docs/architecture/application-graph.md) MUST be updated to describe (a) the two edge sources (`connections` and `dependsOn`), (b) the exclusion list, (c) the new `kind` field on Radius.Core preview, and (d) the Connection-wins de-duplication rule. It MUST call out that `Applications.Core` is unchanged.
+- **FR-021**: The former design note `eng/design-notes/graph/2026-07-implicit-id-dependencies-in-app-graph.md` has been superseded by this spec and removed, so [docs/architecture/application-graph.md](../../../docs/architecture/application-graph.md) and this spec are the only sources of truth on the graph edge contract.
+
+### Key Entities
+
+- **Resource**: A single Radius resource in the graph. Attributes used by this feature: canonical resource ID, `type`, `properties`, and a resolved `dependsOn` (a list of canonical target IDs).
+- **Edge**: A directed relationship between two resources. Wire attributes on `Radius.Core/2025-08-01-preview`: `source`, `target`, `direction` (`Outbound` or `Inbound`), `kind` (`Connection` or `Dependency`).
+- **Exclusion list**: A set of resource-type strings whose members are never nodes and never edge targets.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For the `rabbitmq-app` (../../../my-radius-recipes/deploy/edges/rabbitmq-app.bicep) fixture, the static graph response contains exactly **2 nodes** (`consumer`, `rabbitmq`), zero `Radius.Core/applications` nodes, and the single edge between the two nodes is tagged `Connection`.
+- **SC-002**: For a fixture where a container reads a queue's managed secret via `secretKeyRef` but declares no `connections` block, the static graph response contains **1 outbound `Dependency` edge** on the container to the queue and **1 mirrored inbound `Dependency` edge** on the queue.
+- **SC-003**: Runtime-graph regression coverage in Phase 1:
+  - 100% of existing `Applications.Core` runtime-graph tests produce byte-identical responses to their pre-change golden files.
+  - 100% of existing `Radius.Core/2025-08-01-preview` runtime-graph tests produce responses byte-identical to their pre-change golden files **except** every emitted edge gains `"kind": "Connection"`.
+- **SC-004**: A reviewer inspecting the Phase 1 diff can identify the exported extraction primitives in a shared package; a follow-up prototype call from the `Radius.Core/2025-08-01-preview` runtime handler compiles without duplicating any dependency-resolution logic.
+- **SC-005**: The exclusion list is a single Go source location; adding a new excluded type is a one-line edit plus one new test case.
+
+## Assumptions
+
+- Radius resources are addressable by canonical resource ID and every graph node in scope carries one.
+- `bicep build` continues to emit `dependsOn` for every literal-argument `.id` reference. This is Microsoft's documented behavior ([Azure Resource Manager: resource dependencies](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/resource-dependencies)) and is already relied on by `DiffHash`.
+- `properties.connections[*].source` continues to be an ARM expression resolvable to a canonical resource ID via `collectResources` / `rewriteSymbolicConnections`.
+- The runtime graph's edge extractor is intentionally simpler than the static one because deployed resources do not carry `dependsOn`. Runtime `Dependency` extraction (Phase 2) does not attempt to reconstruct `dependsOn` on the server; instead, the `GetGraphRequest` wire grows an optional `dependsOnEdges` field that callers (typically `rad app graph -a <app>` after a fresh `bicep build`, or the deployment engine) supply. The server merges those edges into the connection-only graph it already builds. No property scanning on stored resources.
+- The `kind` field on Radius.Core preview is additive; consumers that do not read it continue to work. Consumers that opt in (renderers, troubleshooting tools) can differentiate `Connection` vs `Dependency`.
+- `Applications.Core` API versions are frozen for this feature.
+
+## Follow-up work (Phase 2)
+
+Tracked separately once Phase 1 lands:
+
+1. **Caller-supplied `dependsOnEdges` on the runtime API.** Extend `GetGraphRequest` on `Radius.Core/2025-08-01-preview` with an optional `dependsOnEdges` field. Clients that have just compiled a Bicep template pass the extracted edges to the server; the server tags them `Kind: Dependency` and merges them into the graph it builds from stored resources via the shared primitives (FR-017), applying the same Connection-wins de-dup and reciprocal mirroring. Explicitly not a server-side property scanner — the authoritative source of `dependsOn` is Bicep's compiled template, held by the caller.
+2. **Runtime exclusion list.** Apply the same `Radius.Core/*` exclusion in the `Radius.Core/2025-08-01-preview` runtime graph handler.
+3. **Renderer visual treatment.** Update CLI and dashboard renderers to render `Dependency` edges distinctly from `Connection` edges (dotted vs solid line, legend, etc.).
+4. **Additional `Radius.Core/*` types.** As new control-plane types are added, extend the exclusion list. Every extension is one line of code + one test case (SC-005).
+
+## Out of Scope
+
+- Runtime graph handler emission of `Dependency` edges (there is no `dependsOn` at runtime).
+- Any change to `Applications.Core` TypeSpec, generated code, handlers, or tests.
+- Any change to `dynamicrp` or the deployment engine's dependency ordering.
+- Any change to `properties.connections` semantics (`iam`, `disableDefaultEnvVars`, direction inference) — this feature adds a discriminator field only.
+- Renderer-side visual language for the new `kind` field — that is Phase 2 or later.

--- a/specs/004-graph-dependency-edges/tasks.md
+++ b/specs/004-graph-dependency-edges/tasks.md
@@ -1,0 +1,210 @@
+---
+description: "Task list for Application Graph Dependency Edges (Phase 1)"
+---
+
+# Tasks: Application Graph Dependency Edges
+
+**Input**: Design documents from `specs/004-graph-dependency-edges/`
+**Prerequisites**: [spec.md](spec.md), [plan.md](plan.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/wire-change.md](contracts/wire-change.md)
+
+**Tests**: Included. Constitution IV ("Testing Pyramid Discipline") is non-negotiable for the Radius Go codebase — every code task has an associated unit-test task.
+
+**Organization**: Tasks are grouped by user story so each P1 story can be implemented and shipped independently. Task IDs are stable across phases; `[P]` means the task can run in parallel with other `[P]` tasks in the same phase.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel with other `[P]` tasks in the same phase (different files, no dependencies).
+- **[Story]**: `US1`, `US2`, `US3`, `US4`, or `Foundation` / `Polish`.
+
+## Path Conventions
+
+Single Go module `github.com/radius-project/radius`; feature-specific paths per [plan.md § Project Structure](plan.md#project-structure).
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the spec-kit deliverable is in place; nothing to compile yet.
+
+- [ ] T001 [Foundation] Verify `specs/004-graph-dependency-edges/` contains `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/wire-change.md`, `quickstart.md`, and `checklists/requirements.md`. No source-code changes in this task.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Wire-model change + new package skeleton. All three P1 stories consume these outputs. **No US1/US2/US3 story work may start until Phase 2 is complete.**
+
+- [ ] T002 [Foundation] Update `typespec/Radius.Core/applications.tsp`: add `enum ConnectionKind { Connection, Dependency }` and the required `kind: ConnectionKind` field on `ApplicationGraphConnection`. Follow the exact diff in [contracts/wire-change.md](contracts/wire-change.md).
+- [ ] T003 [Foundation] Run `make generate` at repo root. Commit the regenerated `pkg/corerp/api/v20250801preview/zz_generated_models.go`, `swagger/specification/core/resource-manager/Radius.Core/preview/2025-08-01-preview/applications.json`, and any Bicep type extensions produced by the same target.
+- [ ] T004 [P] [Foundation] Create `pkg/graph/edges/doc.go` with the package-level godoc summarizing purpose (edge extraction primitives shared by static and runtime graph builders) and the Phase 2 plug-in point.
+- [ ] T005 [P] [Foundation] Create `pkg/graph/edges/edges.go` with the exported types from [data-model.md](data-model.md#pkggraphedges--go-types): `Resource` and `Edge`. Include a stub `ExtractEdges(resources []Resource, excluded map[string]struct{}) []Edge` that returns `nil`. Every exported symbol has godoc; the doc comment on `ExtractEdges` names the promotion path to an options struct if a second knob emerges.
+- [ ] T006 [Foundation] Verify the workspace compiles: `go build ./...`. Verify the new field is visible in the generated Go model: `grep -n 'Kind' pkg/corerp/api/v20250801preview/zz_generated_models.go`.
+
+**Checkpoint**: Wire has `kind`; new package exists; workspace compiles. P1 stories can now proceed in parallel per their dependency map below.
+
+---
+
+## Phase 3: User Story 2 — Radius.Core control-plane exclusion (Priority: P1) 🎯 smallest slice
+
+**Goal**: `Radius.Core/applications` and `Radius.Core/environments` never appear as graph nodes or edge targets in the static graph.
+
+**Independent Test**: `rabbitmq-app` fixture produces exactly 2 nodes; no edge (outbound or inbound) targets `Radius.Core/applications/rabbitmq-app`.
+
+**Depends on**: Phase 2 (compiling workspace only).
+
+### Implementation
+
+- [ ] T007 [US2] Extend the exclusion list in `pkg/cli/graph/modeled.go` to include `Radius.Core/applications` and `Radius.Core/environments` alongside the existing `Applications.Core/applications`, `Applications.Core/environments`, and `Radius.Core/recipePacks` entries. Keep the list a single source location per FR-005.
+- [ ] T008 [US2] Add or extend table-driven cases in `pkg/cli/graph/modeled_test.go` for:
+  - Fixture with `Radius.Core/applications` declared → assert `resources` has exactly 2 nodes and none has `type == "Radius.Core/applications"`.
+  - Same fixture where every member emits `dependsOn: ["app"]` → assert no edge targets the excluded application ID.
+  - Additional `Radius.Core/environments` entry → same treatment as `applications`.
+- [ ] T009 [US2] Run `go test ./pkg/cli/graph/...`. All existing modeled-graph tests must still pass; new cases must be green.
+
+**Checkpoint (US2)**: The immediate `rabbitmq-app`-shows-as-a-node regression is fixed. This slice is independently mergeable.
+
+---
+
+## Phase 4: User Story 3 — Runtime `kind: Connection` on Radius.Core preview (Priority: P1)
+
+**Goal**: The `Radius.Core/2025-08-01-preview` runtime graph handler emits `kind: Connection` on every edge. `Applications.Core` (any version) is byte-identical to before.
+
+**Independent Test**: Existing Applications.Core golden files unchanged; Radius.Core/2025-08-01-preview golden files updated only to gain `"kind": "Connection"` on every `connections` entry.
+
+**Depends on**: Phase 2.
+
+### Implementation
+
+- [ ] T010 [US3] In `pkg/corerp/frontend/controller/applications/v20250801preview/getgraph.go`, locate the site that converts the internal edge representation to `*corerpv20250801preview.ApplicationGraphConnection`. Set `Kind: to.Ptr(corerpv20250801preview.ConnectionKindConnection)` on every emitted entry (outbound and inbound). No other logic changes.
+- [ ] T011 [P] [US3] Update `pkg/corerp/frontend/controller/applications/v20250801preview/getgraph_test.go` golden expectations: every `connections` entry gains `"kind": "Connection"`. If snapshot files live under `testdata/`, regenerate them and commit the diff.
+- [ ] T012 [P] [US3] Update `pkg/corerp/frontend/controller/applications/v20250801preview/graphicons_test.go` golden expectations (if graph icons tests exercise a connections array). Only `kind: Connection` should differ from pre-change goldens.
+- [ ] T013 [US3] Run `go test ./pkg/corerp/frontend/controller/applications/...`. **Verify Applications.Core (the parent package) tests are byte-identical** — no `.golden` diff, no assertion changes. If Applications.Core tests fail, revert; the constraint (FR-016) is violated.
+
+**Checkpoint (US3)**: Radius.Core preview responses carry `kind` uniformly. Applications.Core untouched. Independently mergeable.
+
+---
+
+## Phase 5: User Story 1 — Static-graph `Dependency` edges + Connection-wins de-dup (Priority: P1)
+
+**Goal**: Static graph surfaces `dependsOn`-only edges tagged `kind: Dependency`, and merges the `connections + dependsOn` overlap to a single `kind: Connection` edge.
+
+**Independent Test**: `rabbitmq-app` fixture emits exactly one edge between `consumer` and `rabbitmq` tagged `Connection`. A variant with the container's `connections` block removed but `secretKeyRef` intact emits exactly one edge tagged `Dependency`.
+
+**Depends on**: Phase 2, Phase 3 (converter must know how to set `Kind` per edge). Not dependent on Phase 4's runtime work; can proceed in parallel with US3.
+
+### Implementation
+
+- [ ] T014 [US1] Implement `ExtractEdges` in `pkg/graph/edges/edges.go` per [data-model.md](data-model.md):
+  - Iterate `resources`; skip those whose `Type` is in `excluded`.
+  - Collect `Connection` edges from `properties.connections[*].source` (canonical Radius IDs; drop unparseable, drop excluded targets, drop targets not in the resource-ID set).
+  - Collect `Dependency` edges from `DependsOn` (drop excluded targets, drop targets not in the resource-ID set).
+  - Connection-wins de-dup on `(Source, Target)` per source resource (FR-011); collapse duplicate `Dependency` tokens (FR-012).
+  - Mirror every outbound edge as inbound on the target with the same `Kind` (FR-010).
+  - Return a slice sorted deterministically by `(Source, Target, Direction, Kind)`.
+- [ ] T015 [US1] Add `pkg/graph/edges/edges_test.go` table-driven unit tests covering:
+  - Empty inputs → empty output.
+  - Single `Connection` edge → outbound + mirrored inbound, both tagged `Connection`.
+  - Single `Dependency` edge → outbound + mirrored inbound, both tagged `Dependency`.
+  - Same pair from both sources → single `Connection` edge (Connection wins).
+  - Multiple `Dependency` tokens on same target → single `Dependency` edge.
+  - Fan-in with mixed kinds from different sources (A→C=Connection, B→C=Dependency) → C has two distinct inbound edges preserving each source's kind.
+  - Excluded target → no edge emitted, mirror not emitted either.
+  - Target not in resource-ID set → edge dropped.
+  - Sorted output determinism → shuffle inputs, output identical.
+- [ ] T016 [US1] Refactor `pkg/cli/graph/modeled.go`:
+  - Build the exclusion set `map[string]struct{}{...}` from the existing constants.
+  - After the existing resource-list construction, build `[]edges.Resource` from each entry: `Type` from `entry["type"]`, `Properties` from `entry["properties"]`, `DependsOn` from `resolveDependsOn(entry["dependsOn"])` (canonical IDs, ARM syntax already stripped).
+  - Call `edges.ExtractEdges(resources, excludedSet)`.
+  - Convert each returned `edges.Edge` back into `*corerpv20250801preview.ApplicationGraphConnection` on the owning source node's `Connections` slice, setting `Direction`, `ID` (the target), and `Kind` per edge. Attach mirrored inbound entries the same way.
+  - Remove the now-obsolete inline connection extraction (`outboundConnections`, `addInboundConnections`) once tests pass. Keep them if lifting them is invasive; the goal is correctness of the emitted graph.
+- [ ] T017 [P] [US1] Extend `pkg/cli/graph/modeled_test.go`:
+  - `rabbitmq-app` fixture: assert 2 nodes; assert `consumer.Connections` contains exactly one entry with `Direction=Outbound`, `ID=…/rabbitMQ/rabbitmq`, `Kind=Connection`; assert `rabbitmq.Connections` has the mirrored `Inbound`/`Connection` entry; assert `rabbitmq.Connections` has no outbound entry to `Radius.Core/applications`.
+  - Variant fixture (container has no `connections` block, only `dependsOn: ["rabbitmq"]`): same shape, but `Kind=Dependency` on both entries.
+  - Fan-in fixture: two containers each `dependsOn` one shared queue — one via `connections`, one via `dependsOn` only — assert the queue has two inbound entries with the correct mixed kinds.
+- [ ] T018 [US1] Run `go test ./pkg/graph/edges/... ./pkg/cli/graph/...`. All existing and new cases green.
+
+**Checkpoint (US1)**: Static graph surfaces implicit dependency edges tagged `Dependency`; overlaps de-dup to `Connection`. This is the headline slice.
+
+---
+
+## Phase 6: User Story 4 — Shared-primitives reuse discipline (Priority: P2)
+
+**Goal**: The Phase 1 diff leaves the extractor callable by the runtime handler in Phase 2 with no CLI-specific dependencies.
+
+**Independent Test**: `pkg/graph/edges/` imports no `pkg/cli/`, no `pkg/corerp/`, no `net/http`, no ARM template syntax.
+
+**Depends on**: Phase 5 (extractor must exist first).
+
+### Implementation
+
+- [ ] T019 [US4] Run `go list -deps ./pkg/graph/edges/... | grep -E 'pkg/cli|pkg/corerp|net/http'`. Expected output: empty. If not empty, refactor to remove the offending imports.
+- [ ] T020 [US4] Add a doc-comment block on `ExtractEdges` in `pkg/graph/edges/edges.go` naming the Phase 2 plug-in point:
+  > "Runtime callers (Phase 2) populate `Resource.DependsOn` from caller-supplied `dependsOnEdges` on the `GetGraphRequest` wire, not from server-side property scanning. Static callers populate it from Bicep's `dependsOn` array via `resolveDependsOn`. The extractor is agnostic to how `DependsOn` was resolved."
+
+**Checkpoint (US4)**: Runtime plug-in is documented and structurally supported. Phase 2 becomes a wiring change.
+
+---
+
+## Phase 7: Polish & Documentation
+
+**Purpose**: Docs and cross-cutting cleanup after all P1/P2 stories land.
+
+- [ ] T021 [P] [Polish] Update [docs/architecture/application-graph.md](../../docs/architecture/application-graph.md) per FR-020:
+  - Describe both edge sources (`connections` and `dependsOn`).
+  - Describe the exclusion list and its membership.
+  - Describe the new `kind` field on `Radius.Core/2025-08-01-preview` and the Connection-wins de-dup rule.
+  - Call out explicitly that `Applications.Core` is unchanged (FR-016).
+- [ ] T022 [P] [Polish] Run `gofmt -w pkg/graph/edges/ pkg/cli/graph/ pkg/corerp/frontend/controller/applications/v20250801preview/` and `go vet ./...`. Fix any diagnostics.
+- [ ] T023 [P] [Polish] Run `golangci-lint run ./pkg/graph/edges/... ./pkg/cli/graph/... ./pkg/corerp/frontend/controller/applications/v20250801preview/...`. Fix any new warnings; zero baseline.
+- [ ] T024 [Polish] Walk through [quickstart.md](quickstart.md) end-to-end against the `rabbitmq-app` fixture. All jq assertions in the quickstart must pass. This closes SC-001 and SC-002.
+- [ ] T025 [Polish] Confirm regenerated artifacts (`zz_generated_models.go`, `swagger/**/applications.json`, Bicep types) match `make generate` output on the final tree; commit any drift.
+
+---
+
+## Dependency Graph
+
+```mermaid
+flowchart LR
+    T001[T001 Setup] --> T002
+    T002[T002 TypeSpec kind + enum] --> T003[T003 make generate]
+    T003 --> T004[T004 doc.go]
+    T003 --> T005[T005 edges.go skeleton]
+    T004 --> T006
+    T005 --> T006[T006 build check]
+    T006 --> US2[Phase 3 US2]
+    T006 --> US3[Phase 4 US3]
+    T006 --> US1[Phase 5 US1]
+    US1 --> US4[Phase 6 US4]
+    US2 --> POLISH[Phase 7 Polish]
+    US3 --> POLISH
+    US1 --> POLISH
+    US4 --> POLISH
+```
+
+- **T004 and T005** run in parallel after T003.
+- **T007 and T008** (US2), **T010 and T011/T012** (US3), and **T014 and T015** (US1) run within their own phase. `[P]` markers indicate what's parallelizable inside each phase.
+- **US2, US3, and US1 can run in parallel** once Phase 2 is complete — they touch different files:
+  - US2 → `pkg/cli/graph/modeled.go` + its test
+  - US3 → `pkg/corerp/frontend/controller/applications/v20250801preview/*.go` + its test goldens
+  - US1 → `pkg/graph/edges/*.go` + `pkg/cli/graph/modeled.go` (US1 will conflict with US2 on `modeled.go`; do US2 first, then rebase US1 on top)
+
+## Suggested commit boundaries
+
+Landing each phase as its own commit keeps review small and history clean:
+
+1. `Foundation`: T001–T006 — one commit including the TypeSpec change, all regenerated files, and the empty `pkg/graph/edges/` package.
+2. `US2`: T007–T009 — one commit fixing the immediate `Radius.Core/applications` node regression.
+3. `US3`: T010–T013 — one commit adding `kind: Connection` on Radius.Core preview runtime responses.
+4. `US1`: T014–T018 — one commit implementing `ExtractEdges` and switching `modeled.go` to consume it.
+5. `US4`: T019–T020 — one commit documenting the Phase 2 plug-in point.
+6. `Polish`: T021–T025 — one commit for docs + lint.
+
+## Success mapping
+
+| Success Criterion | Tasks that verify it |
+|-------------------|----------------------|
+| SC-001 (rabbitmq-app: 2 nodes, single Connection edge) | T008 (US2), T017 (US1), T024 (Polish) |
+| SC-002 (secretKeyRef variant: single Dependency edge) | T017 (US1), T024 (Polish) |
+| SC-003 (App.Core byte-identical; Radius.Core preview gains kind:Connection) | T013 (US3) |
+| SC-004 (shared extractor in a neutral package) | T019 (US4) |
+| SC-005 (exclusion list is one source location, one-line add + one test add) | T007, T008 (US2) |

--- a/specs/004-graph-dependency-edges/tasks.md
+++ b/specs/004-graph-dependency-edges/tasks.md
@@ -96,7 +96,7 @@ Single Go module `github.com/radius-project/radius`; feature-specific paths per 
 
 - [ ] T014 [US1] Implement `ExtractEdges` in `pkg/graph/edges/edges.go` per [data-model.md](data-model.md):
   - Iterate `resources`; skip those whose `Type` is in `excluded`.
-  - Collect `Connection` edges from `properties.connections[*].source` (canonical Radius IDs; drop unparseable, drop excluded targets, drop targets not in the resource-ID set).
+  - Collect `Connection` edges from `properties.connections[*].source` (canonical Radius IDs; drop what cannot be parsed, drop excluded targets, drop targets not in the resource-ID set).
   - Collect `Dependency` edges from `DependsOn` (drop excluded targets, drop targets not in the resource-ID set).
   - Connection-wins de-dup on `(Source, Target)` per source resource (FR-011); collapse duplicate `Dependency` tokens (FR-012).
   - Mirror every outbound edge as inbound on the target with the same `Kind` (FR-010).

--- a/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/openapi.json
+++ b/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/openapi.json
@@ -1266,11 +1266,16 @@
         "direction": {
           "$ref": "#/definitions/Direction",
           "description": "The direction of the connection. 'Outbound' indicates this connection specifies the ID of the destination and 'Inbound' indicates indicates this connection specifies the ID of the source."
+        },
+        "kind": {
+          "$ref": "#/definitions/ConnectionKind",
+          "description": "Discriminator identifying the origin of this edge. 'Connection' edges are author-declared entries under properties.connections. 'Dependency' edges are implicit dependencies derived from Bicep's dependsOn list (static graph only in Phase 1). Every emitted edge carries a kind."
         }
       },
       "required": [
         "id",
-        "direction"
+        "direction",
+        "kind"
       ]
     },
     "ApplicationGraphOutputResource": {
@@ -1632,6 +1637,30 @@
           "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
         }
       ]
+    },
+    "ConnectionKind": {
+      "type": "string",
+      "description": "The origin of a connection: 'Connection' for author-declared entries in properties.connections, 'Dependency' for implicit entries derived from Bicep's dependsOn list.",
+      "enum": [
+        "Connection",
+        "Dependency"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionKind",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "Connection",
+            "value": "Connection",
+            "description": "The edge was declared by the author in properties.connections."
+          },
+          {
+            "name": "Dependency",
+            "value": "Dependency",
+            "description": "The edge was inferred from a Bicep dependsOn entry (implicit dependency). Not emitted by the runtime graph in Phase 1 — runtime dependency extraction is Phase 2."
+          }
+        ]
+      }
     },
     "Direction": {
       "type": "string",

--- a/typespec/Radius.Core/applications.tsp
+++ b/typespec/Radius.Core/applications.tsp
@@ -83,6 +83,9 @@ model ApplicationGraphConnection {
 
   @doc("The direction of the connection. 'Outbound' indicates this connection specifies the ID of the destination and 'Inbound' indicates indicates this connection specifies the ID of the source.")
   direction: Direction;
+
+  @doc("Discriminator identifying the origin of this edge. 'Connection' edges are author-declared entries under properties.connections. 'Dependency' edges are implicit dependencies derived from Bicep's dependsOn list (static graph only in Phase 1). Every emitted edge carries a kind.")
+  kind: ConnectionKind;
 }
 
 @doc("The direction of a connection.")
@@ -92,6 +95,15 @@ enum Direction {
 
   @doc("The resource defining this connection accepts inbound connections from the resource specified by this id.")
   Inbound,
+}
+
+@doc("The origin of a connection: 'Connection' for author-declared entries in properties.connections, 'Dependency' for implicit entries derived from Bicep's dependsOn list.")
+enum ConnectionKind {
+  @doc("The edge was declared by the author in properties.connections.")
+  Connection,
+
+  @doc("The edge was inferred from a Bicep dependsOn entry (implicit dependency). Not emitted by the runtime graph in Phase 1 — runtime dependency extraction is Phase 2.")
+  Dependency,
 }
 
 @doc("Describes a resource in the application graph.")


### PR DESCRIPTION
## Summary

Phase 1 of spec 004 — [`specs/004-graph-dependency-edges/`](specs/004-graph-dependency-edges/).

Two concrete behavior changes to the CLI static graph (`rad app graph app.bicep`):

1. **Edges from `dependsOn`** — the static graph now surfaces implicit dependency edges from Bicep's compiled `dependsOn` list, in addition to the existing `properties.connections` edges. Same-pair overlap de-dupes with **Connection wins** (SC-001). Templates that reference another resource only via `secretKeyRef` now produce a `Kind: Dependency` edge (SC-002).
2. **`Radius.Core/applications` and `Radius.Core/environments` are excluded** from graph nodes and edge targets — fixing the observed regression where the application scope appeared as a node.

Wire change on `Radius.Core/2025-08-01-preview` only: `ApplicationGraphConnection` gains a required `kind: ConnectionKind` field (`Connection` or `Dependency`). **`Applications.Core` is untouched.**

## What's included

| Commit | What |
|--------|------|
| `a166bc9..d435919` (specs) | spec.md, plan.md, tasks.md, research.md, data-model.md, contracts/, quickstart.md, clarifications, ExtractOptions simplification, removed superseded design note |
| `d8c5cf3` foundation/wire | TypeSpec `ConnectionKind` + `kind` field; regenerated Go/Swagger/Bicep types; runtime converter sets `Kind: Connection` on every emitted edge |
| `f3a2eca` foundation/pkg | New `pkg/graph/edges/` package skeleton |
| `70faf98` us2 | Extend exclusion list in `pkg/cli/graph/modeled.go` to cover `Radius.Core/applications` and `Radius.Core/environments` |
| `3bb4110` us1 | Real `ExtractEdges` (connection + dependsOn + Connection-wins de-dup + mirroring + exclusion + deterministic sort); rewire `modeled.go`; drop obsolete inline helpers |
| `8c392be` us4 | Doc comment on `ExtractEdges` naming Phase 2 runtime plug-in (caller-supplied `dependsOnEdges` on `GetGraphRequest`) |
| `ba3843a` polish | Inline updates to `docs/architecture/application-graph.md` — Edge Sources and Kind subsection, class diagram, wire-format callout |

Two additional pre-existing commits (`960d83679`, `90df98cbf`) predate the spec-kit workflow; they only touched the design note that the first spec-kit commit later removes. Net effect: added and removed within the same PR. Happy to squash on request.

## Non-goals for this PR

- **Applications.Core is unchanged** (FR-016). Applications.Core TypeSpec, generated code, handlers, and tests remain byte-identical.
- **No server-side `Kind: Dependency` edges.** The runtime handler sees no `dependsOn` and emits only `Kind: Connection`.
- **No property scanner on the server.** Phase 2 will add server-side dependency edges via a new caller-supplied `dependsOnEdges` field on `GetGraphRequest` — clients that just ran `bicep build` send the compiled list to the server, which merges it via the same `pkg/graph/edges/` primitive. See spec § Follow-up work.

## Follow-ups filed

- radius#12467 — evaluate simple ARM name expressions (`format`, `concat`, `reference('sym').name`) in the static graph so composed resource names like `${appsecret.name}-consumer` render as `appsecret-consumer` in the emitted IDs rather than as the raw ARM expression. Not in scope here.

## Verification

- `make generate` roundtripped cleanly; all regenerated artifacts committed.
- `go build ./...` — clean.
- `go vet ./...` — clean.
- `gofmt -l` on touched packages — empty.
- `go test ./pkg/graph/edges/... ./pkg/cli/graph/... ./pkg/corerp/frontend/controller/applications/...` — all green (11 new primitive tests + 2 new integration tests; no golden updates needed elsewhere).
- `go list -deps ./pkg/graph/edges/...` — no imports from `pkg/cli/`, `pkg/corerp/`, or `net/http` (reuse discipline for Phase 2).
- End-to-end verified against `my-radius-recipes/deploy/edges/rabbitmq-app.bicep`: `Radius.Core/applications` correctly absent; consumer emits two `Kind: Dependency` outbound edges to `appsecret` and `rabbitmq`; mirrored inbounds on both.

## Success criteria (from spec § Success Criteria)

| SC | Verified by |
|----|-------------|
| SC-001 (rabbitmq-app: 2 nodes, single Connection edge, Connection wins) | `TestBuildModeledGraph_ConnectionWinsOverDependencyOnRabbitMQShape` |
| SC-002 (secretKeyRef-only variant: 1 Dependency edge + mirrored inbound) | `TestBuildModeledGraph_ExcludesRadiusCoreApplicationsFromRabbitMQShape` + end-to-end fixture |
| SC-003 (Applications.Core byte-identical; Radius.Core preview gains `kind: Connection`) | Preview handler tests green, Applications.Core tests untouched |
| SC-004 (shared primitive in a neutral package, no CLI/control-plane imports) | `go list -deps` — clean |
| SC-005 (exclusion list is one source location) | `excludedTypes` in `pkg/cli/graph/modeled.go` |

Every commit is Signed-off-by per DCO.