### PR TITLE
fix(cli): stop bicep from inheriting rad's stderr handle

### DIFF
--- a/pkg/cli/bicep/build.go
+++ b/pkg/cli/bicep/build.go
@@ -74,9 +74,9 @@ func runBicepRaw(args ...string) ([]byte, error) {
 
 	var wg sync.WaitGroup
 	wg.Go(func() {
-    if _, err := io.Copy(os.Stderr, stderr); err != nil {
-        _, _ = io.Copy(io.Discard, stderr)
-    }
+		if _, err := io.Copy(os.Stderr, stderr); err != nil {
+			_, _ = io.Copy(io.Discard, stderr)
+		}
 	})
 
 	// copy to our buffer, we don't really need to observe

--- a/pkg/cli/bicep/build.go
+++ b/pkg/cli/bicep/build.go
@@ -51,7 +51,7 @@ func runBicepRaw(args ...string) ([]byte, error) {
 
 	stdout, err := c.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create pipe: %w", err)
+		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
 
 	// Route bicep's stderr through a pipe we own instead of handing it os.Stderr

--- a/pkg/cli/bicep/build.go
+++ b/pkg/cli/bicep/build.go
@@ -66,6 +66,8 @@ func runBicepRaw(args ...string) ([]byte, error) {
 	}
 
 	if err = c.Start(); err != nil {
+		_ = stdout.Close()
+		_ = stderr.Close()
 		return nil, fmt.Errorf("failed executing %q: %w", fullCmd, err)
 	}
 

--- a/pkg/cli/bicep/build.go
+++ b/pkg/cli/bicep/build.go
@@ -62,7 +62,8 @@ func runBicepRaw(args ...string) ([]byte, error) {
 	// leaking the caller's handle to the grandchild.
 	stderr, err := c.StderrPipe()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create pipe: %w", err)
+		_ = stdout.Close()
+		return nil, fmt.Errorf("failed to create stderr pipe: %w", err)
 	}
 
 	if err = c.Start(); err != nil {

--- a/pkg/cli/bicep/build.go
+++ b/pkg/cli/bicep/build.go
@@ -74,7 +74,9 @@ func runBicepRaw(args ...string) ([]byte, error) {
 
 	var wg sync.WaitGroup
 	wg.Go(func() {
-		_, _ = io.Copy(os.Stderr, stderr)
+    if _, err := io.Copy(os.Stderr, stderr); err != nil {
+        _, _ = io.Copy(io.Discard, stderr)
+    }
 	})
 
 	// copy to our buffer, we don't really need to observe

--- a/pkg/cli/bicep/build.go
+++ b/pkg/cli/bicep/build.go
@@ -33,8 +33,8 @@ import (
 // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 const SemanticVersionRegex = `(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`
 
-// Run bicep with the given args and return the stdout. The stderr
-// is not capture but instead redirected to that of the current process.
+// Run bicep with the given args and return the stdout. Stderr is piped
+// through a private pipe and forwarded to the current process's stderr.
 func runBicepRaw(args ...string) ([]byte, error) {
 	if installed, _ := IsBicepInstalled(); !installed {
 		return nil, fmt.Errorf("bicep not installed, run \"rad bicep download\" to install")

--- a/pkg/cli/bicep/build.go
+++ b/pkg/cli/bicep/build.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/radius-project/radius/pkg/cli/bicep/tools"
 )
@@ -47,25 +48,40 @@ func runBicepRaw(args ...string) ([]byte, error) {
 	// runs 'bicep'
 	fullCmd := binPath + " " + strings.Join(args, " ")
 	c := exec.Command(binPath, args...)
-	c.Stderr = os.Stderr
+
 	stdout, err := c.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pipe: %w", err)
 	}
 
-	err = c.Start()
+	// Route bicep's stderr through a pipe we own instead of handing it os.Stderr
+	// directly. If bicep inherits the parent process's real stderr handle, a caller
+	// that launched rad with a piped stderr won't observe that pipe close until
+	// bicep also exits -- which hangs stderr stream-close waits on Windows. Copying
+	// through our own pipe keeps the 'stream bicep stderr to ours' behavior without
+	// leaking the caller's handle to the grandchild.
+	stderr, err := c.StderrPipe()
 	if err != nil {
+		return nil, fmt.Errorf("failed to create pipe: %w", err)
+	}
+
+	if err = c.Start(); err != nil {
 		return nil, fmt.Errorf("failed executing %q: %w", fullCmd, err)
 	}
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		_, _ = io.Copy(os.Stderr, stderr)
+	})
 
 	// copy to our buffer, we don't really need to observe
 	// errors here since it's copying into memory
 	buf := bytes.Buffer{}
 	_, _ = io.Copy(&buf, stdout)
 
-	// Wait() will wait for us to finish draining stderr before returning the exit code
-	err = c.Wait()
-	if err != nil {
+	// Ensure stderr is fully drained before Wait() closes the pipe.
+	wg.Wait()
+	if err = c.Wait(); err != nil {
 		return nil, fmt.Errorf("failed executing %q: %w", fullCmd, err)
 	}
 

--- a/pkg/cli/bicep/build_windows_test.go
+++ b/pkg/cli/bicep/build_windows_test.go
@@ -1,0 +1,95 @@
+//go:build windows
+
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bicep
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const helperProcessEnvVar = "GO_WANT_BICEP_STDERR_HELPER_PROCESS"
+
+func TestVersion_ClosesCallerStderrPipePromptly(t *testing.T) {
+	if os.Getenv(helperProcessEnvVar) == "1" {
+		version := Version()
+		if version != "0.42.1" {
+			fmt.Fprintf(os.Stderr, "unexpected version: %s", version)
+			os.Exit(1)
+		}
+
+		fmt.Fprintln(os.Stderr, "helper completed")
+		return
+	}
+
+	dir := t.TempDir()
+	bicepPath := filepath.Join(dir, "bicep.cmd")
+	err := os.WriteFile(bicepPath, []byte(`@echo off
+if "%1"=="--version" (
+  echo bicep 0.42.1
+  echo fake bicep stderr 1>&2
+  exit /b 0
+)
+
+echo unexpected args: %* 1>&2
+exit /b 1
+`), 0o600)
+	require.NoError(t, err)
+
+	cmd := exec.Command(os.Args[0], "-test.run", "^TestVersion_ClosesCallerStderrPipePromptly$")
+	cmd.Env = append(os.Environ(), helperProcessEnvVar+"=1", BicepEnvVar+"="+bicepPath)
+
+	stderr, err := cmd.StderrPipe()
+	require.NoError(t, err)
+
+	err = cmd.Start()
+	require.NoError(t, err)
+
+	stderrDone := make(chan []byte, 1)
+	go func() {
+		data, _ := io.ReadAll(stderr)
+		stderrDone <- data
+	}()
+
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- cmd.Wait()
+	}()
+
+	select {
+	case err = <-waitDone:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("helper process did not exit")
+	}
+
+	select {
+	case stderrOutput := <-stderrDone:
+		require.Contains(t, string(bytes.TrimSpace(stderrOutput)), "helper completed")
+	case <-time.After(10 * time.Second):
+		t.Fatal("stderr pipe did not reach EOF")
+	}
+}

--- a/pkg/cli/bicep/build_windows_test.go
+++ b/pkg/cli/bicep/build_windows_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package bicep
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -31,65 +30,153 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const helperProcessEnvVar = "GO_WANT_BICEP_STDERR_HELPER_PROCESS"
+const (
+	// bicepHelperModeEnv selects which role the helper subprocess plays.
+	// Set to "rad" to act as the rad-like process that calls Version().
+	bicepHelperModeEnv = "GO_BICEP_HELPER_MODE"
 
-func TestVersion_ClosesCallerStderrPipePromptly(t *testing.T) {
-	if os.Getenv(helperProcessEnvVar) == "1" {
-		version := Version()
-		if version != "0.42.1" {
-			fmt.Fprintf(os.Stderr, "unexpected version: %s", version)
-			os.Exit(1)
-		}
+	// bicepReadyFileEnv is the path of a file the fake bicep creates once it has
+	// started and written its output.  The helper polls for this file so it knows
+	// bicep is alive before it exits.
+	bicepReadyFileEnv = "GO_BICEP_READY_FILE"
 
-		fmt.Fprintln(os.Stderr, "helper completed")
+	// bicepReleaseFileEnv is the path of a file the test creates to signal the
+	// fake bicep that it may exit.  This prevents orphan batch processes.
+	bicepReleaseFileEnv = "GO_BICEP_RELEASE_FILE"
+)
+
+// TestHelperProcess is a subprocess entry point for helper-process tests in
+// this package.  It is invoked by the test binary itself (via exec.Command) when
+// GO_BICEP_HELPER_MODE is set; in all other contexts it returns immediately.
+//
+// When GO_BICEP_HELPER_MODE=rad it simulates a rad-like process:
+//   - it starts Version() in a goroutine (which will block inside runBicepRaw
+//     waiting for the fake bicep to exit), and
+//   - once the fake bicep signals it has started (by creating GO_BICEP_READY_FILE)
+//     the helper writes a message to stderr and calls os.Exit(0), leaving fake
+//     bicep alive as an orphan process.
+//
+// With the OLD implementation (c.Stderr = os.Stderr) fake bicep would inherit
+// the caller's stderr handle; the caller's pipe would therefore stay open even
+// after the helper exited.  With the fixed implementation (StderrPipe) fake
+// bicep never receives the caller's handle, so the caller sees EOF promptly.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv(bicepHelperModeEnv) != "rad" {
 		return
 	}
 
+	// Start Version() asynchronously.  runBicepRaw blocks inside c.Wait() until
+	// fake bicep exits (or this process is killed).
+	go func() {
+		_ = Version()
+	}()
+
+	// Poll until fake bicep has started and written its output.
+	readyFile := os.Getenv(bicepReadyFileEnv)
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(readyFile); err == nil {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	// Exit while fake bicep may still be alive.  This is the crux of the test:
+	// any stderr handle that bicep inherited will keep the caller's pipe open
+	// after we exit; with StderrPipe() bicep never has the caller's handle, so
+	// the pipe closes as soon as we do.
+	fmt.Fprintln(os.Stderr, "rad helper exiting")
+	os.Exit(0)
+}
+
+// TestVersion_ClosesCallerStderrPipePromptly is a Windows-only regression test
+// for https://github.com/radius-project/radius/issues/12516.
+//
+// It verifies that a process that pipes rad's stderr observes EOF on that pipe
+// promptly after rad exits — even when the fake bicep child process is still
+// alive.
+//
+// With the OLD implementation (c.Stderr = os.Stderr), bicep inherits the
+// caller's stderr handle, so io.ReadAll on the caller's pipe blocks until
+// bicep exits.  With the fixed implementation (StderrPipe), bicep never
+// receives the caller's handle, so the pipe reaches EOF as soon as rad exits.
+func TestVersion_ClosesCallerStderrPipePromptly(t *testing.T) {
 	dir := t.TempDir()
+	readyFile := filepath.Join(dir, "bicep.ready")
+	releaseFile := filepath.Join(dir, "bicep.release")
+
+	// Release fake bicep on test exit so we don't leave orphan processes.
+	t.Cleanup(func() {
+		_ = os.WriteFile(releaseFile, []byte("release"), 0o600)
+	})
+
+	// Write a batch-file fake bicep that:
+	//   1. prints the version string to stdout and a message to stderr,
+	//   2. writes the ready-signal file so the helper knows bicep is alive, and
+	//   3. polls until the release-signal file appears (keeping the process alive).
+	//
+	// When fake bicep runs with the OLD implementation it inherits the helper's
+	// real stderr handle (PIPE_A).  With the new implementation it only gets the
+	// private stderr pipe (PIPE_B) that runBicepRaw created, never PIPE_A.
+	bicepScript := "" +
+		"@echo off\r\n" +
+		"echo Bicep CLI version 0.42.1 (abcdef1234)\r\n" +
+		"echo fake bicep stderr 1>&2\r\n" +
+		"echo.>\"%GO_BICEP_READY_FILE%\"\r\n" +
+		":waitloop\r\n" +
+		"if exist \"%GO_BICEP_RELEASE_FILE%\" goto release\r\n" +
+		"timeout /t 1 /nobreak >nul 2>&1\r\n" +
+		"goto waitloop\r\n" +
+		":release\r\n"
 	bicepPath := filepath.Join(dir, "bicep.cmd")
-	err := os.WriteFile(bicepPath, []byte(`@echo off
-if "%1"=="--version" (
-  echo bicep 0.42.1
-  echo fake bicep stderr 1>&2
-  exit /b 0
-)
+	require.NoError(t, os.WriteFile(bicepPath, []byte(bicepScript), 0o600))
 
-echo unexpected args: %* 1>&2
-exit /b 1
-`), 0o600)
+	// Spawn the "rad" helper with stderr piped.
+	// The helper runs Version(), waits for fake bicep to start, then calls
+	// os.Exit(0) while bicep may still be alive.
+	cmd := exec.Command(os.Args[0], "-test.run", "^TestHelperProcess$", "-test.v")
+	cmd.Env = append(os.Environ(),
+		bicepHelperModeEnv+"=rad",
+		bicepReadyFileEnv+"="+readyFile,
+		bicepReleaseFileEnv+"="+releaseFile,
+		BicepEnvVar+"="+bicepPath,
+	)
+
+	stderrPipe, err := cmd.StderrPipe()
 	require.NoError(t, err)
 
-	cmd := exec.Command(os.Args[0], "-test.run", "^TestVersion_ClosesCallerStderrPipePromptly$")
-	cmd.Env = append(os.Environ(), helperProcessEnvVar+"=1", BicepEnvVar+"="+bicepPath)
+	require.NoError(t, cmd.Start())
 
-	stderr, err := cmd.StderrPipe()
-	require.NoError(t, err)
-
-	err = cmd.Start()
-	require.NoError(t, err)
-
-	stderrDone := make(chan []byte, 1)
+	// Read all of the helper's stderr before calling Wait.
+	// Per the StderrPipe contract, Wait closes the pipe, so reads must complete
+	// first.  More importantly, this channel receive IS the regression assertion:
+	// with the old implementation io.ReadAll blocks forever (fake bicep holds the
+	// caller's handle open); with the fix it returns promptly with a nil error
+	// once the helper exits.
+	type stderrResult struct {
+		data []byte
+		err  error
+	}
+	stderrDone := make(chan stderrResult, 1)
 	go func() {
-		data, _ := io.ReadAll(stderr)
-		stderrDone <- data
-	}()
-
-	waitDone := make(chan error, 1)
-	go func() {
-		waitDone <- cmd.Wait()
+		data, err := io.ReadAll(stderrPipe)
+		stderrDone <- stderrResult{data, err}
 	}()
 
 	select {
-	case err = <-waitDone:
-		require.NoError(t, err)
+	case res := <-stderrDone:
+		// nil error means the pipe closed cleanly (not force-closed by Wait).
+		require.NoError(t, res.err,
+			"stderr pipe must close cleanly; a non-nil error indicates Wait closed the pipe before ReadAll finished")
+		require.Contains(t, string(res.data), "rad helper exiting",
+			"helper must have written its exit message before closing stderr")
 	case <-time.After(10 * time.Second):
-		t.Fatal("helper process did not exit")
+		// If we get here, fake bicep is still holding the caller's stderr handle
+		// open — the regression is present.
+		t.Fatal("stderr pipe did not reach EOF within 10 s: " +
+			"regression — fake bicep may be holding the caller's stderr handle open")
 	}
 
-	select {
-	case stderrOutput := <-stderrDone:
-		require.Contains(t, string(bytes.TrimSpace(stderrOutput)), "helper completed")
-	case <-time.After(10 * time.Second):
-		t.Fatal("stderr pipe did not reach EOF")
-	}
+	// The helper already exited via os.Exit(0), so Wait returns immediately.
+	_ = cmd.Wait()
 }

--- a/pkg/cli/bicep/build_windows_test.go
+++ b/pkg/cli/bicep/build_windows_test.go
@@ -80,7 +80,10 @@ func TestHelperProcess(t *testing.T) {
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
-
+	if _, err := os.Stat(readyFile); err != nil {
+		fmt.Fprintf(os.Stderr, "fake bicep did not signal readiness within deadline: %v\n", err)
+		os.Exit(2)
+	}
 	// Exit while fake bicep may still be alive.  This is the crux of the test:
 	// any stderr handle that bicep inherited will keep the caller's pipe open
 	// after we exit; with StderrPipe() bicep never has the caller's handle, so

--- a/pkg/cli/bicep/build_windows_test.go
+++ b/pkg/cli/bicep/build_windows_test.go
@@ -43,6 +43,10 @@ const (
 	// bicepReleaseFileEnv is the path of a file the test creates to signal the
 	// fake bicep that it may exit.  This prevents orphan batch processes.
 	bicepReleaseFileEnv = "GO_BICEP_RELEASE_FILE"
+
+	// bicepChildScriptEnv is the path of a child batch script that fake bicep
+	// starts and then exits immediately. The child keeps stderr open until released.
+	bicepChildScriptEnv = "GO_BICEP_CHILD_SCRIPT"
 )
 
 // TestHelperProcess is a subprocess entry point for helper-process tests in
@@ -113,24 +117,36 @@ func TestVersion_ClosesCallerStderrPipePromptly(t *testing.T) {
 		_ = os.WriteFile(releaseFile, []byte("release"), 0o600)
 	})
 
-	// Write a batch-file fake bicep that:
-	//   1. prints the version string to stdout and a message to stderr,
-	//   2. writes the ready-signal file so the helper knows bicep is alive, and
-	//   3. polls until the release-signal file appears (keeping the process alive).
+	// Write a child batch file that:
+	//   1. writes the ready-signal file so the helper knows a descendant is alive,
+	//   2. polls until the release-signal file appears (keeping the process alive).
 	//
-	// When fake bicep runs with the OLD implementation it inherits the helper's
-	// real stderr handle (PIPE_A).  With the new implementation it only gets the
-	// private stderr pipe (PIPE_B) that runBicepRaw created, never PIPE_A.
-	bicepScript := "" +
+	// This child outlives fake bicep and keeps inherited handles open.
+	bicepChildScript := "" +
 		"@echo off\r\n" +
-		"echo Bicep CLI version 0.42.1 (abcdef1234)\r\n" +
-		"echo fake bicep stderr 1>&2\r\n" +
 		"echo.>\"%GO_BICEP_READY_FILE%\"\r\n" +
 		":waitloop\r\n" +
 		"if exist \"%GO_BICEP_RELEASE_FILE%\" goto release\r\n" +
 		"timeout /t 1 /nobreak >nul 2>&1\r\n" +
 		"goto waitloop\r\n" +
 		":release\r\n"
+	bicepChildPath := filepath.Join(dir, "bicep-child.cmd")
+	require.NoError(t, os.WriteFile(bicepChildPath, []byte(bicepChildScript), 0o600))
+
+	// Write a batch-file fake bicep parent that:
+	//   1. prints the version string to stdout and a message to stderr,
+	//   2. starts a child process that keeps stderr open after parent exit, and
+	//   3. exits immediately.
+	//
+	// With the OLD implementation both parent and child can inherit the helper's
+	// real stderr handle (PIPE_A). With the new implementation they only get the
+	// private stderr pipe (PIPE_B) that runBicepRaw created, never PIPE_A.
+	bicepScript := "" +
+		"@echo off\r\n" +
+		"echo Bicep CLI version 0.42.1 (abcdef1234)\r\n" +
+		"echo fake bicep stderr 1>&2\r\n" +
+		"start \"\" /b \"%GO_BICEP_CHILD_SCRIPT%\"\r\n" +
+		"exit /b 0\r\n"
 	bicepPath := filepath.Join(dir, "bicep.cmd")
 	require.NoError(t, os.WriteFile(bicepPath, []byte(bicepScript), 0o600))
 
@@ -142,6 +158,7 @@ func TestVersion_ClosesCallerStderrPipePromptly(t *testing.T) {
 		bicepHelperModeEnv+"=rad",
 		bicepReadyFileEnv+"="+readyFile,
 		bicepReleaseFileEnv+"="+releaseFile,
+		bicepChildScriptEnv+"="+bicepChildPath,
 		BicepEnvVar+"="+bicepPath,
 	)
 


### PR DESCRIPTION
<!-- Application graph diff unavailable: this repository has no .radius/app.bicep, and its service Dockerfiles require prebuilt binaries rather than providing a valid source-build context for safe automatic modeling. -->

## Summary

- route Bicep stderr through a rad-owned pipe instead of passing through the caller's stderr handle
- preserve live stderr streaming while preventing grandchild handle inheritance on Windows
- drain stdout and stderr before waiting for the Bicep process

## Validation

- `gofmt -l pkg/cli/bicep/build.go`
- `go build ./pkg/cli/...`
- `go vet ./pkg/cli/bicep/...`
- `go test ./pkg/cli/bicep/...`

Fixes #12516