### PR TITLE
build: add ARM64 support for Windows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,6 +95,8 @@ jobs:
             target_arch: arm
           - target_os: windows
             target_arch: amd64
+          - target_os: windows
+            target_arch: arm64
           - target_os: darwin
             target_arch: amd64
           - target_os: darwin

--- a/.github/workflows/nightly-rad-CLI-tests.yaml
+++ b/.github/workflows/nightly-rad-CLI-tests.yaml
@@ -56,7 +56,7 @@ jobs:
           MATRIX_ARCH: ${{ matrix.arch }}
           MATRIX_FILE: ${{ matrix.file }}
           MATRIX_EXT: ${{ matrix.ext }}
-        run: make test-cli-download OS="${MATRIX_OS}" ARCH="${MATRIX_ARCH}" FILE="${MATRIX_FILE}" EXT="${MATRIX_EXT}"
+        run: make test-cli-download CLI_DOWNLOAD_OS="${MATRIX_OS}" CLI_DOWNLOAD_ARCH="${MATRIX_ARCH}" CLI_DOWNLOAD_FILE="${MATRIX_FILE}" CLI_DOWNLOAD_EXT="${MATRIX_EXT}"
 
       - name: Create GitHub issue on failure
         if: ${{ failure() }}

--- a/.github/workflows/nightly-rad-CLI-tests.yaml
+++ b/.github/workflows/nightly-rad-CLI-tests.yaml
@@ -41,6 +41,11 @@ jobs:
             arch: amd64
             file: rad
             ext: .exe
+          - os: windows
+            arch: arm64
+            file: rad
+            ext: .exe
+            minimum_version: v0.60.0
     permissions:
       contents: read
       issues: write # Required to create an issue when the nightly run fails
@@ -56,7 +61,8 @@ jobs:
           MATRIX_ARCH: ${{ matrix.arch }}
           MATRIX_FILE: ${{ matrix.file }}
           MATRIX_EXT: ${{ matrix.ext }}
-        run: make test-cli-download CLI_DOWNLOAD_OS="${MATRIX_OS}" CLI_DOWNLOAD_ARCH="${MATRIX_ARCH}" CLI_DOWNLOAD_FILE="${MATRIX_FILE}" CLI_DOWNLOAD_EXT="${MATRIX_EXT}"
+          MATRIX_MINIMUM_VERSION: ${{ matrix.minimum_version }}
+        run: make test-cli-download CLI_DOWNLOAD_OS="${MATRIX_OS}" CLI_DOWNLOAD_ARCH="${MATRIX_ARCH}" CLI_DOWNLOAD_FILE="${MATRIX_FILE}" CLI_DOWNLOAD_EXT="${MATRIX_EXT}" CLI_DOWNLOAD_MINIMUM_VERSION="${MATRIX_MINIMUM_VERSION}"
 
       - name: Create GitHub issue on failure
         if: ${{ failure() }}

--- a/.github/workflows/nightly-rad-CLI-tests.yaml
+++ b/.github/workflows/nightly-rad-CLI-tests.yaml
@@ -62,7 +62,13 @@ jobs:
           MATRIX_FILE: ${{ matrix.file }}
           MATRIX_EXT: ${{ matrix.ext }}
           MATRIX_MINIMUM_VERSION: ${{ matrix.minimum_version }}
-        run: make test-cli-download CLI_DOWNLOAD_OS="${MATRIX_OS}" CLI_DOWNLOAD_ARCH="${MATRIX_ARCH}" CLI_DOWNLOAD_FILE="${MATRIX_FILE}" CLI_DOWNLOAD_EXT="${MATRIX_EXT}" CLI_DOWNLOAD_MINIMUM_VERSION="${MATRIX_MINIMUM_VERSION}"
+        run: >-
+          make test-cli-download
+          CLI_DOWNLOAD_OS="${MATRIX_OS}"
+          CLI_DOWNLOAD_ARCH="${MATRIX_ARCH}"
+          CLI_DOWNLOAD_FILE="${MATRIX_FILE}"
+          CLI_DOWNLOAD_EXT="${MATRIX_EXT}"
+          CLI_DOWNLOAD_MINIMUM_VERSION="${MATRIX_MINIMUM_VERSION}"
 
       - name: Create GitHub issue on failure
         if: ${{ failure() }}

--- a/build/test-cli-download.sh
+++ b/build/test-cli-download.sh
@@ -26,19 +26,20 @@ EXT=${4:-""}
 MINIMUM_VERSION=${5:-""}
 
 version_is_at_least() {
-    local actual="${1#v}"
-    local minimum="${2#v}"
-    local version_pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
+    local -r actual="${1#v}"
+    local -r minimum="${2#v}"
+    local -r version_pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
     local -a actual_parts
     local -a minimum_parts
+    local index
 
     if [[ ! "${actual}" =~ ${version_pattern} ]]; then
-        echo "Invalid release version: $1" >&2
+        echo "Invalid release version: ${1}" >&2
         return 2
     fi
 
     if [[ ! "${minimum}" =~ ${version_pattern} ]]; then
-        echo "Invalid minimum version: $2" >&2
+        echo "Invalid minimum version: ${2}" >&2
         return 2
     fi
 
@@ -93,7 +94,8 @@ if [[ -n "${MINIMUM_VERSION}" ]]; then
             exit 1
         fi
 
-        echo "Skipping CLI download test for $OS/$ARCH: latest stable release $RAD_VERSION predates $MINIMUM_VERSION"
+        echo "Skipping CLI download test for ${OS}/${ARCH}: latest stable" \
+            "release ${RAD_VERSION} predates ${MINIMUM_VERSION}"
         exit 0
     fi
 fi

--- a/build/test-cli-download.sh
+++ b/build/test-cli-download.sh
@@ -23,6 +23,39 @@ OS=${1:-"linux"}
 ARCH=${2:-"amd64"}
 FILE=${3:-"rad"}
 EXT=${4:-""}
+MINIMUM_VERSION=${5:-""}
+
+version_is_at_least() {
+    local actual="${1#v}"
+    local minimum="${2#v}"
+    local version_pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
+    local -a actual_parts
+    local -a minimum_parts
+
+    if [[ ! "${actual}" =~ ${version_pattern} ]]; then
+        echo "Invalid release version: $1" >&2
+        return 2
+    fi
+
+    if [[ ! "${minimum}" =~ ${version_pattern} ]]; then
+        echo "Invalid minimum version: $2" >&2
+        return 2
+    fi
+
+    IFS=. read -r -a actual_parts <<< "${actual}"
+    IFS=. read -r -a minimum_parts <<< "${minimum}"
+
+    for index in 0 1 2; do
+        if ((10#${actual_parts[$index]} > 10#${minimum_parts[$index]})); then
+            return 0
+        fi
+        if ((10#${actual_parts[$index]} < 10#${minimum_parts[$index]})); then
+            return 1
+        fi
+    done
+
+    return 0
+}
 
 echo "Starting CLI download test for $OS/$ARCH"
 
@@ -50,6 +83,20 @@ if [ -z "$RAD_VERSION" ]; then
 fi
 
 echo "Successfully retrieved RAD_VERSION: $RAD_VERSION"
+
+if [[ -n "${MINIMUM_VERSION}" ]]; then
+    if version_is_at_least "${RAD_VERSION}" "${MINIMUM_VERSION}"; then
+        :
+    else
+        compare_status=$?
+        if ((compare_status == 2)); then
+            exit 1
+        fi
+
+        echo "Skipping CLI download test for $OS/$ARCH: latest stable release $RAD_VERSION predates $MINIMUM_VERSION"
+        exit 0
+    fi
+fi
 
 # Download the CLI binary from GitHub releases
 filename="${FILE}_${OS}_${ARCH}${EXT}"

--- a/build/test.mk
+++ b/build/test.mk
@@ -27,7 +27,12 @@ CLI_DOWNLOAD_MINIMUM_VERSION ?=
 
 .PHONY: test-cli-download
 test-cli-download: ## Test CLI download for specified OS and ARCH (defaults to linux/amd64). Usage: make test-cli-download [CLI_DOWNLOAD_OS=linux] [CLI_DOWNLOAD_ARCH=amd64] [CLI_DOWNLOAD_FILE=rad] [CLI_DOWNLOAD_EXT=] [CLI_DOWNLOAD_MINIMUM_VERSION=]
-	@bash $(CLI_DOWNLOAD_TEST_SCRIPT) "$(CLI_DOWNLOAD_OS)" "$(CLI_DOWNLOAD_ARCH)" "$(CLI_DOWNLOAD_FILE)" "$(CLI_DOWNLOAD_EXT)" "$(CLI_DOWNLOAD_MINIMUM_VERSION)"
+	@bash $(CLI_DOWNLOAD_TEST_SCRIPT) \
+		"$(CLI_DOWNLOAD_OS)" \
+		"$(CLI_DOWNLOAD_ARCH)" \
+		"$(CLI_DOWNLOAD_FILE)" \
+		"$(CLI_DOWNLOAD_EXT)" \
+		"$(CLI_DOWNLOAD_MINIMUM_VERSION)"
 
 # Will be set by our build workflow, this is just a default
 TEST_TIMEOUT ?=1h

--- a/build/test.mk
+++ b/build/test.mk
@@ -23,10 +23,11 @@ CLI_DOWNLOAD_OS ?= linux
 CLI_DOWNLOAD_ARCH ?= amd64
 CLI_DOWNLOAD_FILE ?= rad
 CLI_DOWNLOAD_EXT ?=
+CLI_DOWNLOAD_MINIMUM_VERSION ?=
 
 .PHONY: test-cli-download
-test-cli-download: ## Test CLI download for specified OS and ARCH (defaults to linux/amd64). Usage: make test-cli-download [CLI_DOWNLOAD_OS=linux] [CLI_DOWNLOAD_ARCH=amd64] [CLI_DOWNLOAD_FILE=rad] [CLI_DOWNLOAD_EXT=]
-	@bash $(CLI_DOWNLOAD_TEST_SCRIPT) $(CLI_DOWNLOAD_OS) $(CLI_DOWNLOAD_ARCH) $(CLI_DOWNLOAD_FILE) $(CLI_DOWNLOAD_EXT)
+test-cli-download: ## Test CLI download for specified OS and ARCH (defaults to linux/amd64). Usage: make test-cli-download [CLI_DOWNLOAD_OS=linux] [CLI_DOWNLOAD_ARCH=amd64] [CLI_DOWNLOAD_FILE=rad] [CLI_DOWNLOAD_EXT=] [CLI_DOWNLOAD_MINIMUM_VERSION=]
+	@bash $(CLI_DOWNLOAD_TEST_SCRIPT) "$(CLI_DOWNLOAD_OS)" "$(CLI_DOWNLOAD_ARCH)" "$(CLI_DOWNLOAD_FILE)" "$(CLI_DOWNLOAD_EXT)" "$(CLI_DOWNLOAD_MINIMUM_VERSION)"
 
 # Will be set by our build workflow, this is just a default
 TEST_TIMEOUT ?=1h


### PR DESCRIPTION
## Summary

This pull request makes improvements to the CI/CD workflow configuration, primarily by expanding platform support and aligning environment variable names for greater clarity and consistency.

**CI/CD Platform Support:**

* Added a new build matrix entry for the `windows/arm64` architecture in `.github/workflows/build.yaml`, enabling builds for Windows on ARM64 devices.

**Workflow Variable Naming:**

* Updated the environment variable names used in the `make test-cli-download` command in `.github/workflows/nightly-rad-CLI-tests.yaml` to use the `CLI_DOWNLOAD_` prefix, improving clarity and reducing the risk of variable name collisions.

## Reason for change

<!--
Explain why this change is needed. If it addresses a GitHub issue, link it
below so it is automatically closed when this PR merges (optional).
-->

Fixes: #12503

## How to test

<!-- Describe the steps a reviewer can take to verify these changes. -->

## File change summary

<!-- Summarize the change made in each file that was modified. -->

| File | Summary of change |
| ---- | ----------------- |
|      |                   |
