### PR TITLE
Add --preview flag to `rad deploy -a`

### DIFF
--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 
@@ -131,6 +132,7 @@ rad deploy myapp.bicep --parameters @myfile.json --parameters version=latest
 	commonflags.AddEnvironmentNameFlag(cmd)
 	commonflags.AddApplicationNameFlag(cmd)
 	commonflags.AddParameterFlag(cmd)
+	cmd.Flags().Bool("preview", false, "Deploy the application using the Radius.Core/applications resource type instead of Applications.Core/applications (can also be set via RADIUS_PREVIEW=true)")
 
 	return cmd, runner
 }
@@ -156,6 +158,9 @@ type Runner struct {
 	Workspace                *workspaces.Workspace
 	Providers                *clients.Providers
 	EnvResult                *EnvironmentCheckResult
+	// Preview indicates that the application should be deployed using the
+	// Radius.Core/applications resource type instead of Applications.Core/applications.
+	Preview bool
 }
 
 // NewRunner creates a new instance of the `rad deploy` runner.
@@ -234,6 +239,20 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Resolve whether to use the Radius.Core preview behavior for the application resource.
+	r.Preview, err = resolvePreview(cmd)
+	if err != nil {
+		return err
+	}
+
+	// The --preview flag only affects the application resource, so it requires an application.
+	// Reject only when the flag was set explicitly on the command line; env-var activation
+	// (RADIUS_PREVIEW=true) is intentionally tolerated as a no-op so it can be set globally
+	// without breaking application-less deployments.
+	if cmd.Flags().Changed("preview") && r.Preview && r.ApplicationName == "" {
+		return clierrors.Message("The --preview flag requires an application. Use --application to specify the application name, or set a default application in your workspace.")
+	}
+
 	if r.EnvironmentNameOrID != "" {
 		envResult, err := r.FetchEnvironment(cmd.Context(), r.EnvironmentNameOrID)
 		if err != nil {
@@ -296,7 +315,11 @@ func (r *Runner) Run(ctx context.Context) error {
 	if r.ApplicationName != "" {
 		// Environment validation has already happened, so only create application if we have an environment
 		if r.Providers.Radius.EnvironmentID != "" {
-			if _, err := isApplicationsCoreProvider(r.Providers.Radius.EnvironmentID); err == nil {
+			if r.Preview {
+				if err := r.createRadiusCoreApplicationIfNotFound(ctx); err != nil {
+					return err
+				}
+			} else {
 				client, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, *r.Workspace)
 				if err != nil {
 					return err
@@ -309,24 +332,6 @@ func (r *Runner) Run(ctx context.Context) error {
 				})
 				if err != nil {
 					return err
-				}
-			} else {
-				client := r.RadiusCoreClientFactory.NewApplicationsClient()
-				_, err := client.Get(ctx, r.Workspace.Scope, r.ApplicationName, nil)
-				if err != nil {
-					if clients.Is404Error(err) {
-						_, err = client.CreateOrUpdate(ctx, r.Workspace.Scope, r.ApplicationName, v20250801preview.ApplicationResource{
-							Location: to.Ptr(v1.LocationGlobal),
-							Properties: &v20250801preview.ApplicationProperties{
-								Environment: &r.Providers.Radius.EnvironmentID,
-							},
-						}, nil)
-						if err != nil {
-							return err
-						}
-					} else {
-						return err
-					}
 				}
 			}
 		}
@@ -437,19 +442,58 @@ func (r *Runner) reportMissingParameters(template map[string]any) error {
 	return clierrors.Message("The template %q could not be deployed because of the following errors:\n\n%v", r.FilePath, strings.Join(details, "\n"))
 }
 
-// isApplicationsCoreProvider returns true if the provider is Applications.Core based on the environment ID
-// It returns an error if the ID cannot be parsed
-func isApplicationsCoreProvider(id string) (bool, error) {
-	parsedID, err := resources.Parse(id)
+// resolvePreview reports whether the deploy command should use the Radius.Core preview
+// behavior for the application resource. It returns true when the --preview flag is explicitly
+// set, or when the flag is unset and the RADIUS_PREVIEW environment variable is "true"
+// (case-insensitive). The --preview flag takes precedence over the environment variable.
+//
+// The --preview flag is only registered on the `rad deploy` command. Other commands (e.g.
+// `rad run`) embed this runner without registering the flag; for those, preview is not
+// supported and this function returns false without error.
+func resolvePreview(cmd *cobra.Command) (bool, error) {
+	if cmd.Flags().Lookup("preview") == nil {
+		return false, nil
+	}
+	preview, err := cmd.Flags().GetBool("preview")
 	if err != nil {
 		return false, err
 	}
-
-	providerNamespace := parsedID.ProviderNamespace()
-	if strings.EqualFold(providerNamespace, appCoreProviderName) {
-		return true, nil
+	if !cmd.Flags().Changed("preview") {
+		preview = strings.EqualFold(os.Getenv("RADIUS_PREVIEW"), "true")
 	}
-	return false, nil
+	return preview, nil
+}
+
+// createRadiusCoreApplicationIfNotFound creates the application as a Radius.Core/applications
+// resource if it does not already exist. It lazily initializes the Radius.Core client factory
+// when needed.
+func (r *Runner) createRadiusCoreApplicationIfNotFound(ctx context.Context) error {
+	if r.RadiusCoreClientFactory == nil {
+		clientFactory, err := cmd.InitializeRadiusCoreClientFactory(ctx, r.Workspace)
+		if err != nil {
+			return err
+		}
+		r.RadiusCoreClientFactory = clientFactory
+	}
+
+	client := r.RadiusCoreClientFactory.NewApplicationsClient()
+	_, err := client.Get(ctx, r.Workspace.Scope, r.ApplicationName, nil)
+	if err != nil {
+		if clients.Is404Error(err) {
+			_, err = client.CreateOrUpdate(ctx, r.Workspace.Scope, r.ApplicationName, v20250801preview.ApplicationResource{
+				Location: to.Ptr(v1.LocationGlobal),
+				Properties: &v20250801preview.ApplicationProperties{
+					Environment: &r.Providers.Radius.EnvironmentID,
+				},
+			}, nil)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	return nil
 }
 
 // handleEnvironmentError handles common error patterns for environment retrieval
@@ -789,6 +833,10 @@ func (r *Runner) configureProviders() error {
 			providerNamespace := appCoreProviderName
 			if parsedID, err := resources.Parse(r.Providers.Radius.EnvironmentID); err == nil {
 				providerNamespace = parsedID.ProviderNamespace()
+			}
+			// When preview is enabled, the application is deployed as a Radius.Core/applications resource.
+			if r.Preview {
+				providerNamespace = radiusCoreProviderName
 			}
 			r.Providers.Radius.ApplicationID = r.Workspace.Scope + "/providers/" + providerNamespace + "/applications/" + r.ApplicationName
 

--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -121,6 +121,23 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
+			Name:          "rad deploy - preview flag without application is invalid",
+			Input:         []string{"app.bicep", "--preview"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// The guard rejects the flag before any environment is fetched, so only
+				// PrepareTemplate is exercised.
+				mocks.Bicep.EXPECT().
+					PrepareTemplate("app.bicep").
+					Return(map[string]any{}, nil).
+					Times(1)
+			},
+		},
+		{
 			Name:          "rad deploy - fallback workspace",
 			Input:         []string{"app.bicep", "--group", "my-group", "--environment", "/planes/radius/local/resourceGroups/my-group/providers/Applications.Core/environments/prod"},
 			ExpectedValid: true,
@@ -318,6 +335,55 @@ func Test_Validate(t *testing.T) {
 	}
 
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
+}
+
+func Test_ValidatePreviewEnvVarWithoutApplication(t *testing.T) {
+	// Activating preview via the RADIUS_PREVIEW environment variable (as opposed to the
+	// explicit --preview flag) must be tolerated as a no-op when no application is set, so a
+	// globally exported RADIUS_PREVIEW=true does not break application-less deployments.
+	t.Setenv("RADIUS_PREVIEW", "true")
+
+	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	appCoreEnvID := "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/prod"
+
+	mockAppClient := clients.NewMockApplicationsManagementClient(ctrl)
+	mockAppClient.EXPECT().
+		GetEnvironment(gomock.Any(), appCoreEnvID).
+		Return(v20231001preview.EnvironmentResource{ID: new(appCoreEnvID)}, nil).
+		Times(1)
+
+	mockBicep := bicep.NewMockInterface(ctrl)
+	mockBicep.EXPECT().
+		PrepareTemplate("app.bicep").
+		Return(map[string]any{}, nil).
+		Times(1)
+
+	f := &framework.Impl{
+		ConfigHolder: &framework.ConfigHolder{
+			ConfigFilePath: "",
+			Config:         configWithWorkspace,
+		},
+		Output: &output.MockOutput{},
+		Bicep:  mockBicep,
+	}
+
+	cmd, runner := NewCommand(f)
+	r := runner.(*Runner)
+	r.ConnectionFactory = &connections.MockFactory{ApplicationsManagementClient: mockAppClient}
+
+	cmd.SetContext(context.Background())
+	require.NoError(t, cmd.ParseFlags([]string{"-e", appCoreEnvID}))
+
+	err := r.Validate(cmd, []string{"app.bicep"})
+	require.NoError(t, err, "RADIUS_PREVIEW env var without an application must not error")
+
+	// Preview is still resolved to true, it simply has no effect without an application.
+	require.True(t, r.Preview)
+	require.Empty(t, r.ApplicationName)
 }
 
 func Test_ValidateRadiusCoreEnvProvider(t *testing.T) {
@@ -786,6 +852,207 @@ func Test_Run(t *testing.T) {
 		// All of the output in this command is being done by functions that we mock for testing, so this
 		// is always empty.
 		require.Empty(t, outputSink.Writes)
+	})
+
+	t.Run("Application-scoped deployment with preview creates Radius.Core application", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		bicepMock := bicep.NewMockInterface(ctrl)
+
+		options := deploy.Options{}
+
+		// Capture the CreateOrUpdate request so we can assert on the created resource.
+		var capturedRootScope, capturedAppName string
+		var capturedResource v20250801preview.ApplicationResource
+		createdRadiusCoreApp := false
+		appsServer := func() corerpfake.ApplicationsServer {
+			return corerpfake.ApplicationsServer{
+				Get: func(
+					_ context.Context,
+					_ string,
+					_ string,
+					_ *v20250801preview.ApplicationsClientGetOptions,
+				) (resp azfake.Responder[v20250801preview.ApplicationsClientGetResponse], errResp azfake.ErrorResponder) {
+					errResp.SetResponseError(http.StatusNotFound, "NotFound")
+					return
+				},
+				CreateOrUpdate: func(
+					_ context.Context,
+					rootScope string,
+					applicationName string,
+					resource v20250801preview.ApplicationResource,
+					_ *v20250801preview.ApplicationsClientCreateOrUpdateOptions,
+				) (resp azfake.Responder[v20250801preview.ApplicationsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+					createdRadiusCoreApp = true
+					capturedRootScope = rootScope
+					capturedAppName = applicationName
+					capturedResource = resource
+					resp.SetResponse(http.StatusOK, v20250801preview.ApplicationsClientCreateOrUpdateResponse{
+						ApplicationResource: v20250801preview.ApplicationResource{Name: to.Ptr(applicationName)},
+					}, nil)
+					return
+				},
+			}
+		}
+
+		workspace := &workspaces.Workspace{
+			Connection: map[string]any{
+				"kind":    "kubernetes",
+				"context": "kind-kind",
+			},
+			Name:  "kind-kind",
+			Scope: fmt.Sprintf("/planes/radius/local/resourceGroups/%s", radcli.TestEnvironmentName),
+		}
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(workspace.Scope, nil, nil, appsServer)
+		require.NoError(t, err)
+
+		deployMock := deploy.NewMockInterface(ctrl)
+		deployMock.EXPECT().
+			DeployWithProgress(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, o deploy.Options) (clients.DeploymentResult, error) {
+				options = o
+				return clients.DeploymentResult{}, nil
+			}).
+			Times(1)
+
+		outputSink := &output.MockOutput{}
+		environmentID := fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Radius.Core/environments/%s", radcli.TestEnvironmentName, radcli.TestEnvironmentName)
+		applicationID := fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Radius.Core/applications/test-application", radcli.TestEnvironmentName)
+		providers := clients.Providers{
+			Radius: &clients.RadiusProvider{
+				EnvironmentID: environmentID,
+				ApplicationID: applicationID,
+			},
+		}
+
+		runner := &Runner{
+			Bicep:                   bicepMock,
+			ConnectionFactory:       &connections.MockFactory{},
+			RadiusCoreClientFactory: factory,
+			Deploy:                  deployMock,
+			Output:                  outputSink,
+			Providers:               &providers,
+			FilePath:                "app.bicep",
+			ApplicationName:         "test-application",
+			EnvironmentNameOrID:     environmentID,
+			Parameters:              map[string]map[string]any{},
+			Workspace:               workspace,
+			Template:                map[string]any{},
+			Preview:                 true,
+		}
+
+		err = runner.Run(context.Background())
+		require.NoError(t, err)
+
+		// The application must have been created as a Radius.Core/applications resource.
+		require.True(t, createdRadiusCoreApp, "expected the application to be created via the Radius.Core applications client")
+		// The Radius.Core client normalizes the root scope by trimming the leading slash.
+		require.Equal(t, strings.TrimPrefix(workspace.Scope, "/"), capturedRootScope)
+		require.Equal(t, "test-application", capturedAppName)
+		require.NotNil(t, capturedResource.Properties)
+		require.NotNil(t, capturedResource.Properties.Environment)
+		require.Equal(t, environmentID, *capturedResource.Properties.Environment)
+
+		// Deployment is scoped to the Radius.Core app and env.
+		require.Equal(t, applicationID, options.Providers.Radius.ApplicationID)
+		require.Equal(t, environmentID, options.Providers.Radius.EnvironmentID)
+		require.Empty(t, outputSink.Writes)
+	})
+
+	t.Run("Preview creates Radius.Core application pointing at an Applications.Core environment", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		bicepMock := bicep.NewMockInterface(ctrl)
+
+		// Capture the CreateOrUpdate request so we can assert the environment reference is preserved.
+		var capturedResource v20250801preview.ApplicationResource
+		createdRadiusCoreApp := false
+		appsServer := func() corerpfake.ApplicationsServer {
+			return corerpfake.ApplicationsServer{
+				Get: func(
+					_ context.Context,
+					_ string,
+					_ string,
+					_ *v20250801preview.ApplicationsClientGetOptions,
+				) (resp azfake.Responder[v20250801preview.ApplicationsClientGetResponse], errResp azfake.ErrorResponder) {
+					errResp.SetResponseError(http.StatusNotFound, "NotFound")
+					return
+				},
+				CreateOrUpdate: func(
+					_ context.Context,
+					_ string,
+					applicationName string,
+					resource v20250801preview.ApplicationResource,
+					_ *v20250801preview.ApplicationsClientCreateOrUpdateOptions,
+				) (resp azfake.Responder[v20250801preview.ApplicationsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+					createdRadiusCoreApp = true
+					capturedResource = resource
+					resp.SetResponse(http.StatusOK, v20250801preview.ApplicationsClientCreateOrUpdateResponse{
+						ApplicationResource: v20250801preview.ApplicationResource{Name: to.Ptr(applicationName)},
+					}, nil)
+					return
+				},
+			}
+		}
+
+		workspace := &workspaces.Workspace{
+			Connection: map[string]any{
+				"kind":    "kubernetes",
+				"context": "kind-kind",
+			},
+			Name:  "kind-kind",
+			Scope: fmt.Sprintf("/planes/radius/local/resourceGroups/%s", radcli.TestEnvironmentName),
+		}
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(workspace.Scope, nil, nil, appsServer)
+		require.NoError(t, err)
+
+		deployMock := deploy.NewMockInterface(ctrl)
+		deployMock.EXPECT().
+			DeployWithProgress(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, o deploy.Options) (clients.DeploymentResult, error) {
+				return clients.DeploymentResult{}, nil
+			}).
+			Times(1)
+
+		outputSink := &output.MockOutput{}
+		// Environment resolved to an Applications.Core environment, but preview forces a Radius.Core application.
+		environmentID := fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Applications.Core/environments/%s", radcli.TestEnvironmentName, radcli.TestEnvironmentName)
+		applicationID := fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Radius.Core/applications/test-application", radcli.TestEnvironmentName)
+		providers := clients.Providers{
+			Radius: &clients.RadiusProvider{
+				EnvironmentID: environmentID,
+				ApplicationID: applicationID,
+			},
+		}
+
+		runner := &Runner{
+			Bicep:                   bicepMock,
+			ConnectionFactory:       &connections.MockFactory{},
+			RadiusCoreClientFactory: factory,
+			Deploy:                  deployMock,
+			Output:                  outputSink,
+			Providers:               &providers,
+			FilePath:                "app.bicep",
+			ApplicationName:         "test-application",
+			EnvironmentNameOrID:     environmentID,
+			Parameters:              map[string]map[string]any{},
+			Workspace:               workspace,
+			Template:                map[string]any{},
+			Preview:                 true,
+		}
+
+		err = runner.Run(context.Background())
+		require.NoError(t, err)
+
+		// A Radius.Core application is created and its environment reference is preserved as-is.
+		require.True(t, createdRadiusCoreApp, "expected the application to be created via the Radius.Core applications client")
+		require.NotNil(t, capturedResource.Properties)
+		require.NotNil(t, capturedResource.Properties.Environment)
+		require.Equal(t, environmentID, *capturedResource.Properties.Environment)
 	})
 
 	t.Run("Deployment that doesn't need an app or env", func(t *testing.T) {
@@ -1870,6 +2137,84 @@ func Test_ConfigureProviders(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_ConfigureProviders_Preview(t *testing.T) {
+	// With --preview enabled, the application ID must use the Radius.Core provider namespace
+	// even when the environment is an Applications.Core environment.
+	runner := &Runner{
+		EnvResult: &EnvironmentCheckResult{
+			UseApplicationsCore: true,
+			ApplicationsCoreEnv: &v20231001preview.EnvironmentResource{
+				ID:         new("/planes/radius/local/resourceGroups/test-rg/providers/Applications.Core/environments/myenv"),
+				Properties: &v20231001preview.EnvironmentProperties{},
+			},
+		},
+		ApplicationName: "myapp",
+		Preview:         true,
+		Workspace: &workspaces.Workspace{
+			Scope: "/planes/radius/local/resourceGroups/test-rg",
+		},
+		Providers: &clients.Providers{
+			Radius: &clients.RadiusProvider{},
+		},
+	}
+
+	err := runner.configureProviders()
+	require.NoError(t, err)
+	require.Equal(t, "/planes/radius/local/resourceGroups/test-rg/providers/Radius.Core/applications/myapp", runner.Providers.Radius.ApplicationID)
+}
+
+func Test_resolvePreview(t *testing.T) {
+	newCmd := func() *cobra.Command {
+		c := &cobra.Command{}
+		c.Flags().Bool("preview", false, "")
+		return c
+	}
+
+	t.Run("flag explicitly set to true", func(t *testing.T) {
+		t.Setenv("RADIUS_PREVIEW", "")
+		c := newCmd()
+		require.NoError(t, c.Flags().Set("preview", "true"))
+		preview, err := resolvePreview(c)
+		require.NoError(t, err)
+		require.True(t, preview)
+	})
+
+	t.Run("flag takes precedence over env var", func(t *testing.T) {
+		t.Setenv("RADIUS_PREVIEW", "true")
+		c := newCmd()
+		require.NoError(t, c.Flags().Set("preview", "false"))
+		preview, err := resolvePreview(c)
+		require.NoError(t, err)
+		require.False(t, preview)
+	})
+
+	t.Run("env var activates preview when flag unset", func(t *testing.T) {
+		t.Setenv("RADIUS_PREVIEW", "TRUE")
+		c := newCmd()
+		preview, err := resolvePreview(c)
+		require.NoError(t, err)
+		require.True(t, preview)
+	})
+
+	t.Run("neither flag nor env var set", func(t *testing.T) {
+		t.Setenv("RADIUS_PREVIEW", "")
+		c := newCmd()
+		preview, err := resolvePreview(c)
+		require.NoError(t, err)
+		require.False(t, preview)
+	})
+
+	t.Run("flag not registered returns false without error", func(t *testing.T) {
+		// Commands that embed the deploy runner without registering the --preview flag
+		// (e.g. rad run) must not error, and preview must be disabled regardless of the env var.
+		t.Setenv("RADIUS_PREVIEW", "true")
+		c := &cobra.Command{}
+		preview, err := resolvePreview(c)
+		require.NoError(t, err)
+		require.False(t, preview)
+	})
 }
 
 func Test_addDeploymentErrorContext(t *testing.T) {


### PR DESCRIPTION
## Summary
Add a  --preview  flag to  rad deploy  that provisions the auto-created application as a  Radius.Core/applications  resource instead of the legacy  Applications.Core/applications .

When  rad deploy -a <app> --preview  is run, Radius bootstraps the application (and injects the  application  parameter) using the Radius.Core provider. The flag can also be activated via  RADIUS_PREVIEW=true  (the explicit flag takes precedence). Default behavior is unchanged — without the flag, applications continue to use  Applications.Core .

The flag only affects the application resource that  rad deploy  bootstraps; it does not rewrite resource types declared inside your Bicep/ARM template. It therefore requires an application: setting  --preview  explicitly without  -a  (or a workspace default application) is rejected with a clear error. 

## Reason for change
Radius is migrating from the legacy  Applications.Core/*  resource types to the new  Radius.Core/*  types.  rad deploy  needs a way to opt into creating the application as a  Radius.Core/applications  resource during the preview period. This also replaces a latent bug where the previous provider-selection logic discarded its boolean result ( if _, err := isApplicationsCoreProvider(...); err == nil ) and always took the Applications.Core branch, leaving the Radius.Core path as dead code.


Fixes #12428

## How to test
1. Create a  Radius.Core/environments  environment.
2. Run  rad deploy app.bicep -a myapp --preview  (or  RADIUS_PREVIEW=true rad deploy app.bicep -a myapp ).
3. Verify  myapp  is created as  Radius.Core/applications :  rad resource show radius.core/applications myapp .
4. Run the same command without  --preview  and confirm the application is created under  Applications.Core/applications  (unchanged legacy behavior).
5. Run  rad deploy app.bicep --preview  (no  -a ) and confirm it fails with a message directing you to specify  --application .

## File change summary


| File | Summary of change |
| ---- | ----------------- |
| `pkg/cli/cmd/deploy/deploy.go` | Add `--preview` flag and `Runner.Preview` field; resolve it (flag + `RADIUS_PREVIEW`) in `Validate` with a guard requiring an application when the flag is set explicitly; branch app auto-creation on `Preview` via new `createRadiusCoreApplicationIfNotFound` (Radius.Core client, lazy factory init); force the injected `application` param to the `Radius.Core` namespace under preview; remove the unused/buggy `isApplicationsCoreProvider` helper. |
| `pkg/cli/cmd/deploy/deploy_test.go` | Add tests: Radius.Core app creation under preview (asserting scope, name, and `properties.environment` payload); Radius.Core app pointing at an Applications.Core environment; `configureProviders` namespace override under preview; `resolvePreview` precedence (flag vs `RADIUS_PREVIEW`); `--preview` without application rejected; `RADIUS_PREVIEW` env-var without application tolerated as a no-op. |
