### PR TITLE
Log in to GHCR before rad startup/shutdown in deploy workflow templates

### DIFF
--- a/.github/extension/run-rad-commands-aws.yml
+++ b/.github/extension/run-rad-commands-aws.yml
@@ -66,6 +66,21 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
+      - name: Log in to GHCR for the state archive
+        # The OCI-backed Radius state archive authenticates to GHCR using the
+        # runner's Docker credential store (~/.docker/config.json). rad startup
+        # (restore-state) and rad shutdown (teardown) open that archive, so the
+        # runner must be logged in BEFORE those steps run -- otherwise the pull
+        # is anonymous and GHCR rejects the private radius-state package with a
+        # 401. docker login persists for the whole job, covering teardown too.
+        # GITHUB_TOKEN has packages: write (set at job level) for repo-linked
+        # packages; a PAT can be supplied instead for other-owner packages.
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Get target cluster kubeconfig
         run: |
           mkdir -p "$HOME/.kube"

--- a/.github/extension/run-rad-commands-azure.yml
+++ b/.github/extension/run-rad-commands-azure.yml
@@ -72,6 +72,21 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Log in to GHCR for the state archive
+        # The OCI-backed Radius state archive authenticates to GHCR using the
+        # runner's Docker credential store (~/.docker/config.json). rad startup
+        # (restore-state) and rad shutdown (teardown) open that archive, so the
+        # runner must be logged in BEFORE those steps run -- otherwise the pull
+        # is anonymous and GHCR rejects the private radius-state package with a
+        # 401. docker login persists for the whole job, covering teardown too.
+        # GITHUB_TOKEN has packages: write (set at job level) for repo-linked
+        # packages; a PAT can be supplied instead for other-owner packages.
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Get target cluster kubeconfig
         run: |
           mkdir -p "$HOME/.kube"


### PR DESCRIPTION
## Summary

The OCI-backed Radius state archive authenticates to GHCR **only** via the runner's Docker credential store (`credentials.NewStoreFromDocker` in `pkg/statearchive/oci/oci.go` and `ghcr.go`). The Azure and AWS deploy workflow templates never ran a `docker login` to GHCR before `rad startup` (the `restore-state` action) or `rad shutdown` (the `teardown` action), so opening a private `radius-state` package produced an **anonymous** token request that GHCR rejected:

```
Error: failed to open state archive: failed to resolve OCI archive "radius-state":
HEAD ".../manifests/radius-state": GET ".../token?scope=repository%3A...%3Apull...":
response status code 401: unauthorized: authentication required
```

The registry credentials that already exist in the templates (`github.actor` / `secrets.GITHUB_TOKEN`) were passed only to the later `run-rad-commands` action, where they create a Kubernetes secret for the containerImages recipe — they never logged the runner into GHCR.

## Change

Add a `docker/login-action` step (`ghcr.io`, `github.actor` / `secrets.GITHUB_TOKEN`) early in the `deploy` job of both `run-rad-commands-azure.yml` and `run-rad-commands-aws.yml`, before `Set up control plane` / `Restore Radius state` / `Teardown`. `docker login` writes `~/.docker/config.json`, which persists for the whole job, so `rad startup` and `rad shutdown` both authenticate. `packages: write` is already granted at the job level.

This mirrors the GHCR auth setup in the `repo-radius-state-e2e.yaml` workflow (#12476), which logs into GHCR the same way before its state save/restore steps.

## Note on package provisioning

The login is necessary but not always sufficient: the GHCR state package must also be **private/internal and linked to the repository** for `GITHUB_TOKEN` to authenticate, and Radius' visibility guard refuses public packages for state. Provisioning the package with that visibility/linkage is the responsibility of the per-environment deploy tooling that sets `RADIUS_STATE_REGISTRY` (analogous to the `precreate-repo-radius-state-package.sh` step in #12476), not these templates.

## Testing

- YAML of both templates validated with `yaml.safe_load`.
- `docker/login-action` pinned to `af1e73f918a031802d376d3c8bbc3fe56130a9b0` (v4.4.0), consistent with the other pins under `.github/workflows/`.