### PR TITLE
fix(test): stabilize Core RP gateway functional tests

### DIFF
--- a/test/functional-portable/corerp/noncloud/resources/gateway_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/gateway_test.go
@@ -439,7 +439,7 @@ func testGatewayWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest,
 	stopChan := make(chan struct{})
 
 	// portChan will be populated with the assigned port once the port-forward connection is opened on it
-	portChan := make(chan int)
+	portChan := make(chan int, 1)
 
 	// errorChan receives both startup and runtime failures. Buffer it so ExposeIngress
 	// can finish after this helper closes the session.
@@ -454,6 +454,8 @@ func testGatewayWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest,
 			return errors.New("portforward stopped before becoming ready")
 		}
 		return fmt.Errorf("portforward failed: %w", err)
+	case <-ctx.Done():
+		return fmt.Errorf("portforward setup canceled: %w", ctx.Err())
 	case localPort := <-portChan:
 		protocol := "http"
 		if isHttps {

--- a/test/functional-portable/corerp/noncloud/resources/gateway_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/gateway_test.go
@@ -441,8 +441,7 @@ func testGatewayWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest,
 	// portChan will be populated with the assigned port once the port-forward connection is opened on it
 	portChan := make(chan int, 1)
 
-	// errorChan receives both startup and runtime failures. Buffer it so ExposeIngress
-	// can finish after this helper closes the session.
+	// errorChan receives the single startup or runtime failure while request probes are in flight.
 	errorChan := make(chan error, 1)
 
 	go testutil.ExposeIngress(t, ctx, at.Options.K8sClient, at.Options.K8sConfig, remotePort, stopChan, portChan, errorChan)

--- a/test/functional-portable/corerp/noncloud/resources/gateway_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/gateway_test.go
@@ -662,7 +662,7 @@ func newTestHTTPClient(isHttps bool, hostname string) *http.Client {
 	}
 }
 
-func Test_TestGatewayAvailability_PortForwardStops(t *testing.T) {
+func TestGatewayAvailability_PortForwardStops(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {

--- a/test/functional-portable/corerp/noncloud/resources/gateway_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/gateway_test.go
@@ -122,9 +122,8 @@ func Test_GatewayDNS(t *testing.T) {
 	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, appNamespace)
 	test.PreSetup = preSetup
 	test.Steps[0].Executor = step.NewDeployExecutor(template, testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
-	test.RunSerial = true
 
-	test.Test(t)
+	runGatewayTest(t, test)
 }
 
 func Test_Gateway_SSLPassthrough(t *testing.T) {
@@ -190,9 +189,8 @@ func Test_Gateway_SSLPassthrough(t *testing.T) {
 	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, appNamespace)
 	test.PreSetup = preSetup
 	test.Steps[0].Executor = step.NewDeployExecutor(template, testutil.GetMagpieImage(), "@testdata/parameters/test-tls-cert.parameters.json", fmt.Sprintf("environment=%s", previewEnvID))
-	test.RunSerial = true
 
-	test.Test(t)
+	runGatewayTest(t, test)
 }
 
 func Test_Gateway_Timeout(t *testing.T) {
@@ -254,8 +252,7 @@ func Test_Gateway_Timeout(t *testing.T) {
 			},
 		},
 	})
-	test.RunSerial = true
-	test.Test(t)
+	runGatewayTest(t, test)
 }
 
 func Test_Gateway_Timeout_Backend_Exceeds_Request(t *testing.T) {
@@ -381,9 +378,8 @@ func Test_Gateway_TLSTermination(t *testing.T) {
 			},
 		},
 	})
-	test.RunSerial = true
 
-	test.Test(t)
+	runGatewayTest(t, test)
 }
 
 func Test_Gateway_Failure(t *testing.T) {
@@ -430,6 +426,14 @@ func Test_Gateway_Failure(t *testing.T) {
 	test.Test(t)
 }
 
+// runGatewayTest prevents route reconciliation and probes from overlapping on the
+// single Contour/Envoy dataplane used by the functional-test cluster.
+func runGatewayTest(t *testing.T, test rp.RPTest) {
+	t.Helper()
+	test.RunSerial = true
+	test.Test(t)
+}
+
 func testGatewayWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest, namespace, hostname string, remotePort int, isHttps bool, tests []GatewayTestConfig) error {
 	// stopChan will close the port-forward connection on close
 	stopChan := make(chan struct{})
@@ -446,6 +450,9 @@ func testGatewayWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest,
 
 	select {
 	case err := <-errorChan:
+		if err == nil {
+			return errors.New("portforward stopped before becoming ready")
+		}
 		return fmt.Errorf("portforward failed: %w", err)
 	case localPort := <-portChan:
 		protocol := "http"
@@ -523,6 +530,9 @@ func testGatewayAvailability(t *testing.T, ctx context.Context, hostname, baseUR
 		case err := <-portForwardErrors:
 			if lastRes != nil {
 				lastRes.Body.Close()
+			}
+			if err == nil {
+				return fmt.Errorf("portforward stopped while probing %s", urlPath)
 			}
 			return fmt.Errorf("portforward stopped while probing %s: %w", urlPath, err)
 		case <-ctx.Done():

--- a/test/functional-portable/corerp/noncloud/resources/gateway_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/gateway_test.go
@@ -19,10 +19,13 @@ package resource_test
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/http/httputil"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -32,6 +35,8 @@ import (
 	"github.com/radius-project/radius/test/testutil"
 	"github.com/radius-project/radius/test/validation"
 	"github.com/stretchr/testify/require"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -95,7 +100,7 @@ func Test_GatewayDNS(t *testing.T) {
 				// Set up pod port-forwarding for the shared Gateway API envoy
 				t.Logf("Setting up portforward")
 
-				err := testGatewayWithPortForward(t, ctx, ct, hostname, httpRemotePort, false, []GatewayTestConfig{
+				err := testGatewayWithPortForward(t, ctx, ct, appNamespace, hostname, httpRemotePort, false, []GatewayTestConfig{
 					// /healthz is exposed on the frontend container, reached via the '/' rule
 					{
 						Path:               "healthz",
@@ -117,6 +122,7 @@ func Test_GatewayDNS(t *testing.T) {
 	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, appNamespace)
 	test.PreSetup = preSetup
 	test.Steps[0].Executor = step.NewDeployExecutor(template, testutil.GetMagpieImage(), fmt.Sprintf("environment=%s", previewEnvID))
+	test.RunSerial = true
 
 	test.Test(t)
 }
@@ -162,7 +168,7 @@ func Test_Gateway_SSLPassthrough(t *testing.T) {
 			PostStepVerify: func(ctx context.Context, t *testing.T, ct rp.RPTest) {
 				// Set up pod port-forwarding for the shared Gateway API envoy
 				t.Logf("Setting up portforward")
-				err := testGatewayWithPortForward(t, ctx, ct, hostname, httpsRemotePort, true, []GatewayTestConfig{
+				err := testGatewayWithPortForward(t, ctx, ct, appNamespace, hostname, httpsRemotePort, true, []GatewayTestConfig{
 					// /healthz is exposed on frontend container (which terminates TLS itself)
 					{
 						Path:               "healthz",
@@ -184,6 +190,7 @@ func Test_Gateway_SSLPassthrough(t *testing.T) {
 	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, appNamespace)
 	test.PreSetup = preSetup
 	test.Steps[0].Executor = step.NewDeployExecutor(template, testutil.GetMagpieImage(), "@testdata/parameters/test-tls-cert.parameters.json", fmt.Sprintf("environment=%s", previewEnvID))
+	test.RunSerial = true
 
 	test.Test(t)
 }
@@ -229,7 +236,7 @@ func Test_Gateway_Timeout(t *testing.T) {
 
 				// Set up pod port-forwarding for contour-envoy
 				t.Logf("Setting up portforward")
-				err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpRemotePort, false, []GatewayTestConfig{
+				err = testGatewayWithPortForward(t, ctx, ct, appNamespace, metadata.Hostname, httpRemotePort, false, []GatewayTestConfig{
 					// /healthz is exposed on frontend container
 					{
 						Path:               "healthz",
@@ -247,6 +254,7 @@ func Test_Gateway_Timeout(t *testing.T) {
 			},
 		},
 	})
+	test.RunSerial = true
 	test.Test(t)
 }
 
@@ -355,7 +363,7 @@ func Test_Gateway_TLSTermination(t *testing.T) {
 
 				// Set up pod port-forwarding for contour-envoy
 				t.Logf("Setting up portforward")
-				err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpsRemotePort, true, []GatewayTestConfig{
+				err = testGatewayWithPortForward(t, ctx, ct, appNamespace, metadata.Hostname, httpsRemotePort, true, []GatewayTestConfig{
 					// /healthz is exposed on frontend container
 					{
 						Path:               "healthz",
@@ -373,6 +381,7 @@ func Test_Gateway_TLSTermination(t *testing.T) {
 			},
 		},
 	})
+	test.RunSerial = true
 
 	test.Test(t)
 }
@@ -421,21 +430,23 @@ func Test_Gateway_Failure(t *testing.T) {
 	test.Test(t)
 }
 
-func testGatewayWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest, hostname string, remotePort int, isHttps bool, tests []GatewayTestConfig) error {
+func testGatewayWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest, namespace, hostname string, remotePort int, isHttps bool, tests []GatewayTestConfig) error {
 	// stopChan will close the port-forward connection on close
 	stopChan := make(chan struct{})
 
 	// portChan will be populated with the assigned port once the port-forward connection is opened on it
 	portChan := make(chan int)
 
-	// errorChan will contain any errors created from initializing the port-forwarding session
-	errorChan := make(chan error)
+	// errorChan receives both startup and runtime failures. Buffer it so ExposeIngress
+	// can finish after this helper closes the session.
+	errorChan := make(chan error, 1)
 
 	go testutil.ExposeIngress(t, ctx, at.Options.K8sClient, at.Options.K8sConfig, remotePort, stopChan, portChan, errorChan)
+	defer close(stopChan)
 
 	select {
 	case err := <-errorChan:
-		return fmt.Errorf("portforward failed with error: %s", err)
+		return fmt.Errorf("portforward failed: %w", err)
 	case localPort := <-portChan:
 		protocol := "http"
 		if isHttps {
@@ -446,8 +457,8 @@ func testGatewayWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest,
 		t.Logf("Portforward session active at %s", baseURL)
 
 		for _, test := range tests {
-			if err := testGatewayAvailability(t, hostname, baseURL, test.Path, test.ExpectedStatusCode, isHttps); err != nil {
-				close(stopChan)
+			if err := testGatewayAvailability(t, ctx, hostname, baseURL, test.Path, test.ExpectedStatusCode, isHttps, errorChan); err != nil {
+				logGatewayNetworkDiagnostics(t, ctx, at, namespace)
 				return err
 			}
 		}
@@ -458,9 +469,9 @@ func testGatewayWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest,
 	}
 }
 
-func testGatewayAvailability(t *testing.T, hostname, baseURL, path string, expectedStatusCode int, isHttps bool) error {
+func testGatewayAvailability(t *testing.T, ctx context.Context, hostname, baseURL, path string, expectedStatusCode int, isHttps bool, portForwardErrors <-chan error) error {
 	urlPath := strings.TrimSuffix(baseURL, "/") + "/" + strings.TrimPrefix(path, "/")
-	req, err := http.NewRequest(http.MethodGet, urlPath, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlPath, nil)
 	if err != nil {
 		return err
 	}
@@ -468,6 +479,7 @@ func testGatewayAvailability(t *testing.T, hostname, baseURL, path string, expec
 	req.Host = hostname
 
 	client := newTestHTTPClient(isHttps, hostname)
+	defer client.CloseIdleConnections()
 
 	// A freshly-deployed gateway can briefly return errors (e.g. HTTP 503 from Envoy) while
 	// Contour programs the xDS route/cluster for the new route. Poll over a realistic window
@@ -507,8 +519,19 @@ func testGatewayAvailability(t *testing.T, hostname, baseURL, path string, expec
 			break
 		}
 
-		// Wait for retryBackoff before trying again
-		time.Sleep(retryBackoff)
+		select {
+		case err := <-portForwardErrors:
+			if lastRes != nil {
+				lastRes.Body.Close()
+			}
+			return fmt.Errorf("portforward stopped while probing %s: %w", urlPath, err)
+		case <-ctx.Done():
+			if lastRes != nil {
+				lastRes.Body.Close()
+			}
+			return fmt.Errorf("gateway probe canceled: %w", ctx.Err())
+		case <-time.After(retryBackoff):
+		}
 	}
 
 	// The poll budget is exhausted; dump the last request and response to help with debugging.
@@ -530,6 +553,76 @@ func testGatewayAvailability(t *testing.T, hostname, baseURL, path string, expec
 	}
 
 	return fmt.Errorf("failed to make request to %s after %d attempts over %s", urlPath, attempts, timeout)
+}
+
+func logGatewayNetworkDiagnostics(t *testing.T, ctx context.Context, at rp.RPTest, namespace string) {
+	t.Helper()
+	t.Logf("Gateway network diagnostics for namespace %s", namespace)
+
+	services, err := at.Options.K8sClient.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Logf("failed to list Services: %v", err)
+	} else {
+		for _, service := range services.Items {
+			ports := make([]string, 0, len(service.Spec.Ports))
+			for _, port := range service.Spec.Ports {
+				ports = append(ports, fmt.Sprintf("%s:%d->%s/%s", port.Name, port.Port, port.TargetPort.String(), port.Protocol))
+			}
+			t.Logf("Service %s/%s: clusterIP=%s ports=%s selector=%v", service.Namespace, service.Name, service.Spec.ClusterIP, strings.Join(ports, ","), service.Spec.Selector)
+		}
+	}
+
+	endpointSlices, err := at.Options.K8sClient.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Logf("failed to list EndpointSlices: %v", err)
+		return
+	}
+
+	for _, endpointSlice := range endpointSlices.Items {
+		ports := make([]string, 0, len(endpointSlice.Ports))
+		for _, port := range endpointSlice.Ports {
+			portName := "<unnamed>"
+			if port.Name != nil {
+				portName = *port.Name
+			}
+			portNumber := "<unknown>"
+			if port.Port != nil {
+				portNumber = strconv.FormatInt(int64(*port.Port), 10)
+			}
+			protocol := "<unknown>"
+			if port.Protocol != nil {
+				protocol = string(*port.Protocol)
+			}
+			ports = append(ports, fmt.Sprintf("%s:%s/%s", portName, portNumber, protocol))
+		}
+
+		endpoints := make([]string, 0, len(endpointSlice.Endpoints))
+		for _, endpoint := range endpointSlice.Endpoints {
+			endpoints = append(endpoints, fmt.Sprintf(
+				"%s ready=%s serving=%s terminating=%s",
+				strings.Join(endpoint.Addresses, ","),
+				optionalBool(endpoint.Conditions.Ready),
+				optionalBool(endpoint.Conditions.Serving),
+				optionalBool(endpoint.Conditions.Terminating),
+			))
+		}
+
+		t.Logf(
+			"EndpointSlice %s/%s: service=%s ports=%s endpoints=[%s]",
+			endpointSlice.Namespace,
+			endpointSlice.Name,
+			endpointSlice.Labels[discoveryv1.LabelServiceName],
+			strings.Join(ports, ","),
+			strings.Join(endpoints, "; "),
+		)
+	}
+}
+
+func optionalBool(value *bool) string {
+	if value == nil {
+		return "unknown"
+	}
+	return strconv.FormatBool(*value)
 }
 
 func newTestHTTPClient(isHttps bool, hostname string) *http.Client {
@@ -556,4 +649,20 @@ func newTestHTTPClient(isHttps bool, hostname string) *http.Client {
 	return &http.Client{
 		Transport: transport,
 	}
+}
+
+func Test_TestGatewayAvailability_PortForwardStops(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+		responseWriter.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	portForwardErrors := make(chan error, 1)
+	portForwardErrors <- errors.New("tunnel closed")
+
+	err := testGatewayAvailability(t, t.Context(), "localhost", server.URL, "healthz", http.StatusOK, false, portForwardErrors)
+	require.ErrorContains(t, err, "portforward stopped while probing")
+	require.ErrorContains(t, err, "tunnel closed")
 }

--- a/test/functional-portable/corerp/noncloud/resources/gateway_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/gateway_test.go
@@ -570,7 +570,10 @@ func logGatewayNetworkDiagnostics(t *testing.T, ctx context.Context, at rp.RPTes
 	t.Helper()
 	t.Logf("Gateway network diagnostics for namespace %s", namespace)
 
-	services, err := at.Options.K8sClient.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
+	diagnosticsCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+
+	services, err := at.Options.K8sClient.CoreV1().Services(namespace).List(diagnosticsCtx, metav1.ListOptions{})
 	if err != nil {
 		t.Logf("failed to list Services: %v", err)
 	} else {
@@ -583,7 +586,7 @@ func logGatewayNetworkDiagnostics(t *testing.T, ctx context.Context, at rp.RPTes
 		}
 	}
 
-	endpointSlices, err := at.Options.K8sClient.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{})
+	endpointSlices, err := at.Options.K8sClient.DiscoveryV1().EndpointSlices(namespace).List(diagnosticsCtx, metav1.ListOptions{})
 	if err != nil {
 		t.Logf("failed to list EndpointSlices: %v", err)
 		return

--- a/test/testutil/portforward_test.go
+++ b/test/testutil/portforward_test.go
@@ -135,6 +135,42 @@ func TestRunPortForward_ContextCanceledBeforePortReportsError(t *testing.T) {
 	}
 }
 
+func TestRunPortForward_ForwardPortsNilReportsError(t *testing.T) {
+	t.Parallel()
+
+	forwarder := fakePortForwardRunner{
+		forwardPorts: func() error {
+			return nil
+		},
+		getPorts: func() ([]portforward.ForwardedPort, error) {
+			return nil, errors.New("GetPorts called before ready")
+		},
+	}
+
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+	portChan := make(chan int)
+	errorChan := make(chan error)
+	done := make(chan struct{})
+	go func() {
+		runPortForward(context.Background(), forwarder, stopChan, readyChan, portChan, errorChan)
+		close(done)
+	}()
+
+	select {
+	case err := <-errorChan:
+		require.ErrorIs(t, err, errPortForwardStopped)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for unexpected port-forward stop error")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runPortForward blocked after reporting an unexpected stop")
+	}
+}
+
 func TestRunPortForward_GetPortsErrorDoesNotBlockOnForwardResult(t *testing.T) {
 	t.Parallel()
 

--- a/test/testutil/portforward_test.go
+++ b/test/testutil/portforward_test.go
@@ -39,6 +39,102 @@ func (f fakePortForwardRunner) GetPorts() ([]portforward.ForwardedPort, error) {
 	return f.getPorts()
 }
 
+func TestRunPortForward_ContextCanceledBeforeReadyReportsError(t *testing.T) {
+	t.Parallel()
+
+	forwardPortsStarted := make(chan struct{})
+	forwardPortsRelease := make(chan struct{})
+	defer close(forwardPortsRelease)
+
+	forwarder := fakePortForwardRunner{
+		forwardPorts: func() error {
+			close(forwardPortsStarted)
+			<-forwardPortsRelease
+			return nil
+		},
+		getPorts: func() ([]portforward.ForwardedPort, error) {
+			return nil, errors.New("GetPorts called before ready")
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+	portChan := make(chan int)
+	errorChan := make(chan error)
+	done := make(chan struct{})
+	go func() {
+		runPortForward(ctx, forwarder, stopChan, readyChan, portChan, errorChan)
+		close(done)
+	}()
+
+	<-forwardPortsStarted
+	cancel()
+
+	select {
+	case err := <-errorChan:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for context cancellation error")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runPortForward blocked after reporting context cancellation")
+	}
+}
+
+func TestRunPortForward_ContextCanceledBeforePortReportsError(t *testing.T) {
+	t.Parallel()
+
+	forwardPortsRelease := make(chan struct{})
+	defer close(forwardPortsRelease)
+	getPortsStarted := make(chan struct{})
+	getPortsRelease := make(chan struct{})
+
+	forwarder := fakePortForwardRunner{
+		forwardPorts: func() error {
+			<-forwardPortsRelease
+			return nil
+		},
+		getPorts: func() ([]portforward.ForwardedPort, error) {
+			close(getPortsStarted)
+			<-getPortsRelease
+			return []portforward.ForwardedPort{{Local: 43210, Remote: 8080}}, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+	close(readyChan)
+	portChan := make(chan int)
+	errorChan := make(chan error)
+	done := make(chan struct{})
+	go func() {
+		runPortForward(ctx, forwarder, stopChan, readyChan, portChan, errorChan)
+		close(done)
+	}()
+
+	<-getPortsStarted
+	cancel()
+	close(getPortsRelease)
+
+	select {
+	case err := <-errorChan:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for context cancellation error")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runPortForward blocked after reporting context cancellation")
+	}
+}
+
 func TestRunPortForward_GetPortsErrorDoesNotBlockOnForwardResult(t *testing.T) {
 	t.Parallel()
 

--- a/test/testutil/portforward_test.go
+++ b/test/testutil/portforward_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/portforward"
+)
+
+type fakePortForwardRunner struct {
+	forwardPorts func() error
+	getPorts     func() ([]portforward.ForwardedPort, error)
+}
+
+func (f fakePortForwardRunner) ForwardPorts() error {
+	return f.forwardPorts()
+}
+
+func (f fakePortForwardRunner) GetPorts() ([]portforward.ForwardedPort, error) {
+	return f.getPorts()
+}
+
+func TestRunPortForward_GetPortsErrorDoesNotBlockOnForwardResult(t *testing.T) {
+	t.Parallel()
+
+	getPortsErr := errors.New("failed to get ports")
+	forwardPortsErr := errors.New("forwarding stopped")
+	forwardPortsRelease := make(chan struct{})
+	forwardPortsReturned := make(chan struct{})
+	readyChan := make(chan struct{})
+	close(readyChan)
+
+	forwarder := fakePortForwardRunner{
+		forwardPorts: func() error {
+			<-forwardPortsRelease
+			close(forwardPortsReturned)
+			return forwardPortsErr
+		},
+		getPorts: func() ([]portforward.ForwardedPort, error) {
+			close(forwardPortsRelease)
+			<-forwardPortsReturned
+			return nil, getPortsErr
+		},
+	}
+
+	stopChan := make(chan struct{})
+	portChan := make(chan int)
+	errorChan := make(chan error)
+	done := make(chan struct{})
+	go func() {
+		runPortForward(context.Background(), forwarder, stopChan, readyChan, portChan, errorChan)
+		close(done)
+	}()
+
+	select {
+	case err := <-errorChan:
+		require.ErrorIs(t, err, getPortsErr)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for GetPorts error")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runPortForward blocked after reporting the GetPorts error")
+	}
+
+	select {
+	case err := <-errorChan:
+		t.Fatalf("received unexpected second error: %v", err)
+	default:
+	}
+}
+
+func TestRunPortForward_ForwardsRuntimeError(t *testing.T) {
+	t.Parallel()
+
+	forwardPortsErr := errors.New("forwarding stopped")
+	forwardPortsRelease := make(chan struct{})
+	readyChan := make(chan struct{})
+	close(readyChan)
+
+	forwarder := fakePortForwardRunner{
+		forwardPorts: func() error {
+			<-forwardPortsRelease
+			return forwardPortsErr
+		},
+		getPorts: func() ([]portforward.ForwardedPort, error) {
+			return []portforward.ForwardedPort{{Local: 43210, Remote: 8080}}, nil
+		},
+	}
+
+	stopChan := make(chan struct{})
+	portChan := make(chan int)
+	errorChan := make(chan error)
+	go runPortForward(context.Background(), forwarder, stopChan, readyChan, portChan, errorChan)
+
+	select {
+	case port := <-portChan:
+		require.Equal(t, 43210, port)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for forwarded port")
+	}
+
+	close(forwardPortsRelease)
+	select {
+	case err := <-errorChan:
+		require.ErrorIs(t, err, forwardPortsErr)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runtime forwarding error")
+	}
+}

--- a/test/testutil/portforward_test.go
+++ b/test/testutil/portforward_test.go
@@ -135,6 +135,59 @@ func TestRunPortForward_ContextCanceledBeforePortReportsError(t *testing.T) {
 	}
 }
 
+func TestRunPortForward_GetPortsErrorAfterContextCanceledReportsError(t *testing.T) {
+	t.Parallel()
+
+	getPortsErr := errors.New("failed to get ports")
+	forwardPortsRelease := make(chan struct{})
+	defer close(forwardPortsRelease)
+	getPortsStarted := make(chan struct{})
+	getPortsRelease := make(chan struct{})
+
+	forwarder := fakePortForwardRunner{
+		forwardPorts: func() error {
+			<-forwardPortsRelease
+			return nil
+		},
+		getPorts: func() ([]portforward.ForwardedPort, error) {
+			close(getPortsStarted)
+			<-getPortsRelease
+			return nil, getPortsErr
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+	close(readyChan)
+	portChan := make(chan int)
+	errorChan := make(chan error)
+	done := make(chan struct{})
+	go func() {
+		runPortForward(ctx, forwarder, stopChan, readyChan, portChan, errorChan)
+		close(done)
+	}()
+
+	<-getPortsStarted
+	cancel()
+	close(getPortsRelease)
+
+	select {
+	case err := <-errorChan:
+		require.ErrorIs(t, err, getPortsErr)
+	case <-done:
+		t.Fatal("runPortForward returned without reporting the GetPorts error")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for GetPorts error")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runPortForward blocked after reporting the GetPorts error")
+	}
+}
+
 func TestRunPortForward_ForwardPortsNilReportsError(t *testing.T) {
 	t.Parallel()
 

--- a/test/testutil/testutil.go
+++ b/test/testutil/testutil.go
@@ -268,6 +268,7 @@ func runPortForward(ctx context.Context, forwarder portForwardRunner, stopChan <
 		sendPortForwardError(ctx, stopChan, errorChan, err)
 		return
 	case <-ctx.Done():
+		sendPortForwardError(context.WithoutCancel(ctx), stopChan, errorChan, ctx.Err())
 		return
 	case <-stopChan:
 		return
@@ -289,6 +290,7 @@ func runPortForward(ctx context.Context, forwarder portForwardRunner, stopChan <
 		sendPortForwardError(ctx, stopChan, errorChan, err)
 		return
 	case <-ctx.Done():
+		sendPortForwardError(context.WithoutCancel(ctx), stopChan, errorChan, ctx.Err())
 		return
 	case <-stopChan:
 		return

--- a/test/testutil/testutil.go
+++ b/test/testutil/testutil.go
@@ -256,6 +256,8 @@ type portForwardRunner interface {
 	GetPorts() ([]portforward.ForwardedPort, error)
 }
 
+var errPortForwardStopped = errors.New("port-forwarder stopped unexpectedly")
+
 func runPortForward(ctx context.Context, forwarder portForwardRunner, stopChan <-chan struct{}, readyChan <-chan struct{}, portChan chan<- int, errorChan chan<- error) {
 	forwardResultChan := make(chan error, 1)
 	go func() {
@@ -305,6 +307,10 @@ func runPortForward(ctx context.Context, forwarder portForwardRunner, stopChan <
 }
 
 func sendPortForwardError(ctx context.Context, stopChan <-chan struct{}, errorChan chan<- error, err error) {
+	if err == nil {
+		err = errPortForwardStopped
+	}
+
 	select {
 	case <-stopChan:
 		return

--- a/test/testutil/testutil.go
+++ b/test/testutil/testutil.go
@@ -19,6 +19,7 @@ package testutil
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -247,20 +248,72 @@ func ExposePod(t *testing.T, ctx context.Context, client *k8s.Clientset, config 
 		return
 	}
 
-	// Run the port-forward with the desired configuration
+	runPortForward(ctx, forwarder, stopChan, readyChan, portChan, errorChan)
+}
+
+type portForwardRunner interface {
+	ForwardPorts() error
+	GetPorts() ([]portforward.ForwardedPort, error)
+}
+
+func runPortForward(ctx context.Context, forwarder portForwardRunner, stopChan <-chan struct{}, readyChan <-chan struct{}, portChan chan<- int, errorChan chan<- error) {
+	forwardResultChan := make(chan error, 1)
 	go func() {
-		errorChan <- forwarder.ForwardPorts()
+		forwardResultChan <- forwarder.ForwardPorts()
 	}()
 
-	// Wait for the forwarder to be ready, then get the assigned port
-	<-readyChan
-	ports, err := forwarder.GetPorts()
-	if err != nil {
-		errorChan <- err
+	select {
+	case <-readyChan:
+	case err := <-forwardResultChan:
+		sendPortForwardError(ctx, stopChan, errorChan, err)
+		return
+	case <-ctx.Done():
+		return
+	case <-stopChan:
+		return
 	}
 
-	// Send the assigned port to then portChan channel
-	portChan <- int(ports[0].Local)
+	ports, err := forwarder.GetPorts()
+	if err != nil {
+		sendPortForwardError(ctx, stopChan, errorChan, err)
+		return
+	}
+	if len(ports) == 0 {
+		sendPortForwardError(ctx, stopChan, errorChan, errors.New("port-forwarder returned no ports"))
+		return
+	}
+
+	select {
+	case portChan <- int(ports[0].Local):
+	case err := <-forwardResultChan:
+		sendPortForwardError(ctx, stopChan, errorChan, err)
+		return
+	case <-ctx.Done():
+		return
+	case <-stopChan:
+		return
+	}
+
+	select {
+	case err := <-forwardResultChan:
+		sendPortForwardError(ctx, stopChan, errorChan, err)
+	case <-ctx.Done():
+	case <-stopChan:
+	}
+}
+
+func sendPortForwardError(ctx context.Context, stopChan <-chan struct{}, errorChan chan<- error, err error) {
+	select {
+	case <-stopChan:
+		return
+	default:
+	}
+
+	select {
+	case errorChan <- err:
+	case <-ctx.Done():
+	case <-stopChan:
+	}
 }
 
 // IsMapSubSet returns true if the expectedMap is a subset of the actualMap

--- a/test/testutil/testutil.go
+++ b/test/testutil/testutil.go
@@ -267,10 +267,10 @@ func runPortForward(ctx context.Context, forwarder portForwardRunner, stopChan <
 	select {
 	case <-readyChan:
 	case err := <-forwardResultChan:
-		sendPortForwardError(ctx, stopChan, errorChan, err)
+		sendPortForwardError(stopChan, errorChan, err)
 		return
 	case <-ctx.Done():
-		sendPortForwardError(context.WithoutCancel(ctx), stopChan, errorChan, ctx.Err())
+		sendPortForwardError(stopChan, errorChan, ctx.Err())
 		return
 	case <-stopChan:
 		return
@@ -278,21 +278,21 @@ func runPortForward(ctx context.Context, forwarder portForwardRunner, stopChan <
 
 	ports, err := forwarder.GetPorts()
 	if err != nil {
-		sendPortForwardError(ctx, stopChan, errorChan, err)
+		sendPortForwardError(stopChan, errorChan, err)
 		return
 	}
 	if len(ports) == 0 {
-		sendPortForwardError(ctx, stopChan, errorChan, errors.New("port-forwarder returned no ports"))
+		sendPortForwardError(stopChan, errorChan, errors.New("port-forwarder returned no ports"))
 		return
 	}
 
 	select {
 	case portChan <- int(ports[0].Local):
 	case err := <-forwardResultChan:
-		sendPortForwardError(ctx, stopChan, errorChan, err)
+		sendPortForwardError(stopChan, errorChan, err)
 		return
 	case <-ctx.Done():
-		sendPortForwardError(context.WithoutCancel(ctx), stopChan, errorChan, ctx.Err())
+		sendPortForwardError(stopChan, errorChan, ctx.Err())
 		return
 	case <-stopChan:
 		return
@@ -300,13 +300,13 @@ func runPortForward(ctx context.Context, forwarder portForwardRunner, stopChan <
 
 	select {
 	case err := <-forwardResultChan:
-		sendPortForwardError(ctx, stopChan, errorChan, err)
+		sendPortForwardError(stopChan, errorChan, err)
 	case <-ctx.Done():
 	case <-stopChan:
 	}
 }
 
-func sendPortForwardError(ctx context.Context, stopChan <-chan struct{}, errorChan chan<- error, err error) {
+func sendPortForwardError(stopChan <-chan struct{}, errorChan chan<- error, err error) {
 	if err == nil {
 		err = errPortForwardStopped
 	}
@@ -319,7 +319,6 @@ func sendPortForwardError(ctx context.Context, stopChan <-chan struct{}, errorCh
 
 	select {
 	case errorChan <- err:
-	case <-ctx.Done():
 	case <-stopChan:
 	}
 }


### PR DESCRIPTION
## Summary

Stabilizes the Core RP non-cloud gateway functional tests that failed in [workflow run 29985997017](https://github.com/radius-project/radius/actions/runs/29985997017/job/89138246862). The change isolates tests that share the Contour/Envoy dataplane, hardens port-forward lifecycle handling, and adds actionable Kubernetes network diagnostics.

## Reason for change

The failing job reported six failure entries, but they represented three distinct tests: `Test_GatewayDNS`, `Test_Gateway_Timeout`, and `Test_Gateway_SSLPassthrough`.

`Test_GatewayDNS` and `Test_Gateway_Timeout` reached Envoy but received HTTP 503 responses for the full 90-second probe window with `upstream connect error or disconnect/reset before headers. reset reason: connection timeout`. `Test_Gateway_SSLPassthrough` received an initial EOF, after which its local port-forward listener stopped accepting connections. The backend pods, Contour, and Envoy remained Ready with zero restarts.

The positive gateway tests inherited `t.Parallel()` through `RPTest` and overlapped while reconciling routes and probing the single shared Contour/Envoy dataplane. The test helper also closed the port-forward only on request failure, left successful sessions running, used unbuffered notification channels, and stopped observing tunnel errors after startup.

The triggering PR changed only GitHub Actions dependencies and its standalone functional run passed, so the evidence points to shared test infrastructure and port-forward lifecycle handling rather than a product regression.

The fix:

- Runs positive gateway tests serially through the existing `RPTest.RunSerial` mechanism.
- Always closes the port-forward session.
- Buffers ready/error notifications and honors context cancellation during startup and retry waits.
- Surfaces post-start tunnel termination immediately instead of retrying connection failures for 90 seconds.
- Logs Services and EndpointSlices, including selected addresses and readiness conditions, when a gateway probe fails.
- Adds focused coverage for a port-forward that stops after startup.

## How to test

```bash
go test ./test/functional-portable/corerp/noncloud/resources -run '^Test_TestGatewayAvailability_PortForwardStops$' -count=1
go test ./test/functional-portable/corerp/noncloud/resources -run '^$'
go vet ./test/functional-portable/corerp/noncloud/resources
```

Also verified with `gofmt`, `git diff --check`, and VS Code diagnostics. The full KinD functional suite was not available locally; the `corerp-noncloud` PR check provides the end-to-end validation.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `test/functional-portable/corerp/noncloud/resources/gateway_test.go` | Serializes shared-dataplane gateway tests, fixes port-forward cleanup and runtime error handling, adds Service/EndpointSlice diagnostics, and covers tunnel termination. |