### PR TITLE
Pass RADIUS_STATE_* vars to rad startup/shutdown in deploy workflows

### DIFF
--- a/.github/extension/run-rad-commands-aws.yml
+++ b/.github/extension/run-rad-commands-aws.yml
@@ -44,6 +44,17 @@ jobs:
     name: Deploy with Radius
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    # OCI-backed Radius control-plane state, provisioned per-environment by the
+    # deploy tooling (canvas extension) as environment variables. Set at job
+    # level (not workflow level) so environment-scoped vars.* resolve, and so the
+    # shared restore-state (rad startup) and teardown (rad shutdown) actions —
+    # plus the deploy/app-graph commands — inherit them and can open the state
+    # archive. Without these, rad startup fails with "OCI archive repository is
+    # not configured; set RADIUS_STATE_REGISTRY or RADIUS_GRAPH_REGISTRY".
+    env:
+      RADIUS_STATE_BACKEND: ${{ vars.RADIUS_STATE_BACKEND }}
+      RADIUS_STATE_REGISTRY: ${{ vars.RADIUS_STATE_REGISTRY }}
+      RADIUS_STATE_ARCHIVE: ${{ vars.RADIUS_STATE_ARCHIVE }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/extension/run-rad-commands-azure.yml
+++ b/.github/extension/run-rad-commands-azure.yml
@@ -49,6 +49,17 @@ jobs:
     name: Deploy with Radius
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    # OCI-backed Radius control-plane state, provisioned per-environment by the
+    # deploy tooling (canvas extension) as environment variables. Set at job
+    # level (not workflow level) so environment-scoped vars.* resolve, and so the
+    # shared restore-state (rad startup) and teardown (rad shutdown) actions —
+    # plus the deploy/app-graph commands — inherit them and can open the state
+    # archive. Without these, rad startup fails with "OCI archive repository is
+    # not configured; set RADIUS_STATE_REGISTRY or RADIUS_GRAPH_REGISTRY".
+    env:
+      RADIUS_STATE_BACKEND: ${{ vars.RADIUS_STATE_BACKEND }}
+      RADIUS_STATE_REGISTRY: ${{ vars.RADIUS_STATE_REGISTRY }}
+      RADIUS_STATE_ARCHIVE: ${{ vars.RADIUS_STATE_ARCHIVE }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Description

Deploys dispatched through the Radius canvas extension fail in the **Restore Radius state** step with:

```
Error: failed to open state archive: OCI archive repository is not configured; set RADIUS_STATE_REGISTRY or RADIUS_GRAPH_REGISTRY
Command failed: ... rad startup
```

### Root cause

The canvas extension provisions the OCI state package and sets these **environment-scoped GitHub variables** on the target GitHub Environment at environment-creation time:

- `RADIUS_STATE_BACKEND` (e.g. `oci`)
- `RADIUS_STATE_REGISTRY` (e.g. `ghcr.io/<owner>/<repo>-radius-state-<env>-<hash>`)
- `RADIUS_STATE_ARCHIVE` (e.g. `radius-state`)

But the deploy workflow templates never map these into the process environment, so `rad startup` (shared `restore-state` action) and `rad shutdown` (shared `teardown` action) never see them. `run-rad-commands-azure.yml` / `run-rad-commands-aws.yml` only expose `ENVIRONMENT`, `APP_FILE`, `APP_IMAGE`, and recipe-pack vars.

### Fix

Add a **job-level** `env:` block to the `deploy` job in both `run-rad-commands-azure.yml` and `run-rad-commands-aws.yml` exposing the three `RADIUS_STATE_*` vars.

Job level is deliberate: environment-scoped `vars.*` only resolve within a job that declares `environment:`, and a job-level `env:` is inherited by every step — including the shared `restore-state`/`teardown` composite actions where `rad startup`/`rad shutdown` run, plus the deploy/app-graph commands.

```yaml
    env:
      RADIUS_STATE_BACKEND: ${{ vars.RADIUS_STATE_BACKEND }}
      RADIUS_STATE_REGISTRY: ${{ vars.RADIUS_STATE_REGISTRY }}
      RADIUS_STATE_ARCHIVE: ${{ vars.RADIUS_STATE_ARCHIVE }}
```

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes #12471
