### PR TITLE
refactor(test): use t.Context() instead of context.Background()

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,10 +3,11 @@
 ---
 version: "2"
 linters:
-  # Only enable forbidigo explicitly. The v2 defaults (errcheck, gosimple, govet,
-  # ineffassign, staticcheck, unused) are implicitly enabled to match v1 behavior.
+  # Only enable forbidigo and usetesting explicitly. The v2 defaults (errcheck, gosimple,
+  # govet, ineffassign, staticcheck, unused) are implicitly enabled to match v1 behavior.
   enable:
     - forbidigo
+    - usetesting
   settings:
     # Configure default linters to match v1 behavior (less strict)
     errcheck:
@@ -103,3 +104,17 @@ linters:
           msg: "# Do not use except for inside main(). Suppress this message with //nolint:forbidigo at the end of the line if it is correct."
         - pattern: 'log\.Fatal(f|ln)?'
           msg: "# Do not use except for inside main(). Suppress this message with //nolint:forbidigo at the end of the line if it is correct."
+
+    usetesting:
+      # Tests must use the test-scoped context so work started by a test is cancelled with it.
+      # Suppress with '//nolint:usetesting' when a context must outlive the test, for example
+      # inside t.Cleanup (t.Context() is cancelled before cleanup runs) or in a detached goroutine.
+      context-background: true
+      context-todo: true
+      # The os.* checks below are unrelated to context handling; leave them off to keep this
+      # linter focused.
+      os-chdir: false
+      os-create-temp: false
+      os-mkdir-temp: false
+      os-setenv: false
+      os-temp-dir: false

--- a/internal/tooling/updater.go
+++ b/internal/tooling/updater.go
@@ -334,7 +334,7 @@ func (client *Client) hash(ctx context.Context, url string) (string, error) {
 
 func (client *Client) writeResponse(ctx context.Context, url string, destination io.Writer) error {
 	var lastError error
-	for attempt := 0; attempt < requestAttempts; attempt++ {
+	for attempt := range requestAttempts {
 		request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return fmt.Errorf("create request for %s: %w", url, err)
@@ -408,8 +408,8 @@ func newerVersion(candidate, current string) (bool, error) {
 }
 
 func parseChecksum(contents []byte, format, asset string) (string, error) {
-	lines := strings.Split(string(contents), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(string(contents), "\n")
+	for line := range lines {
 		fields := strings.Fields(line)
 		if len(fields) == 0 {
 			continue
@@ -444,7 +444,7 @@ func parseYQChecksum(orderContents, checksumContents []byte, asset string) (stri
 		return "", fmt.Errorf("SHA-256 column not found in checksums_hashes_order")
 	}
 
-	for _, line := range strings.Split(string(checksumContents), "\n") {
+	for line := range strings.SplitSeq(string(checksumContents), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) > column && fields[0] == asset {
 			return validateHash(fields[column])

--- a/internal/tooling/updater_test.go
+++ b/internal/tooling/updater_test.go
@@ -1,7 +1,6 @@
 package tooling
 
 import (
-	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -37,7 +36,7 @@ func TestUpdateManifestRefreshesVersionAndChecksum(t *testing.T) {
 	manifest := githubToolManifest(server.URL, 0)
 	client := NewClient("")
 	client.HTTP = server.Client()
-	result, err := UpdateManifest(context.Background(), &manifest, client)
+	result, err := UpdateManifest(t.Context(), &manifest, client)
 	if err != nil {
 		t.Fatalf("UpdateManifest() error = %v", err)
 	}
@@ -92,7 +91,7 @@ func TestUpdateManifestAppliesReleaseCooldown(t *testing.T) {
 			manifest := githubToolManifest(server.URL, 7)
 			client := NewClient("")
 			client.HTTP = server.Client()
-			result, err := UpdateManifest(context.Background(), &manifest, client)
+			result, err := UpdateManifest(t.Context(), &manifest, client)
 			if err != nil {
 				t.Fatalf("UpdateManifest() error = %v", err)
 			}
@@ -119,7 +118,7 @@ func TestUpdateManifestRejectsUnknownReleaseDateDuringCooldown(t *testing.T) {
 	manifest := githubToolManifest(server.URL, 7)
 	client := NewClient("")
 	client.HTTP = server.Client()
-	_, err := UpdateManifest(context.Background(), &manifest, client)
+	_, err := UpdateManifest(t.Context(), &manifest, client)
 	if err == nil || !strings.Contains(err.Error(), "reported no release date") {
 		t.Fatalf("UpdateManifest() error = %v, want missing release date error", err)
 	}
@@ -175,7 +174,7 @@ func TestLatestVersionReportsReleaseDate(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
 			})
 
-			release, err := client.LatestVersion(context.Background(), test.tool)
+			release, err := client.LatestVersion(t.Context(), test.tool)
 			if err != nil {
 				t.Fatalf("LatestVersion() error = %v", err)
 			}
@@ -271,7 +270,7 @@ func TestClientOnlyAuthenticatesExactGitHubAPIHost(t *testing.T) {
 					Body:       io.NopCloser(strings.NewReader("{}")),
 				}, nil
 			})
-			if _, err := client.get(context.Background(), test.url); err != nil {
+			if _, err := client.get(t.Context(), test.url); err != nil {
 				t.Fatalf("get() error = %v", err)
 			}
 		})
@@ -355,7 +354,7 @@ func TestChecksumCachesSharedFile(t *testing.T) {
 	client.HTTP = server.Client()
 
 	for _, platform := range []string{"linux_amd64", "linux_arm64"} {
-		if _, err := client.Checksum(context.Background(), tool, platform, tool.Version); err != nil {
+		if _, err := client.Checksum(t.Context(), tool, platform, tool.Version); err != nil {
 			t.Fatalf("Checksum(%s) error = %v", platform, err)
 		}
 	}
@@ -389,7 +388,7 @@ func TestChecksumStreamsDownloadedAsset(t *testing.T) {
 		ChecksumSource: ChecksumSource{Type: "download"},
 	}
 
-	got, err := client.Checksum(context.Background(), tool, "linux_amd64", tool.Version)
+	got, err := client.Checksum(t.Context(), tool, "linux_amd64", tool.Version)
 	if err != nil {
 		t.Fatalf("Checksum() error = %v", err)
 	}

--- a/pkg/armrpc/api/v1/armrequestcontext_test.go
+++ b/pkg/armrpc/api/v1/armrequestcontext_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -54,7 +53,7 @@ func TestFromARMRequest(t *testing.T) {
 
 	for _, tt := range headerTests {
 		t.Run(tt.desc, func(t *testing.T) {
-			req, err := getTestHTTPRequest("./testdata/armrpcheaders.json")
+			req, err := getTestHTTPRequest(t, "./testdata/armrpcheaders.json")
 			require.NoError(t, err)
 
 			if tt.refererUrl == "" {
@@ -162,7 +161,7 @@ func TestFromARMRequest_PrefersURLWhenRefererResourceDiffers(t *testing.T) {
 }
 
 func TestSystemData(t *testing.T) {
-	req, err := getTestHTTPRequest("./testdata/armrpcheaders.json")
+	req, err := getTestHTTPRequest(t, "./testdata/armrpcheaders.json")
 	require.NoError(t, err)
 	serviceCtx, err := FromARMRequest(req, "", LocationGlobal)
 	require.NoError(t, err)
@@ -179,11 +178,11 @@ func TestSystemData(t *testing.T) {
 
 func TestFromContext(t *testing.T) {
 	t.Run("ARMRequestContext is injected", func(t *testing.T) {
-		req, err := getTestHTTPRequest("./testdata/armrpcheaders.json")
+		req, err := getTestHTTPRequest(t, "./testdata/armrpcheaders.json")
 		require.NoError(t, err)
 		serviceCtx, err := FromARMRequest(req, "", LocationGlobal)
 		require.NoError(t, err)
-		ctx := context.Background()
+		ctx := t.Context()
 		newCtx := WithARMRequestContext(ctx, serviceCtx)
 
 		sCtx := ARMRequestContextFromContext(newCtx)
@@ -193,7 +192,7 @@ func TestFromContext(t *testing.T) {
 
 	t.Run("ARMRequestContext is not injected", func(t *testing.T) {
 		require.Panics(t, func() {
-			ARMRequestContextFromContext(context.Background())
+			ARMRequestContextFromContext(t.Context())
 		})
 	})
 }
@@ -214,7 +213,7 @@ func TestTopQueryParam(t *testing.T) {
 
 	for _, tt := range topQueryParamCases {
 		t.Run(tt.desc, func(t *testing.T) {
-			req, err := getTestHTTPRequest("./testdata/armrpcheaders.json")
+			req, err := getTestHTTPRequest(t, "./testdata/armrpcheaders.json")
 
 			q := req.URL.Query()
 			q.Add(tt.qpKey, tt.qpValue)
@@ -235,7 +234,7 @@ func TestTopQueryParam(t *testing.T) {
 	}
 }
 
-func getTestHTTPRequest(headerFile string) (*http.Request, error) {
+func getTestHTTPRequest(t *testing.T, headerFile string) (*http.Request, error) {
 	jsonData, err := os.ReadFile(headerFile)
 	if err != nil {
 		return nil, err
@@ -246,7 +245,7 @@ func getTestHTTPRequest(headerFile string) (*http.Request, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, strings.ToLower(parsed["Referer"]), nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, strings.ToLower(parsed["Referer"]), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/armrpc/asyncoperation/statusmanager/statusmanager_test.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/statusmanager_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package statusmanager
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -167,7 +166,7 @@ func TestCreateAsyncOperationStatus(t *testing.T) {
 				OperationTimeout: operationTimeoutDuration,
 				RetryAfter:       opererationRetryAfterDuration,
 			}
-			err := aomTest.manager.QueueAsyncOperation(context.TODO(), reqCtx, options)
+			err := aomTest.manager.QueueAsyncOperation(t.Context(), reqCtx, options)
 
 			if tt.SaveErr == nil && tt.EnqueueErr == nil && tt.DeleteErr == nil {
 				require.NoError(t, err)
@@ -211,7 +210,7 @@ func TestDeleteAsyncOperationStatus(t *testing.T) {
 			aomTest.databaseClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.DeleteErr)
 			rid, err := resources.ParseResource(azureEnvResourceID)
 			require.NoError(t, err)
-			err = aomTest.manager.Delete(context.TODO(), rid, uuid.New())
+			err = aomTest.manager.Delete(t.Context(), rid, uuid.New())
 
 			if tt.DeleteErr != nil {
 				require.Error(t, err, deleteErr)
@@ -255,7 +254,7 @@ func TestGetAsyncOperationStatus(t *testing.T) {
 
 			rid, err := resources.ParseResource(azureEnvResourceID)
 			require.NoError(t, err)
-			aos, err := aomTest.manager.Get(context.TODO(), rid, uuid.New())
+			aos, err := aomTest.manager.Get(t.Context(), rid, uuid.New())
 
 			if tt.GetErr == nil {
 				require.NoError(t, err)
@@ -309,7 +308,7 @@ func TestUpdateAsyncOperationStatus(t *testing.T) {
 			testAos.Status = v1.ProvisioningStateSucceeded
 			rid, err := resources.ParseResource(azureEnvResourceID)
 			require.NoError(t, err)
-			err = aomTest.manager.Update(context.TODO(), rid, opID, v1.ProvisioningStateAccepted, nil, nil)
+			err = aomTest.manager.Update(t.Context(), rid, opID, v1.ProvisioningStateAccepted, nil, nil)
 
 			if tt.GetErr == nil && tt.SaveErr == nil {
 				require.NoError(t, err)

--- a/pkg/armrpc/asyncoperation/worker/worker_runoperation_test.go
+++ b/pkg/armrpc/asyncoperation/worker/worker_runoperation_test.go
@@ -116,7 +116,7 @@ func newTestContext(t *testing.T, lockTime time.Duration) (*testContext, *gomock
 	inmemQ := inmemory.NewInMemQueue(lockTime)
 	databaseClient := database.NewMockClient(mctrl)
 	return &testContext{
-		ctx:       context.Background(),
+		ctx:       t.Context(),
 		mockSC:    databaseClient,
 		mockSM:    manager.NewMockStatusManager(mctrl),
 		internalQ: inmemQ,
@@ -433,7 +433,7 @@ func TestRunOperation_Successfully(t *testing.T) {
 
 	msg, err := tCtx.testQueue.Dequeue(tCtx.ctx, queue.QueueClientConfig{})
 	require.NoError(t, err)
-	worker.runOperation(context.Background(), msg, testCtrl)
+	worker.runOperation(t.Context(), msg, testCtrl)
 
 	// Ensure that message is finished.
 	require.Equal(t, 0, tCtx.internalQ.Len(), "message is finished")
@@ -479,7 +479,7 @@ func TestRunOperation_ExtendMessageLock(t *testing.T) {
 	old := msg.NextVisibleAt
 	require.NoError(t, err)
 
-	worker.runOperation(context.Background(), msg, testCtrl)
+	worker.runOperation(t.Context(), msg, testCtrl)
 
 	require.Equal(t, 0, tCtx.internalQ.Len(), "message is finished")
 	require.Greater(t, msg.NextVisibleAt.UnixNano(), old.UnixNano(), "message lock is extended")
@@ -573,7 +573,7 @@ func TestRunOperation_Timeout(t *testing.T) {
 
 	msg, err := tCtx.testQueue.Dequeue(tCtx.ctx, queue.QueueClientConfig{})
 	require.NoError(t, err)
-	worker.runOperation(context.Background(), msg, testCtrl)
+	worker.runOperation(t.Context(), msg, testCtrl)
 	<-done
 
 	require.Equal(t, 0, tCtx.internalQ.Len(), "message is finished")

--- a/pkg/armrpc/asyncoperation/worker/worker_test.go
+++ b/pkg/armrpc/asyncoperation/worker/worker_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 	"time"
 
-	manager "github.com/radius-project/radius/pkg/armrpc/asyncoperation/statusmanager"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	manager "github.com/radius-project/radius/pkg/armrpc/asyncoperation/statusmanager"
 	"github.com/radius-project/radius/pkg/components/database"
 	"github.com/radius-project/radius/pkg/ucp/resources"
 
@@ -178,10 +178,10 @@ func TestIsDuplicated(t *testing.T) {
 	t.Run("updating status refreshed recently is duplicated", func(t *testing.T) {
 		sm.EXPECT().Get(gomock.Any(), rID, opID).Return(&manager.Status{
 			AsyncOperationStatus: v1.AsyncOperationStatus{Status: v1.ProvisioningStateUpdating},
-			LastUpdatedTime: time.Now().UTC().Add(-5 * time.Second),
+			LastUpdatedTime:      time.Now().UTC().Add(-5 * time.Second),
 		}, nil)
 
-		dup, err := worker.isDuplicated(context.Background(), resourceID, opID)
+		dup, err := worker.isDuplicated(t.Context(), resourceID, opID)
 		require.NoError(t, err)
 		require.True(t, dup)
 	})
@@ -189,10 +189,10 @@ func TestIsDuplicated(t *testing.T) {
 	t.Run("updating status older than dedup window is not duplicated", func(t *testing.T) {
 		sm.EXPECT().Get(gomock.Any(), rID, opID).Return(&manager.Status{
 			AsyncOperationStatus: v1.AsyncOperationStatus{Status: v1.ProvisioningStateUpdating},
-			LastUpdatedTime: time.Now().UTC().Add(-2 * time.Minute),
+			LastUpdatedTime:      time.Now().UTC().Add(-2 * time.Minute),
 		}, nil)
 
-		dup, err := worker.isDuplicated(context.Background(), resourceID, opID)
+		dup, err := worker.isDuplicated(t.Context(), resourceID, opID)
 		require.NoError(t, err)
 		require.False(t, dup)
 	})
@@ -200,10 +200,10 @@ func TestIsDuplicated(t *testing.T) {
 	t.Run("terminal status is duplicated", func(t *testing.T) {
 		sm.EXPECT().Get(gomock.Any(), rID, opID).Return(&manager.Status{
 			AsyncOperationStatus: v1.AsyncOperationStatus{Status: v1.ProvisioningStateFailed},
-			LastUpdatedTime: time.Now().UTC().Add(-10 * time.Minute),
+			LastUpdatedTime:      time.Now().UTC().Add(-10 * time.Minute),
 		}, nil)
 
-		dup, err := worker.isDuplicated(context.Background(), resourceID, opID)
+		dup, err := worker.isDuplicated(t.Context(), resourceID, opID)
 		require.NoError(t, err)
 		require.True(t, dup)
 	})

--- a/pkg/armrpc/asyncoperation/worker/worker_test.go
+++ b/pkg/armrpc/asyncoperation/worker/worker_test.go
@@ -89,7 +89,7 @@ func TestUpdateResourceState(t *testing.T) {
 			defer mctrl.Finish()
 
 			databaseClient := database.NewMockClient(mctrl)
-			ctx := context.Background()
+			ctx := t.Context()
 
 			databaseClient.
 				EXPECT().

--- a/pkg/armrpc/authentication/certvalidator_test.go
+++ b/pkg/armrpc/authentication/certvalidator_test.go
@@ -78,7 +78,7 @@ func TestCertValidation(t *testing.T) {
 				Thumbprint:  tc.fakeCertThumbprint,
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			log := logr.FromContextOrDiscard(ctx)
 			armCertMgr := NewArmCertManager(metadataEndpoint, log)
 			ArmCertStore.Store(tc.fakeCertThumbprint, cert)

--- a/pkg/armrpc/authentication/certvalidator_test.go
+++ b/pkg/armrpc/authentication/certvalidator_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package authentication
 
 import (
-	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -92,7 +91,7 @@ func TestCertValidation(t *testing.T) {
 				})
 
 			handler := middleware.LowercaseURLPath(r)
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, tc.armid, nil)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, tc.armid, nil)
 			require.NoError(t, err)
 			req.Header.Set(IngressCertThumbprintHeader, tc.headerThumbprint)
 			handler.ServeHTTP(w, req)

--- a/pkg/armrpc/frontend/controller/util_test.go
+++ b/pkg/armrpc/frontend/controller/util_test.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -49,7 +48,7 @@ func TestReadJSONBody(t *testing.T) {
 
 	for _, tc := range contentTypeTests {
 		t.Run(tc.contentType, func(t *testing.T) {
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, "http://github.com", bytes.NewBuffer(tc.body))
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, "http://github.com", bytes.NewBuffer(tc.body))
 			require.NoError(t, err)
 			req.Header.Set("Content-Type", tc.contentType)
 			// act
@@ -117,7 +116,7 @@ func TestValidateEtag_IfMatch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			armRequestContext := v1.ARMRequestContextFromContext(
 				v1.WithARMRequestContext(
-					context.Background(), &v1.ARMRequestContext{
+					t.Context(), &v1.ARMRequestContext{
 						IfMatch: tt.ifMatchEtag,
 					}))
 			result := ValidateETag(*armRequestContext, tt.etagProvided)
@@ -170,7 +169,7 @@ func TestValidateEtag_IfNoneMatch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			armRequestContext := v1.ARMRequestContextFromContext(
 				v1.WithARMRequestContext(
-					context.Background(), &v1.ARMRequestContext{
+					t.Context(), &v1.ARMRequestContext{
 						IfNoneMatch: tt.ifNoneMatchEtag,
 					}))
 			result := ValidateETag(*armRequestContext, tt.etagProvided)

--- a/pkg/armrpc/frontend/defaultoperation/createorupdatesubscription_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/createorupdatesubscription_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package defaultoperation
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -49,13 +48,13 @@ func TestSubscriptionsRunWithArmV2ApiVersion(t *testing.T) {
 		expected := &v1.Subscription{}
 		_ = json.Unmarshal(rawReq, expected)
 
-		req, err := rpctest.NewHTTPRequestFromJSON(context.Background(), http.MethodPost, subscriptionHeaderfile, expected)
+		req, err := rpctest.NewHTTPRequestFromJSON(t.Context(), http.MethodPost, subscriptionHeaderfile, expected)
 		require.NoError(t, err)
 
 		// arrange
 		op, err := NewCreateOrUpdateSubscription(ctrl.Options{})
 		require.NoError(t, err)
-		ctx := v1.WithARMRequestContext(context.Background(), &v1.ARMRequestContext{
+		ctx := v1.WithARMRequestContext(t.Context(), &v1.ARMRequestContext{
 			APIVersion: v1.SubscriptionAPIVersion,
 		})
 		w := httptest.NewRecorder()
@@ -76,7 +75,7 @@ func TestSubscriptionsRunWithUnsupportedAPIVersion(t *testing.T) {
 	// arrange
 	op, err := NewCreateOrUpdateSubscription(ctrl.Options{})
 	require.NoError(t, err)
-	ctx := v1.WithARMRequestContext(context.Background(), &v1.ARMRequestContext{
+	ctx := v1.WithARMRequestContext(t.Context(), &v1.ARMRequestContext{
 		APIVersion: "unknownversion",
 	})
 	w := httptest.NewRecorder()

--- a/pkg/armrpc/frontend/defaultoperation/defaultasyncdelete_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/defaultasyncdelete_test.go
@@ -64,7 +64,7 @@ func TestDefaultAsyncDelete(t *testing.T) {
 
 			w := httptest.NewRecorder()
 
-			req, err := rpctest.NewHTTPRequestFromJSON(context.Background(), http.MethodDelete, resourceTestHeaderFile, nil)
+			req, err := rpctest.NewHTTPRequestFromJSON(t.Context(), http.MethodDelete, resourceTestHeaderFile, nil)
 			require.NoError(t, err)
 			req.Header.Set("If-Match", tt.etag)
 

--- a/pkg/armrpc/frontend/defaultoperation/defaultasyncput_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/defaultasyncput_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package defaultoperation
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -83,7 +82,7 @@ func TestDefaultAsyncPut_Create(t *testing.T) {
 			reqModel, reqDataModel, _ := loadTestResurce()
 
 			w := httptest.NewRecorder()
-			req, err := rpctest.NewHTTPRequestFromJSON(context.Background(), http.MethodPut, resourceTestHeaderFile, reqModel)
+			req, err := rpctest.NewHTTPRequestFromJSON(t.Context(), http.MethodPut, resourceTestHeaderFile, reqModel)
 			require.NoError(t, err)
 
 			ctx := rpctest.NewARMRequestContext(req)
@@ -259,7 +258,7 @@ func TestDefaultAsyncPut_Update(t *testing.T) {
 			reqDataModel.InternalMetadata.AsyncProvisioningState = tt.curState
 
 			w := httptest.NewRecorder()
-			req, err := rpctest.NewHTTPRequestFromJSON(context.Background(), http.MethodPatch, resourceTestHeaderFile, reqModel)
+			req, err := rpctest.NewHTTPRequestFromJSON(t.Context(), http.MethodPatch, resourceTestHeaderFile, reqModel)
 			require.NoError(t, err)
 
 			ctx := rpctest.NewARMRequestContext(req)

--- a/pkg/armrpc/frontend/defaultoperation/defaultsyncdelete_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/defaultsyncdelete_test.go
@@ -54,7 +54,7 @@ func TestDefaultSyncDelete(t *testing.T) {
 
 			w := httptest.NewRecorder()
 
-			req, err := rpctest.NewHTTPRequestFromJSON(context.Background(), http.MethodDelete, resourceTestHeaderFile, nil)
+			req, err := rpctest.NewHTTPRequestFromJSON(t.Context(), http.MethodDelete, resourceTestHeaderFile, nil)
 			require.NoError(t, err)
 			req.Header.Set("If-Match", tt.etag)
 

--- a/pkg/armrpc/frontend/defaultoperation/defaultsyncput_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/defaultsyncput_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package defaultoperation
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -66,7 +65,7 @@ func TestDefaultSyncPut_Create(t *testing.T) {
 			reqModel, _, _ := loadTestResurce()
 
 			w := httptest.NewRecorder()
-			req, err := rpctest.NewHTTPRequestFromJSON(context.Background(), http.MethodPut, resourceTestHeaderFile, reqModel)
+			req, err := rpctest.NewHTTPRequestFromJSON(t.Context(), http.MethodPut, resourceTestHeaderFile, reqModel)
 			require.NoError(t, err)
 
 			ctx := rpctest.NewARMRequestContext(req)
@@ -186,7 +185,7 @@ func TestDefaultSyncPut_Update(t *testing.T) {
 			_ = json.Unmarshal(testutil.ReadFixture(tt.datamodelFile), reqDataModel)
 
 			w := httptest.NewRecorder()
-			req, err := rpctest.NewHTTPRequestFromJSON(context.Background(), http.MethodPatch, resourceTestHeaderFile, reqModel)
+			req, err := rpctest.NewHTTPRequestFromJSON(t.Context(), http.MethodPatch, resourceTestHeaderFile, reqModel)
 			require.NoError(t, err)
 
 			ctx := rpctest.NewARMRequestContext(req)

--- a/pkg/armrpc/frontend/defaultoperation/getoperationstatus_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/getoperationstatus_test.go
@@ -39,7 +39,7 @@ func TestGetOperationStatusRun(t *testing.T) {
 	defer mctrl.Finish()
 
 	databaseClient := database.NewMockClient(mctrl)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	rawDataModel := testutil.ReadFixture("operationstatus_datamodel.json")
 	osDataModel := &manager.Status{}

--- a/pkg/armrpc/frontend/defaultoperation/getresource_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/getresource_test.go
@@ -91,7 +91,7 @@ func TestGetResourceRun(t *testing.T) {
 	defer mctrl.Finish()
 
 	databaseClient := database.NewMockClient(mctrl)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	testResourceDataModel := &testDataModel{
 		Name: "ResourceName",

--- a/pkg/armrpc/frontend/defaultoperation/listresources_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/listresources_test.go
@@ -44,7 +44,7 @@ func TestListResourcesRun(t *testing.T) {
 	defer mctrl.Finish()
 
 	databaseClient := database.NewMockClient(mctrl)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	testResourceDataModel := &testDataModel{
 		Name: "ResourceName",

--- a/pkg/armrpc/frontend/server/handler_test.go
+++ b/pkg/armrpc/frontend/server/handler_test.go
@@ -208,7 +208,7 @@ func Test_HandlerErrModelConversion(t *testing.T) {
 	req := httptest.NewRequest(handlerTest.method, handlerTest.url, nil)
 	responseWriter := httptest.NewRecorder()
 	err := &v1.ErrModelConversion{PropertyName: "namespace", ValidValue: "63 characters or less"}
-	HandleError(context.Background(), responseWriter, req, err)
+	HandleError(t.Context(), responseWriter, req, err)
 
 	bodyBytes, e := io.ReadAll(responseWriter.Body)
 	require.NoError(t, e)
@@ -230,7 +230,7 @@ func Test_HandlerErrInvalidModelConversion(t *testing.T) {
 
 	req := httptest.NewRequest(handlerTest.method, handlerTest.url, nil)
 	responseWriter := httptest.NewRecorder()
-	HandleError(context.Background(), responseWriter, req, v1.ErrInvalidModelConversion)
+	HandleError(t.Context(), responseWriter, req, v1.ErrInvalidModelConversion)
 
 	bodyBytes, e := io.ReadAll(responseWriter.Body)
 	require.NoError(t, e)
@@ -253,7 +253,7 @@ func Test_HandlerErrInternal(t *testing.T) {
 	req := httptest.NewRequest(handlerTest.method, handlerTest.url, nil)
 	responseWriter := httptest.NewRecorder()
 	err := errors.New("Internal error")
-	HandleError(context.Background(), responseWriter, req, err)
+	HandleError(t.Context(), responseWriter, req, err)
 
 	bodyBytes, e := io.ReadAll(responseWriter.Body)
 	require.NoError(t, e)
@@ -282,7 +282,7 @@ func Test_HandlerForController_OperationType(t *testing.T) {
 	require.NoError(t, err)
 
 	rCtx := &v1.ARMRequestContext{}
-	req = req.WithContext(v1.WithARMRequestContext(context.Background(), rCtx))
+	req = req.WithContext(v1.WithARMRequestContext(t.Context(), rCtx))
 
 	handler.ServeHTTP(w, req)
 

--- a/pkg/armrpc/rest/results_test.go
+++ b/pkg/armrpc/rest/results_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rest
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -118,7 +117,7 @@ func Test_OKResponse_Empty(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://example.com", nil)
 	w := httptest.NewRecorder()
 
-	err := response.Apply(context.TODO(), w, req)
+	err := response.Apply(t.Context(), w, req)
 	require.NoError(t, err)
 
 	require.Equal(t, http.StatusOK, w.Code)
@@ -135,7 +134,7 @@ func Test_OKResponse_WithBody(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://example.com", nil)
 	w := httptest.NewRecorder()
 
-	err := response.Apply(context.TODO(), w, req)
+	err := response.Apply(t.Context(), w, req)
 	require.NoError(t, err)
 
 	require.Equal(t, http.StatusOK, w.Code)
@@ -258,7 +257,7 @@ func TestGetAsyncLocationPath(t *testing.T) {
 			req := httptest.NewRequest("GET", tt.base, nil)
 			req.Header.Add(v1.RefererHeader, tt.referer.String())
 			w := httptest.NewRecorder()
-			err = r.Apply(context.Background(), w, req)
+			err = r.Apply(t.Context(), w, req)
 			require.NoError(t, err)
 
 			require.NotNil(t, w.Header().Get("Location"))

--- a/pkg/armrpc/rpctest/controllers.go
+++ b/pkg/armrpc/rpctest/controllers.go
@@ -38,7 +38,7 @@ func NewControllerContext(t *testing.T) *ControllerContext {
 	mctrl := gomock.NewController(t)
 
 	return &ControllerContext{
-		Ctx:    context.Background(),
+		Ctx:    t.Context(),
 		MCtrl:  mctrl,
 		MockSC: database.NewMockClient(mctrl),
 	}

--- a/pkg/armrpc/rpctest/routers.go
+++ b/pkg/armrpc/rpctest/routers.go
@@ -122,7 +122,7 @@ func AssertRequests(t *testing.T, tests []HandlerTestSpec, pathBase, rootScope s
 			require.NoError(t, err)
 
 			rCtx := &v1.ARMRequestContext{}
-			req = req.WithContext(v1.WithARMRequestContext(context.Background(), rCtx))
+			req = req.WithContext(v1.WithARMRequestContext(t.Context(), rCtx))
 
 			r.ServeHTTP(w, req)
 			require.NotEqual(t, 404, w.Result().StatusCode)

--- a/pkg/armrpc/servicecontext/middleware_test.go
+++ b/pkg/armrpc/servicecontext/middleware_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package servicecontext
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -92,7 +91,7 @@ func TestARMRequestCtx(t *testing.T) {
 
 			testUrl := testPathBase + tt.url
 
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, testUrl, nil)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, testUrl, nil)
 			require.NoError(t, err)
 			handler.ServeHTTP(w, req)
 

--- a/pkg/azure/credential/ucpcredentials_test.go
+++ b/pkg/azure/credential/ucpcredentials_test.go
@@ -90,7 +90,7 @@ func Test_RefreshCredentials_ServicePrincipal(t *testing.T) {
 		require.NoError(t, err)
 		p.fakeCredential.ServicePrincipal.ClientID = ""
 
-		err = c.refreshCredentials(context.TODO())
+		err = c.refreshCredentials(t.Context())
 		require.Error(t, err)
 	})
 
@@ -99,7 +99,7 @@ func Test_RefreshCredentials_ServicePrincipal(t *testing.T) {
 		c, err := NewUCPCredential(UCPCredentialOptions{Provider: p})
 		require.NoError(t, err)
 
-		err = c.refreshCredentials(context.TODO())
+		err = c.refreshCredentials(t.Context())
 		require.NoError(t, err)
 		require.False(t, c.isExpired())
 	})
@@ -109,7 +109,7 @@ func Test_RefreshCredentials_ServicePrincipal(t *testing.T) {
 		c, err := NewUCPCredential(UCPCredentialOptions{Provider: p})
 		require.NoError(t, err)
 
-		err = c.refreshCredentials(context.TODO())
+		err = c.refreshCredentials(t.Context())
 		require.NoError(t, err)
 
 		// reset next refresh time.
@@ -117,7 +117,7 @@ func Test_RefreshCredentials_ServicePrincipal(t *testing.T) {
 		require.True(t, c.isExpired())
 		old := c.tokenCred
 
-		err = c.refreshCredentials(context.TODO())
+		err = c.refreshCredentials(t.Context())
 		require.NoError(t, err)
 		require.False(t, c.isExpired())
 		require.Equal(t, old, c.tokenCred)
@@ -131,7 +131,7 @@ func Test_RefreshCredentials_WorkloadIdentity(t *testing.T) {
 		require.NoError(t, err)
 		p.fakeCredential.WorkloadIdentity.ClientID = ""
 
-		err = c.refreshCredentials(context.TODO())
+		err = c.refreshCredentials(t.Context())
 		require.Error(t, err)
 	})
 
@@ -140,7 +140,7 @@ func Test_RefreshCredentials_WorkloadIdentity(t *testing.T) {
 		c, err := NewUCPCredential(UCPCredentialOptions{Provider: p, TokenFilePath: "/var/run/secrets/azure/tokens/azure-identity-token"})
 		require.NoError(t, err)
 
-		err = c.refreshCredentials(context.TODO())
+		err = c.refreshCredentials(t.Context())
 		require.NoError(t, err)
 		require.False(t, c.isExpired())
 	})
@@ -150,7 +150,7 @@ func Test_RefreshCredentials_WorkloadIdentity(t *testing.T) {
 		c, err := NewUCPCredential(UCPCredentialOptions{Provider: p, TokenFilePath: "/var/run/secrets/azure/tokens/azure-identity-token"})
 		require.NoError(t, err)
 
-		err = c.refreshCredentials(context.TODO())
+		err = c.refreshCredentials(t.Context())
 		require.NoError(t, err)
 
 		// reset next refresh time.
@@ -158,7 +158,7 @@ func Test_RefreshCredentials_WorkloadIdentity(t *testing.T) {
 		require.True(t, c.isExpired())
 		old := c.tokenCred
 
-		err = c.refreshCredentials(context.TODO())
+		err = c.refreshCredentials(t.Context())
 		require.NoError(t, err)
 		require.False(t, c.isExpired())
 		require.Equal(t, old, c.tokenCred)

--- a/pkg/cli/clients/management_test.go
+++ b/pkg/cli/clients/management_test.go
@@ -413,7 +413,7 @@ func Test_Resource(t *testing.T) {
 
 		expectedResourceList := []generated.GenericResource{*listPages[0].Value[0], *listPages[0].Value[1], *listPages[1].Value[0], *listPages[1].Value[1]}
 
-		resources, err := client.ListResourcesOfType(context.Background(), testResourceType)
+		resources, err := client.ListResourcesOfType(t.Context(), testResourceType)
 		require.NoError(t, err)
 		require.Equal(t, expectedResourceList, resources)
 	})
@@ -424,7 +424,7 @@ func Test_Resource(t *testing.T) {
 		mockResourceProviderClient.EXPECT().NewListProviderSummariesPager("local", gomock.Any()).Return(pager(resourceProviderSummaryPages)).AnyTimes()
 		client := createResourceProviderClient(mockResourceProviderClient)
 
-		resourceTypes, err := client.ListAllResourceTypesNames(context.Background(), "local")
+		resourceTypes, err := client.ListAllResourceTypesNames(t.Context(), "local")
 		require.NoError(t, err)
 		require.Equal(t, []string{
 			"Applications.Test1/resourceType1",
@@ -466,7 +466,7 @@ func Test_Resource(t *testing.T) {
 
 		expectedResourceList := []generated.GenericResource{*listPages[0].Value[0]}
 
-		resources, err := client.ListResourcesOfTypeInApplication(context.Background(), "test-application", testResourceType)
+		resources, err := client.ListResourcesOfTypeInApplication(t.Context(), "test-application", testResourceType)
 		require.NoError(t, err)
 		require.Equal(t, expectedResourceList, resources)
 	})
@@ -502,7 +502,7 @@ func Test_Resource(t *testing.T) {
 
 		expectedResourceList := []generated.GenericResource{*listPages[0].Value[0], *listPages[0].Value[1]}
 
-		resources, err := client.ListResourcesOfTypeInEnvironment(context.Background(), "test-environment", testResourceType)
+		resources, err := client.ListResourcesOfTypeInEnvironment(t.Context(), "test-environment", testResourceType)
 		require.NoError(t, err)
 		require.Equal(t, expectedResourceList, resources)
 	})
@@ -544,7 +544,7 @@ func Test_Resource(t *testing.T) {
 
 		expectedResourceList := []generated.GenericResource{*listPages[0].Value[0]}
 
-		resources, err := client.ListResourcesInApplication(context.Background(), "test-application")
+		resources, err := client.ListResourcesInApplication(t.Context(), "test-application")
 		require.NoError(t, err)
 		require.Equal(t, expectedResourceList, resources)
 	})
@@ -586,7 +586,7 @@ func Test_Resource(t *testing.T) {
 
 		expectedResourceList := []generated.GenericResource{*listPages[0].Value[0], *listPages[0].Value[1]}
 
-		resources, err := client.ListResourcesInEnvironment(context.Background(), "test-environment")
+		resources, err := client.ListResourcesInEnvironment(t.Context(), "test-environment")
 		require.NoError(t, err)
 		require.Equal(t, expectedResourceList, resources)
 	})
@@ -620,7 +620,7 @@ func Test_Resource(t *testing.T) {
 			Get(gomock.Any(), testResourceName, gomock.Any()).
 			Return(generated.GenericResourcesClientGetResponse{GenericResource: expectedResource}, nil)
 
-		resource, err := client.GetResource(context.Background(), testResourceType, testResourceID)
+		resource, err := client.GetResource(t.Context(), testResourceType, testResourceID)
 		require.NoError(t, err)
 		require.Equal(t, expectedResource, resource)
 	})
@@ -633,7 +633,7 @@ func Test_Resource(t *testing.T) {
 			BeginCreateOrUpdate(gomock.Any(), testResourceName, expectedResource, gomock.Any()).
 			Return(poller(&generated.GenericResourcesClientCreateOrUpdateResponse{GenericResource: expectedResource}), nil)
 
-		response, err := client.CreateOrUpdateResource(context.Background(), testResourceType, testResourceID, &expectedResource)
+		response, err := client.CreateOrUpdateResource(t.Context(), testResourceType, testResourceID, &expectedResource)
 		require.NoError(t, err)
 		require.Equal(t, expectedResource, response)
 	})
@@ -667,7 +667,7 @@ func Test_Resource(t *testing.T) {
 			BeginDelete(gomock.Any(), testResourceName, gomock.Any()).
 			Return(poller(&generated.GenericResourcesClientDeleteResponse{}), nil)
 
-		deleted, err := client.DeleteResource(context.Background(), testResourceType, testResourceID, false)
+		deleted, err := client.DeleteResource(t.Context(), testResourceType, testResourceID, false)
 		require.NoError(t, err)
 		require.True(t, deleted)
 	})
@@ -718,7 +718,7 @@ func Test_Resource(t *testing.T) {
 
 		// Test via GetResource which calls getGenericClient internally
 		// This indirectly tests that getGenericClient handles Radius.Core resources correctly
-		_, err := client.GetResource(context.Background(), "Radius.Core/environments", "test-env")
+		_, err := client.GetResource(t.Context(), "Radius.Core/environments", "test-env")
 		require.NoError(t, err)
 	})
 }
@@ -743,7 +743,7 @@ func Test_ForceDeletePolicy(t *testing.T) {
 			},
 		})
 
-		req, err := runtime.NewRequest(context.Background(), http.MethodDelete, "http://localhost/test?api-version=2023-10-01-preview")
+		req, err := runtime.NewRequest(t.Context(), http.MethodDelete, "http://localhost/test?api-version=2023-10-01-preview")
 		require.NoError(t, err)
 
 		_, err = pipeline.Do(req)
@@ -770,7 +770,7 @@ func Test_ForceDeletePolicy(t *testing.T) {
 			},
 		})
 
-		req, err := runtime.NewRequest(context.Background(), http.MethodGet, "http://localhost/test?api-version=2023-10-01-preview")
+		req, err := runtime.NewRequest(t.Context(), http.MethodGet, "http://localhost/test?api-version=2023-10-01-preview")
 		require.NoError(t, err)
 
 		_, err = pipeline.Do(req)
@@ -848,7 +848,7 @@ func Test_DeleteResource_ForceQueryParameter(t *testing.T) {
 			}
 
 			// Assert the delete call succeeds so failures in later requests are not silently ignored.
-			_, err := client.DeleteResource(context.Background(), "Applications.Test/testResource", testScope+"/providers/Applications.Test/testResource/myresource", tt.force)
+			_, err := client.DeleteResource(t.Context(), "Applications.Test/testResource", testScope+"/providers/Applications.Test/testResource/myresource", tt.force)
 			require.NoError(t, err)
 
 			require.NotEmpty(t, capturedURLs, "expected at least one HTTP request")
@@ -944,7 +944,7 @@ func Test_DeleteApplication_ForceQueryParameter(t *testing.T) {
 			}
 
 			// Assert the delete call succeeds so failures in later requests are not silently ignored.
-			_, err := client.DeleteApplication(context.Background(), testScope+"/providers/Applications.Core/applications/test-app", tt.force)
+			_, err := client.DeleteApplication(t.Context(), testScope+"/providers/Applications.Core/applications/test-app", tt.force)
 			require.NoError(t, err)
 
 			require.NotEmpty(t, appDeleteURLs, "expected at least one DELETE request to applications endpoint")
@@ -1058,7 +1058,7 @@ func Test_Application(t *testing.T) {
 
 		expectedResourceList := []corerp.ApplicationResource{*listPages[0].Value[0], *listPages[0].Value[1], *listPages[1].Value[0], *listPages[1].Value[1]}
 
-		resources, err := client.ListApplications(context.Background())
+		resources, err := client.ListApplications(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, expectedResourceList, resources)
 	})
@@ -1073,7 +1073,7 @@ func Test_Application(t *testing.T) {
 
 		expectedResourceList := []corerp.ApplicationResource{*listPages[0].Value[0], *listPages[0].Value[1]}
 
-		resources, err := client.ListApplicationsInEnvironment(context.Background(), "test-environment")
+		resources, err := client.ListApplicationsInEnvironment(t.Context(), "test-environment")
 		require.NoError(t, err)
 		require.Equal(t, expectedResourceList, resources)
 	})
@@ -1086,7 +1086,7 @@ func Test_Application(t *testing.T) {
 			Get(gomock.Any(), testResourceName, gomock.Any()).
 			Return(corerp.ApplicationsClientGetResponse{ApplicationResource: expectedResource}, nil)
 
-		application, err := client.GetApplication(context.Background(), testResourceID)
+		application, err := client.GetApplication(t.Context(), testResourceID)
 		require.NoError(t, err)
 		require.Equal(t, expectedResource, application)
 	})
@@ -1107,7 +1107,7 @@ func Test_Application(t *testing.T) {
 			GetGraph(gomock.Any(), testResourceName, gomock.Any(), gomock.Any()).
 			Return(corerp.ApplicationsClientGetGraphResponse{ApplicationGraphResponse: expectedGraph}, nil)
 
-		graph, err := client.GetApplicationGraph(context.Background(), testResourceID)
+		graph, err := client.GetApplicationGraph(t.Context(), testResourceID)
 		require.NoError(t, err)
 		require.Equal(t, expectedGraph, graph)
 	})
@@ -1120,7 +1120,7 @@ func Test_Application(t *testing.T) {
 			CreateOrUpdate(gomock.Any(), testResourceName, expectedResource, gomock.Any()).
 			Return(corerp.ApplicationsClientCreateOrUpdateResponse{}, nil)
 
-		err := client.CreateOrUpdateApplication(context.Background(), testResourceID, &expectedResource)
+		err := client.CreateOrUpdateApplication(t.Context(), testResourceID, &expectedResource)
 		require.NoError(t, err)
 	})
 
@@ -1136,7 +1136,7 @@ func Test_Application(t *testing.T) {
 			CreateOrUpdate(gomock.Any(), testResourceName, expectedResource, gomock.Any()).
 			Return(corerp.ApplicationsClientCreateOrUpdateResponse{}, nil)
 
-		err := client.CreateApplicationIfNotFound(context.Background(), testResourceID, &expectedResource)
+		err := client.CreateApplicationIfNotFound(t.Context(), testResourceID, &expectedResource)
 		require.NoError(t, err)
 	})
 
@@ -1222,7 +1222,7 @@ func Test_Application(t *testing.T) {
 				return corerp.ApplicationsClientDeleteResponse{}, nil
 			})
 
-		deleted, err := client.DeleteApplication(context.Background(), testResourceID, false)
+		deleted, err := client.DeleteApplication(t.Context(), testResourceID, false)
 		require.NoError(t, err)
 		require.True(t, deleted)
 	})
@@ -1302,7 +1302,7 @@ func Test_Application(t *testing.T) {
 				return corerp.ApplicationsClientDeleteResponse{}, nil
 			})
 
-		deleted, err := client.DeleteApplication(context.Background(), testResourceID, false)
+		deleted, err := client.DeleteApplication(t.Context(), testResourceID, false)
 		require.NoError(t, err)
 		require.True(t, deleted)
 	})
@@ -1341,7 +1341,7 @@ func Test_Application(t *testing.T) {
 		// Delete should NOT be called when ListResourcesInApplication fails with non-404 error
 		// No expectation set for mock.Delete()
 
-		deleted, err := client.DeleteApplication(context.Background(), testResourceID, false)
+		deleted, err := client.DeleteApplication(t.Context(), testResourceID, false)
 		require.Error(t, err)
 		require.False(t, deleted)
 		// Verify the error is propagated correctly
@@ -1423,7 +1423,7 @@ func Test_Environment(t *testing.T) {
 
 		expectedResourceList := []corerp.EnvironmentResource{*listPages[0].Value[0], *listPages[0].Value[1], *listPages[1].Value[0], *listPages[1].Value[1]}
 
-		resources, err := client.ListEnvironments(context.Background())
+		resources, err := client.ListEnvironments(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, expectedResourceList, resources)
 	})
@@ -1438,7 +1438,7 @@ func Test_Environment(t *testing.T) {
 
 		expectedResourceList := []corerp.EnvironmentResource{*listPages[0].Value[0], *listPages[0].Value[1], *listPages[1].Value[0], *listPages[1].Value[1]}
 
-		resources, err := client.ListEnvironmentsAll(context.Background())
+		resources, err := client.ListEnvironmentsAll(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, expectedResourceList, resources)
 	})
@@ -1451,7 +1451,7 @@ func Test_Environment(t *testing.T) {
 			Get(gomock.Any(), testResourceName, gomock.Any()).
 			Return(corerp.EnvironmentsClientGetResponse{EnvironmentResource: expectedResource}, nil)
 
-		environment, err := client.GetEnvironment(context.Background(), testResourceID)
+		environment, err := client.GetEnvironment(t.Context(), testResourceID)
 		require.NoError(t, err)
 		require.Equal(t, expectedResource, environment)
 	})
@@ -1481,7 +1481,7 @@ func Test_Environment(t *testing.T) {
 				},
 			}, nil)
 
-		result, err := client.GetRecipeMetadata(context.Background(), testResourceID, expectedMetadata)
+		result, err := client.GetRecipeMetadata(t.Context(), testResourceID, expectedMetadata)
 		require.NoError(t, err)
 		require.Equal(t, expectedResult, result)
 	})
@@ -1494,7 +1494,7 @@ func Test_Environment(t *testing.T) {
 			CreateOrUpdate(gomock.Any(), testResourceName, expectedResource, gomock.Any()).
 			Return(corerp.EnvironmentsClientCreateOrUpdateResponse{EnvironmentResource: expectedResource}, nil)
 
-		err := client.CreateOrUpdateEnvironment(context.Background(), testResourceID, &expectedResource)
+		err := client.CreateOrUpdateEnvironment(t.Context(), testResourceID, &expectedResource)
 		require.NoError(t, err)
 	})
 
@@ -1610,7 +1610,7 @@ func Test_Environment(t *testing.T) {
 				return corerp.EnvironmentsClientDeleteResponse{}, nil
 			})
 
-		deleted, err := client.DeleteEnvironment(context.Background(), testResourceID)
+		deleted, err := client.DeleteEnvironment(t.Context(), testResourceID)
 		require.NoError(t, err)
 		require.True(t, deleted)
 	})
@@ -1679,7 +1679,7 @@ func Test_RadiusCoreEnvironment(t *testing.T) {
 			*listPages[1].Value[0],
 		}
 
-		resources, err := client.ListRadiusCoreEnvironmentsAll(context.Background())
+		resources, err := client.ListRadiusCoreEnvironmentsAll(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, expected, resources)
 	})
@@ -1757,7 +1757,7 @@ func Test_ResourceGroup(t *testing.T) {
 
 		expected := []ucp.ResourceGroupResource{*resourceGroupPages[0].Value[0], *resourceGroupPages[0].Value[1], *resourceGroupPages[1].Value[0], *resourceGroupPages[1].Value[1]}
 
-		groups, err := client.ListResourceGroups(context.Background(), "local")
+		groups, err := client.ListResourceGroups(t.Context(), "local")
 		require.NoError(t, err)
 		require.Equal(t, expected, groups)
 	})
@@ -1770,7 +1770,7 @@ func Test_ResourceGroup(t *testing.T) {
 			Get(gomock.Any(), "local", testResourceName, gomock.Any()).
 			Return(ucp.ResourceGroupsClientGetResponse{ResourceGroupResource: expectedResource}, nil)
 
-		group, err := client.GetResourceGroup(context.Background(), "local", testResourceName)
+		group, err := client.GetResourceGroup(t.Context(), "local", testResourceName)
 		require.NoError(t, err)
 		require.Equal(t, expectedResource, group)
 	})
@@ -1783,7 +1783,7 @@ func Test_ResourceGroup(t *testing.T) {
 			CreateOrUpdate(gomock.Any(), "local", testResourceName, expectedResource, gomock.Any()).
 			Return(ucp.ResourceGroupsClientCreateOrUpdateResponse{}, nil)
 
-		err := client.CreateOrUpdateResourceGroup(context.Background(), "local", testResourceName, &expectedResource)
+		err := client.CreateOrUpdateResourceGroup(t.Context(), "local", testResourceName, &expectedResource)
 		require.NoError(t, err)
 	})
 
@@ -1836,7 +1836,7 @@ func Test_ResourceGroup(t *testing.T) {
 				return ucp.ResourceGroupsClientDeleteResponse{}, nil
 			})
 
-		deleted, err := client.DeleteResourceGroup(context.Background(), "local", testResourceName)
+		deleted, err := client.DeleteResourceGroup(t.Context(), "local", testResourceName)
 		require.NoError(t, err)
 		require.True(t, deleted)
 	})
@@ -1860,7 +1860,7 @@ func Test_DeleteResourceGroup(t *testing.T) {
 		// Expect group deletion
 		mockResourceGroupDeletion(rgClient, "local", "test-rg")
 
-		deleted, err := client.DeleteResourceGroup(context.Background(), "local", "test-rg")
+		deleted, err := client.DeleteResourceGroup(t.Context(), "local", "test-rg")
 		require.NoError(t, err)
 		require.True(t, deleted)
 	})
@@ -1889,7 +1889,7 @@ func Test_DeleteResourceGroup(t *testing.T) {
 		// Expect group deletion
 		mockResourceGroupDeletion(rgClient, "local", "test-rg")
 
-		deleted, err := client.DeleteResourceGroup(context.Background(), "local", "test-rg")
+		deleted, err := client.DeleteResourceGroup(t.Context(), "local", "test-rg")
 		require.NoError(t, err)
 		require.True(t, deleted)
 	})
@@ -1909,7 +1909,7 @@ func Test_DeleteResourceGroup(t *testing.T) {
 		mockProviderSummaryForDeletion(rpClient, "local", "Applications.Core")
 		mockResourceDeletionFailure(genericClient, "test-env", "deletion failed")
 
-		deleted, err := client.DeleteResourceGroup(context.Background(), "local", "test-rg")
+		deleted, err := client.DeleteResourceGroup(t.Context(), "local", "test-rg")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to delete resources in group")
 		require.False(t, deleted)
@@ -1919,7 +1919,7 @@ func Test_DeleteResourceGroup(t *testing.T) {
 // runListTest is a helper for testing list operations with filters
 func runListTest(t *testing.T, client *UCPApplicationsManagementClient, resourceGroupName, environmentID, applicationID string, expectedNames []string) {
 	resources, err := client.ListResourcesInResourceGroupFiltered(
-		context.Background(), "local", resourceGroupName, environmentID, applicationID)
+		t.Context(), "local", resourceGroupName, environmentID, applicationID)
 	require.NoError(t, err)
 	require.Len(t, resources, len(expectedNames))
 	for i, expectedName := range expectedNames {
@@ -1958,7 +1958,7 @@ func Test_ListResourcesInResourceGroup(t *testing.T) {
 			NewListByRootScopePager(gomock.Any()).
 			Return(pager(allResources)).Times(4)
 
-		resources, err := client.ListResourcesInResourceGroup(context.Background(), "local", "test-group")
+		resources, err := client.ListResourcesInResourceGroup(t.Context(), "local", "test-group")
 		require.NoError(t, err)
 		require.Len(t, resources, 4)
 		require.Equal(t, "resource1", *resources[0].Name)
@@ -1977,7 +1977,7 @@ func Test_ListResourcesInResourceGroup(t *testing.T) {
 			NewListByRootScopePager(gomock.Any()).
 			Return(pager(emptyResources)).Times(4)
 
-		resources, err := client.ListResourcesInResourceGroup(context.Background(), "local", "test-group")
+		resources, err := client.ListResourcesInResourceGroup(t.Context(), "local", "test-group")
 		require.NoError(t, err)
 		require.Empty(t, resources)
 	})
@@ -2034,7 +2034,7 @@ func Test_ListResourcesInResourceGroup(t *testing.T) {
 			NewListByRootScopePager(gomock.Any()).
 			Return(pager(emptyResources)).Times(1)
 
-		resources, err := client.ListResourcesInResourceGroup(context.Background(), "local", "test-group")
+		resources, err := client.ListResourcesInResourceGroup(t.Context(), "local", "test-group")
 		require.NoError(t, err)
 		require.Len(t, resources, 1)
 		require.Equal(t, "resource1", *resources[0].Name)
@@ -2096,7 +2096,7 @@ func Test_ListResourcesInResourceGroup(t *testing.T) {
 // runListResourcesOfTypeTest is a helper for testing list resources of type operations with filters
 func runListResourcesOfTypeTest(t *testing.T, client *UCPApplicationsManagementClient, resourceGroupName, resourceType, environmentID, applicationID string, expectedNames []string) {
 	resources, err := client.ListResourcesOfTypeInResourceGroupFiltered(
-		context.Background(), "local", resourceGroupName, resourceType, environmentID, applicationID)
+		t.Context(), "local", resourceGroupName, resourceType, environmentID, applicationID)
 	require.NoError(t, err)
 	require.Len(t, resources, len(expectedNames))
 	for i, expectedName := range expectedNames {
@@ -2139,7 +2139,7 @@ func Test_ListResourcesOfTypeInResourceGroup(t *testing.T) {
 			Return(pager(allResourcesOfType))
 
 		resources, err := client.ListResourcesOfTypeInResourceGroup(
-			context.Background(), "local", "test-group", testResourceType)
+			t.Context(), "local", "test-group", testResourceType)
 		require.NoError(t, err)
 		require.Len(t, resources, 3)
 		require.Equal(t, "resource1", *resources[0].Name)
@@ -2161,7 +2161,7 @@ func Test_ListResourcesOfTypeInResourceGroup(t *testing.T) {
 			Return(pager(emptyResources))
 
 		resources, err := client.ListResourcesOfTypeInResourceGroup(
-			context.Background(), "local", "test-group", testResourceType)
+			t.Context(), "local", "test-group", testResourceType)
 		require.NoError(t, err)
 		require.Empty(t, resources)
 	})
@@ -2175,7 +2175,7 @@ func Test_ListResourcesOfTypeInResourceGroup(t *testing.T) {
 			Return(ucp.ResourceProvidersClientGetProviderSummaryResponse{}, fmt.Errorf("provider not found"))
 
 		_, err := client.ListResourcesOfTypeInResourceGroup(
-			context.Background(), "local", "test-group", "Unknown.Provider/unknownType")
+			t.Context(), "local", "test-group", "Unknown.Provider/unknownType")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "provider not found")
 	})
@@ -2318,7 +2318,7 @@ func Test_ResourceProvider(t *testing.T) {
 
 		expected := []ucp.ResourceProviderResource{*resourceProviderPages[0].Value[0], *resourceProviderPages[0].Value[1], *resourceProviderPages[1].Value[0], *resourceProviderPages[1].Value[1]}
 
-		groups, err := client.ListResourceProviders(context.Background(), "local")
+		groups, err := client.ListResourceProviders(t.Context(), "local")
 		require.NoError(t, err)
 		require.Equal(t, expected, groups)
 	})
@@ -2331,7 +2331,7 @@ func Test_ResourceProvider(t *testing.T) {
 			Get(gomock.Any(), "local", testResourceProviderName, gomock.Any()).
 			Return(ucp.ResourceProvidersClientGetResponse{ResourceProviderResource: expectedResource}, nil)
 
-		group, err := client.GetResourceProvider(context.Background(), "local", testResourceProviderName)
+		group, err := client.GetResourceProvider(t.Context(), "local", testResourceProviderName)
 		require.NoError(t, err)
 		require.Equal(t, expectedResource, group)
 	})
@@ -2344,7 +2344,7 @@ func Test_ResourceProvider(t *testing.T) {
 			BeginCreateOrUpdate(gomock.Any(), "local", testResourceProviderName, expectedResource, gomock.Any()).
 			Return(poller(&ucp.ResourceProvidersClientCreateOrUpdateResponse{ResourceProviderResource: expectedResource}), nil)
 
-		result, err := client.CreateOrUpdateResourceProvider(context.Background(), "local", testResourceProviderName, &expectedResource)
+		result, err := client.CreateOrUpdateResourceProvider(t.Context(), "local", testResourceProviderName, &expectedResource)
 		require.NoError(t, err)
 		require.Equal(t, result, expectedResource)
 	})
@@ -2360,7 +2360,7 @@ func Test_ResourceProvider(t *testing.T) {
 				return poller(&ucp.ResourceProvidersClientDeleteResponse{}), nil
 			})
 
-		deleted, err := client.DeleteResourceProvider(context.Background(), "local", testResourceProviderName)
+		deleted, err := client.DeleteResourceProvider(t.Context(), "local", testResourceProviderName)
 		require.NoError(t, err)
 		require.True(t, deleted)
 	})
@@ -2374,7 +2374,7 @@ func Test_ResourceProvider(t *testing.T) {
 			Return(pager(resourceProviderSummaryPages))
 		expected := []ucp.ResourceProviderSummary{*resourceProviderSummaryPages[0].Value[0], *resourceProviderSummaryPages[0].Value[1], *resourceProviderSummaryPages[1].Value[0], *resourceProviderSummaryPages[1].Value[1], *resourceProviderSummaryPages[1].Value[2]}
 
-		resourceProviderSummaries, err := client.ListResourceProviderSummaries(context.Background(), "local")
+		resourceProviderSummaries, err := client.ListResourceProviderSummaries(t.Context(), "local")
 		require.NoError(t, err)
 		require.Equal(t, expected, resourceProviderSummaries)
 	})
@@ -2402,7 +2402,7 @@ func Test_ResourceProvider(t *testing.T) {
 			GetProviderSummary(gomock.Any(), "local", testResourceProviderName, gomock.Any()).
 			Return(ucp.ResourceProvidersClientGetProviderSummaryResponse{ResourceProviderSummary: expectedResource}, nil)
 
-		summary, err := client.GetResourceProviderSummary(context.Background(), "local", testResourceProviderName)
+		summary, err := client.GetResourceProviderSummary(t.Context(), "local", testResourceProviderName)
 		require.NoError(t, err)
 		require.Equal(t, expectedResource, summary)
 	})
@@ -2437,7 +2437,7 @@ func Test_ResourceType(t *testing.T) {
 			BeginCreateOrUpdate(gomock.Any(), "local", testResourceProviderName, testResourceTypeName, expectedResource, gomock.Any()).
 			Return(poller(&ucp.ResourceTypesClientCreateOrUpdateResponse{ResourceTypeResource: expectedResource}), nil)
 
-		result, err := client.CreateOrUpdateResourceType(context.Background(), "local", testResourceProviderName, testResourceTypeName, &expectedResource)
+		result, err := client.CreateOrUpdateResourceType(t.Context(), "local", testResourceProviderName, testResourceTypeName, &expectedResource)
 		require.NoError(t, err)
 		require.Equal(t, expectedResource, result)
 	})
@@ -2453,7 +2453,7 @@ func Test_ResourceType(t *testing.T) {
 				return poller(&ucp.ResourceTypesClientDeleteResponse{}), nil
 			})
 
-		deleted, err := client.DeleteResourceType(context.Background(), "local", testResourceProviderName, testResourceTypeName)
+		deleted, err := client.DeleteResourceType(t.Context(), "local", testResourceProviderName, testResourceTypeName)
 		require.NoError(t, err)
 		require.True(t, deleted)
 	})
@@ -2489,7 +2489,7 @@ func Test_APIVersion(t *testing.T) {
 			BeginCreateOrUpdate(gomock.Any(), "local", testResourceProviderName, testResourceTypeName, testAPIVersionResourceName, expectedResource, gomock.Any()).
 			Return(poller(&ucp.APIVersionsClientCreateOrUpdateResponse{APIVersionResource: expectedResource}), nil)
 
-		result, err := client.CreateOrUpdateAPIVersion(context.Background(), "local", testResourceProviderName, testResourceTypeName, testAPIVersionResourceName, &expectedResource)
+		result, err := client.CreateOrUpdateAPIVersion(t.Context(), "local", testResourceProviderName, testResourceTypeName, testAPIVersionResourceName, &expectedResource)
 		require.NoError(t, err)
 		require.Equal(t, expectedResource, result)
 	})
@@ -2524,7 +2524,7 @@ func Test_Location(t *testing.T) {
 			BeginCreateOrUpdate(gomock.Any(), "local", testResourceProviderName, testLocationName, expectedResource, gomock.Any()).
 			Return(poller(&ucp.LocationsClientCreateOrUpdateResponse{LocationResource: expectedResource}), nil)
 
-		result, err := client.CreateOrUpdateLocation(context.Background(), "local", testResourceProviderName, testLocationName, &expectedResource)
+		result, err := client.CreateOrUpdateLocation(t.Context(), "local", testResourceProviderName, testLocationName, &expectedResource)
 		require.NoError(t, err)
 		require.Equal(t, expectedResource, result)
 	})

--- a/pkg/cli/cmd/app/delete/delete_test.go
+++ b/pkg/cli/cmd/app/delete/delete_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package delete
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -166,7 +165,7 @@ func Test_Delete(t *testing.T) {
 			Confirm:           true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -235,7 +234,7 @@ func Test_Delete(t *testing.T) {
 			EnvironmentName:   "default",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -291,7 +290,7 @@ func Test_Delete(t *testing.T) {
 			EnvironmentName:   "default",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Empty(t, outputSink.Writes)
 	})
@@ -349,7 +348,7 @@ func Test_Delete(t *testing.T) {
 			Confirm:           true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -406,7 +405,7 @@ func Test_Delete(t *testing.T) {
 			EnvironmentName:   "default",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Equal(t, &prompt.ErrExitConsole{}, err)
 		require.Empty(t, outputSink.Writes)
 	})
@@ -461,7 +460,7 @@ func Test_Delete(t *testing.T) {
 			Confirm:           true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Failed to delete application")
 		require.Contains(t, err.Error(), "delete operation failed")
@@ -517,7 +516,7 @@ func Test_Delete(t *testing.T) {
 			Confirm:           true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -579,7 +578,7 @@ func Test_Delete(t *testing.T) {
 			Confirm:           true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -643,7 +642,7 @@ func Test_Delete(t *testing.T) {
 			Force:             true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// Verify warning was logged before the delete result

--- a/pkg/cli/cmd/app/delete/preview/delete_test.go
+++ b/pkg/cli/cmd/app/delete/preview/delete_test.go
@@ -159,7 +159,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, []any{
 			output.LogOutput{
@@ -192,7 +192,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// Verify resource count message and final deleted message are present
@@ -236,7 +236,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, []any{
 			output.LogOutput{
@@ -269,7 +269,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 false,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, []any{
 			output.LogOutput{
@@ -300,7 +300,7 @@ func Test_Run(t *testing.T) {
 			Force:                   true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// First log should be the force warning.
@@ -348,7 +348,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Failed to delete resources for application 'test-app'")
 	})
@@ -375,7 +375,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "simulated list error")
 	})
@@ -425,7 +425,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 	})
 
@@ -468,7 +468,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 	})
 
@@ -498,7 +498,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 false,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// Must reach the final "Application deleted" log.

--- a/pkg/cli/cmd/app/graph/graph_test.go
+++ b/pkg/cli/cmd/app/graph/graph_test.go
@@ -188,7 +188,7 @@ func Test_Run(t *testing.T) {
 		ApplicationName: "test-app",
 	}
 
-	err := runner.Run(context.Background())
+	err := runner.Run(t.Context())
 	require.NoError(t, err)
 
 	expectedOutput := `Displaying application: test-app
@@ -269,7 +269,7 @@ func Test_Run_JSON(t *testing.T) {
 		ApplicationName: "test-app",
 	}
 
-	err := runner.Run(context.Background())
+	err := runner.Run(t.Context())
 	require.NoError(t, err)
 
 	require.Len(t, outputSink.Writes, 1)
@@ -331,7 +331,7 @@ func TestRunner_RunModeled_LocalFilesystem(t *testing.T) {
 		BicepFilePath: sampleBicepPath,
 	}
 
-	err := runner.Run(context.Background())
+	err := runner.Run(t.Context())
 	require.NoError(t, err)
 
 	contents, err := os.ReadFile(defaultModeledGraphFile)
@@ -369,7 +369,7 @@ func TestRunner_RunModeled_OrphanBranchPersistence(t *testing.T) {
 		GraphStore:    storeMock,
 	}
 
-	err := runner.Run(context.Background())
+	err := runner.Run(t.Context())
 	require.NoError(t, err)
 
 	_, statErr := os.Stat(defaultModeledGraphFile)
@@ -409,7 +409,7 @@ func TestRunner_RunModeled_RealGitStore_SlashBranch(t *testing.T) {
 		GraphStore:    store,
 	}
 
-	err = runner.Run(context.Background())
+	err = runner.Run(t.Context())
 	require.NoError(t, err, "runModeled must accept slash-containing GITHUB_HEAD_REF values")
 }
 
@@ -441,7 +441,7 @@ func TestRunner_RunModeled_FallsBackToRefName(t *testing.T) {
 		GraphStore:    storeMock,
 	}
 
-	require.NoError(t, runner.Run(context.Background()))
+	require.NoError(t, runner.Run(t.Context()))
 }
 
 func TestRunner_RunModeled_NoBranchInEnv(t *testing.T) {
@@ -466,7 +466,7 @@ func TestRunner_RunModeled_NoBranchInEnv(t *testing.T) {
 		GraphStore:    persistence.NewMockStore(ctrl),
 	}
 
-	err := runner.Run(context.Background())
+	err := runner.Run(t.Context())
 	require.Error(t, err)
 }
 
@@ -489,7 +489,7 @@ func TestRunner_RunModeled_BicepCompileError(t *testing.T) {
 		BicepFilePath: sampleBicepPath,
 	}
 
-	err := runner.Run(context.Background())
+	err := runner.Run(t.Context())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "syntax error")
 }
@@ -515,7 +515,7 @@ func TestRunner_RunModeled_NilGraphStore(t *testing.T) {
 		GraphStore:    nil,
 	}
 
-	err := runner.Run(context.Background())
+	err := runner.Run(t.Context())
 	require.Error(t, err)
 }
 
@@ -546,7 +546,7 @@ func TestRunner_RunModeled_StoreSaveError(t *testing.T) {
 		GraphStore:    storeMock,
 	}
 
-	err := runner.Run(context.Background())
+	err := runner.Run(t.Context())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "push rejected")
 	require.Contains(t, err.Error(), gitstore.DefaultGraphBranch)

--- a/pkg/cli/cmd/app/graph/preview/graph_test.go
+++ b/pkg/cli/cmd/app/graph/preview/graph_test.go
@@ -116,7 +116,7 @@ func Test_Run(t *testing.T) {
 			Output:                  outputSink,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Len(t, outputSink.Writes, 1)
 
@@ -170,7 +170,7 @@ func Test_Run(t *testing.T) {
 			Output:                  outputSink,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Len(t, outputSink.Writes, 1)
 
@@ -192,7 +192,7 @@ func Test_Run(t *testing.T) {
 			Output:                  outputSink,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Len(t, outputSink.Writes, 1)
 
@@ -233,7 +233,7 @@ func Test_Run(t *testing.T) {
 			Output:                  &output.MockOutput{},
 		}
 
-		require.NoError(t, runner.Run(context.Background()))
+		require.NoError(t, runner.Run(t.Context()))
 		require.Nil(t, received.IncludeIcons, "IncludeIcons must be nil by default (opt-in only)")
 	})
 
@@ -267,7 +267,7 @@ func Test_Run(t *testing.T) {
 			Output:                  &output.MockOutput{},
 		}
 
-		require.NoError(t, runner.Run(context.Background()))
+		require.NoError(t, runner.Run(t.Context()))
 		require.NotNil(t, received.IncludeIcons)
 		require.True(t, *received.IncludeIcons)
 	})
@@ -299,7 +299,7 @@ func Test_Run(t *testing.T) {
 			Output:                  &output.MockOutput{},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		require.Equal(t, clierrors.Message("Application %q does not exist or has been deleted.", "test-app"), err)
 	})
@@ -331,7 +331,7 @@ func Test_Run(t *testing.T) {
 			Output:                  &output.MockOutput{},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 	})
 }
@@ -410,7 +410,7 @@ func Test_Run_EnrichedMode(t *testing.T) {
 		Output:                  &output.MockOutput{},
 	}
 
-	require.NoError(t, runner.Run(context.Background()))
+	require.NoError(t, runner.Run(t.Context()))
 
 	require.NotNil(t, received.DependsOnEdges, "enriched mode must forward extracted edges")
 	entries, ok := received.DependsOnEdges[consumerID]
@@ -454,7 +454,7 @@ func Test_Run_EnrichedMode_CompileError_Wrapped(t *testing.T) {
 		Output:                  &output.MockOutput{},
 	}
 
-	err = runner.Run(context.Background())
+	err = runner.Run(t.Context())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "./bad.bicep")
 }

--- a/pkg/cli/cmd/app/list/list_test.go
+++ b/pkg/cli/cmd/app/list/list_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package list
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -114,7 +113,7 @@ func Test_Run(t *testing.T) {
 		Output:            outputSink,
 	}
 
-	err := runner.Run(context.Background())
+	err := runner.Run(t.Context())
 	require.NoError(t, err)
 
 	expected := []any{

--- a/pkg/cli/cmd/app/list/preview/list_test.go
+++ b/pkg/cli/cmd/app/list/preview/list_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package preview
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -185,7 +184,7 @@ func Test_Run(t *testing.T) {
 				Output:                  outputSink,
 			}
 
-			err = runner.Run(context.Background())
+			err = runner.Run(t.Context())
 			if tc.expectError {
 				require.Error(t, err)
 				require.Empty(t, outputSink.Writes)

--- a/pkg/cli/cmd/app/show/preview/show_test.go
+++ b/pkg/cli/cmd/app/show/preview/show_test.go
@@ -126,7 +126,7 @@ func Test_Run(t *testing.T) {
 				Output:                  outputSink,
 			}
 
-			err = runner.Run(context.Background())
+			err = runner.Run(t.Context())
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedOutput, outputSink.Writes)
 		})
@@ -159,7 +159,7 @@ func Test_Run(t *testing.T) {
 			Output:                  outputSink,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		require.Equal(t, clierrors.Message("The application %q was not found or has been deleted.", "test-app"), err)
 		require.Empty(t, outputSink.Writes)
@@ -192,7 +192,7 @@ func Test_Run(t *testing.T) {
 			Output:                  outputSink,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		// Should NOT be the 404 user-facing message.
 		require.NotEqual(t, clierrors.Message("The application %q was not found or has been deleted.", "test-app"), err)
@@ -212,7 +212,7 @@ func Test_Run(t *testing.T) {
 			Output:                  outputSink,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, []any{
 			output.FormattedOutput{

--- a/pkg/cli/cmd/app/show/show_test.go
+++ b/pkg/cli/cmd/app/show/show_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package list
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -120,7 +119,7 @@ func Test_Run(t *testing.T) {
 			ApplicationName:   "test-app",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -161,7 +160,7 @@ func Test_Run(t *testing.T) {
 			ApplicationName:   "test-app",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, err)
 		require.Equal(t, clierrors.Message("The application \"test-app\" was not found or has been deleted."), err)
 

--- a/pkg/cli/cmd/app/status/preview/status_test.go
+++ b/pkg/cli/cmd/app/status/preview/status_test.go
@@ -128,7 +128,7 @@ func Test_Run(t *testing.T) {
 			Output:          outputSink,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Len(t, outputSink.Writes, 1)
 
@@ -193,7 +193,7 @@ func Test_Run(t *testing.T) {
 			Output:          outputSink,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// Should have: status table, blank line, gateway table
@@ -241,7 +241,7 @@ func Test_Run(t *testing.T) {
 			Output:                  &output.MockOutput{},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "was not found or has been deleted")
 	})
@@ -276,7 +276,7 @@ func Test_Run(t *testing.T) {
 			Output:          outputSink,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Len(t, outputSink.Writes, 1)
 
@@ -309,7 +309,7 @@ func Test_Run(t *testing.T) {
 			Output:                  &output.MockOutput{},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "simulated error")
 	})

--- a/pkg/cli/cmd/app/status/status_test.go
+++ b/pkg/cli/cmd/app/status/status_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package status
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -151,7 +150,7 @@ func Test_Run(t *testing.T) {
 			ApplicationName: "test-app",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		applicationStatus := clients.ApplicationStatus{
@@ -211,7 +210,7 @@ func Test_Run(t *testing.T) {
 			ApplicationName:   "test-app",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, err)
 		require.Equal(t, clierrors.Message("The application \"test-app\" was not found or has been deleted."), err)
 

--- a/pkg/cli/cmd/bicep/generatekubernetesmanifest/generatekubernetesmanifest_test.go
+++ b/pkg/cli/cmd/bicep/generatekubernetesmanifest/generatekubernetesmanifest_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package bicep
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -183,7 +182,7 @@ func Test_Run(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, fileExists)
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		fileExists = runner.FileSystem.Exists(yamlFilePath)

--- a/pkg/cli/cmd/bicep/publish/publish_test.go
+++ b/pkg/cli/cmd/bicep/publish/publish_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package publish
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -212,7 +211,7 @@ func Test_pushBlob(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotDesc, err := pushBlob(context.Background(), tt.mediaType, tt.blob, tt.target)
+			gotDesc, err := pushBlob(t.Context(), tt.mediaType, tt.blob, tt.target)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("pushBlob() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cli/cmd/credential/list/list_test.go
+++ b/pkg/cli/cmd/credential/list/list_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package list
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/connections"
@@ -100,7 +99,7 @@ func Test_Run(t *testing.T) {
 				Format:            "table",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{

--- a/pkg/cli/cmd/credential/register/aws/accesskey/accesskey_test.go
+++ b/pkg/cli/cmd/credential/register/aws/accesskey/accesskey_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package accesskey
 
 import (
-	"context"
 	"testing"
 
 	"go.uber.org/mock/gomock"
@@ -135,7 +134,7 @@ func Test_Run(t *testing.T) {
 				SecretAccessKey: testSecretAccessKey,
 				KubeContext:     "my-context",
 			}
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{

--- a/pkg/cli/cmd/credential/register/aws/irsa/irsa_test.go
+++ b/pkg/cli/cmd/credential/register/aws/irsa/irsa_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package irsa
 
 import (
-	"context"
 	"testing"
 
 	"go.uber.org/mock/gomock"
@@ -119,7 +118,7 @@ func Test_Run(t *testing.T) {
 				IAMRole:     roleARN,
 				KubeContext: "my-context",
 			}
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{

--- a/pkg/cli/cmd/credential/register/azure/sp/serviceprincipal_test.go
+++ b/pkg/cli/cmd/credential/register/azure/sp/serviceprincipal_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package sp
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -151,7 +150,7 @@ func Test_Run(t *testing.T) {
 				KubeContext:  "my-context",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{

--- a/pkg/cli/cmd/credential/register/azure/wi/workloadidentity_test.go
+++ b/pkg/cli/cmd/credential/register/azure/wi/workloadidentity_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package wi
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -135,7 +134,7 @@ func Test_Run(t *testing.T) {
 				KubeContext: "my-context",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{

--- a/pkg/cli/cmd/credential/show/show_test.go
+++ b/pkg/cli/cmd/credential/show/show_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package show
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clierrors"
@@ -132,7 +131,7 @@ func Test_Run(t *testing.T) {
 				Format:            "table",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			credentialFormatOutput := credentialFormatAzureServicePrincipal()
@@ -180,7 +179,7 @@ func Test_Run(t *testing.T) {
 				Format:            "table",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			credentialFormatOutput := credentialFormatAzureWorkloadIdentity()
@@ -218,7 +217,7 @@ func Test_Run(t *testing.T) {
 				Format:            "table",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			expected := clierrors.Message("The credentials for cloud provider %q could not be found.", runner.Kind)
 			require.Equal(t, expected, err)
 		})
@@ -253,7 +252,7 @@ func Test_Run(t *testing.T) {
 				Format:            "table",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			credentialFormatOutput := credentialFormatAWSAccessKey()
@@ -295,7 +294,7 @@ func Test_Run(t *testing.T) {
 				Format:            "table",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			expected := clierrors.Message("The credentials for cloud provider %q could not be found.", runner.Kind)
 			require.Equal(t, expected, err)
 		})

--- a/pkg/cli/cmd/credential/unregister/unregister_test.go
+++ b/pkg/cli/cmd/credential/unregister/unregister_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package unregister
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/connections"
@@ -112,7 +111,7 @@ func Test_Run(t *testing.T) {
 				Format:            "table",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{
@@ -145,7 +144,7 @@ func Test_Run(t *testing.T) {
 				Format:            "table",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{

--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -375,7 +375,7 @@ func Test_ValidatePreviewEnvVarWithoutApplication(t *testing.T) {
 	r := runner.(*Runner)
 	r.ConnectionFactory = &connections.MockFactory{ApplicationsManagementClient: mockAppClient}
 
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 	require.NoError(t, cmd.ParseFlags([]string{"-e", appCoreEnvID}))
 
 	err := r.Validate(cmd, []string{"app.bicep"})
@@ -463,7 +463,7 @@ func Test_ValidateRadiusCoreEnvProvider(t *testing.T) {
 
 		// Parse the flags manually to set the environment flag
 		cmd.SetArgs([]string{"app.bicep", "-e", "prod"})
-		cmd.SetContext(context.Background())
+		cmd.SetContext(t.Context())
 		err = cmd.ParseFlags([]string{"-e", "prod"})
 		require.NoError(t, err)
 
@@ -535,7 +535,7 @@ func Test_ValidateRadiusCoreEnvProvider(t *testing.T) {
 
 		// Parse the flags manually to set the environment flag with a non-existent environment
 		cmd.SetArgs([]string{"app.bicep", "-e", "nonexistent"})
-		cmd.SetContext(context.Background())
+		cmd.SetContext(t.Context())
 		err = cmd.ParseFlags([]string{"-e", "nonexistent"})
 		require.NoError(t, err)
 
@@ -629,7 +629,7 @@ func Test_ValidateRadiusCoreEnvProvider(t *testing.T) {
 
 		// Parse the flags manually to set the environment flag with a conflicting environment name
 		cmd.SetArgs([]string{"app.bicep", "-e", "conflictenv"})
-		cmd.SetContext(context.Background())
+		cmd.SetContext(t.Context())
 		err = cmd.ParseFlags([]string{"-e", "conflictenv"})
 		require.NoError(t, err)
 
@@ -704,7 +704,7 @@ func Test_Run(t *testing.T) {
 			Template:            map[string]any{},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// Deployment is scoped to env
@@ -776,7 +776,7 @@ func Test_Run(t *testing.T) {
 			Template:            map[string]any{},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// Deployment is scoped to env
@@ -842,7 +842,7 @@ func Test_Run(t *testing.T) {
 			Template:            map[string]any{},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// Deployment is scoped to app and env
@@ -943,7 +943,7 @@ func Test_Run(t *testing.T) {
 			Preview:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// The application must have been created as a Radius.Core/applications resource.
@@ -1045,7 +1045,7 @@ func Test_Run(t *testing.T) {
 			Preview:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// A Radius.Core application is created and its environment reference is preserved as-is.
@@ -1106,7 +1106,7 @@ func Test_Run(t *testing.T) {
 			Template:            map[string]any{},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 
 		// Even though GetEnvironment returns a 404 error (indicated by EnvCheckResult being nil), the deployment should still succeed
 		require.NoError(t, err)
@@ -1156,7 +1156,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 
 		// Even though GetEnvironment returns a 404 error, the deployment should still succeed
 		require.Error(t, err)
@@ -1236,7 +1236,7 @@ func Test_setupRecipePacks(t *testing.T) {
 			},
 		}
 
-		err = runner.setupRecipePack(context.Background(), template)
+		err = runner.setupRecipePack(t.Context(), template)
 		require.NoError(t, err)
 
 		// Verify that the default recipe pack was injected.
@@ -1263,7 +1263,7 @@ func Test_setupRecipePacks(t *testing.T) {
 			},
 		}
 
-		err := runner.setupRecipePack(context.Background(), template)
+		err := runner.setupRecipePack(t.Context(), template)
 		require.NoError(t, err)
 
 		packs, _ := getRecipePacks(t, template, "env")
@@ -1288,7 +1288,7 @@ func Test_setupRecipePacks(t *testing.T) {
 			},
 		}
 
-		err := runner.setupRecipePack(context.Background(), template)
+		err := runner.setupRecipePack(t.Context(), template)
 		require.NoError(t, err)
 	})
 
@@ -1309,7 +1309,7 @@ func Test_setupRecipePacks(t *testing.T) {
 		}
 
 		// Should be a no-op since we only handle Radius.Core environments
-		err := runner.setupRecipePack(context.Background(), template)
+		err := runner.setupRecipePack(t.Context(), template)
 		require.NoError(t, err)
 	})
 
@@ -1348,7 +1348,7 @@ func Test_setupRecipePacks(t *testing.T) {
 			},
 		}
 
-		err = runner.setupRecipePack(context.Background(), template)
+		err = runner.setupRecipePack(t.Context(), template)
 		require.NoError(t, err)
 
 		// envWithPacks should be untouched — still just 1 pack.
@@ -1395,7 +1395,7 @@ func Test_setupRecipePacks(t *testing.T) {
 			},
 		}
 
-		err = runner.setupRecipePack(context.Background(), template)
+		err = runner.setupRecipePack(t.Context(), template)
 		require.NoError(t, err)
 
 		packs, ok := getRecipePacks(t, template, "env")
@@ -1435,7 +1435,7 @@ func Test_setupRecipePacks(t *testing.T) {
 			},
 		}
 
-		err = runner.setupRecipePack(context.Background(), template)
+		err = runner.setupRecipePack(t.Context(), template)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to get default recipe pack from default scope")
 	})
@@ -1462,7 +1462,7 @@ func Test_setupRecipePacks(t *testing.T) {
 			},
 		}
 
-		err := runner.setupRecipePack(context.Background(), template)
+		err := runner.setupRecipePack(t.Context(), template)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "resource group creation failed")
 	})
@@ -1827,7 +1827,7 @@ func Test_getApplicationsCoreEnvironment(t *testing.T) {
 				ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: mockClient},
 			}
 
-			env, err := runner.getApplicationsCoreEnvironment(context.Background(), "myenv")
+			env, err := runner.getApplicationsCoreEnvironment(t.Context(), "myenv")
 
 			if tc.shouldError {
 				require.Error(t, err)
@@ -1893,7 +1893,7 @@ func Test_getRadiusCoreEnvironment(t *testing.T) {
 				},
 			}
 
-			env, err := runner.getRadiusCoreEnvironment(context.Background(), tc.environmentName)
+			env, err := runner.getRadiusCoreEnvironment(t.Context(), tc.environmentName)
 
 			if tc.shouldError {
 				require.Error(t, err)
@@ -2007,7 +2007,7 @@ func Test_FetchEnvironment(t *testing.T) {
 				runner.RadiusCoreClientFactory = factory
 			}
 
-			result, err := runner.FetchEnvironment(context.Background(), tc.envNameOrID)
+			result, err := runner.FetchEnvironment(t.Context(), tc.envNameOrID)
 
 			if tc.shouldError {
 				require.Error(t, err)

--- a/pkg/cli/cmd/env/create/create_test.go
+++ b/pkg/cli/cmd/env/create/create_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package create
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -272,7 +271,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 		appManagementClient.EXPECT().
-			CreateOrUpdateEnvironment(context.Background(), "default", &corerp.EnvironmentResource{
+			CreateOrUpdateEnvironment(t.Context(), "default", &corerp.EnvironmentResource{
 				Location:   to.Ptr(v1.LocationGlobal),
 				Properties: testEnvProperties,
 			}).
@@ -310,7 +309,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, expectedOutput, outputSink.Writes)
 	})
@@ -336,7 +335,7 @@ func Test_Run(t *testing.T) {
 			Providers: testProviders,
 		}
 		appManagementClient.EXPECT().
-			CreateOrUpdateEnvironment(context.Background(), "default", &corerp.EnvironmentResource{
+			CreateOrUpdateEnvironment(t.Context(), "default", &corerp.EnvironmentResource{
 				Location:   to.Ptr(v1.LocationGlobal),
 				Properties: testEnvProperties,
 			}).
@@ -373,7 +372,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, expectedOutput, outputSink.Writes)
 	})
@@ -393,7 +392,7 @@ func Test_Run(t *testing.T) {
 		expectedError := errors.New("failed to create the environment")
 
 		appManagementClient.EXPECT().
-			CreateOrUpdateEnvironment(context.Background(), "default", &corerp.EnvironmentResource{
+			CreateOrUpdateEnvironment(t.Context(), "default", &corerp.EnvironmentResource{
 				Location:   to.Ptr(v1.LocationGlobal),
 				Properties: testEnvProperties,
 			}).
@@ -422,7 +421,7 @@ func Test_Run(t *testing.T) {
 			ConfigFileInterface: configFileInterface,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, err)
 		require.Equal(t, expectedError, err)
 		require.Empty(t, outputSink.Writes)

--- a/pkg/cli/cmd/env/create/preview/create_test.go
+++ b/pkg/cli/cmd/env/create/preview/create_test.go
@@ -379,7 +379,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.Equal(t, expectedOutput, outputSink.Writes)
@@ -419,7 +419,7 @@ func Test_Run(t *testing.T) {
 			ResourceGroupName:         "test-resource-group",
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 	})
 
@@ -457,7 +457,7 @@ func Test_Run(t *testing.T) {
 			ResourceGroupName:         "test-resource-group",
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to get default recipe pack from default scope")
 	})
@@ -533,7 +533,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.NotNil(t, capturedResource.Properties)
@@ -599,7 +599,7 @@ func Test_Run(t *testing.T) {
 			recipePacks:             []string{"pack1", "pack2"},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// The specified packs replace the default and are resolved to full IDs.
@@ -672,7 +672,7 @@ func Test_Run(t *testing.T) {
 			recipePacks:             []string{fullPackID},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.Len(t, capturedEnv.Properties.RecipePacks, 1)
@@ -700,7 +700,7 @@ func Test_Run(t *testing.T) {
 			recipePacks:             []string{"missing-pack"},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Recipe pack \"missing-pack\" does not exist")
 	})
@@ -722,7 +722,7 @@ func Test_Run(t *testing.T) {
 			recipePacks:             []string{"some-pack"},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		// A server-side failure must not be reported as "does not exist".
 		require.NotContains(t, err.Error(), "does not exist")

--- a/pkg/cli/cmd/env/delete/delete_test.go
+++ b/pkg/cli/cmd/env/delete/delete_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package delete
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -141,7 +140,7 @@ func Test_Show(t *testing.T) {
 			Confirm:           true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -194,7 +193,7 @@ func Test_Show(t *testing.T) {
 			EnvironmentName:   "test-env",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -250,7 +249,7 @@ func Test_Show(t *testing.T) {
 			EnvironmentName:   "test-env",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -306,7 +305,7 @@ func Test_Show(t *testing.T) {
 			EnvironmentName:   "test-env",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -353,7 +352,7 @@ func Test_Show(t *testing.T) {
 			EnvironmentName:   "test-env",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.Empty(t, outputSink.Writes)
@@ -398,7 +397,7 @@ func Test_Show(t *testing.T) {
 			Confirm:           true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -445,7 +444,7 @@ func Test_Show(t *testing.T) {
 			EnvironmentName:   "test-env",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Equal(t, &prompt.ErrExitConsole{}, err)
 		require.Empty(t, outputSink.Writes)
 	})

--- a/pkg/cli/cmd/env/delete/preview/delete_test.go
+++ b/pkg/cli/cmd/env/delete/preview/delete_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package preview
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -121,7 +120,7 @@ func Test_Run(t *testing.T) {
 				Confirm:                 true,
 			}
 
-			err = runner.Run(context.Background())
+			err = runner.Run(t.Context())
 			require.NoError(t, err)
 			require.Equal(t, ct.expectedLogs, outputSink.Writes)
 		})

--- a/pkg/cli/cmd/env/envswitch/preview/switch_test.go
+++ b/pkg/cli/cmd/env/envswitch/preview/switch_test.go
@@ -138,7 +138,7 @@ func Test_Validate(t *testing.T) {
 			}
 
 			cmd.SetArgs(tc.args)
-			cmd.SetContext(context.Background())
+			cmd.SetContext(t.Context())
 
 			err := r.Validate(cmd, tc.args)
 			if tc.expectError {

--- a/pkg/cli/cmd/env/list/list_test.go
+++ b/pkg/cli/cmd/env/list/list_test.go
@@ -17,7 +17,6 @@
 package list
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -116,7 +115,7 @@ func Test_Run(t *testing.T) {
 		Output:            outputSink,
 	}
 
-	err := runner.Run(context.Background())
+	err := runner.Run(t.Context())
 	require.NoError(t, err)
 
 	expected := []any{

--- a/pkg/cli/cmd/env/list/preview/list_test.go
+++ b/pkg/cli/cmd/env/list/preview/list_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package preview
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -117,7 +116,7 @@ func Test_Run(t *testing.T) {
 				Output:                  outputSink,
 			}
 
-			err = runner.Run(context.Background())
+			err = runner.Run(t.Context())
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedOutput, outputSink.Writes)
 		})

--- a/pkg/cli/cmd/env/show/preview/show_test.go
+++ b/pkg/cli/cmd/env/show/preview/show_test.go
@@ -197,7 +197,7 @@ func Test_Run(t *testing.T) {
 				Output:                  outputSink,
 			}
 
-			err = runner.Run(context.Background())
+			err = runner.Run(t.Context())
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedOutput, outputSink.Writes)
 		})
@@ -290,7 +290,7 @@ func Test_Run_RecipeSortOrder(t *testing.T) {
 		Output:                  outputSink,
 	}
 
-	err = runner.Run(context.Background())
+	err = runner.Run(t.Context())
 	require.NoError(t, err)
 
 	// Verify the recipes are sorted by RecipePack first, then by ResourceType

--- a/pkg/cli/cmd/env/show/show_test.go
+++ b/pkg/cli/cmd/env/show/show_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package show
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -123,7 +122,7 @@ func Test_Show(t *testing.T) {
 			EnvironmentName:   "test-env",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -164,7 +163,7 @@ func Test_Show(t *testing.T) {
 			EnvironmentName:   "test-env",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, err)
 		require.Equal(t, clierrors.Message("The environment \"test-env\" was not found or has been deleted."), err)
 

--- a/pkg/cli/cmd/env/update/preview/update_test.go
+++ b/pkg/cli/cmd/env/update/preview/update_test.go
@@ -274,7 +274,7 @@ func Test_Run(t *testing.T) {
 				},
 			}
 
-			err = runner.Run(context.Background())
+			err = runner.Run(t.Context())
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedOutput, outputSink.Writes)
 		})
@@ -347,7 +347,7 @@ func Test_Run_RecipePacksReplaced(t *testing.T) {
 		providers:               &v20250801preview.Providers{},
 	}
 
-	err = runner.Run(context.Background())
+	err = runner.Run(t.Context())
 	require.NoError(t, err)
 
 	// The old pack should be gone — only the two new packs should remain.
@@ -449,7 +449,7 @@ func Test_Run_DefaultsKubernetesNamespace(t *testing.T) {
 			providers:               &v20250801preview.Providers{},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.NotNil(t, captured.Properties)
@@ -477,7 +477,7 @@ func Test_Run_DefaultsKubernetesNamespace(t *testing.T) {
 			providers:               &v20250801preview.Providers{},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.NotNil(t, captured.Properties.Providers.Kubernetes)
@@ -506,7 +506,7 @@ func Test_Run_DefaultsKubernetesNamespace(t *testing.T) {
 			},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.NotNil(t, captured.Properties.Providers.Kubernetes)
@@ -532,7 +532,7 @@ func Test_Run_DefaultsKubernetesNamespace(t *testing.T) {
 			providers:               &v20250801preview.Providers{},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.NotNil(t, captured.Properties.Providers)
@@ -563,7 +563,7 @@ func Test_Run_DefaultsKubernetesNamespace(t *testing.T) {
 			providers:               &v20250801preview.Providers{},
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.NotNil(t, captured.Properties.Providers)
@@ -606,7 +606,7 @@ func Test_syncRecipePackReferences(t *testing.T) {
 
 		newPackIDs := []*string{to.Ptr(pack1FullID)}
 
-		err = syncRecipePackReferences(context.Background(), envID, nil, newPackIDs, workspace, factory)
+		err = syncRecipePackReferences(t.Context(), envID, nil, newPackIDs, workspace, factory)
 		require.NoError(t, err)
 		require.Len(t, capturedReferencedBy, 1)
 		require.Equal(t, envID, *capturedReferencedBy[0])
@@ -649,7 +649,7 @@ func Test_syncRecipePackReferences(t *testing.T) {
 
 		oldPackIDs := []*string{to.Ptr(pack1FullID)}
 
-		err = syncRecipePackReferences(context.Background(), envID, oldPackIDs, nil, workspace, factory)
+		err = syncRecipePackReferences(t.Context(), envID, oldPackIDs, nil, workspace, factory)
 		require.NoError(t, err)
 		// This env is removed; the other env remains.
 		require.Len(t, capturedReferencedBy, 1)
@@ -695,7 +695,7 @@ func Test_syncRecipePackReferences(t *testing.T) {
 		oldPackIDs := []*string{to.Ptr(pack1FullID), to.Ptr(pack2FullID)}
 		newPackIDs := []*string{to.Ptr(pack1FullID), to.Ptr(pack3FullID)}
 
-		err = syncRecipePackReferences(context.Background(), envID, oldPackIDs, newPackIDs, workspace, factory)
+		err = syncRecipePackReferences(t.Context(), envID, oldPackIDs, newPackIDs, workspace, factory)
 		require.NoError(t, err)
 
 		require.False(t, createOrUpdateCalled["pack1"], "unchanged pack should not be updated")
@@ -719,7 +719,7 @@ func Test_syncRecipePackReferences(t *testing.T) {
 
 		oldPackIDs := []*string{to.Ptr(pack1FullID)}
 
-		err = syncRecipePackReferences(context.Background(), envID, oldPackIDs, nil, workspace, factory)
+		err = syncRecipePackReferences(t.Context(), envID, oldPackIDs, nil, workspace, factory)
 		require.NoError(t, err)
 	})
 }

--- a/pkg/cli/cmd/env/update/update_test.go
+++ b/pkg/cli/cmd/env/update/update_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package update
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -138,7 +137,7 @@ func Test_Update(t *testing.T) {
 			noFlagsSet: true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, nil, err)
 	})
@@ -188,7 +187,7 @@ func Test_Update(t *testing.T) {
 			providers:         testProviders,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, expectedError)
 		require.Equal(t, expectedError.Error(), err.Error())
 	})
@@ -240,7 +239,7 @@ func Test_Update(t *testing.T) {
 			providers:         testProviders,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, expectedError)
 		require.Equal(t, clierrors.Message(envNotFoundErrMessageFmt, "test-env"), err)
 	})
@@ -303,7 +302,7 @@ func Test_Update(t *testing.T) {
 			providers:         testProviders,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, expectedError)
 		require.Equal(t, expectedErrorMessage, err.Error())
 	})
@@ -373,7 +372,7 @@ func Test_Update(t *testing.T) {
 			providers:         testProviders,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		environment.Properties.Providers = testProviders
@@ -446,7 +445,7 @@ func Test_Update(t *testing.T) {
 			providers:         testProviders,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -505,7 +504,7 @@ func Test_Update(t *testing.T) {
 			providers:         &corerp.Providers{},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 	})
 
@@ -542,7 +541,7 @@ func Test_Update(t *testing.T) {
 			providers:         &corerp.Providers{},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "existing compute kind is not Kubernetes")
 	})
@@ -688,7 +687,7 @@ func Test_Update(t *testing.T) {
 					clearEnvAzure:     tc.clearEnvAzure,
 				}
 
-				err := runner.Run(context.Background())
+				err := runner.Run(t.Context())
 				require.NoError(t, err)
 
 				expected := []any{

--- a/pkg/cli/cmd/group/create/create_test.go
+++ b/pkg/cli/cmd/group/create/create_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package create
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -111,7 +110,7 @@ func Test_Run(t *testing.T) {
 			Output:               outputSink,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{

--- a/pkg/cli/cmd/group/delete/delete_test.go
+++ b/pkg/cli/cmd/group/delete/delete_test.go
@@ -17,7 +17,6 @@
 package delete
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -310,7 +309,7 @@ func Test_Run(t *testing.T) {
 			}
 
 			// Execute
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 
 			// Verify results
 			if tt.expectedError != nil {

--- a/pkg/cli/cmd/group/groupswitch/switch_test.go
+++ b/pkg/cli/cmd/group/groupswitch/switch_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package groupswitch
 
 import (
-	"context"
 	"errors"
 	"path"
 	"testing"
@@ -161,7 +160,7 @@ func Test_Run(t *testing.T) {
 				Output:               outputSink,
 			}
 
-			err = runner.Run(context.Background())
+			err = runner.Run(t.Context())
 			require.NoError(t, err)
 
 			actualConfig, err := cli.ReadWorkspaceSection(config)
@@ -232,7 +231,7 @@ func Test_Run(t *testing.T) {
 			}
 
 			expected := clierrors.Message("The resource group %q does not exist. Run `rad group create` or `rad init` and try again.", runner.UCPResourceGroupName)
-			err = runner.Run(context.Background())
+			err = runner.Run(t.Context())
 			require.Equal(t, expected, err)
 		})
 	})

--- a/pkg/cli/cmd/group/list/list_test.go
+++ b/pkg/cli/cmd/group/list/list_test.go
@@ -17,7 +17,6 @@
 package list
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -123,7 +122,7 @@ func Test_Run(t *testing.T) {
 			Output:            outputSink,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{

--- a/pkg/cli/cmd/group/show/show_test.go
+++ b/pkg/cli/cmd/group/show/show_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package show
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -116,7 +115,7 @@ func Test_Run(t *testing.T) {
 			Output:               outputSink,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		resourceGroup := v20231001preview.ResourceGroupResource{

--- a/pkg/cli/cmd/install/kubernetes/kubernetes_test.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes_test.go
@@ -604,7 +604,7 @@ func Test_Run(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:                    helmMock,
 			Output:                  outputMock,
@@ -675,7 +675,7 @@ func Test_Run(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:                    helmMock,
 			Output:                  outputMock,

--- a/pkg/cli/cmd/install/kubernetes/kubernetes_test.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes_test.go
@@ -147,7 +147,7 @@ func Test_Run(t *testing.T) {
 		outputMock := &output.MockOutput{}
 		factory, k8sMock, postInstallWrites := expectDefaultGroupAndEnvCreation(t, ctrl)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:                helmMock,
 			Output:              outputMock,
@@ -190,7 +190,7 @@ func Test_Run(t *testing.T) {
 		helmMock := helm.NewMockInterface(ctrl)
 		outputMock := &output.MockOutput{}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:   helmMock,
 			Output: outputMock,
@@ -235,7 +235,7 @@ func Test_Run(t *testing.T) {
 		k8sMock := cli_kubernetes.NewMockInterface(ctrl)
 		factory := &connections.MockFactory{ApplicationsManagementClient: mgmtMock}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:                helmMock,
 			Output:              outputMock,
@@ -289,7 +289,7 @@ func Test_Run(t *testing.T) {
 		outputMock := &output.MockOutput{}
 		factory, k8sMock, postInstallWrites := expectDefaultGroupAndEnvCreation(t, ctrl)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:                helmMock,
 			Output:              outputMock,
@@ -335,7 +335,7 @@ func Test_Run(t *testing.T) {
 		outputMock := &output.MockOutput{}
 		factory, k8sMock, postInstallWrites := expectDefaultGroupAndEnvCreation(t, ctrl)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:                helmMock,
 			Output:              outputMock,
@@ -377,7 +377,7 @@ func Test_Run(t *testing.T) {
 		outputMock := &output.MockOutput{}
 		factory, k8sMock, postInstallWrites := expectDefaultGroupAndEnvCreation(t, ctrl)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:                helmMock,
 			Output:              outputMock,
@@ -420,7 +420,7 @@ func Test_Run(t *testing.T) {
 		outputMock := &output.MockOutput{}
 		factory, k8sMock, postInstallWrites := expectDefaultGroupAndEnvCreation(t, ctrl)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:                helmMock,
 			Output:              outputMock,
@@ -478,7 +478,7 @@ func Test_Run(t *testing.T) {
 		// GetEnvironment / CreateOrUpdateEnvironment must not be called: the runner should bail out
 		// as soon as the resource group create fails.
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:                helmMock,
 			Output:              outputMock,
@@ -532,7 +532,7 @@ func Test_Run(t *testing.T) {
 			Return(boom).
 			Times(1)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:                helmMock,
 			Output:              outputMock,

--- a/pkg/cli/cmd/radinit/aws_test.go
+++ b/pkg/cli/cmd/radinit/aws_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package radinit
 
 import (
-	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -52,7 +51,7 @@ func Test_enterAWSCloudProvider_AccessKey(t *testing.T) {
 	setAWSRegionPrompt(prompter, regions, "region")
 
 	options := &initOptions{}
-	provider, err := runner.enterAWSCloudProvider(context.Background(), options)
+	provider, err := runner.enterAWSCloudProvider(t.Context(), options)
 	require.NoError(t, err)
 
 	expected := &aws.Provider{
@@ -88,7 +87,7 @@ func Test_enterAWSCloudProvider_IRSA(t *testing.T) {
 	setAWSRegionPrompt(prompter, regions, "region")
 
 	options := &initOptions{}
-	provider, err := runner.enterAWSCloudProvider(context.Background(), options)
+	provider, err := runner.enterAWSCloudProvider(t.Context(), options)
 	require.NoError(t, err)
 
 	expected := &aws.Provider{

--- a/pkg/cli/cmd/radinit/azure_test.go
+++ b/pkg/cli/cmd/radinit/azure_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package radinit
 
 import (
-	"context"
 	"sort"
 	"testing"
 
@@ -62,7 +61,7 @@ func Test_enterAzureCloudProvider_ServicePrincipal(t *testing.T) {
 
 	options := &initOptions{}
 
-	provider, err := runner.enterAzureCloudProvider(context.Background(), options)
+	provider, err := runner.enterAzureCloudProvider(t.Context(), options)
 	require.NoError(t, err)
 
 	expected := &azure.Provider{
@@ -117,7 +116,7 @@ func Test_enterAzureCloudProvider_WorkloadIdentity(t *testing.T) {
 
 	options := &initOptions{}
 
-	provider, err := runner.enterAzureCloudProvider(context.Background(), options)
+	provider, err := runner.enterAzureCloudProvider(t.Context(), options)
 	require.NoError(t, err)
 
 	expected := &azure.Provider{
@@ -177,7 +176,7 @@ func Test_selectAzureSubscription(t *testing.T) {
 		setAzureSubscriptions(client, &subscriptions)
 		setAzureSubscriptionConfirmPrompt(prompter, subscriptions.Default.Name, prompt.ConfirmYes)
 
-		selected, err := common.SelectAzureSubscription(context.Background(), prompter, client)
+		selected, err := common.SelectAzureSubscription(t.Context(), prompter, client)
 		require.NoError(t, err)
 		require.NotNil(t, selected)
 
@@ -196,7 +195,7 @@ func Test_selectAzureSubscription(t *testing.T) {
 		setAzureSubscriptionConfirmPrompt(prompter, subscriptions.Default.Name, prompt.ConfirmNo)
 		setAzureSubsubscriptionPrompt(prompter, subscriptionNames, subscriptions.Subscriptions[2].Name)
 
-		selected, err := common.SelectAzureSubscription(context.Background(), prompter, client)
+		selected, err := common.SelectAzureSubscription(t.Context(), prompter, client)
 		require.NoError(t, err)
 		require.NotNil(t, selected)
 
@@ -214,7 +213,7 @@ func Test_selectAzureSubscription(t *testing.T) {
 		setAzureSubscriptions(client, &subscriptions)
 		setAzureSubsubscriptionPrompt(prompter, subscriptionNames, subscriptions.Subscriptions[2].Name)
 
-		selected, err := common.SelectAzureSubscription(context.Background(), prompter, client)
+		selected, err := common.SelectAzureSubscription(t.Context(), prompter, client)
 		require.NoError(t, err)
 		require.NotNil(t, selected)
 
@@ -306,7 +305,7 @@ func Test_selectAzureResourceGroup(t *testing.T) {
 		setAzureResourceGroups(client, subscription.ID, resourceGroups)
 		setAzureResourceGroupPrompt(prompter, resourceGroupNames, *resourceGroups[1].Name)
 
-		name, err := common.SelectAzureResourceGroup(context.Background(), prompter, &outputSink, client, subscription)
+		name, err := common.SelectAzureResourceGroup(t.Context(), prompter, &outputSink, client, subscription)
 		require.NoError(t, err)
 
 		require.Equal(t, *resourceGroups[1].Name, name)
@@ -326,7 +325,7 @@ func Test_selectAzureResourceGroup(t *testing.T) {
 		setSelectAzureResourceGroupLocationPrompt(prompter, locationDisplayNames, *locations[1].DisplayName)
 		setAzureCreateOrUpdateResourceGroup(client, subscription.ID, "test-resource-group", *locations[1].Name)
 
-		name, err := common.SelectAzureResourceGroup(context.Background(), prompter, &outputSink, client, subscription)
+		name, err := common.SelectAzureResourceGroup(t.Context(), prompter, &outputSink, client, subscription)
 		require.NoError(t, err)
 
 		require.Equal(t, "test-resource-group", name)
@@ -350,7 +349,7 @@ func Test_selectAzureResourceGroup(t *testing.T) {
 		setAzureResourceGroupNamePrompt(prompter, "test-resource-group")
 		setAzureCheckResourceGroupExistence(client, subscription.ID, "test-resource-group", true)
 
-		name, err := common.SelectAzureResourceGroup(context.Background(), prompter, &outputSink, client, subscription)
+		name, err := common.SelectAzureResourceGroup(t.Context(), prompter, &outputSink, client, subscription)
 		require.NoError(t, err)
 
 		require.Equal(t, "test-resource-group", name)
@@ -391,7 +390,7 @@ func Test_selectExistingAzureResourceGroup(t *testing.T) {
 	setAzureResourceGroups(client, subscription.ID, resourceGroups)
 	setAzureResourceGroupPrompt(prompter, resourceGroupNames, *resourceGroups[1].Name)
 
-	name, err := common.SelectExistingAzureResourceGroup(context.Background(), prompter, client, subscription)
+	name, err := common.SelectExistingAzureResourceGroup(t.Context(), prompter, client, subscription)
 	require.NoError(t, err)
 
 	require.Equal(t, *resourceGroups[1].Name, name)
@@ -478,7 +477,7 @@ func Test_selectAzureResourceGroupLocation(t *testing.T) {
 	setAzureLocations(client, subscription.ID, locations)
 	setSelectAzureResourceGroupLocationPrompt(prompter, locationDisplayNames, *locations[1].DisplayName)
 
-	location, err := common.SelectAzureResourceGroupLocation(context.Background(), prompter, client, subscription)
+	location, err := common.SelectAzureResourceGroupLocation(t.Context(), prompter, client, subscription)
 	require.NoError(t, err)
 	require.Equal(t, locations[1], *location)
 }

--- a/pkg/cli/cmd/radinit/cloud_test.go
+++ b/pkg/cli/cmd/radinit/cloud_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package radinit
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/aws"
@@ -74,7 +73,7 @@ func Test_enterCloudProviderOptions(t *testing.T) {
 		runner := Runner{}
 
 		options := initOptions{}
-		err := runner.enterCloudProviderOptions(context.Background(), &options)
+		err := runner.enterCloudProviderOptions(t.Context(), &options)
 		require.NoError(t, err)
 		require.Nil(t, options.CloudProviders.AWS)
 		require.Nil(t, options.CloudProviders.Azure)
@@ -84,7 +83,7 @@ func Test_enterCloudProviderOptions(t *testing.T) {
 		runner := Runner{Full: true}
 
 		options := initOptions{Environment: environmentOptions{Create: false}}
-		err := runner.enterCloudProviderOptions(context.Background(), &options)
+		err := runner.enterCloudProviderOptions(t.Context(), &options)
 		require.NoError(t, err)
 		require.Nil(t, options.CloudProviders.AWS)
 		require.Nil(t, options.CloudProviders.Azure)
@@ -101,7 +100,7 @@ func Test_enterCloudProviderOptions(t *testing.T) {
 		initAddCloudProviderPromptNo(prompter)
 
 		options := initOptions{Environment: environmentOptions{Create: true}}
-		err := runner.enterCloudProviderOptions(context.Background(), &options)
+		err := runner.enterCloudProviderOptions(t.Context(), &options)
 		require.NoError(t, err)
 		require.Nil(t, options.CloudProviders.AWS)
 		require.Nil(t, options.CloudProviders.Azure)
@@ -120,7 +119,7 @@ func Test_enterCloudProviderOptions(t *testing.T) {
 		initSelectCloudProvider(prompter, confirmCloudProviderBackNavigationSentinel)
 
 		options := initOptions{Environment: environmentOptions{Create: true}}
-		err := runner.enterCloudProviderOptions(context.Background(), &options)
+		err := runner.enterCloudProviderOptions(t.Context(), &options)
 		require.NoError(t, err)
 		require.Nil(t, options.CloudProviders.AWS)
 		require.Nil(t, options.CloudProviders.Azure)
@@ -141,7 +140,7 @@ func Test_enterCloudProviderOptions(t *testing.T) {
 		initAddCloudProviderPromptNo(prompter)
 
 		options := initOptions{Environment: environmentOptions{Create: true}}
-		err := runner.enterCloudProviderOptions(context.Background(), &options)
+		err := runner.enterCloudProviderOptions(t.Context(), &options)
 		require.NoError(t, err)
 		require.Nil(t, options.CloudProviders.Azure)
 		require.Equal(t, awsProviderAccessKey, *options.CloudProviders.AWS)
@@ -168,7 +167,7 @@ func Test_enterCloudProviderOptions(t *testing.T) {
 		initAddCloudProviderPromptNo(prompter)
 
 		options := initOptions{Environment: environmentOptions{Create: true}}
-		err := runner.enterCloudProviderOptions(context.Background(), &options)
+		err := runner.enterCloudProviderOptions(t.Context(), &options)
 		require.NoError(t, err)
 		require.Nil(t, options.CloudProviders.Azure)
 		require.Equal(t, awsProviderIRSA, *options.CloudProviders.AWS)
@@ -195,7 +194,7 @@ func Test_enterCloudProviderOptions(t *testing.T) {
 		initAddCloudProviderPromptNo(prompter)
 
 		options := initOptions{Environment: environmentOptions{Create: true}}
-		err := runner.enterCloudProviderOptions(context.Background(), &options)
+		err := runner.enterCloudProviderOptions(t.Context(), &options)
 		require.NoError(t, err)
 		require.Nil(t, options.CloudProviders.AWS)
 		require.Equal(t, azureProviderServicePrincipal, *options.CloudProviders.Azure)
@@ -223,7 +222,7 @@ func Test_enterCloudProviderOptions(t *testing.T) {
 		initAddCloudProviderPromptNo(prompter)
 
 		options := initOptions{Environment: environmentOptions{Create: true}}
-		err := runner.enterCloudProviderOptions(context.Background(), &options)
+		err := runner.enterCloudProviderOptions(t.Context(), &options)
 		require.NoError(t, err)
 		require.Nil(t, options.CloudProviders.AWS)
 		require.Equal(t, azureProviderWorkloadIdentity, *options.CloudProviders.Azure)
@@ -255,7 +254,7 @@ func Test_enterCloudProviderOptions(t *testing.T) {
 		initAddCloudProviderPromptNo(prompter)
 
 		options := initOptions{Environment: environmentOptions{Create: true}}
-		err := runner.enterCloudProviderOptions(context.Background(), &options)
+		err := runner.enterCloudProviderOptions(t.Context(), &options)
 		require.NoError(t, err)
 		require.Equal(t, awsProviderAccessKey, *options.CloudProviders.AWS)
 		require.Equal(t, azureProviderServicePrincipal, *options.CloudProviders.Azure)
@@ -294,7 +293,7 @@ func Test_enterCloudProviderOptions(t *testing.T) {
 		initAddCloudProviderPromptNo(prompter)
 
 		options := initOptions{Environment: environmentOptions{Create: true}}
-		err := runner.enterCloudProviderOptions(context.Background(), &options)
+		err := runner.enterCloudProviderOptions(t.Context(), &options)
 		require.NoError(t, err)
 		require.Nil(t, options.CloudProviders.Azure)
 		require.Equal(t, awsProvider, *options.CloudProviders.AWS)

--- a/pkg/cli/cmd/radinit/environment_test.go
+++ b/pkg/cli/cmd/radinit/environment_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package radinit
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -55,7 +54,7 @@ func Test_enterEnvironmentOptions(t *testing.T) {
 		initNamespacePrompt(prompter, "test-namespace")
 
 		options := initOptions{Cluster: clusterOptions{Install: true}}
-		err := runner.enterEnvironmentOptions(context.Background(), &workspaces.Workspace{}, &options)
+		err := runner.enterEnvironmentOptions(t.Context(), &workspaces.Workspace{}, &options)
 		require.NoError(t, err)
 
 		expected := environmentOptions{
@@ -81,7 +80,7 @@ func Test_enterEnvironmentOptions(t *testing.T) {
 		initNamespacePrompt(prompter, "test-namespace")
 
 		options := initOptions{}
-		err := runner.enterEnvironmentOptions(context.Background(), &workspaces.Workspace{}, &options)
+		err := runner.enterEnvironmentOptions(t.Context(), &workspaces.Workspace{}, &options)
 		require.NoError(t, err)
 
 		expected := environmentOptions{
@@ -105,7 +104,7 @@ func Test_enterEnvironmentOptions(t *testing.T) {
 		initExistingEnvironmentSelection(prompter, "test-env1")
 
 		options := initOptions{}
-		err := runner.enterEnvironmentOptions(context.Background(), &workspaces.Workspace{}, &options)
+		err := runner.enterEnvironmentOptions(t.Context(), &workspaces.Workspace{}, &options)
 		require.NoError(t, err)
 
 		expected := environmentOptions{
@@ -144,7 +143,7 @@ func Test_selectExistingEnvironment(t *testing.T) {
 
 		setExistingEnvironments(applicationsClient, environments)
 
-		name, err := runner.selectExistingEnvironment(context.Background(), &workspaces.Workspace{})
+		name, err := runner.selectExistingEnvironment(t.Context(), &workspaces.Workspace{})
 		require.NoError(t, err)
 		require.Equal(t, defaultEnvironmentName, *name)
 	})
@@ -162,7 +161,7 @@ func Test_selectExistingEnvironment(t *testing.T) {
 		setExistingEnvironments(applicationsClient, environments)
 		initExistingEnvironmentSelection(prompter, "test-env1")
 
-		name, err := runner.selectExistingEnvironment(context.Background(), &workspaces.Workspace{})
+		name, err := runner.selectExistingEnvironment(t.Context(), &workspaces.Workspace{})
 		require.NoError(t, err)
 		require.Equal(t, "test-env1", *name)
 	})
@@ -179,7 +178,7 @@ func Test_selectExistingEnvironment(t *testing.T) {
 		environments := []corerp.EnvironmentResource{}
 		setExistingEnvironments(applicationsClient, environments)
 
-		name, err := runner.selectExistingEnvironment(context.Background(), &workspaces.Workspace{})
+		name, err := runner.selectExistingEnvironment(t.Context(), &workspaces.Workspace{})
 		require.NoError(t, err)
 		require.Nil(t, name)
 	})
@@ -196,7 +195,7 @@ func Test_selectExistingEnvironment(t *testing.T) {
 		setExistingEnvironments(applicationsClient, environments)
 		initExistingEnvironmentSelection(prompter, "test-env1")
 
-		name, err := runner.selectExistingEnvironment(context.Background(), &workspaces.Workspace{})
+		name, err := runner.selectExistingEnvironment(t.Context(), &workspaces.Workspace{})
 		require.NoError(t, err)
 		require.Equal(t, "test-env1", *name)
 	})
@@ -213,7 +212,7 @@ func Test_selectExistingEnvironment(t *testing.T) {
 		setExistingEnvironments(applicationsClient, environments)
 		initExistingEnvironmentSelection(prompter, selectExistingEnvironmentCreateSentinel)
 
-		name, err := runner.selectExistingEnvironment(context.Background(), &workspaces.Workspace{})
+		name, err := runner.selectExistingEnvironment(t.Context(), &workspaces.Workspace{})
 		require.NoError(t, err)
 		require.Nil(t, name)
 	})

--- a/pkg/cli/cmd/radinit/init_test.go
+++ b/pkg/cli/cmd/radinit/init_test.go
@@ -938,20 +938,20 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			configFileInterface := framework.NewMockConfigFileInterface(ctrl)
 			configFileInterface.EXPECT().
-				ConfigFromContext(context.Background()).
+				ConfigFromContext(t.Context()).
 				Return(nil).
 				Times(1)
 
 			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
 			appManagementClient.EXPECT().
-				CreateOrUpdateResourceGroup(context.Background(), "local", "default", gomock.Any()).
+				CreateOrUpdateResourceGroup(t.Context(), "local", "default", gomock.Any()).
 				Return(nil).
 				Times(1)
 
 			devRecipeClient := NewMockDevRecipeClient(ctrl)
 			if !tc.full {
 				devRecipeClient.EXPECT().
-					GetDevRecipes(context.Background()).
+					GetDevRecipes(t.Context()).
 					Return(tc.recipes, nil).
 					Times(1)
 			}
@@ -964,7 +964,7 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 				Recipes:   tc.recipes,
 			}
 			appManagementClient.EXPECT().
-				CreateOrUpdateEnvironment(context.Background(), "default", &corerp.EnvironmentResource{
+				CreateOrUpdateEnvironment(t.Context(), "default", &corerp.EnvironmentResource{
 					Location:   to.Ptr(v1.LocationGlobal),
 					Properties: testEnvProperties,
 				}).
@@ -974,14 +974,14 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 			credentialManagementClient := cli_credential.NewMockCredentialManagementClient(ctrl)
 			if tc.azureProvider != nil {
 				credentialManagementClient.EXPECT().
-					PutAzure(context.Background(), gomock.Any()).
+					PutAzure(t.Context(), gomock.Any()).
 					Return(nil).
 					Times(1)
 			}
 			if tc.awsProvider != nil {
 				if tc.awsProvider.AccessKey != nil {
 					credentialManagementClient.EXPECT().
-						PutAWS(context.Background(), ucp.AwsCredentialResource{
+						PutAWS(t.Context(), ucp.AwsCredentialResource{
 							Location: to.Ptr(v1.LocationGlobal),
 							Type:     to.Ptr(cli_credential.AWSCredential),
 							Properties: &ucp.AwsAccessKeyCredentialProperties{
@@ -996,7 +996,7 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 						Times(1)
 				} else {
 					credentialManagementClient.EXPECT().
-						PutAWS(context.Background(), ucp.AwsCredentialResource{
+						PutAWS(t.Context(), ucp.AwsCredentialResource{
 							Location: to.Ptr(v1.LocationGlobal),
 							Type:     to.Ptr(cli_credential.AWSCredential),
 							Properties: &ucp.AwsIRSACredentialProperties{
@@ -1013,7 +1013,7 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 			}
 
 			configFileInterface.EXPECT().
-				EditWorkspaces(context.Background(), gomock.Any(), gomock.Any()).
+				EditWorkspaces(t.Context(), gomock.Any(), gomock.Any()).
 				Return(nil).
 				Times(1)
 
@@ -1030,7 +1030,7 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 			}
 
 			helmInterface.EXPECT().
-				InstallRadius(context.Background(), gomock.Any(), "kind-kind").
+				InstallRadius(t.Context(), gomock.Any(), "kind-kind").
 				DoAndReturn(func(ctx context.Context, clusterOptions helm.ClusterOptions, kubeContext string) error {
 					// Verify the SetArgs and SetFileArgs are passed correctly
 					assert.Equal(t, expectedClusterOptions.Radius.SetArgs, clusterOptions.Radius.SetArgs)
@@ -1083,7 +1083,7 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 				SetFile: tc.setFile,
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			if len(tc.expectedOutput) == 0 {

--- a/pkg/cli/cmd/radinit/options_test.go
+++ b/pkg/cli/cmd/radinit/options_test.go
@@ -18,7 +18,6 @@ package radinit
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/framework"
@@ -44,7 +43,7 @@ func Test_enterInitOptions(t *testing.T) {
 		initHelmMockRadiusNotInstalled(helm)
 		setScaffoldApplicationPromptNo(prompter)
 
-		options, workspace, err := runner.enterInitOptions(context.Background())
+		options, workspace, err := runner.enterInitOptions(t.Context())
 		require.NoError(t, err)
 
 		expectedWorkspace := workspaces.Workspace{
@@ -92,7 +91,7 @@ func Test_enterInitOptions(t *testing.T) {
 		initAddCloudProviderPromptNo(prompter)
 		setScaffoldApplicationPromptNo(prompter)
 
-		options, workspace, err := runner.enterInitOptions(context.Background())
+		options, workspace, err := runner.enterInitOptions(t.Context())
 		require.NoError(t, err)
 
 		expectedWorkspace := workspaces.Workspace{
@@ -151,7 +150,7 @@ workspaces:
 		initAddCloudProviderPromptNo(prompter)
 		setScaffoldApplicationPromptNo(prompter)
 
-		options, workspace, err := runner.enterInitOptions(context.Background())
+		options, workspace, err := runner.enterInitOptions(t.Context())
 		require.NoError(t, err)
 
 		expectedWorkspace := workspaces.Workspace{
@@ -216,7 +215,7 @@ workspaces:
 		initAddCloudProviderPromptNo(prompter)
 		setScaffoldApplicationPromptNo(prompter)
 
-		options, workspace, err := runner.enterInitOptions(context.Background())
+		options, workspace, err := runner.enterInitOptions(t.Context())
 		require.NoError(t, err)
 
 		expectedWorkspace := workspaces.Workspace{

--- a/pkg/cli/cmd/radinit/preview/init_test.go
+++ b/pkg/cli/cmd/radinit/preview/init_test.go
@@ -787,13 +787,13 @@ func newScaffoldTestRunner(t *testing.T, expectCompletion bool, appServerFactory
 
 	configFileInterface := framework.NewMockConfigFileInterface(ctrl)
 	configFileInterface.EXPECT().
-		ConfigFromContext(context.Background()).
+		ConfigFromContext(t.Context()).
 		Return(nil).
 		Times(1)
 
 	appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
 	appManagementClient.EXPECT().
-		CreateOrUpdateResourceGroup(context.Background(), "local", "default", gomock.Any()).
+		CreateOrUpdateResourceGroup(t.Context(), "local", "default", gomock.Any()).
 		Return(nil).
 		Times(2)
 
@@ -805,14 +805,14 @@ func newScaffoldTestRunner(t *testing.T, expectCompletion bool, appServerFactory
 
 	if expectCompletion {
 		configFileInterface.EXPECT().
-			EditWorkspaces(context.Background(), gomock.Any(), gomock.Any()).
+			EditWorkspaces(t.Context(), gomock.Any(), gomock.Any()).
 			Return(nil).
 			Times(1)
 	}
 
 	helmInterface := helm.NewMockInterface(ctrl)
 	helmInterface.EXPECT().
-		InstallRadius(context.Background(), gomock.Any(), "kind-kind").
+		InstallRadius(t.Context(), gomock.Any(), "kind-kind").
 		Return(nil).
 		Times(1)
 
@@ -909,7 +909,7 @@ func Test_Run_WithApplicationScaffold(t *testing.T) {
 			}
 		})
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		assert.Equal(t, 1, getCalled, "Get should be called once")
@@ -956,7 +956,7 @@ func Test_Run_WithApplicationScaffold(t *testing.T) {
 			}
 		})
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		assert.Equal(t, 1, getCalled, "Get should be called once")
@@ -999,7 +999,7 @@ func Test_Run_WithApplicationScaffold(t *testing.T) {
 			}
 		})
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Failed to check for existing application.")
 
@@ -1041,7 +1041,7 @@ func Test_Run_WithApplicationScaffold(t *testing.T) {
 			}
 		})
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Failed to create application.")
 
@@ -1219,13 +1219,13 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			configFileInterface := framework.NewMockConfigFileInterface(ctrl)
 			configFileInterface.EXPECT().
-				ConfigFromContext(context.Background()).
+				ConfigFromContext(t.Context()).
 				Return(nil).
 				Times(1)
 
 			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
 			appManagementClient.EXPECT().
-				CreateOrUpdateResourceGroup(context.Background(), "local", "default", gomock.Any()).
+				CreateOrUpdateResourceGroup(t.Context(), "local", "default", gomock.Any()).
 				Return(nil).
 				Times(2)
 
@@ -1237,14 +1237,14 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 			credentialManagementClient := cli_credential.NewMockCredentialManagementClient(ctrl)
 			if tc.azureProvider != nil {
 				credentialManagementClient.EXPECT().
-					PutAzure(context.Background(), gomock.Any()).
+					PutAzure(t.Context(), gomock.Any()).
 					Return(nil).
 					Times(1)
 			}
 			if tc.awsProvider != nil {
 				if tc.awsProvider.AccessKey != nil {
 					credentialManagementClient.EXPECT().
-						PutAWS(context.Background(), ucp.AwsCredentialResource{
+						PutAWS(t.Context(), ucp.AwsCredentialResource{
 							Location: to.Ptr(v1.LocationGlobal),
 							Type:     to.Ptr(cli_credential.AWSCredential),
 							Properties: &ucp.AwsAccessKeyCredentialProperties{
@@ -1259,7 +1259,7 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 						Times(1)
 				} else {
 					credentialManagementClient.EXPECT().
-						PutAWS(context.Background(), ucp.AwsCredentialResource{
+						PutAWS(t.Context(), ucp.AwsCredentialResource{
 							Location: to.Ptr(v1.LocationGlobal),
 							Type:     to.Ptr(cli_credential.AWSCredential),
 							Properties: &ucp.AwsIRSACredentialProperties{
@@ -1276,7 +1276,7 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 			}
 
 			configFileInterface.EXPECT().
-				EditWorkspaces(context.Background(), gomock.Any(), gomock.Any()).
+				EditWorkspaces(t.Context(), gomock.Any(), gomock.Any()).
 				Return(nil).
 				Times(1)
 
@@ -1293,7 +1293,7 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 			}
 
 			helmInterface.EXPECT().
-				InstallRadius(context.Background(), gomock.Any(), "kind-kind").
+				InstallRadius(t.Context(), gomock.Any(), "kind-kind").
 				DoAndReturn(func(ctx context.Context, clusterOptions helm.ClusterOptions, kubeContext string) error {
 					// Verify the SetArgs and SetFileArgs are passed correctly
 					assert.Equal(t, expectedClusterOptions.Radius.SetArgs, clusterOptions.Radius.SetArgs)
@@ -1348,7 +1348,7 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 				SetFile: tc.setFile,
 			}
 
-			err = runner.Run(context.Background())
+			err = runner.Run(t.Context())
 			require.NoError(t, err)
 
 			if len(tc.expectedOutput) == 0 {

--- a/pkg/cli/cmd/recipe/list/list_test.go
+++ b/pkg/cli/cmd/recipe/list/list_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package list
 
 import (
-	"context"
 	"sort"
 	"testing"
 
@@ -147,7 +146,7 @@ func Test_Run(t *testing.T) {
 			Format:            "table",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{

--- a/pkg/cli/cmd/recipe/register/register_test.go
+++ b/pkg/cli/cmd/recipe/register/register_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package register
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -164,7 +163,7 @@ func Test_Run(t *testing.T) {
 			Return(envResource, nil).Times(1)
 
 		appManagementClient.EXPECT().
-			CreateOrUpdateEnvironment(context.Background(), "kind-kind", &envResource).
+			CreateOrUpdateEnvironment(t.Context(), "kind-kind", &envResource).
 			Return(nil).Times(1)
 
 		outputSink := &output.MockOutput{}
@@ -190,7 +189,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, expectedOutput, outputSink.Writes)
 	})
@@ -235,7 +234,7 @@ func Test_Run(t *testing.T) {
 			Times(1)
 
 		appManagementClient.EXPECT().
-			CreateOrUpdateEnvironment(context.Background(), "kind-kind", &envResource).
+			CreateOrUpdateEnvironment(t.Context(), "kind-kind", &envResource).
 			Return(expectedError).
 			Times(1)
 
@@ -250,7 +249,7 @@ func Test_Run(t *testing.T) {
 			RecipeName:        "cosmosDB_new",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, err)
 		require.Equal(t, expectedErrorMessage, err.Error())
 	})
@@ -277,7 +276,7 @@ func Test_Run(t *testing.T) {
 			RecipeName:        "cosmosDB_new",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, err)
 		require.Equal(t, expectedError, err)
 	})
@@ -317,7 +316,7 @@ func Test_Run(t *testing.T) {
 			Return(envResource, nil).Times(1)
 
 		appManagementClient.EXPECT().
-			CreateOrUpdateEnvironment(context.Background(), "kind-kind", &envResource).
+			CreateOrUpdateEnvironment(t.Context(), "kind-kind", &envResource).
 			Return(nil).Times(1)
 
 		outputSink := &output.MockOutput{}
@@ -343,7 +342,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, expectedOutput, outputSink.Writes)
 	})
@@ -374,7 +373,7 @@ func Test_Run(t *testing.T) {
 			Return(envResource, nil).Times(1)
 
 		appManagementClient.EXPECT().
-			CreateOrUpdateEnvironment(context.Background(), "kind-kind", &envResource).
+			CreateOrUpdateEnvironment(t.Context(), "kind-kind", &envResource).
 			Return(nil).Times(1)
 
 		outputSink := &output.MockOutput{}
@@ -399,7 +398,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, expectedOutput, outputSink.Writes)
 	})
@@ -427,7 +426,7 @@ func Test_Run(t *testing.T) {
 			Return(envResource, nil).Times(1)
 
 		appManagementClient.EXPECT().
-			CreateOrUpdateEnvironment(context.Background(), "kind-kind", &envResource).
+			CreateOrUpdateEnvironment(t.Context(), "kind-kind", &envResource).
 			Return(nil).Times(1)
 
 		outputSink := &output.MockOutput{}
@@ -452,7 +451,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, expectedOutput, outputSink.Writes)
 	})

--- a/pkg/cli/cmd/recipe/show/show_test.go
+++ b/pkg/cli/cmd/recipe/show/show_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package show
 
 import (
-	"context"
 	"testing"
 
 	"go.uber.org/mock/gomock"
@@ -150,7 +149,7 @@ func Test_Run(t *testing.T) {
 			ResourceType:      datastoresrp.MongoDatabasesResourceType,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -229,7 +228,7 @@ func Test_Run(t *testing.T) {
 			ResourceType:      datastoresrp.MongoDatabasesResourceType,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -298,7 +297,7 @@ func Test_Run(t *testing.T) {
 			ResourceType:      datastoresrp.RedisCachesResourceType,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -377,7 +376,7 @@ func Test_Run(t *testing.T) {
 			ResourceType:      datastoresrp.MongoDatabasesResourceType,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{

--- a/pkg/cli/cmd/recipe/unregister/unregister_test.go
+++ b/pkg/cli/cmd/recipe/unregister/unregister_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package unregister
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -126,7 +125,7 @@ func Test_Run(t *testing.T) {
 				GetEnvironment(gomock.Any(), gomock.Any()).
 				Return(envResource, nil).Times(1)
 			appManagementClient.EXPECT().
-				CreateOrUpdateEnvironment(context.Background(), "kind-kind", &v20231001preview.EnvironmentResource{
+				CreateOrUpdateEnvironment(t.Context(), "kind-kind", &v20231001preview.EnvironmentResource{
 					Location:   to.Ptr(v1.LocationGlobal),
 					Properties: testEnvProperties,
 				}).
@@ -152,7 +151,7 @@ func Test_Run(t *testing.T) {
 				},
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 			require.Equal(t, expectedOutput, outputSink.Writes)
 		})
@@ -194,7 +193,7 @@ func Test_Run(t *testing.T) {
 				Return(envResource, nil).
 				Times(1)
 			appManagementClient.EXPECT().
-				CreateOrUpdateEnvironment(context.Background(), "kind-kind", &v20231001preview.EnvironmentResource{
+				CreateOrUpdateEnvironment(t.Context(), "kind-kind", &v20231001preview.EnvironmentResource{
 					Location:   to.Ptr(v1.LocationGlobal),
 					Properties: testEnvProperties,
 				}).
@@ -211,7 +210,7 @@ func Test_Run(t *testing.T) {
 				ResourceType:      "Applications.Datastores/mongoDatabases",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.Error(t, err)
 			require.Equal(t, expectedErrorMessage, err.Error())
 		})
@@ -243,7 +242,7 @@ func Test_Run(t *testing.T) {
 				GetEnvironment(gomock.Any(), gomock.Any()).
 				Return(envResource, nil).Times(1)
 			appManagementClient.EXPECT().
-				CreateOrUpdateEnvironment(context.Background(), "kind-kind", &v20231001preview.EnvironmentResource{
+				CreateOrUpdateEnvironment(t.Context(), "kind-kind", &v20231001preview.EnvironmentResource{
 					Location:   to.Ptr(v1.LocationGlobal),
 					Properties: testEnvProperties,
 				}).
@@ -269,7 +268,7 @@ func Test_Run(t *testing.T) {
 				},
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 			require.Equal(t, expectedOutput, outputSink.Writes)
 		})
@@ -309,7 +308,7 @@ func Test_Run(t *testing.T) {
 				ResourceType:      "Applications.Datastores/mongoDatabases",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.Error(t, err)
 		})
 
@@ -347,7 +346,7 @@ func Test_Run(t *testing.T) {
 				ResourceType:      "Applications.Datastores/redisCaches",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.Error(t, err)
 		})
 
@@ -377,7 +376,7 @@ func Test_Run(t *testing.T) {
 				ResourceType:      "Applications.Datastores/mongoDatabases",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.Error(t, err)
 		})
 
@@ -417,7 +416,7 @@ func Test_Run(t *testing.T) {
 				GetEnvironment(gomock.Any(), gomock.Any()).
 				Return(envResource, nil).Times(1)
 			appManagementClient.EXPECT().
-				CreateOrUpdateEnvironment(context.Background(), "kind-kind", &v20231001preview.EnvironmentResource{
+				CreateOrUpdateEnvironment(t.Context(), "kind-kind", &v20231001preview.EnvironmentResource{
 					Location:   to.Ptr(v1.LocationGlobal),
 					Properties: testEnvProperties,
 				}).
@@ -443,7 +442,7 @@ func Test_Run(t *testing.T) {
 				},
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 			require.Equal(t, expectedOutput, outputSink.Writes)
 		})

--- a/pkg/cli/cmd/recipepack/delete/delete_test.go
+++ b/pkg/cli/cmd/recipepack/delete/delete_test.go
@@ -156,7 +156,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// Pack must be removed from the environment's RecipePacks list.
@@ -195,7 +195,7 @@ func Test_Run(t *testing.T) {
 			Confirm:           true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, []any{
 			output.LogOutput{Format: msgRecipePackDeleted, Params: []any{packName}},
@@ -244,7 +244,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, []any{
 			output.LogOutput{Format: msgRecipePackDeleted, Params: []any{packName}},
@@ -272,7 +272,7 @@ func Test_Run(t *testing.T) {
 			Confirm:           false,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Empty(t, outputSink.Writes)
 	})
@@ -295,7 +295,7 @@ func Test_Run(t *testing.T) {
 			Confirm:           true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), packName)
 	})
@@ -318,7 +318,7 @@ func Test_Run(t *testing.T) {
 			Confirm:           true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.EqualError(t, err, "test error")
 	})
 
@@ -361,7 +361,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "An error occurred while retrieving environment")
 	})
@@ -420,7 +420,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Failed to update environment")
 	})
@@ -453,7 +453,7 @@ func Test_Run(t *testing.T) {
 			Confirm:           true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, []any{
 			output.LogOutput{Format: msgRecipePackNotFound, Params: []any{packName}},
@@ -522,7 +522,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// Both referenced envs should have been updated using the injected factory,
@@ -603,7 +603,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                 true,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.Len(t, capturedEnv.Properties.RecipePacks, 1)

--- a/pkg/cli/cmd/recipepack/list/list_test.go
+++ b/pkg/cli/cmd/recipepack/list/list_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package list
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -114,7 +113,7 @@ func Test_Run(t *testing.T) {
 		Output:            outputSink,
 	}
 
-	err := runner.Run(context.Background())
+	err := runner.Run(t.Context())
 	require.NoError(t, err)
 
 	expected := []any{

--- a/pkg/cli/cmd/recipepack/show/show_test.go
+++ b/pkg/cli/cmd/recipepack/show/show_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package show
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -126,7 +125,7 @@ func Test_Run(t *testing.T) {
 			Format:            "json",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -168,7 +167,7 @@ func Test_Run(t *testing.T) {
 			Format:            "table",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// Table format produces a table write followed by display (LogInfo) output

--- a/pkg/cli/cmd/resource/create/create_test.go
+++ b/pkg/cli/cmd/resource/create/create_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package create
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -114,7 +113,7 @@ func Test_Run(t *testing.T) {
 			Format:                         "table",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, []any{
 			output.LogOutput{

--- a/pkg/cli/cmd/resource/delete/delete_test.go
+++ b/pkg/cli/cmd/resource/delete/delete_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package delete
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -132,7 +131,7 @@ func Test_Run(t *testing.T) {
 				Format:                         "table",
 				Confirm:                        true,
 			}
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.Error(t, err)
 			require.Equal(t, responseError, err)
 		})
@@ -168,7 +167,7 @@ func Test_Run(t *testing.T) {
 				Confirm:                        true,
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{
@@ -210,7 +209,7 @@ func Test_Run(t *testing.T) {
 				Confirm:                        true,
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{
@@ -266,7 +265,7 @@ func Test_Run(t *testing.T) {
 				InputPrompter:                  promptMock,
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{
@@ -323,7 +322,7 @@ func Test_Run(t *testing.T) {
 				InputPrompter:                  promptMock,
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{
@@ -390,7 +389,7 @@ func Test_Run(t *testing.T) {
 				InputPrompter:                  promptMock,
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{
@@ -445,7 +444,7 @@ func Test_Run(t *testing.T) {
 				InputPrompter:                  promptMock,
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{
@@ -499,7 +498,7 @@ func Test_Run(t *testing.T) {
 				ResourceName:                   "test-container",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			require.Empty(t, outputSink.Writes)
@@ -536,7 +535,7 @@ func Test_Run(t *testing.T) {
 				Force:                          true,
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{

--- a/pkg/cli/cmd/resource/list/list_test.go
+++ b/pkg/cli/cmd/resource/list/list_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package list
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -191,7 +190,7 @@ func Test_Run(t *testing.T) {
 				ResourceProviderNamespace: "MyCompany.Resources",
 			}
 
-			err = runner.Run(context.Background())
+			err = runner.Run(t.Context())
 			require.Error(t, err)
 			require.IsType(t, err, clierrors.Message("The application %q could not be found in workspace %q. Make sure you specify the correct application with '-a/--application'.", "test-app", radcli.TestWorkspaceName))
 		})
@@ -228,7 +227,7 @@ func Test_Run(t *testing.T) {
 				ResourceProviderNamespace: "MyCompany.Resources",
 			}
 
-			err = runner.Run(context.Background())
+			err = runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{
@@ -281,7 +280,7 @@ func Test_Run(t *testing.T) {
 				ResourceProviderNamespace: "MyCompany.Resources",
 			}
 
-			err = runner.Run(context.Background())
+			err = runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{
@@ -325,7 +324,7 @@ func Test_Run(t *testing.T) {
 				ResourceProviderNamespace: "MyCompany.Resources",
 			}
 
-			err = runner.Run(context.Background())
+			err = runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{
@@ -363,7 +362,7 @@ func Test_Run(t *testing.T) {
 				Format:            "table",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{
@@ -394,7 +393,7 @@ func Test_Run(t *testing.T) {
 				Format:            "table",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.Error(t, err)
 			require.IsType(t, clierrors.Message("The application %q could not be found in workspace %q. Make sure you specify the correct application with '-a/--application'.", "test-app", radcli.TestWorkspaceName), err)
 		})
@@ -425,7 +424,7 @@ func Test_Run(t *testing.T) {
 				Format:            "table",
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 
 			expected := []any{

--- a/pkg/cli/cmd/resource/show/show_test.go
+++ b/pkg/cli/cmd/resource/show/show_test.go
@@ -17,7 +17,6 @@
 package show
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -115,7 +114,7 @@ func Test_Run(t *testing.T) {
 			Format:                         "table",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{

--- a/pkg/cli/cmd/resourceprovider/create/create_test.go
+++ b/pkg/cli/cmd/resourceprovider/create/create_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package create
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/framework"
@@ -85,7 +84,7 @@ func Test_Run(t *testing.T) {
 			ResourceProviderManifestFilePath: "testdata/valid.yaml",
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.Equal(t, []any{
@@ -113,7 +112,7 @@ func Test_Run(t *testing.T) {
 			ResourceProviderManifestFilePath: "testdata/valid.yaml",
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		require.Empty(t, outputSink.Writes)
 	})

--- a/pkg/cli/cmd/resourceprovider/delete/delete_test.go
+++ b/pkg/cli/cmd/resourceprovider/delete/delete_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package delete
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -90,7 +89,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                   true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -131,7 +130,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                   true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -178,7 +177,7 @@ func Test_Run(t *testing.T) {
 			ResourceProviderNamespace: "Applications.Test",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{

--- a/pkg/cli/cmd/resourceprovider/list/list_test.go
+++ b/pkg/cli/cmd/resourceprovider/list/list_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package list
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -110,7 +109,7 @@ func Test_Run(t *testing.T) {
 			Output:            outputSink,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{

--- a/pkg/cli/cmd/resourceprovider/show/show_test.go
+++ b/pkg/cli/cmd/resourceprovider/show/show_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package show
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -101,7 +100,7 @@ func Test_Run(t *testing.T) {
 			ResourceProviderNamespace: "Applications.Test",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -142,7 +141,7 @@ func Test_Run(t *testing.T) {
 			ResourceProviderNamespace: "Applications.AnotherTest",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Error(t, err)
 		require.Equal(t, clierrors.Message("The resource provider \"Applications.AnotherTest\" was not found or has been deleted."), err)
 

--- a/pkg/cli/cmd/resourcetype/common/resourcetype_test.go
+++ b/pkg/cli/cmd/resourcetype/common/resourcetype_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package common
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/manifest"
@@ -33,7 +32,7 @@ func Test_GetResourceTypeDetails(t *testing.T) {
 		clientFactory, err := manifest.NewTestClientFactory(manifest.WithResourceProviderServerNoError)
 		require.NoError(t, err)
 
-		res, err := GetResourceTypeDetails(context.Background(), "MyCompany.Resources", "testResources", clientFactory)
+		res, err := GetResourceTypeDetails(t.Context(), "MyCompany.Resources", "testResources", clientFactory)
 		require.NoError(t, err)
 		require.Equal(t, "MyCompany.Resources/testResources", res.Name)
 
@@ -46,7 +45,7 @@ func Test_GetResourceTypeDetails(t *testing.T) {
 		clientFactory, err := manifest.NewTestClientFactory(manifest.WithResourceProviderServerNotFoundError)
 		require.NoError(t, err)
 
-		_, err = GetResourceTypeDetails(context.Background(), "MyCompany.Resources", "testResources", clientFactory)
+		_, err = GetResourceTypeDetails(t.Context(), "MyCompany.Resources", "testResources", clientFactory)
 		require.Error(t, err)
 		require.Equal(t, "The resource type \"MyCompany.Resources/testResources\" does not exist.", err.Error())
 	})
@@ -58,7 +57,7 @@ func Test_GetResourceTypeDetails(t *testing.T) {
 		clientFactory, err := manifest.NewTestClientFactory(manifest.WithResourceProviderServerNoError)
 		require.NoError(t, err)
 
-		_, err = GetResourceTypeDetails(context.Background(), "MyCompany.Resources", "missingResources", clientFactory)
+		_, err = GetResourceTypeDetails(t.Context(), "MyCompany.Resources", "missingResources", clientFactory)
 		require.Error(t, err)
 		require.Equal(t, "The resource type \"MyCompany.Resources/missingResources\" does not exist.", err.Error())
 	})
@@ -70,7 +69,7 @@ func Test_GetResourceTypeDetails(t *testing.T) {
 		clientFactory, err := manifest.NewTestClientFactory(manifest.WithResourceProviderServerInternalError)
 		require.NoError(t, err)
 
-		_, err = GetResourceTypeDetails(context.Background(), "MyCompany.Resources", "testResources", clientFactory)
+		_, err = GetResourceTypeDetails(t.Context(), "MyCompany.Resources", "testResources", clientFactory)
 		require.Error(t, err)
 	})
 }

--- a/pkg/cli/cmd/resourcetype/create/create_test.go
+++ b/pkg/cli/cmd/resourcetype/create/create_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package create
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/framework"
@@ -88,7 +87,7 @@ func Test_Run(t *testing.T) {
 			ResourceTypeName:                 "testResources",
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.Contains(t, outputSink.Writes, output.LogOutput{
@@ -118,7 +117,7 @@ func Test_Run(t *testing.T) {
 			ResourceTypeName:                 "", // Empty resource type name
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		// Verify the concise success log lines for both resource types are emitted
@@ -155,7 +154,7 @@ func Test_Run(t *testing.T) {
 			ResourceTypeName:                 expectedResourceType,
 		}
 
-		_ = runner.Run(context.Background())
+		_ = runner.Run(t.Context())
 
 		// Verify only the specified resource type produced a success line.
 		require.Contains(t, outputSink.Writes, output.LogOutput{
@@ -189,7 +188,7 @@ func Test_Run(t *testing.T) {
 			ResourceTypeName:                 expectedResourceType,
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unexpected status code 500.")
 	})

--- a/pkg/cli/cmd/resourcetype/delete/delete_test.go
+++ b/pkg/cli/cmd/resourcetype/delete/delete_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package delete
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -98,7 +97,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                   true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -141,7 +140,7 @@ func Test_Run(t *testing.T) {
 			Confirm:                   true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -190,7 +189,7 @@ func Test_Run(t *testing.T) {
 			ResourceTypeSuffix:        "testResources",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{

--- a/pkg/cli/cmd/resourcetype/list/list_test.go
+++ b/pkg/cli/cmd/resourcetype/list/list_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package list
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -137,7 +136,7 @@ func Test_Run(t *testing.T) {
 			Output:            outputSink,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{

--- a/pkg/cli/cmd/resourcetype/show/show_test.go
+++ b/pkg/cli/cmd/resourcetype/show/show_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package show
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clierrors"
@@ -121,7 +120,7 @@ func Test_Run(t *testing.T) {
 			ResourceTypeSuffix:        "testResources",
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -206,7 +205,7 @@ func Test_Run(t *testing.T) {
 			ResourceTypeSuffix:        "exampleResources",
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		require.Equal(t, clierrors.Message("The resource type \"Applications.AnotherTest/exampleResources\" does not exist."), err)
 
@@ -238,7 +237,7 @@ func Test_Run(t *testing.T) {
 			ResourceTypeSuffix:        "anotherResources",
 		}
 
-		err = runner.Run(context.Background())
+		err = runner.Run(t.Context())
 		require.Error(t, err)
 		require.Equal(t, clierrors.Message("The resource type \"Applications.Test/anotherResources\" does not exist."), err)
 

--- a/pkg/cli/cmd/rollback/kubernetes/kubernetes_test.go
+++ b/pkg/cli/cmd/rollback/kubernetes/kubernetes_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubernetes
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -244,7 +243,7 @@ func TestRunner_Run(t *testing.T) {
 
 			tt.mockSetup(helmMock, outputMock)
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 
 			if tt.expectedError == "" {
 				require.NoError(t, err)
@@ -364,7 +363,7 @@ func TestRunner_Run_ListRevisions(t *testing.T) {
 
 			tt.mockSetup(helmMock, outputMock)
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 
 			if tt.expectedError == "" {
 				require.NoError(t, err)

--- a/pkg/cli/cmd/run/run_test.go
+++ b/pkg/cli/cmd/run/run_test.go
@@ -326,7 +326,7 @@ func Test_ValidateWithFakeEnvServer(t *testing.T) {
 
 		// Parse the flags manually to set the environment and app flags
 		cmd.SetArgs([]string{"app.bicep", "-e", "prod", "-a", "my-app"})
-		cmd.SetContext(context.Background())
+		cmd.SetContext(t.Context())
 		err = cmd.ParseFlags([]string{"-e", "prod", "-a", "my-app"})
 		require.NoError(t, err)
 
@@ -400,7 +400,7 @@ func Test_ValidateWithFakeEnvServer(t *testing.T) {
 
 		// Parse the flags manually to set the environment flag with a non-existent environment
 		cmd.SetArgs([]string{"app.bicep", "-e", "nonexistent", "-a", "my-app"})
-		cmd.SetContext(context.Background())
+		cmd.SetContext(t.Context())
 		err = cmd.ParseFlags([]string{"-e", "nonexistent", "-a", "my-app"})
 		require.NoError(t, err)
 

--- a/pkg/cli/cmd/shutdown/shutdown_test.go
+++ b/pkg/cli/cmd/shutdown/shutdown_test.go
@@ -129,7 +129,7 @@ func Test_Run_BacksUpBothStoresAndCommits(t *testing.T) {
 	r, session, stateDir := newTestRunner(t, ctrl, client)
 	session.EXPECT().Commit(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
-	err := r.Run(context.Background())
+	err := r.Run(t.Context())
 	require.NoError(t, err)
 
 	require.True(t, client.dbCalled, "databases should be backed up")
@@ -146,7 +146,7 @@ func Test_Run_DatabaseBackupFailureStopsBeforeCommit(t *testing.T) {
 	// deferred session.Close is still expected (verified by the mock at ctrl.Finish).
 	r, _, _ := newTestRunner(t, ctrl, client)
 
-	err := r.Run(context.Background())
+	err := r.Run(t.Context())
 	require.ErrorContains(t, err, "pg_dump boom")
 	require.False(t, client.tfCalled, "terraform backup should not run after database failure")
 }
@@ -159,7 +159,7 @@ func Test_Run_CommitFailureIsReturned(t *testing.T) {
 	r, session, _ := newTestRunner(t, ctrl, client)
 	session.EXPECT().Commit(gomock.Any(), gomock.Any()).Return(errors.New("push rejected")).Times(1)
 
-	err := r.Run(context.Background())
+	err := r.Run(t.Context())
 	require.ErrorContains(t, err, "push rejected")
 }
 
@@ -180,7 +180,7 @@ func Test_Run_ArchiveOpenFailureIsReturned(t *testing.T) {
 		Archive:     archive,
 	}
 
-	err := r.Run(context.Background())
+	err := r.Run(t.Context())
 	require.ErrorContains(t, err, "failed to open state archive")
 	require.ErrorContains(t, err, "not a git repo")
 	require.False(t, client.dbCalled, "no backup should run when the archive cannot be opened")

--- a/pkg/cli/cmd/startup/startup_test.go
+++ b/pkg/cli/cmd/startup/startup_test.go
@@ -171,7 +171,7 @@ func Test_Run_RestoresInOrderWaitDatabaseTerraform(t *testing.T) {
 	client := &fakeStateRestoreClient{}
 	r, scaler := newTestRunner(t, ctrl, client)
 
-	err := r.Run(context.Background())
+	err := r.Run(t.Context())
 	require.NoError(t, err)
 
 	require.True(t, client.waited)
@@ -191,7 +191,7 @@ func Test_Run_ScaleDownFailureStopsBeforeRestore(t *testing.T) {
 	r, scaler := newTestRunner(t, ctrl, client)
 	scaler.scaleDownErr = errors.New("scale down boom")
 
-	err := r.Run(context.Background())
+	err := r.Run(t.Context())
 	require.ErrorContains(t, err, "scale down boom")
 	require.False(t, client.waited, "no restore should run if scale down failed")
 	require.False(t, scaler.upCalled, "scale up should not run if scale down failed")
@@ -204,7 +204,7 @@ func Test_Run_WaitFailureStopsBeforeRestore(t *testing.T) {
 	client := &fakeStateRestoreClient{waitErr: errors.New("db never ready")}
 	r, scaler := newTestRunner(t, ctrl, client)
 
-	err := r.Run(context.Background())
+	err := r.Run(t.Context())
 	require.ErrorContains(t, err, "db never ready")
 	require.False(t, client.dbCalled)
 	require.False(t, client.tfCalled)
@@ -218,7 +218,7 @@ func Test_Run_DatabaseRestoreFailureScalesBackUp(t *testing.T) {
 	client := &fakeStateRestoreClient{restoreDBErr: errors.New("psql boom")}
 	r, scaler := newTestRunner(t, ctrl, client)
 
-	err := r.Run(context.Background())
+	err := r.Run(t.Context())
 	require.ErrorContains(t, err, "psql boom")
 	require.False(t, client.tfCalled, "terraform restore must not run after database restore failure")
 	require.True(t, scaler.upCalled, "control plane must be scaled back up after a failed restore")
@@ -246,7 +246,7 @@ func Test_Run_ArchiveOpenFailureIsReturned(t *testing.T) {
 		},
 	}
 
-	err := r.Run(context.Background())
+	err := r.Run(t.Context())
 	require.ErrorContains(t, err, "failed to open state archive")
 	require.ErrorContains(t, err, "not a git repo")
 	require.False(t, client.waited, "no restore should run when the archive cannot be opened")

--- a/pkg/cli/cmd/uninstall/kubernetes/kubernetes_test.go
+++ b/pkg/cli/cmd/uninstall/kubernetes/kubernetes_test.go
@@ -78,7 +78,7 @@ func Test_Run(t *testing.T) {
 		outputMock := &output.MockOutput{}
 		promptMock := prompt.NewMockInterface(ctrl)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:        helmMock,
 			Output:      outputMock,
@@ -124,7 +124,7 @@ func Test_Run(t *testing.T) {
 		outputMock := &output.MockOutput{}
 		promptMock := prompt.NewMockInterface(ctrl)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:        helmMock,
 			Output:      outputMock,
@@ -157,7 +157,7 @@ func Test_Run(t *testing.T) {
 		promptMock := prompt.NewMockInterface(ctrl)
 		connFactory := &connections.MockFactory{ApplicationsManagementClient: appManagementClient}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:        helmMock,
 			Output:      outputMock,
@@ -276,7 +276,7 @@ func Test_Run(t *testing.T) {
 		promptMock := prompt.NewMockInterface(ctrl)
 		connFactory := &connections.MockFactory{ApplicationsManagementClient: appManagementClient}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:        helmMock,
 			Output:      outputMock,
@@ -396,7 +396,7 @@ func Test_Run(t *testing.T) {
 		outputMock := &output.MockOutput{}
 		promptMock := prompt.NewMockInterface(ctrl)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:        helmMock,
 			Output:      outputMock,
@@ -437,7 +437,7 @@ func Test_Run(t *testing.T) {
 		helmMock := helm.NewMockInterface(ctrl)
 		outputMock := &output.MockOutput{}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:       helmMock,
 			Output:     outputMock,
@@ -484,7 +484,7 @@ func Test_Run(t *testing.T) {
 		envErr := errors.New("failed to connect")
 		factory := &errorApplicationsFactory{MockFactory: &connections.MockFactory{}, err: envErr}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		runner := &Runner{
 			Helm:        helmMock,
 			Output:      outputMock,

--- a/pkg/cli/cmd/upgrade/kubernetes/kubernetes_test.go
+++ b/pkg/cli/cmd/upgrade/kubernetes/kubernetes_test.go
@@ -260,7 +260,7 @@ func TestRunner_Run(t *testing.T) {
 				SetFile:       tt.setFile,
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/pkg/cli/cmd/utils_test.go
+++ b/pkg/cli/cmd/utils_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -151,7 +150,7 @@ func TestPopulateRecipePackClients(t *testing.T) {
 			scope: {}, // placeholder client
 		}
 
-		err := PopulateRecipePackClients(context.Background(), &workspaces.Workspace{Scope: scope}, clientsByScope, nil)
+		err := PopulateRecipePackClients(t.Context(), &workspaces.Workspace{Scope: scope}, clientsByScope, nil)
 		require.NoError(t, err)
 		require.Len(t, clientsByScope, 1)
 	})
@@ -165,7 +164,7 @@ func TestPopulateRecipePackClients(t *testing.T) {
 			scope + "/providers/Radius.Core/recipePacks/pack2",
 		}
 
-		err := PopulateRecipePackClients(context.Background(), &workspaces.Workspace{Scope: scope}, clientsByScope, packIDs)
+		err := PopulateRecipePackClients(t.Context(), &workspaces.Workspace{Scope: scope}, clientsByScope, packIDs)
 		require.NoError(t, err)
 		require.Len(t, clientsByScope, 1, "no new scopes should be added")
 	})

--- a/pkg/cli/cmd/version/version_test.go
+++ b/pkg/cli/cmd/version/version_test.go
@@ -1,7 +1,6 @@
 package version
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -360,7 +359,7 @@ func TestRun(t *testing.T) {
 				mockOutput.EXPECT().WriteFormatted(tc.format, gomock.Any(), gomock.Any()).Return(nil)
 			}
 
-			err := runner.Run(context.Background())
+			err := runner.Run(t.Context())
 			require.NoError(t, err)
 		})
 	}

--- a/pkg/cli/cmd/workspace/create/create_test.go
+++ b/pkg/cli/cmd/workspace/create/create_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package create
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -142,7 +141,7 @@ func Test_ValidateApplicationsCoreEnvironment(t *testing.T) {
 		mgmt := clients.NewMockApplicationsManagementClient(ctrl)
 		mgmt.EXPECT().GetEnvironment(gomock.Any(), "env1").Return(corerp.EnvironmentResource{}, radcli.Create404Error()).Times(1)
 
-		id, err := ValidateApplicationsCoreEnvironment(context.Background(), ws, mgmt, "env1")
+		id, err := ValidateApplicationsCoreEnvironment(t.Context(), ws, mgmt, "env1")
 		require.Error(t, err)
 		require.Empty(t, id)
 		require.Contains(t, err.Error(), wantID)
@@ -155,7 +154,7 @@ func Test_ValidateApplicationsCoreEnvironment(t *testing.T) {
 		mgmt := clients.NewMockApplicationsManagementClient(ctrl)
 		mgmt.EXPECT().GetEnvironment(gomock.Any(), "env1").Return(corerp.EnvironmentResource{}, errors.New("connection refused")).Times(1)
 
-		id, err := ValidateApplicationsCoreEnvironment(context.Background(), ws, mgmt, "env1")
+		id, err := ValidateApplicationsCoreEnvironment(t.Context(), ws, mgmt, "env1")
 		require.Error(t, err)
 		require.Empty(t, id)
 		require.Contains(t, err.Error(), "Failed to get environment")
@@ -180,7 +179,7 @@ func Test_Run(t *testing.T) {
 
 		configFileInterface := framework.NewMockConfigFileInterface(ctrl)
 		configFileInterface.EXPECT().
-			EditWorkspaces(context.Background(), gomock.Any(), workspace).
+			EditWorkspaces(t.Context(), gomock.Any(), workspace).
 			Return(nil).Times(1)
 
 		runner := &Runner{
@@ -191,7 +190,7 @@ func Test_Run(t *testing.T) {
 			Output:              outputSink,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, []any{
 			output.LogOutput{

--- a/pkg/cli/cmd/workspace/create/preview/create_test.go
+++ b/pkg/cli/cmd/workspace/create/preview/create_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package preview
 
 import (
-	"context"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -195,7 +194,7 @@ func Test_Run(t *testing.T) {
 
 		configFileInterface := framework.NewMockConfigFileInterface(ctrl)
 		configFileInterface.EXPECT().
-			EditWorkspaces(context.Background(), gomock.Any(), workspace).
+			EditWorkspaces(t.Context(), gomock.Any(), workspace).
 			Return(nil).Times(1)
 
 		runner := &Runner{
@@ -208,7 +207,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 	})
 }
@@ -239,7 +238,7 @@ func newRunnerForEnvValidation(t *testing.T, ctrl *gomock.Controller, factory *c
 	}
 
 	cmd, runnerIface := NewCommand(fw)
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 	runner := runnerIface.(*Runner)
 	runner.RadiusCoreClientFactory = factory
 

--- a/pkg/cli/cmd/workspace/delete/delete_test.go
+++ b/pkg/cli/cmd/workspace/delete/delete_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package delete
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -112,7 +111,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.Equal(t, []any{
@@ -149,7 +148,7 @@ func Test_Run(t *testing.T) {
 			Confirm: true,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.Equal(t, []any{
@@ -184,7 +183,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		require.Empty(t, outputSink.Writes)
@@ -208,7 +207,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.Equal(t, &prompt.ErrExitConsole{}, err)
 		require.Empty(t, outputSink.Writes)
 	})

--- a/pkg/cli/cmd/workspace/list/list_test.go
+++ b/pkg/cli/cmd/workspace/list/list_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package list
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli"
@@ -96,7 +95,7 @@ func Test_Run(t *testing.T) {
 			Output: outputSink,
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{

--- a/pkg/cli/cmd/workspace/show/show_test.go
+++ b/pkg/cli/cmd/workspace/show/show_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package show
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/cmd/workspace/common"
@@ -98,7 +97,7 @@ func Test_Run(t *testing.T) {
 			},
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -127,7 +126,7 @@ func Test_Run(t *testing.T) {
 			Workspace:    workspaces.MakeFallbackWorkspace(),
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{

--- a/pkg/cli/cmd/workspace/switch/switch_test.go
+++ b/pkg/cli/cmd/workspace/switch/switch_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package workspaceswitch // switch is a reserved word in go, so we can't use it as a package name.
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli"
@@ -104,7 +103,7 @@ func Test_Run(t *testing.T) {
 			WorkspaceName:       "current-workspace",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -145,7 +144,7 @@ func Test_Run(t *testing.T) {
 			WorkspaceName:       "new-workspace",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{
@@ -190,7 +189,7 @@ func Test_Run(t *testing.T) {
 			WorkspaceName:       "new-workspace",
 		}
 
-		err := runner.Run(context.Background())
+		err := runner.Run(t.Context())
 		require.NoError(t, err)
 
 		expected := []any{

--- a/pkg/cli/delete/delete_test.go
+++ b/pkg/cli/delete/delete_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package delete
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -50,7 +49,7 @@ func Test_DeleteApplicationWithProgress_ErrorScenarios(t *testing.T) {
 			ProgressText:        "Deleting application...",
 		}
 
-		deleted, err := DeleteApplicationWithProgress(context.Background(), appManagementClient, options)
+		deleted, err := DeleteApplicationWithProgress(t.Context(), appManagementClient, options)
 		require.Error(t, err)
 		require.False(t, deleted)
 		require.Contains(t, err.Error(), "not a valid resource id")
@@ -83,7 +82,7 @@ func Test_DeleteApplicationWithProgress_ErrorScenarios(t *testing.T) {
 			ProgressText:        "Deleting application...",
 		}
 
-		deleted, err := DeleteApplicationWithProgress(context.Background(), appManagementClient, options)
+		deleted, err := DeleteApplicationWithProgress(t.Context(), appManagementClient, options)
 		require.Error(t, err)
 		require.False(t, deleted)
 		require.Contains(t, err.Error(), "not a valid resource id")
@@ -120,7 +119,7 @@ func Test_DeleteApplicationWithProgress_ErrorScenarios(t *testing.T) {
 			ProgressText:        "Deleting application...",
 		}
 
-		deleted, err := DeleteApplicationWithProgress(context.Background(), appManagementClient, options)
+		deleted, err := DeleteApplicationWithProgress(t.Context(), appManagementClient, options)
 		require.NoError(t, err)
 		require.True(t, deleted)
 	})
@@ -141,7 +140,7 @@ func Test_DeleteApplicationWithProgress_ErrorScenarios(t *testing.T) {
 			ProgressText:        "Deleting application...",
 		}
 
-		deleted, err := DeleteApplicationWithProgress(context.Background(), appManagementClient, options)
+		deleted, err := DeleteApplicationWithProgress(t.Context(), appManagementClient, options)
 		require.Error(t, err)
 		require.False(t, deleted)
 		require.Contains(t, err.Error(), "failed to list resources")
@@ -178,7 +177,7 @@ func Test_DeleteApplicationWithProgress_ErrorScenarios(t *testing.T) {
 			ProgressText:        "Deleting application...",
 		}
 
-		deleted, err := DeleteApplicationWithProgress(context.Background(), appManagementClient, options)
+		deleted, err := DeleteApplicationWithProgress(t.Context(), appManagementClient, options)
 		require.NoError(t, err)
 		require.True(t, deleted)
 	})
@@ -214,7 +213,7 @@ func Test_DeleteApplicationWithProgress_ErrorScenarios(t *testing.T) {
 			ProgressText:        "Deleting application...",
 		}
 
-		deleted, err := DeleteApplicationWithProgress(context.Background(), appManagementClient, options)
+		deleted, err := DeleteApplicationWithProgress(t.Context(), appManagementClient, options)
 		require.NoError(t, err)
 		require.True(t, deleted)
 	})
@@ -247,7 +246,7 @@ func Test_DeleteApplicationWithProgress_ErrorScenarios(t *testing.T) {
 			Force:               true,
 		}
 
-		deleted, err := DeleteApplicationWithProgress(context.Background(), appManagementClient, options)
+		deleted, err := DeleteApplicationWithProgress(t.Context(), appManagementClient, options)
 		require.NoError(t, err)
 		require.True(t, deleted)
 	})

--- a/pkg/cli/deployment/diagnostics_test.go
+++ b/pkg/cli/deployment/diagnostics_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package deployment
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -116,7 +115,7 @@ func Test_findNamespaceOfContainerPreview(t *testing.T) {
 				Return(tt.resource, tt.getErr)
 
 			dc := &ARMDiagnosticsClient{Preview: true, ManagementClient: managementClient}
-			namespace, err := dc.findNamespaceOfContainerPreview(context.Background(), resourceName)
+			namespace, err := dc.findNamespaceOfContainerPreview(t.Context(), resourceName)
 
 			if tt.expectErr {
 				require.Error(t, err)

--- a/pkg/cli/helm/cluster_test.go
+++ b/pkg/cli/helm/cluster_test.go
@@ -44,7 +44,7 @@ func Test_Helm_InstallRadius(t *testing.T) {
 		Helm:                           mockHelmClient,
 		configureDefaultContourGateway: gatewayCalls.configure,
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 	options := NewDefaultClusterOptions()
 
@@ -104,7 +104,7 @@ func Test_Helm_UninstallRadius(t *testing.T) {
 		Helm:                        mockHelmClient,
 		removeDefaultContourGateway: gatewayCalls.remove,
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 	options := NewDefaultClusterOptions()
 	options.Contour.Namespace = "contour-system"
@@ -138,7 +138,7 @@ func Test_Helm_UninstallRadius_ReleaseNotFound(t *testing.T) {
 		Helm:                        mockHelmClient,
 		removeDefaultContourGateway: (&defaultContourGatewayCalls{}).remove,
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 	options := NewDefaultClusterOptions()
 
@@ -258,7 +258,7 @@ func Test_Helm_UpgradeRadius(t *testing.T) {
 		Helm:                           mockHelmClient,
 		configureDefaultContourGateway: gatewayCalls.configure,
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 	options := NewDefaultClusterOptions()
 
@@ -334,7 +334,7 @@ func Test_Helm_UpgradeRadius_ContourNotInstalled(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 	options := NewDefaultClusterOptions()
 
@@ -444,7 +444,7 @@ func Test_Helm_UpgradeRadius_RadiusUpgradeError(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 	options := NewDefaultClusterOptions()
 
@@ -480,7 +480,7 @@ func Test_Helm_UpgradeRadius_ContourUpgradeError(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 	options := NewDefaultClusterOptions()
 
@@ -557,7 +557,7 @@ func Test_Helm_UpgradeRadius_CheckInstallError(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 	options := NewDefaultClusterOptions()
 
@@ -610,7 +610,7 @@ func Test_Helm_UpgradeRadius_ResetValues(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 	options := NewDefaultClusterOptions()
 	options.ResetValues = true
@@ -663,7 +663,7 @@ func Test_Helm_RollbackRadius_Success(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 
 	// Mock history with multiple versions
@@ -692,7 +692,7 @@ func Test_Helm_RollbackRadius_NoOlderVersion(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 
 	// Mock history with only one version
@@ -715,7 +715,7 @@ func Test_Helm_RollbackRadius_SameVersionSkipped(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 
 	// Mock history with same versions (no semantic rollback available)
@@ -739,7 +739,7 @@ func Test_Helm_RollbackRadius_HistoryError(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 
 	mockHelmClient.EXPECT().
@@ -758,7 +758,7 @@ func Test_Helm_RollbackRadiusToRevision_Success(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 	targetRevision := 3
 
@@ -789,7 +789,7 @@ func Test_Helm_RollbackRadiusToRevision_RevisionNotFound(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 	targetRevision := 999
 
@@ -814,7 +814,7 @@ func Test_Helm_RollbackRadiusToRevision_RollbackError(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 	targetRevision := 1
 
@@ -845,7 +845,7 @@ func Test_Helm_GetRadiusRevisions_Success(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 
 	// Mock history with multiple versions
@@ -901,7 +901,7 @@ func Test_Helm_GetRadiusRevisions_NoRevisions(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 
 	// Mock empty history
@@ -923,7 +923,7 @@ func Test_Helm_GetRadiusRevisions_HistoryError(t *testing.T) {
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 
 	mockHelmClient.EXPECT().
@@ -942,7 +942,7 @@ func Test_Helm_GetRadiusRevisions_MultipleUpgradesWithDifferentTimestamps(t *tes
 
 	mockHelmClient := NewMockHelmClient(ctrl)
 	impl := &Impl{Helm: mockHelmClient}
-	ctx := context.Background()
+	ctx := t.Context()
 	kubeContext := "test-context"
 
 	// Mock history simulating multiple upgrades and rollbacks across different days

--- a/pkg/cli/helm/contour_gateway_test.go
+++ b/pkg/cli/helm/contour_gateway_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package helm
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -36,16 +35,16 @@ func TestReconcileDefaultContourGatewayCreatesResources(t *testing.T) {
 
 	client := fakedynamic.NewSimpleDynamicClient(runtime.NewScheme())
 
-	err := reconcileDefaultContourGateway(context.Background(), client)
+	err := reconcileDefaultContourGateway(t.Context(), client)
 	require.NoError(t, err)
 
-	gatewayClass, err := client.Resource(gatewayClassGVR).Get(context.Background(), ContourGatewayClassName, metav1.GetOptions{})
+	gatewayClass, err := client.Resource(gatewayClassGVR).Get(t.Context(), ContourGatewayClassName, metav1.GetOptions{})
 	require.NoError(t, err)
 	controllerName, _, _ := unstructured.NestedString(gatewayClass.Object, "spec", "controllerName")
 	require.Equal(t, ContourGatewayControllerName, controllerName)
 	require.True(t, isRadiusManaged(gatewayClass))
 
-	gateway, err := client.Resource(gatewayGVR).Namespace(DefaultContourGatewayNamespace).Get(context.Background(), DefaultContourGatewayName, metav1.GetOptions{})
+	gateway, err := client.Resource(gatewayGVR).Namespace(DefaultContourGatewayNamespace).Get(t.Context(), DefaultContourGatewayName, metav1.GetOptions{})
 	require.NoError(t, err)
 	gatewayClassName, _, _ := unstructured.NestedString(gateway.Object, "spec", "gatewayClassName")
 	require.Equal(t, ContourGatewayClassName, gatewayClassName)
@@ -91,13 +90,13 @@ func TestWaitForDefaultContourGatewayRetriesGatewayAPINotFound(t *testing.T) {
 		return false, nil, nil
 	})
 
-	err := waitForDefaultContourGateway(context.Background(), client, time.Millisecond, time.Second)
+	err := waitForDefaultContourGateway(t.Context(), client, time.Millisecond, time.Second)
 	require.NoError(t, err)
 	require.Equal(t, 2, createGatewayClassAttempts)
 
-	_, err = client.Resource(gatewayClassGVR).Get(context.Background(), ContourGatewayClassName, metav1.GetOptions{})
+	_, err = client.Resource(gatewayClassGVR).Get(t.Context(), ContourGatewayClassName, metav1.GetOptions{})
 	require.NoError(t, err)
-	_, err = client.Resource(gatewayGVR).Namespace(DefaultContourGatewayNamespace).Get(context.Background(), DefaultContourGatewayName, metav1.GetOptions{})
+	_, err = client.Resource(gatewayGVR).Namespace(DefaultContourGatewayNamespace).Get(t.Context(), DefaultContourGatewayName, metav1.GetOptions{})
 	require.NoError(t, err)
 }
 
@@ -116,7 +115,7 @@ func TestReconcileDefaultContourGatewayAllowsExistingMatchingGatewayClass(t *tes
 			},
 		},
 	})
-	err := reconcileDefaultContourGateway(context.Background(), client)
+	err := reconcileDefaultContourGateway(t.Context(), client)
 	require.NoError(t, err)
 }
 
@@ -142,13 +141,13 @@ func TestReconcileDefaultContourGatewayPreservesExistingGatewayMetadata(t *testi
 	}, "spec", "listeners"))
 
 	client := fakedynamic.NewSimpleDynamicClient(runtime.NewScheme(), newContourGatewayClass())
-	_, err := client.Resource(gatewayGVR).Namespace(DefaultContourGatewayNamespace).Create(context.Background(), existingGateway, metav1.CreateOptions{})
+	_, err := client.Resource(gatewayGVR).Namespace(DefaultContourGatewayNamespace).Create(t.Context(), existingGateway, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	err = reconcileDefaultContourGateway(context.Background(), client)
+	err = reconcileDefaultContourGateway(t.Context(), client)
 	require.NoError(t, err)
 
-	gateway, err := client.Resource(gatewayGVR).Namespace(DefaultContourGatewayNamespace).Get(context.Background(), DefaultContourGatewayName, metav1.GetOptions{})
+	gateway, err := client.Resource(gatewayGVR).Namespace(DefaultContourGatewayNamespace).Get(t.Context(), DefaultContourGatewayName, metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Equal(t, "preserve", gateway.GetAnnotations()["example.com/annotation"])
 	require.Equal(t, []string{"example.com/finalizer"}, gateway.GetFinalizers())
@@ -176,7 +175,7 @@ func TestReconcileDefaultContourGatewayRejectsConflictingGatewayClass(t *testing
 			},
 		},
 	})
-	err := reconcileDefaultContourGateway(context.Background(), client)
+	err := reconcileDefaultContourGateway(t.Context(), client)
 	require.ErrorContains(t, err, "already exists with controllerName")
 }
 
@@ -188,12 +187,12 @@ func TestDeleteDefaultContourGatewayResourcesOnlyDeletesManagedResources(t *test
 	managedGateway := newContourGateway()
 	client := fakedynamic.NewSimpleDynamicClient(runtime.NewScheme(), unmanagedGatewayClass, managedGateway)
 
-	err := deleteDefaultContourGatewayResources(context.Background(), client)
+	err := deleteDefaultContourGatewayResources(t.Context(), client)
 	require.NoError(t, err)
 
-	_, err = client.Resource(gatewayClassGVR).Get(context.Background(), ContourGatewayClassName, metav1.GetOptions{})
+	_, err = client.Resource(gatewayClassGVR).Get(t.Context(), ContourGatewayClassName, metav1.GetOptions{})
 	require.NoError(t, err)
-	_, err = client.Resource(gatewayGVR).Namespace(DefaultContourGatewayNamespace).Get(context.Background(), DefaultContourGatewayName, metav1.GetOptions{})
+	_, err = client.Resource(gatewayGVR).Namespace(DefaultContourGatewayNamespace).Get(t.Context(), DefaultContourGatewayName, metav1.GetOptions{})
 	require.True(t, apierrors.IsNotFound(err))
 }
 
@@ -205,14 +204,14 @@ func TestDeleteDefaultContourGatewayResourcesPreservesGatewayClassForUnmanagedGa
 	unmanagedGateway.SetLabels(nil)
 	unmanagedGateway.SetNamespace(DefaultContourGatewayNamespace)
 	client := fakedynamic.NewSimpleDynamicClient(runtime.NewScheme(), managedGatewayClass)
-	_, err := client.Resource(gatewayGVR).Namespace(DefaultContourGatewayNamespace).Create(context.Background(), unmanagedGateway, metav1.CreateOptions{})
+	_, err := client.Resource(gatewayGVR).Namespace(DefaultContourGatewayNamespace).Create(t.Context(), unmanagedGateway, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	err = deleteDefaultContourGatewayResources(context.Background(), client)
+	err = deleteDefaultContourGatewayResources(t.Context(), client)
 	require.NoError(t, err)
 
-	_, err = client.Resource(gatewayClassGVR).Get(context.Background(), ContourGatewayClassName, metav1.GetOptions{})
+	_, err = client.Resource(gatewayClassGVR).Get(t.Context(), ContourGatewayClassName, metav1.GetOptions{})
 	require.NoError(t, err)
-	_, err = client.Resource(gatewayGVR).Namespace(DefaultContourGatewayNamespace).Get(context.Background(), DefaultContourGatewayName, metav1.GetOptions{})
+	_, err = client.Resource(gatewayGVR).Namespace(DefaultContourGatewayNamespace).Get(t.Context(), DefaultContourGatewayName, metav1.GetOptions{})
 	require.NoError(t, err)
 }

--- a/pkg/cli/kubernetes/kubernetes_test.go
+++ b/pkg/cli/kubernetes/kubernetes_test.go
@@ -54,7 +54,7 @@ func TestDeleteNamespace(t *testing.T) {
 	namespace := "radius-test"
 	f := k8sfake.NewClientset(&v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: namespace}})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := f.CoreV1().Namespaces().Get(ctx, namespace, meta_v1.GetOptions{})
 	require.NoError(t, err)
 	err = deleteNamespace(ctx, f, namespace)

--- a/pkg/cli/kubernetes/kubernetes_test.go
+++ b/pkg/cli/kubernetes/kubernetes_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubernetes
 
 import (
-	"context"
 	"errors"
 	"os"
 	"testing"
@@ -43,7 +42,7 @@ func TestEnsureNamespace(t *testing.T) {
 		}
 	})
 
-	ctx := context.TODO()
+	ctx := t.Context()
 	err := EnsureNamespace(ctx, f, "radius-test")
 	require.NoError(t, err)
 	_, err = f.CoreV1().Namespaces().Get(ctx, "radius-test", meta_v1.GetOptions{})

--- a/pkg/cli/kubernetes/portforward/application_watcher_test.go
+++ b/pkg/cli/kubernetes/portforward/application_watcher_test.go
@@ -54,7 +54,7 @@ func Test_ApplicationWatcher_Updated_HandleNewDeployment(t *testing.T) {
 	aw := NewApplicationWatcher(Options{Client: client})
 	defer stopDeploymentWatchers(aw)
 
-	aw.updated(context.Background(), createDeployment("test", "1", "1"))
+	aw.updated(t.Context(), createDeployment("test", "1", "1"))
 	require.Contains(t, aw.deploymentWatchers, "test")
 }
 

--- a/pkg/cli/kubernetes/portforward/deployment_watcher_test.go
+++ b/pkg/cli/kubernetes/portforward/deployment_watcher_test.go
@@ -288,7 +288,7 @@ func Test_DeploymentWatcher_Deleted_NoOtherReplicas(t *testing.T) {
 	defer stopPodWatchers(dw)
 
 	// Step 1: Add a pod
-	dw.updated(context.Background(), createPod("p1", "rs1"), map[string]bool{})
+	dw.updated(t.Context(), createPod("p1", "rs1"), map[string]bool{})
 	require.NotNil(t, dw.podWatcher)
 	require.Equal(t, dw.podWatcher.Pod.Name, "p1")
 	existing := dw.podWatcher

--- a/pkg/cli/kubernetes/portforward/pod_watcher_test.go
+++ b/pkg/cli/kubernetes/portforward/pod_watcher_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func Test_podWatcher_CanShutdownGracefully(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	pod := &corev1.Pod{
 		ObjectMeta: v1.ObjectMeta{
@@ -87,7 +87,7 @@ func Test_podWatcher_CanShutdownGracefully(t *testing.T) {
 }
 
 func Test_podWatcher_CanStartWhenPodIsReady(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	pod := &corev1.Pod{
 		ObjectMeta: v1.ObjectMeta{

--- a/pkg/cli/kubernetes/portforward/util_test.go
+++ b/pkg/cli/kubernetes/portforward/util_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package portforward
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/kubernetes"
@@ -178,7 +177,7 @@ func Test_findStaleReplicaSets(t *testing.T) {
 	require.NoError(t, err)
 
 	client := fake.NewClientset(objs...)
-	actual, err := findStaleReplicaSets(context.Background(), client, "default", "3", labelSelector)
+	actual, err := findStaleReplicaSets(t.Context(), client, "default", "3", labelSelector)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 }

--- a/pkg/cli/manifest/registermanifest_test.go
+++ b/pkg/cli/manifest/registermanifest_test.go
@@ -86,7 +86,7 @@ func TestRegisterDirectory(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			clientFactory := createTestClientFactory(t)
 
-			err := RegisterDirectory(context.Background(), clientFactory, tt.planeName, tt.directoryPath, nil)
+			err := RegisterDirectory(t.Context(), clientFactory, tt.planeName, tt.directoryPath, nil)
 			if tt.expectError {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedErrorMessage)
@@ -141,7 +141,7 @@ func TestRegisterFile(t *testing.T) {
 			clientFactory := createTestClientFactory(t)
 			logger, logBuffer := createTestLogger()
 
-			err := RegisterFile(context.Background(), clientFactory, tt.planeName, tt.filePath, logger)
+			err := RegisterFile(t.Context(), clientFactory, tt.planeName, tt.filePath, logger)
 			if tt.expectError {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedErrorMessage)
@@ -216,7 +216,7 @@ func TestRegisterType(t *testing.T) {
 			clientFactory := createTestClientFactory(t)
 			logger, logBuffer := createTestLogger()
 
-			err := RegisterType(context.Background(), clientFactory, tt.planeName, tt.filePath, tt.resourceTypeName, "", logger)
+			err := RegisterType(t.Context(), clientFactory, tt.planeName, tt.filePath, tt.resourceTypeName, "", logger)
 			if tt.expectError {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedErrorMessage)
@@ -270,7 +270,7 @@ func TestRegisterResourceProvider(t *testing.T) {
 			resourceProvider, err := ReadFile(tt.filePath)
 			require.NoError(t, err)
 
-			err = RegisterResourceProvider(context.Background(), clientFactory, tt.planeName, *resourceProvider, logger)
+			err = RegisterResourceProvider(t.Context(), clientFactory, tt.planeName, *resourceProvider, logger)
 			if tt.expectError {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedErrorMessage)
@@ -381,7 +381,7 @@ func TestRetryOperationWithContext(t *testing.T) {
 				return &azcore.ResponseError{StatusCode: 409}
 			},
 			setupCtx: func() context.Context {
-				ctx, cancel := context.WithCancel(context.Background())
+				ctx, cancel := context.WithCancel(t.Context())
 				cancel() // Cancel immediately
 				return ctx
 			},
@@ -394,7 +394,7 @@ func TestRetryOperationWithContext(t *testing.T) {
 				return &azcore.ResponseError{StatusCode: 409}
 			},
 			setupCtx: func() context.Context {
-				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+				ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 				// Ensure cancel is called after context is done
 				go func() {
 					<-ctx.Done()
@@ -544,7 +544,7 @@ func TestEnsureResourceProviderExists(t *testing.T) {
 
 			logger, _ := createTestLogger()
 
-			err = EnsureResourceProviderExists(context.Background(), clientFactory, tt.planeName, tt.resourceProvider, logger)
+			err = EnsureResourceProviderExists(t.Context(), clientFactory, tt.planeName, tt.resourceProvider, logger)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -616,7 +616,7 @@ func TestCreateEmptyResourceProvider(t *testing.T) {
 			clientFactory := createTestClientFactory(t)
 			logger, _ := createTestLogger()
 
-			err := CreateEmptyResourceProvider(context.Background(), clientFactory, tt.planeName, tt.resourceProvider, logger)
+			err := CreateEmptyResourceProvider(t.Context(), clientFactory, tt.planeName, tt.resourceProvider, logger)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -680,7 +680,7 @@ func TestValidateManifest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resourceProvider, err := ValidateManifest(context.Background(), tt.filePath)
+			resourceProvider, err := ValidateManifest(t.Context(), tt.filePath)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -698,7 +698,7 @@ func TestValidateManifest(t *testing.T) {
 func TestValidateManifest_MergesBaseResourceManifest(t *testing.T) {
 	t.Parallel()
 
-	resourceProvider, err := ValidateManifest(context.Background(), "testdata/merge-base-manifest.yaml")
+	resourceProvider, err := ValidateManifest(t.Context(), "testdata/merge-base-manifest.yaml")
 	require.NoError(t, err)
 	require.NotNil(t, resourceProvider)
 
@@ -881,7 +881,7 @@ func TestRegisterResourceProvider_ErrorScenarios(t *testing.T) {
 			logger, _ := createTestLogger()
 
 			testErrorScenario(t, func() error {
-				return RegisterResourceProvider(context.Background(), clientFactory, tt.planeName, tt.resourceProvider, logger)
+				return RegisterResourceProvider(t.Context(), clientFactory, tt.planeName, tt.resourceProvider, logger)
 			}, tt.expectError, tt.expectedErrorMessage)
 		})
 	}
@@ -926,7 +926,7 @@ func TestRegisterType_ErrorScenarios(t *testing.T) {
 			logger, _ := createTestLogger()
 
 			testErrorScenario(t, func() error {
-				return RegisterType(context.Background(), clientFactory, "local", tt.filePath, tt.typeName, "", logger)
+				return RegisterType(t.Context(), clientFactory, "local", tt.filePath, tt.typeName, "", logger)
 			}, tt.expectError, tt.expectedErrorMessage)
 		})
 	}
@@ -938,7 +938,7 @@ func TestRegisterType_IconFileNotFound(t *testing.T) {
 	clientFactory := createTestClientFactory(t)
 	logger, _ := createTestLogger()
 
-	err := RegisterType(context.Background(), clientFactory, "local",
+	err := RegisterType(t.Context(), clientFactory, "local",
 		"testdata/registerdirectory/resourceprovider-valid2.yaml", "testResource3",
 		"testdata/nonexistent-icon.svg", logger)
 
@@ -956,7 +956,7 @@ func TestRegisterType_IconValidationRejectsBadSVG(t *testing.T) {
 	badIcon := filepath.Join(dir, "bad.svg")
 	require.NoError(t, os.WriteFile(badIcon, []byte(`<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`), 0o600))
 
-	err := RegisterType(context.Background(), clientFactory, "local",
+	err := RegisterType(t.Context(), clientFactory, "local",
 		"testdata/registerdirectory/resourceprovider-valid2.yaml", "testResource3",
 		badIcon, logger)
 
@@ -993,7 +993,7 @@ func TestRegisterFile_ErrorScenarios(t *testing.T) {
 			clientFactory := createTestClientFactory(t)
 
 			testErrorScenario(t, func() error {
-				return RegisterFile(context.Background(), clientFactory, "local", tt.filePath, nil)
+				return RegisterFile(t.Context(), clientFactory, "local", tt.filePath, nil)
 			}, tt.expectError, tt.expectedErrorMessage)
 		})
 	}
@@ -1077,7 +1077,7 @@ func TestCreateResourceProviderResource(t *testing.T) {
 				}
 			}
 
-			err = createResourceProviderResource(context.Background(), clientFactory, tt.planeName, tt.resourceProvider, tt.locationName, logger)
+			err = createResourceProviderResource(t.Context(), clientFactory, tt.planeName, tt.resourceProvider, tt.locationName, logger)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -1090,7 +1090,7 @@ func TestCreateResourceProviderResource(t *testing.T) {
 				// For successful operations, verify the resource provider was created by attempting to get it
 				if tt.name != "Success_WithNilLogger" {
 					// Verify the resource provider exists by checking the logs or calling the Get method
-					rp, getErr := clientFactory.NewResourceProvidersClient().Get(context.Background(), tt.planeName, tt.resourceProvider.Namespace, nil)
+					rp, getErr := clientFactory.NewResourceProvidersClient().Get(t.Context(), tt.planeName, tt.resourceProvider.Namespace, nil)
 					require.NoError(t, getErr)
 					require.Equal(t, new(tt.resourceProvider.Namespace), rp.Name)
 				}
@@ -1203,7 +1203,7 @@ func TestCreateLocationResource(t *testing.T) {
 				}
 			}
 
-			err = createLocationResource(context.Background(), clientFactory, tt.planeName, tt.namespace, tt.locationName, tt.address, tt.resourceTypes, logger)
+			err = createLocationResource(t.Context(), clientFactory, tt.planeName, tt.namespace, tt.locationName, tt.address, tt.resourceTypes, logger)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -1215,7 +1215,7 @@ func TestCreateLocationResource(t *testing.T) {
 
 				// For successful operations, verify the location was created by attempting to get it
 				if tt.name != "Success_WithNilLogger" {
-					location, getErr := clientFactory.NewLocationsClient().Get(context.Background(), tt.planeName, tt.namespace, tt.locationName, nil)
+					location, getErr := clientFactory.NewLocationsClient().Get(t.Context(), tt.planeName, tt.namespace, tt.locationName, nil)
 					require.NoError(t, getErr)
 					require.Equal(t, new(tt.locationName), location.Name)
 
@@ -1423,7 +1423,7 @@ func createTestLogger() (func(format string, args ...any), *bytes.Buffer) {
 
 // verifyResourceProviderExists verifies that a resource provider exists with the expected name
 func verifyResourceProviderExists(t *testing.T, clientFactory *v20231001preview.ClientFactory, planeName, expectedResourceProvider string) {
-	rp, err := clientFactory.NewResourceProvidersClient().Get(context.Background(), planeName, expectedResourceProvider, nil)
+	rp, err := clientFactory.NewResourceProvidersClient().Get(t.Context(), planeName, expectedResourceProvider, nil)
 	require.NoError(t, err, "Failed to retrieve the expected resource provider")
 	require.Equal(t, new(expectedResourceProvider), rp.Name)
 }
@@ -1470,7 +1470,7 @@ func verifyRetryBehavior(t *testing.T, operation func() error, expectedAttempts 
 		return operation()
 	}
 
-	err := retryOperation(context.Background(), wrappedOp, logger)
+	err := retryOperation(t.Context(), wrappedOp, logger)
 
 	if expectedError != "" {
 		require.Error(t, err)

--- a/pkg/cli/manifest/validation_test.go
+++ b/pkg/cli/manifest/validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package manifest
 
 import (
-	"context"
 	"testing"
 
 	"github.com/go-playground/validator/v10"
@@ -283,7 +282,7 @@ func TestCapabilityValidation(t *testing.T) {
 }
 
 func TestValidateManifestSchemas(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("nil provider", func(t *testing.T) {
 		err := validateManifestSchemas(ctx, nil)

--- a/pkg/cli/tfstate/tfstate_test.go
+++ b/pkg/cli/tfstate/tfstate_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tfstate
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,7 +54,7 @@ func Test_Backup_WritesLabelledSecretsOnly(t *testing.T) {
 	stateDir := t.TempDir()
 	client := NewClient(clientset, DefaultNamespace)
 
-	err := client.Backup(context.Background(), stateDir)
+	err := client.Backup(t.Context(), stateDir)
 	require.NoError(t, err)
 
 	entries, err := os.ReadDir(filepath.Join(stateDir, SubDir))
@@ -78,7 +77,7 @@ func Test_Backup_ClearsStaleFiles(t *testing.T) {
 	)
 	client := NewClient(clientset, DefaultNamespace)
 
-	err := client.Backup(context.Background(), stateDir)
+	err := client.Backup(t.Context(), stateDir)
 	require.NoError(t, err)
 
 	require.NoFileExists(t, stalePath)
@@ -90,7 +89,7 @@ func Test_Backup_NoSecrets(t *testing.T) {
 	stateDir := t.TempDir()
 	client := NewClient(clientset, DefaultNamespace)
 
-	err := client.Backup(context.Background(), stateDir)
+	err := client.Backup(t.Context(), stateDir)
 	require.NoError(t, err)
 	require.False(t, HasBackup(stateDir))
 }
@@ -112,13 +111,13 @@ func Test_BackupRestore_RoundTrip(t *testing.T) {
 	source := fake.NewSimpleClientset(original)
 	stateDir := t.TempDir()
 
-	require.NoError(t, NewClient(source, DefaultNamespace).Backup(context.Background(), stateDir))
+	require.NoError(t, NewClient(source, DefaultNamespace).Backup(t.Context(), stateDir))
 
 	// Restore into a fresh, empty cluster.
 	target := fake.NewSimpleClientset()
-	require.NoError(t, NewClient(target, DefaultNamespace).Restore(context.Background(), stateDir))
+	require.NoError(t, NewClient(target, DefaultNamespace).Restore(t.Context(), stateDir))
 
-	restored, err := target.CoreV1().Secrets(DefaultNamespace).Get(context.Background(), "tfstate-default-aaa", metav1.GetOptions{})
+	restored, err := target.CoreV1().Secrets(DefaultNamespace).Get(t.Context(), "tfstate-default-aaa", metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Equal(t, []byte("round-trip-state"), restored.Data["tfstate"])
 	require.Equal(t, "true", restored.Labels["tfstate"])
@@ -131,15 +130,15 @@ func Test_Restore_UpdatesExistingSecret(t *testing.T) {
 	source := fake.NewSimpleClientset(
 		tfstateSecret("tfstate-default-aaa", map[string][]byte{"tfstate": []byte("new-state")}),
 	)
-	require.NoError(t, NewClient(source, DefaultNamespace).Backup(context.Background(), stateDir))
+	require.NoError(t, NewClient(source, DefaultNamespace).Backup(t.Context(), stateDir))
 
 	// Target already has a secret of the same name with stale data.
 	target := fake.NewSimpleClientset(
 		tfstateSecret("tfstate-default-aaa", map[string][]byte{"tfstate": []byte("old-state")}),
 	)
-	require.NoError(t, NewClient(target, DefaultNamespace).Restore(context.Background(), stateDir))
+	require.NoError(t, NewClient(target, DefaultNamespace).Restore(t.Context(), stateDir))
 
-	updated, err := target.CoreV1().Secrets(DefaultNamespace).Get(context.Background(), "tfstate-default-aaa", metav1.GetOptions{})
+	updated, err := target.CoreV1().Secrets(DefaultNamespace).Get(t.Context(), "tfstate-default-aaa", metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Equal(t, []byte("new-state"), updated.Data["tfstate"])
 }
@@ -148,10 +147,10 @@ func Test_Restore_NoBackupIsNoOp(t *testing.T) {
 	target := fake.NewSimpleClientset()
 	stateDir := t.TempDir()
 
-	err := NewClient(target, DefaultNamespace).Restore(context.Background(), stateDir)
+	err := NewClient(target, DefaultNamespace).Restore(t.Context(), stateDir)
 	require.NoError(t, err)
 
-	secrets, err := target.CoreV1().Secrets(DefaultNamespace).List(context.Background(), metav1.ListOptions{})
+	secrets, err := target.CoreV1().Secrets(DefaultNamespace).List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Empty(t, secrets.Items)
 }

--- a/pkg/components/database/databaseprovider/storageprovider_test.go
+++ b/pkg/components/database/databaseprovider/storageprovider_test.go
@@ -32,7 +32,7 @@ func Test_FromOptions(t *testing.T) {
 	require.NotNil(t, provider)
 	require.Equal(t, options, provider.options)
 
-	client, err := provider.GetClient(context.Background())
+	client, err := provider.GetClient(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, client)
 }
@@ -43,7 +43,7 @@ func Test_FromMemory(t *testing.T) {
 	require.NotNil(t, provider)
 	require.Equal(t, TypeInMemory, provider.options.Provider)
 
-	client, err := provider.GetClient(context.Background())
+	client, err := provider.GetClient(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, client)
 }
@@ -55,7 +55,7 @@ func Test_FromClient(t *testing.T) {
 	require.NotNil(t, provider)
 	require.Same(t, mockClient, provider.result.client)
 
-	client, err := provider.GetClient(context.Background())
+	client, err := provider.GetClient(t.Context())
 	require.NoError(t, err)
 	require.Same(t, client, mockClient)
 }
@@ -70,12 +70,12 @@ func Test_GetClient_CachedClient(t *testing.T) {
 		return mockClient, nil
 	})
 
-	client, err := provider.GetClient(context.Background())
+	client, err := provider.GetClient(t.Context())
 	require.NoError(t, err)
 	require.Same(t, mockClient, client)
 
 	// Do it twice to ensure the client is cached.
-	client, err = provider.GetClient(context.Background())
+	client, err = provider.GetClient(t.Context())
 	require.NoError(t, err)
 	require.Same(t, mockClient, client)
 
@@ -93,13 +93,13 @@ func Test_GetClient_CachedError(t *testing.T) {
 		return nil, expectedErr
 	})
 
-	client, err := provider.GetClient(context.Background())
+	client, err := provider.GetClient(t.Context())
 	require.Error(t, err)
 	require.Equal(t, "failed to initialize database client: oh noes!", err.Error())
 	require.Nil(t, client)
 
 	// Do it twice to ensure the client is cached.
-	client, err = provider.GetClient(context.Background())
+	client, err = provider.GetClient(t.Context())
 	require.Error(t, err)
 	require.Equal(t, "failed to initialize database client: oh noes!", err.Error())
 	require.Nil(t, client)
@@ -111,7 +111,7 @@ func TestGetClient_UnsupportedProvider(t *testing.T) {
 	options := Options{Provider: "unsupported"}
 	provider := FromOptions(options)
 
-	client, err := provider.GetClient(context.Background())
+	client, err := provider.GetClient(t.Context())
 
 	require.Error(t, err)
 	require.Nil(t, client)
@@ -179,7 +179,7 @@ func TestInitialize(t *testing.T) {
 	options := Options{Provider: TypeInMemory}
 	provider := FromOptions(options)
 
-	result := provider.initialize(context.Background())
+	result := provider.initialize(t.Context())
 
 	require.NoError(t, result.err)
 	require.NotNil(t, result.client)

--- a/pkg/components/queue/client_test.go
+++ b/pkg/components/queue/client_test.go
@@ -57,7 +57,7 @@ func TestStartDequeuer(t *testing.T) {
 			return nil, ErrInvalidMessage
 		}).AnyTimes().After(secondCall)
 
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(t.Context())
 	msgCh, err := StartDequeuer(ctx, mockCli, WithDequeueInterval(defaultTestDequeueInterval))
 	require.NoError(t, err)
 

--- a/pkg/components/queue/inmemory/client_test.go
+++ b/pkg/components/queue/inmemory/client_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package inmemory
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,9 +29,9 @@ func TestNamedQueue(t *testing.T) {
 	cli1 := NewNamedQueue("queue1")
 	cli2 := NewNamedQueue("queue2")
 
-	err := cli1.Enqueue(context.Background(), &queue.Message{Data: []byte("test1")})
+	err := cli1.Enqueue(t.Context(), &queue.Message{Data: []byte("test1")})
 	require.NoError(t, err)
-	err = cli2.Enqueue(context.Background(), &queue.Message{Data: []byte("test2")})
+	err = cli2.Enqueue(t.Context(), &queue.Message{Data: []byte("test2")})
 	require.NoError(t, err)
 
 	require.Equal(t, 1, cli1.queue.Len())

--- a/pkg/components/queue/queueprovider/provider_test.go
+++ b/pkg/components/queue/queueprovider/provider_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package queueprovider
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,10 +29,10 @@ func TestGetClient_ValidQueue(t *testing.T) {
 		InMemory: &InMemoryQueueOptions{},
 	})
 
-	oldcli, err := p.GetClient(context.TODO())
+	oldcli, err := p.GetClient(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, oldcli)
-	newcli, err := p.GetClient(context.TODO())
+	newcli, err := p.GetClient(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, oldcli, newcli)
 }
@@ -44,6 +43,6 @@ func TestGetClient_InvalidQueue(t *testing.T) {
 		Provider: QueueProviderType("undefined"),
 	})
 
-	_, err := p.GetClient(context.TODO())
+	_, err := p.GetClient(t.Context())
 	require.ErrorIs(t, ErrUnsupportedQueueProvider, err)
 }

--- a/pkg/components/secret/client_test.go
+++ b/pkg/components/secret/client_test.go
@@ -35,7 +35,7 @@ func Test_SaveSecret(t *testing.T) {
 	defer mctrl.Finish()
 
 	mockSecretClient := NewMockClient(mctrl)
-	ctx := context.Background()
+	ctx := t.Context()
 	azureSecret, err := newTestAzureSecret()
 	require.NoError(t, err)
 	saveError := errors.New("Failed to Save Secret")
@@ -74,7 +74,7 @@ func Test_GetSecret(t *testing.T) {
 	defer mctrl.Finish()
 
 	mockSecretClient := NewMockClient(mctrl)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	testSecretResponse, err := newTestAzureSecretResponse()
 	getError := errors.New("Failed to Save Secret")

--- a/pkg/components/secret/client_test.go
+++ b/pkg/components/secret/client_test.go
@@ -34,7 +34,6 @@ func Test_SaveSecret(t *testing.T) {
 	defer mctrl.Finish()
 
 	mockSecretClient := NewMockClient(mctrl)
-	ctx := t.Context()
 	azureSecret, err := newTestAzureSecret()
 	require.NoError(t, err)
 	saveError := errors.New("Failed to Save Secret")
@@ -49,6 +48,7 @@ func Test_SaveSecret(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
+			ctx := t.Context()
 			if tt.isSuccess {
 				mockSecretClient.EXPECT().
 					Save(ctx, testSecretName, gomock.Any()).
@@ -73,7 +73,6 @@ func Test_GetSecret(t *testing.T) {
 	defer mctrl.Finish()
 
 	mockSecretClient := NewMockClient(mctrl)
-	ctx := t.Context()
 
 	testSecretResponse, err := newTestAzureSecretResponse()
 	getError := errors.New("Failed to Save Secret")
@@ -88,6 +87,7 @@ func Test_GetSecret(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
+			ctx := t.Context()
 			if tt.isSuccess {
 				mockSecretClient.EXPECT().
 					Get(ctx, testSecretName).

--- a/pkg/components/secret/client_test.go
+++ b/pkg/components/secret/client_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package secret
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -52,11 +51,11 @@ func Test_SaveSecret(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			if tt.isSuccess {
 				mockSecretClient.EXPECT().
-					Save(context.Background(), testSecretName, gomock.Any()).
+					Save(t.Context(), testSecretName, gomock.Any()).
 					Return(nil).Times(1)
 			} else {
 				mockSecretClient.EXPECT().
-					Save(context.Background(), testSecretName, gomock.Any()).
+					Save(t.Context(), testSecretName, gomock.Any()).
 					Return(saveError).Times(1)
 			}
 			err := SaveSecret(ctx, tt.secretClient, testSecretName, tt.secret)
@@ -91,11 +90,11 @@ func Test_GetSecret(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			if tt.isSuccess {
 				mockSecretClient.EXPECT().
-					Get(context.Background(), testSecretName).
+					Get(t.Context(), testSecretName).
 					Return(testSecretResponse, nil).Times(1)
 			} else {
 				mockSecretClient.EXPECT().
-					Get(context.Background(), testSecretName).
+					Get(t.Context(), testSecretName).
 					Return(nil, getError).Times(1)
 			}
 			secretResponse, err := GetSecret[testSecretObject](ctx, tt.secretClient, testSecretName)

--- a/pkg/components/secret/client_test.go
+++ b/pkg/components/secret/client_test.go
@@ -51,11 +51,11 @@ func Test_SaveSecret(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			if tt.isSuccess {
 				mockSecretClient.EXPECT().
-					Save(t.Context(), testSecretName, gomock.Any()).
+					Save(ctx, testSecretName, gomock.Any()).
 					Return(nil).Times(1)
 			} else {
 				mockSecretClient.EXPECT().
-					Save(t.Context(), testSecretName, gomock.Any()).
+					Save(ctx, testSecretName, gomock.Any()).
 					Return(saveError).Times(1)
 			}
 			err := SaveSecret(ctx, tt.secretClient, testSecretName, tt.secret)
@@ -90,11 +90,11 @@ func Test_GetSecret(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			if tt.isSuccess {
 				mockSecretClient.EXPECT().
-					Get(t.Context(), testSecretName).
+					Get(ctx, testSecretName).
 					Return(testSecretResponse, nil).Times(1)
 			} else {
 				mockSecretClient.EXPECT().
-					Get(t.Context(), testSecretName).
+					Get(ctx, testSecretName).
 					Return(nil, getError).Times(1)
 			}
 			secretResponse, err := GetSecret[testSecretObject](ctx, tt.secretClient, testSecretName)

--- a/pkg/components/secret/inmemory/client_test.go
+++ b/pkg/components/secret/inmemory/client_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package inmemory
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -31,7 +30,7 @@ const (
 )
 
 func Test_Save(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	secretValue, err := json.Marshal("test_secret_value")
 	require.NoError(t, err)
@@ -84,7 +83,7 @@ func Test_Save(t *testing.T) {
 }
 
 func Test_Get(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	secretValue, err := json.Marshal("test_secret_value")
 	require.NoError(t, err)
@@ -126,7 +125,7 @@ func Test_Get(t *testing.T) {
 }
 
 func Test_Delete(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	secretValue, err := json.Marshal("test_secret_value")
 	require.NoError(t, err)

--- a/pkg/components/secret/kubernetes/client_test.go
+++ b/pkg/components/secret/kubernetes/client_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubernetes
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -36,7 +35,7 @@ func Test_Save(t *testing.T) {
 	k8sFakeClient := Client{
 		K8sClient: k8sutil.NewFakeKubeClient(scheme.Scheme),
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	secretValue, err := json.Marshal("test_secret_value")
 	require.NoError(t, err)
 	updatedSecretValue, err := json.Marshal("updated_secret_value")
@@ -82,7 +81,7 @@ func Test_Get(t *testing.T) {
 	k8sFakeClient := Client{
 		K8sClient: k8sutil.NewFakeKubeClient(scheme.Scheme),
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	secretValue, err := json.Marshal("test_secret_value")
 	require.NoError(t, err)
 	tests := []struct {
@@ -121,7 +120,7 @@ func Test_Delete(t *testing.T) {
 	k8sFakeClient := Client{
 		K8sClient: k8sutil.NewFakeKubeClient(scheme.Scheme),
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	secretValue, err := json.Marshal("test_secret_value")
 	require.NoError(t, err)
 	tests := []struct {

--- a/pkg/components/secret/secretprovider/provider_test.go
+++ b/pkg/components/secret/secretprovider/provider_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package secretprovider
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,7 +26,7 @@ func TestGetClient_InvalidType(t *testing.T) {
 	secretProvider := NewSecretProvider(SecretProviderOptions{
 		Provider: "invalid_client_type",
 	})
-	client, err := secretProvider.GetClient(context.TODO())
+	client, err := secretProvider.GetClient(t.Context())
 	require.Equal(t, err, ErrUnsupportedSecretProvider)
 	require.Nil(t, client)
 }

--- a/pkg/components/trace/util_test.go
+++ b/pkg/components/trace/util_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package trace
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,7 +34,7 @@ func TestExtractTraceparent(t *testing.T) {
 
 	for _, traceparent := range traceparentTests {
 		t.Run(traceparent, func(t *testing.T) {
-			ctx := WithTraceparent(context.TODO(), traceparent)
+			ctx := WithTraceparent(t.Context(), traceparent)
 
 			tp := ExtractTraceparent(ctx)
 			require.Equal(t, traceparent, tp)

--- a/pkg/controller/reconciler/flux_controller_test.go
+++ b/pkg/controller/reconciler/flux_controller_test.go
@@ -299,7 +299,7 @@ func runFluxControllerTest(t *testing.T, opts runFluxControllerTestOptions, step
 	namespacesToCleanup := make(map[string]bool)
 	defer func() {
 		// Clean up namespaces at the end of the test using fresh context
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second) //nolint:usetesting
 		defer cancel()
 
 		for ns := range namespacesToCleanup {

--- a/pkg/corerp/backend/controller/createorupdateresource_test.go
+++ b/pkg/corerp/backend/controller/createorupdateresource_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -208,7 +207,7 @@ func TestCreateOrUpdateResourceRun_20231001Preview(t *testing.T) {
 			genCtrl, err := NewCreateOrUpdateResource(opts)
 			require.NoError(t, err)
 
-			res, err := genCtrl.Run(context.Background(), req)
+			res, err := genCtrl.Run(t.Context(), req)
 
 			if tt.convErr {
 				tt.expErr = fmt.Errorf("invalid resource type: %q for dependent resource ID: %q", strings.ToLower(tt.rt), parsedID.String())
@@ -380,7 +379,7 @@ func TestCreateOrUpdateResourceRun_20231001Preview(t *testing.T) {
 			genCtrl, err := NewCreateOrUpdateResource(opts)
 			require.NoError(t, err)
 
-			res, err := genCtrl.Run(context.Background(), req)
+			res, err := genCtrl.Run(t.Context(), req)
 
 			if tt.convErr {
 				tt.expErr = fmt.Errorf("invalid resource type: %q for dependent resource ID: %q", strings.ToLower(tt.rt), parsedID.String())

--- a/pkg/corerp/backend/controller/deleteresource_test.go
+++ b/pkg/corerp/backend/controller/deleteresource_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -100,7 +99,7 @@ func TestDeleteResourceRun_20231001Preview(t *testing.T) {
 			ctrl, err := NewDeleteResource(opts)
 			require.NoError(t, err)
 
-			_, err = ctrl.Run(context.Background(), req)
+			_, err = ctrl.Run(t.Context(), req)
 
 			if tt.getErr != nil || tt.dpDelErr != nil || tt.scDelErr != nil {
 				require.Error(t, err)

--- a/pkg/corerp/backend/deployment/deploymentprocessor_test.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor_test.go
@@ -1130,7 +1130,7 @@ func Test_fetchSecrets(t *testing.T) {
 func Test_FailedDeploymentProcessor_AllMethodsReturnError(t *testing.T) {
 	sentinel := errors.New("target cluster unavailable")
 	p := NewFailedDeploymentProcessor(sentinel)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := p.Render(ctx, resources.ID{}, nil)
 	require.ErrorIs(t, err, sentinel)

--- a/pkg/corerp/frontend/controller/applications/getgraph_test.go
+++ b/pkg/corerp/frontend/controller/applications/getgraph_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package applications
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -42,7 +41,7 @@ func TestGetGraphRun_20231001Preview(t *testing.T) {
 
 	databaseClient := database.NewMockClient(mctrl)
 	req, err := rpctest.NewHTTPRequestWithContent(
-		context.Background(),
+		t.Context(),
 		v1.OperationPost.HTTPMethod(),
 		"http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/Applications/myapp/getGraph?api-version=2023-10-01-preview", nil)
 
@@ -83,7 +82,7 @@ func TestComputeGraphResponse_InvalidEnvironmentID(t *testing.T) {
 
 	// An empty/invalid environment ID string must surface as a parse error from
 	// resources.Parse and not a panic or a successful response.
-	resp, err := ComputeGraphResponse(context.Background(), applicationID, "not-a-valid-resource-id", conn)
+	resp, err := ComputeGraphResponse(t.Context(), applicationID, "not-a-valid-resource-id", conn)
 	require.Error(t, err)
 	require.Nil(t, resp)
 }
@@ -105,7 +104,7 @@ func TestComputeGraphResponse_UCPProvidersError(t *testing.T) {
 	require.NoError(t, err)
 
 	resp, err := ComputeGraphResponse(
-		context.Background(),
+		t.Context(),
 		applicationID,
 		"/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/myenv",
 		conn,
@@ -138,7 +137,7 @@ func TestComputeGraphResponse_ListByApplicationError(t *testing.T) {
 	require.NoError(t, err)
 
 	resp, err := ComputeGraphResponse(
-		context.Background(),
+		t.Context(),
 		applicationID,
 		"/planes/radius/local/resourceGroups/env-rg/providers/Applications.Core/environments/myenv",
 		conn,
@@ -183,7 +182,7 @@ func TestComputeGraphResponse_ListByEnvironmentError(t *testing.T) {
 	require.NoError(t, err)
 
 	resp, err := ComputeGraphResponse(
-		context.Background(),
+		t.Context(),
 		applicationID,
 		"/planes/radius/local/resourceGroups/env-rg/providers/Applications.Core/environments/myenv",
 		conn,
@@ -200,7 +199,7 @@ func TestGetGraphRun_DatabaseError(t *testing.T) {
 
 	databaseClient := database.NewMockClient(mctrl)
 	req, err := rpctest.NewHTTPRequestWithContent(
-		context.Background(),
+		t.Context(),
 		v1.OperationPost.HTTPMethod(),
 		"http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/Applications/myapp/getGraph?api-version=2023-10-01-preview", nil)
 	require.NoError(t, err)
@@ -256,7 +255,7 @@ func TestGetGraphRun_ComputeGraphSuccess(t *testing.T) {
 		}), nil)
 
 	req, err := rpctest.NewHTTPRequestWithContent(
-		context.Background(),
+		t.Context(),
 		v1.OperationPost.HTTPMethod(),
 		"http://localhost:8080"+appIDStr+"/getGraph?api-version=2023-10-01-preview", nil)
 	require.NoError(t, err)

--- a/pkg/corerp/frontend/controller/applications/graph_util_test.go
+++ b/pkg/corerp/frontend/controller/applications/graph_util_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package applications
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -258,7 +257,7 @@ func Test_getAPIVersionForResourceType_Validation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// For validation tests, we just need to check the parsing logic
 			// We'll use a nil clientOptions since validation happens first
-			_, err := getAPIVersionForResourceType(context.Background(), tt.resourceType, nil)
+			_, err := getAPIVersionForResourceType(t.Context(), tt.resourceType, nil)
 
 			// Verify results
 			require.Error(t, err)
@@ -749,7 +748,7 @@ func Test_azureTenantID(t *testing.T) {
 				},
 			}
 
-			got := azureTenantID(context.Background(), opts)
+			got := azureTenantID(t.Context(), opts)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/corerp/frontend/controller/applications/v20250801preview/getgraph_test.go
+++ b/pkg/corerp/frontend/controller/applications/v20250801preview/getgraph_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v20250801preview
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -41,7 +40,7 @@ func TestGetGraphRun_20250801Preview(t *testing.T) {
 
 	databaseClient := database.NewMockClient(mctrl)
 	req, err := rpctest.NewHTTPRequestWithContent(
-		context.Background(),
+		t.Context(),
 		v1.OperationPost.HTTPMethod(),
 		"http://localhost:8080/planes/radius/local/resourcegroups/default/providers/Radius.Core/applications/myapp/getGraph?api-version=2025-08-01-preview", nil)
 
@@ -80,7 +79,7 @@ func TestGetGraphRun_20250801Preview_DatabaseError(t *testing.T) {
 
 	databaseClient := database.NewMockClient(mctrl)
 	req, err := rpctest.NewHTTPRequestWithContent(
-		context.Background(),
+		t.Context(),
 		v1.OperationPost.HTTPMethod(),
 		"http://localhost:8080/planes/radius/local/resourcegroups/default/providers/Radius.Core/applications/myapp/getGraph?api-version=2025-08-01-preview", nil)
 	require.NoError(t, err)
@@ -136,7 +135,7 @@ func TestGetGraphRun_20250801Preview_ComputeGraphSuccess(t *testing.T) {
 		}), nil)
 
 	req, err := rpctest.NewHTTPRequestWithContent(
-		context.Background(),
+		t.Context(),
 		v1.OperationPost.HTTPMethod(),
 		"http://localhost:8080"+appIDStr+"/getGraph?api-version=2025-08-01-preview", nil)
 	require.NoError(t, err)

--- a/pkg/corerp/frontend/controller/applications/v20250801preview/graphicons_test.go
+++ b/pkg/corerp/frontend/controller/applications/v20250801preview/graphicons_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v20250801preview
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -123,7 +122,7 @@ func Test_fetchIcons_HashOnly(t *testing.T) {
 		},
 	}
 
-	icons, err := fetchIcons(context.Background(), conn, graph, false)
+	icons, err := fetchIcons(t.Context(), conn, graph, false)
 	require.NoError(t, err)
 	require.NotNil(t, icons)
 
@@ -147,7 +146,7 @@ func Test_fetchIcons_EmptyGraph(t *testing.T) {
 	conn, err := sdk.NewDirectConnection(server.URL)
 	require.NoError(t, err)
 
-	icons, err := fetchIcons(context.Background(), conn, &corerpv20250801preview.ApplicationGraphResponse{}, false)
+	icons, err := fetchIcons(t.Context(), conn, &corerpv20250801preview.ApplicationGraphResponse{}, false)
 	require.NoError(t, err)
 	assert.Nil(t, icons)
 }
@@ -189,7 +188,7 @@ func Test_fetchIcons_ExternalProviderNotFound(t *testing.T) {
 
 	// includeBytes=false because the reviewer's report was specifically that
 	// the graph errored even when the caller had not opted into inline bytes.
-	icons, err := fetchIcons(context.Background(), conn, graph, false)
+	icons, err := fetchIcons(t.Context(), conn, graph, false)
 	require.NoError(t, err)
 	require.NotNil(t, icons)
 
@@ -259,7 +258,7 @@ func Test_fetchIcons_IntegrityCheck(t *testing.T) {
 		},
 	}
 
-	icons, err := fetchIcons(context.Background(), conn, graph, true)
+	icons, err := fetchIcons(t.Context(), conn, graph, true)
 	require.NoError(t, err, "integrity failure must not fail the whole request")
 	require.NotNil(t, icons)
 

--- a/pkg/corerp/frontend/controller/bicepsettings/validator_test.go
+++ b/pkg/corerp/frontend/controller/bicepsettings/validator_test.go
@@ -15,7 +15,6 @@
 package bicepsettings
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/armrpc/rest"
@@ -104,7 +103,7 @@ func TestValidateRequest(t *testing.T) {
 				},
 			}
 
-			resp, err := ValidateRequest(context.Background(), r, nil, nil)
+			resp, err := ValidateRequest(t.Context(), r, nil, nil)
 			require.NoError(t, err)
 
 			if !tc.wantReject {

--- a/pkg/corerp/frontend/controller/containers/validator_test.go
+++ b/pkg/corerp/frontend/controller/containers/validator_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package containers
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -178,7 +177,7 @@ func TestValidateAndMutateRequest_IdentityProperty(t *testing.T) {
 
 	for _, tc := range requestTests {
 		t.Run(tc.desc, func(t *testing.T) {
-			r, err := ValidateAndMutateRequest(context.Background(), tc.newResource, tc.oldResource, nil)
+			r, err := ValidateAndMutateRequest(t.Context(), tc.newResource, tc.oldResource, nil)
 
 			require.NoError(t, err)
 			if tc.resp != nil {

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
@@ -43,7 +43,7 @@ func TestCreateOrUpdateEnvironmentRun_20231001Preview(t *testing.T) {
 	defer mctrl.Finish()
 
 	databaseClient := database.NewMockClient(mctrl)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	createNewResourceCases := []struct {
 		desc               string

--- a/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
+++ b/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
@@ -42,7 +42,7 @@ func TestGetRecipeMetadataRun_20231001Preview(t *testing.T) {
 	defer mctrl.Finish()
 	databaseClient := database.NewMockClient(mctrl)
 	mEngine := engine.NewMockEngine(mctrl)
-	ctx := context.Background()
+	ctx := t.Context()
 	t.Parallel()
 	t.Run("get recipe metadata run", func(t *testing.T) {
 		envInput, envDataModel, expectedOutput := getTestModelsGetRecipeMetadata20231001preview()

--- a/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
+++ b/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
@@ -315,7 +315,7 @@ func TestGetRecipeMetadataFromRegistry_ConfiguredParameterValuesAppearedInRespon
 
 	controller := ctl.(*GetRecipeMetadata)
 	result, err := controller.GetRecipeMetadataFromRegistry(
-		context.Background(),
+		t.Context(),
 		recipeProperties,
 		recipeDataModel,
 		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/applications.core/environments/env0",

--- a/pkg/corerp/frontend/controller/environments/v20250801preview/createorupdateenvironment_test.go
+++ b/pkg/corerp/frontend/controller/environments/v20250801preview/createorupdateenvironment_test.go
@@ -63,7 +63,7 @@ func TestCreateOrUpdateEnvironmentRun_20250801Preview(t *testing.T) {
 	defer mctrl.Finish()
 
 	databaseClient := database.NewMockClient(mctrl)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// The shared environment fixtures reference a recipe pack by ID; mock its
 	// existence for every subtest so the controller's recipe pack validation
@@ -384,7 +384,7 @@ func TestCreateOrUpdateEnvironmentRun_20250801Preview(t *testing.T) {
 }
 
 func TestCreateOrUpdateEnvironment_RecipePackValidation(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	testCases := []struct {
 		desc               string
@@ -765,7 +765,7 @@ func TestCreateOrUpdateEnvironment_RecipePackValidation(t *testing.T) {
 // bare name is resolved against the environment's own plane and resource group, while a
 // full resource ID is stored unchanged.
 func TestCreateOrUpdateEnvironment_RecipePackNormalization(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const (
 		envID          = "/planes/radius/local/resourceGroups/testGroup/providers/Radius.Core/environments/my-k8s-env"

--- a/pkg/corerp/frontend/controller/environments/v20250801preview/validateconfigref_test.go
+++ b/pkg/corerp/frontend/controller/environments/v20250801preview/validateconfigref_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v20250801preview
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -62,7 +61,7 @@ func TestValidateConfigRef_InvalidResourceID(t *testing.T) {
 	// No DB calls expected: parsing fails first.
 
 	e := newControllerForValidateConfigRef(databaseClient)
-	resp := validateConfigRef(context.Background(), e, "not a resource id", datamodel.TerraformSettingsResourceType, "terraformSettings")
+	resp := validateConfigRef(t.Context(), e, "not a resource id", datamodel.TerraformSettingsResourceType, "terraformSettings")
 
 	br, ok := resp.(*rest.BadRequestResponse)
 	require.True(t, ok, "expected BadRequestResponse, got %T", resp)
@@ -77,7 +76,7 @@ func TestValidateConfigRef_WrongType(t *testing.T) {
 
 	e := newControllerForValidateConfigRef(databaseClient)
 	// recipePackID has a valid ARM-style structure but the wrong resource type.
-	resp := validateConfigRef(context.Background(), e, recipePackID, datamodel.TerraformSettingsResourceType, "terraformSettings")
+	resp := validateConfigRef(t.Context(), e, recipePackID, datamodel.TerraformSettingsResourceType, "terraformSettings")
 
 	br, ok := resp.(*rest.BadRequestResponse)
 	require.True(t, ok, "expected BadRequestResponse, got %T", resp)
@@ -99,7 +98,7 @@ func TestValidateConfigRef_NotFound_ReturnsBadRequest(t *testing.T) {
 		Return(nil, &database.ErrNotFound{ID: tfConfigID})
 
 	e := newControllerForValidateConfigRef(databaseClient)
-	resp := validateConfigRef(context.Background(), e, tfConfigID, datamodel.TerraformSettingsResourceType, "terraformSettings")
+	resp := validateConfigRef(t.Context(), e, tfConfigID, datamodel.TerraformSettingsResourceType, "terraformSettings")
 
 	br, ok := resp.(*rest.BadRequestResponse)
 	require.True(t, ok, "expected BadRequestResponse for missing resource, got %T", resp)
@@ -116,7 +115,7 @@ func TestValidateConfigRef_DatabaseError_ReturnsInternalServerError(t *testing.T
 		Return(nil, errors.New("database is on fire"))
 
 	e := newControllerForValidateConfigRef(databaseClient)
-	resp := validateConfigRef(context.Background(), e, tfConfigID, datamodel.TerraformSettingsResourceType, "terraformSettings")
+	resp := validateConfigRef(t.Context(), e, tfConfigID, datamodel.TerraformSettingsResourceType, "terraformSettings")
 
 	ise, ok := resp.(*rest.InternalServerErrorResponse)
 	require.True(t, ok, "expected InternalServerErrorResponse for transport failure, got %T", resp)
@@ -139,7 +138,7 @@ func TestValidateConfigRef_HappyPath_TerraformSettings(t *testing.T) {
 		}, nil)
 
 	e := newControllerForValidateConfigRef(databaseClient)
-	resp := validateConfigRef(context.Background(), e, tfConfigID, datamodel.TerraformSettingsResourceType, "terraformSettings")
+	resp := validateConfigRef(t.Context(), e, tfConfigID, datamodel.TerraformSettingsResourceType, "terraformSettings")
 	require.Nil(t, resp, "expected validateConfigRef to return nil on success")
 }
 
@@ -159,6 +158,6 @@ func TestValidateConfigRef_HappyPath_BicepSettings(t *testing.T) {
 		}, nil)
 
 	e := newControllerForValidateConfigRef(databaseClient)
-	resp := validateConfigRef(context.Background(), e, bicepSettingsID, datamodel.BicepSettingsResourceType, "bicepSettings")
+	resp := validateConfigRef(t.Context(), e, bicepSettingsID, datamodel.BicepSettingsResourceType, "bicepSettings")
 	require.Nil(t, resp, "expected validateConfigRef to return nil on success")
 }

--- a/pkg/corerp/frontend/controller/extenders/listsecretsextender_test.go
+++ b/pkg/corerp/frontend/controller/extenders/listsecretsextender_test.go
@@ -43,7 +43,7 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 			mctrl.Finish()
 		}, mds, msm
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, extenderDataModel, _ := getTestModels20231001preview()
 	expectedSecrets := map[string]any{

--- a/pkg/corerp/frontend/controller/gateways/validator_test.go
+++ b/pkg/corerp/frontend/controller/gateways/validator_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package gateways
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/armrpc/rest"
@@ -112,7 +111,7 @@ func TestValidateAndMutateRequest_Gateway(t *testing.T) {
 
 	for _, tc := range requestTests {
 		t.Run(tc.desc, func(t *testing.T) {
-			r, err := ValidateAndMutateRequest(context.Background(), tc.newResource, tc.oldResource, nil)
+			r, err := ValidateAndMutateRequest(t.Context(), tc.newResource, tc.oldResource, nil)
 
 			require.NoError(t, err)
 			if tc.resp != nil {

--- a/pkg/corerp/frontend/controller/secretstores/kubernetes_test.go
+++ b/pkg/corerp/frontend/controller/secretstores/kubernetes_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package secretstores
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -76,7 +75,7 @@ func TestGetNamespace(t *testing.T) {
 		}, nil)
 
 		secret.Properties.Application = testAppID
-		ns, err := getNamespace(context.TODO(), secret, opt)
+		ns, err := getNamespace(t.Context(), secret, opt)
 		require.NoError(t, err)
 		require.Equal(t, "app0-ns", ns)
 	})
@@ -92,7 +91,7 @@ func TestGetNamespace(t *testing.T) {
 			Data: *envData,
 		}, nil)
 
-		ns, err := getNamespace(context.TODO(), secret, opt)
+		ns, err := getNamespace(t.Context(), secret, opt)
 		require.NoError(t, err)
 		require.Equal(t, "default", ns)
 	})
@@ -107,7 +106,7 @@ func TestGetNamespace(t *testing.T) {
 			Data: *envData,
 		}, nil)
 
-		_, err := getNamespace(context.TODO(), secret, opt)
+		_, err := getNamespace(t.Context(), secret, opt)
 		require.Error(t, err)
 	})
 }
@@ -351,7 +350,7 @@ func TestValidateAndMutateRequest(t *testing.T) {
 			if tt.modifyResource != nil {
 				tt.modifyResource(newResource, tt.oldResource)
 			}
-			resp, err := ValidateAndMutateRequest(context.TODO(), newResource, tt.oldResource, nil)
+			resp, err := ValidateAndMutateRequest(t.Context(), newResource, tt.oldResource, nil)
 			tt.assertions(t, resp, err, newResource, tt.oldResource)
 		})
 	}
@@ -372,7 +371,7 @@ func TestUpsertSecret(t *testing.T) {
 			KubeClient: k8sutil.NewFakeKubeClient(nil, ksecret),
 		}
 
-		resp, err := UpsertSecret(context.TODO(), newResource, nil, opt)
+		resp, err := UpsertSecret(t.Context(), newResource, nil, opt)
 		require.NoError(t, err)
 
 		// assert
@@ -398,13 +397,13 @@ func TestUpsertSecret(t *testing.T) {
 			KubeClient: k8sutil.NewFakeKubeClient(nil, ksecret),
 		}
 
-		resp, err := UpsertSecret(context.TODO(), newResource, nil, opt)
+		resp, err := UpsertSecret(t.Context(), newResource, nil, opt)
 		require.NoError(t, err)
 		require.Nil(t, resp)
 
 		// assert
 		actual := &corev1.Secret{}
-		err = opt.KubeClient.Get(context.TODO(), runtimeclient.ObjectKey{Namespace: "default", Name: "secret"}, actual)
+		err = opt.KubeClient.Get(t.Context(), runtimeclient.ObjectKey{Namespace: "default", Name: "secret"}, actual)
 		require.NoError(t, err)
 		require.Equal(t, "dGxzLmtleS1wcmlrZXkK", string(actual.Data["tls.crt"]))
 		require.Equal(t, "dGxzLmNlcnQK", string(actual.Data["tls.key"]))
@@ -420,7 +419,7 @@ func TestUpsertSecret(t *testing.T) {
 			KubeClient: k8sutil.NewFakeKubeClient(nil),
 		}
 
-		_, err := UpsertSecret(context.TODO(), newResource, oldResource, opt)
+		_, err := UpsertSecret(t.Context(), newResource, oldResource, opt)
 		require.NoError(t, err)
 
 		// assert
@@ -445,16 +444,16 @@ func TestUpsertSecret(t *testing.T) {
 			KubeClient:     k8sutil.NewFakeKubeClient(nil),
 		}
 
-		_, err := ValidateAndMutateRequest(context.TODO(), newResource, nil, opt)
+		_, err := ValidateAndMutateRequest(t.Context(), newResource, nil, opt)
 		require.NoError(t, err)
-		_, err = UpsertSecret(context.TODO(), newResource, nil, opt)
+		_, err = UpsertSecret(t.Context(), newResource, nil, opt)
 		require.NoError(t, err)
 
 		// assert
 		require.Equal(t, "app0-ns/secret0", newResource.Properties.Resource)
 		ksecret := &corev1.Secret{}
 
-		err = opt.KubeClient.Get(context.TODO(), runtimeclient.ObjectKey{Namespace: "app0-ns", Name: "secret0"}, ksecret)
+		err = opt.KubeClient.Get(t.Context(), runtimeclient.ObjectKey{Namespace: "app0-ns", Name: "secret0"}, ksecret)
 		require.NoError(t, err)
 
 		require.Equal(t, "dGxzLmNydA==", string(ksecret.Data["tls.crt"]))
@@ -491,9 +490,9 @@ func TestUpsertSecret(t *testing.T) {
 			KubeClient:     k8sutil.NewFakeKubeClient(nil),
 		}
 
-		_, err := ValidateAndMutateRequest(context.TODO(), newResource, nil, opt)
+		_, err := ValidateAndMutateRequest(t.Context(), newResource, nil, opt)
 		require.NoError(t, err)
-		_, err = UpsertSecret(context.TODO(), newResource, oldResource, opt)
+		_, err = UpsertSecret(t.Context(), newResource, oldResource, opt)
 		require.NoError(t, err)
 
 		// assert
@@ -520,9 +519,9 @@ func TestUpsertSecret(t *testing.T) {
 			KubeClient:     k8sutil.NewFakeKubeClient(nil),
 		}
 
-		_, err := ValidateAndMutateRequest(context.TODO(), newResource, nil, opt)
+		_, err := ValidateAndMutateRequest(t.Context(), newResource, nil, opt)
 		require.NoError(t, err)
-		resp, err := UpsertSecret(context.TODO(), newResource, oldResource, opt)
+		resp, err := UpsertSecret(t.Context(), newResource, oldResource, opt)
 		require.NoError(t, err)
 
 		// assert
@@ -541,16 +540,16 @@ func TestUpsertSecret(t *testing.T) {
 			KubeClient:     k8sutil.NewFakeKubeClient(nil),
 		}
 
-		_, err := ValidateAndMutateRequest(context.TODO(), newResource, nil, opt)
+		_, err := ValidateAndMutateRequest(t.Context(), newResource, nil, opt)
 		require.NoError(t, err)
-		_, err = UpsertSecret(context.TODO(), newResource, nil, opt)
+		_, err = UpsertSecret(t.Context(), newResource, nil, opt)
 		require.NoError(t, err)
 
 		// assert
 		require.Equal(t, "test-namespace/secret0", newResource.Properties.Resource)
 		ksecret := &corev1.Secret{}
 
-		err = opt.KubeClient.Get(context.TODO(), runtimeclient.ObjectKey{Namespace: "test-namespace", Name: "secret0"}, ksecret)
+		err = opt.KubeClient.Get(t.Context(), runtimeclient.ObjectKey{Namespace: "test-namespace", Name: "secret0"}, ksecret)
 		require.NoError(t, err)
 
 		require.Equal(t, "dGxzLmNydA==", string(ksecret.Data["tls.crt"]))
@@ -578,9 +577,9 @@ func TestUpsertSecret(t *testing.T) {
 			KubeClient:     k8sutil.NewFakeKubeClient(nil),
 		}
 
-		_, err := ValidateAndMutateRequest(context.TODO(), newResource, nil, opt)
+		_, err := ValidateAndMutateRequest(t.Context(), newResource, nil, opt)
 		require.NoError(t, err)
-		_, err = UpsertSecret(context.TODO(), newResource, nil, opt)
+		_, err = UpsertSecret(t.Context(), newResource, nil, opt)
 		require.Error(t, err)
 		require.Equal(t, err.Error(), "no Kubernetes namespace")
 	})
@@ -596,9 +595,9 @@ func TestUpsertSecret(t *testing.T) {
 			KubeClient:     k8sutil.NewFakeKubeClient(nil),
 		}
 
-		_, err := ValidateAndMutateRequest(context.TODO(), newResource, nil, opt)
+		_, err := ValidateAndMutateRequest(t.Context(), newResource, nil, opt)
 		require.NoError(t, err)
-		resp, err := UpsertSecret(context.TODO(), newResource, nil, opt)
+		resp, err := UpsertSecret(t.Context(), newResource, nil, opt)
 		require.NoError(t, err)
 
 		// assert
@@ -614,7 +613,7 @@ func TestUpsertSecret(t *testing.T) {
 			KubeClient: k8sutil.NewFakeKubeClient(nil),
 		}
 
-		resp, _ := UpsertSecret(context.TODO(), newResource, nil, opt)
+		resp, _ := UpsertSecret(t.Context(), newResource, nil, opt)
 		r := resp.(*rest.BadRequestResponse)
 		require.Equal(t, "'default/secret' referenced resource does not exist.", r.Body.Error.Message)
 	})
@@ -627,7 +626,7 @@ func TestUpsertSecret(t *testing.T) {
 			KubeClient: k8sutil.NewFakeKubeClient(nil),
 		}
 
-		_, err := UpsertSecret(context.TODO(), newResource, oldResource, opt)
+		_, err := UpsertSecret(t.Context(), newResource, oldResource, opt)
 		require.NoError(t, err)
 
 		// assert
@@ -653,11 +652,11 @@ func TestDeleteSecret(t *testing.T) {
 			KubeClient: k8sutil.NewFakeKubeClient(nil, ksecret),
 		}
 
-		resp, err := DeleteRadiusSecret(context.TODO(), res, opt)
+		resp, err := DeleteRadiusSecret(t.Context(), res, opt)
 		require.NoError(t, err)
 		require.Nil(t, resp)
 
-		err = opt.KubeClient.Get(context.TODO(), runtimeclient.ObjectKey{Namespace: "default", Name: "letsencrypt-prod"}, ksecret)
+		err = opt.KubeClient.Get(t.Context(), runtimeclient.ObjectKey{Namespace: "default", Name: "letsencrypt-prod"}, ksecret)
 		require.True(t, apierrors.IsNotFound(err))
 	})
 
@@ -675,11 +674,11 @@ func TestDeleteSecret(t *testing.T) {
 			KubeClient: k8sutil.NewFakeKubeClient(nil, ksecret),
 		}
 
-		resp, err := DeleteRadiusSecret(context.TODO(), res, opt)
+		resp, err := DeleteRadiusSecret(t.Context(), res, opt)
 		require.NoError(t, err)
 		require.Nil(t, resp)
 
-		err = opt.KubeClient.Get(context.TODO(), runtimeclient.ObjectKey{Namespace: "default", Name: "letsencrypt-prod"}, ksecret)
+		err = opt.KubeClient.Get(t.Context(), runtimeclient.ObjectKey{Namespace: "default", Name: "letsencrypt-prod"}, ksecret)
 		require.False(t, apierrors.IsNotFound(err))
 	})
 }

--- a/pkg/corerp/frontend/controller/secretstores/listsecrets_test.go
+++ b/pkg/corerp/frontend/controller/secretstores/listsecrets_test.go
@@ -43,7 +43,7 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 
 	databaseClient := database.NewMockClient(mctrl)
 	req, err := rpctest.NewHTTPRequestWithContent(
-		context.Background(),
+		t.Context(),
 		v1.OperationPost.HTTPMethod(),
 		"http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/secretStores/secret0/listsecrets?api-version=2023-10-01-preview", nil)
 	require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestListSecrets_InvalidKubernetesSecret(t *testing.T) {
 
 	databaseClient := database.NewMockClient(mctrl)
 	req, err := rpctest.NewHTTPRequestWithContent(
-		context.Background(),
+		t.Context(),
 		v1.OperationPost.HTTPMethod(),
 		"http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/secretStores/secret0/listsecrets?api-version=2023-10-01-preview", nil)
 	require.NoError(t, err)

--- a/pkg/corerp/frontend/controller/volumes/validator_test.go
+++ b/pkg/corerp/frontend/controller/volumes/validator_test.go
@@ -85,7 +85,7 @@ func TestValidateRequest(t *testing.T) {
 			name: "invalid-kind",
 			args: args{
 				ctx: v1.WithARMRequestContext(
-					context.Background(), &v1.ARMRequestContext{
+					t.Context(), &v1.ARMRequestContext{
 						ResourceID: mustParseResourceID(resourceID),
 						HTTPMethod: http.MethodPut,
 					}),
@@ -107,7 +107,7 @@ func TestValidateRequest(t *testing.T) {
 			name: "csi-driver-not-installed",
 			args: args{
 				ctx: v1.WithARMRequestContext(
-					context.Background(), &v1.ARMRequestContext{
+					t.Context(), &v1.ARMRequestContext{
 						ResourceID: mustParseResourceID(resourceID),
 						HTTPMethod: http.MethodPut,
 					}),
@@ -131,7 +131,7 @@ func TestValidateRequest(t *testing.T) {
 			name: "csi-driver-installed",
 			args: args{
 				ctx: v1.WithARMRequestContext(
-					context.Background(), &v1.ARMRequestContext{
+					t.Context(), &v1.ARMRequestContext{
 						ResourceID: mustParseResourceID(resourceID),
 						HTTPMethod: http.MethodPut,
 					}),

--- a/pkg/corerp/handlers/kubernetes_deployment_waiter_test.go
+++ b/pkg/corerp/handlers/kubernetes_deployment_waiter_test.go
@@ -105,7 +105,7 @@ func startInformers(ctx context.Context, clientSet *fake.Clientset) informers.Sh
 }
 
 func TestWaitUntilReady_NewResource(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create first deployment that will be watched
 	deployment := &v1.Deployment{
@@ -156,7 +156,7 @@ func TestWaitUntilReady_NewResource(t *testing.T) {
 }
 
 func TestWaitUntilReady_Timeout(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	// Create first deployment that will be watched
 	deployment := &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -193,7 +193,7 @@ func TestWaitUntilReady_Timeout(t *testing.T) {
 }
 
 func TestWaitUntilReady_DifferentResourceName(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	// Create first deployment that will be watched
 	deployment := &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -318,7 +318,7 @@ func TestGetPodsInDeployment(t *testing.T) {
 		clientSet: fakeClient,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	informerFactory := startInformers(ctx, fakeClient)
 
 	// Call the getPodsInDeployment function
@@ -405,7 +405,7 @@ func TestGetCurrentReplicaSetForDeployment(t *testing.T) {
 		clientSet: fakeClient,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	informerFactory := startInformers(ctx, fakeClient)
 
 	// Call the getNewestReplicaSetForDeployment function
@@ -558,7 +558,7 @@ func TestCheckPodStatus(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	deploymentWaiter := NewDeploymentWaiter(fake.NewClientset())
 	for _, tc := range podTests {
 		pod.Status.Conditions = tc.podCondition
@@ -578,7 +578,7 @@ func TestCheckAllPodsReady_Success(t *testing.T) {
 	// Create a fake Kubernetes clientset
 	clientset := fake.NewClientset()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := clientset.AppsV1().Deployments("test-namespace").Create(ctx, testDeployment, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -638,7 +638,7 @@ func TestCheckAllPodsReady_Fail(t *testing.T) {
 	// Create a fake Kubernetes clientset
 	clientset := fake.NewClientset()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := clientset.AppsV1().Deployments("test-namespace").Create(ctx, testDeployment, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -705,7 +705,7 @@ func TestCheckDeploymentStatus_AllReady(t *testing.T) {
 	// Create a fake Kubernetes fakeClient
 	fakeClient := fake.NewClientset()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := fakeClient.AppsV1().Deployments("test-namespace").Create(ctx, testDeployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 	replicaSet := addReplicaSetToDeployment(t, ctx, fakeClient, testDeployment)
@@ -783,7 +783,7 @@ func TestCheckDeploymentStatus_NoReplicaSetsFound(t *testing.T) {
 	// Create a fake Kubernetes fakeClient
 	fakeClient := fake.NewClientset()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := fakeClient.AppsV1().Deployments("test-namespace").Create(ctx, testDeployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
@@ -855,7 +855,7 @@ func TestCheckDeploymentStatus_PodsNotReady(t *testing.T) {
 	// Create a fake Kubernetes fakeClient
 	fakeClient := fake.NewClientset()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := fakeClient.AppsV1().Deployments("test-namespace").Create(ctx, testDeployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 	replicaSet := addReplicaSetToDeployment(t, ctx, fakeClient, testDeployment)
@@ -940,7 +940,7 @@ func TestCheckDeploymentStatus_ObservedGenerationMismatch(t *testing.T) {
 	// Create a fake Kubernetes fakeClient
 	fakeClient := fake.NewClientset()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := fakeClient.AppsV1().Deployments("test-namespace").Create(ctx, generationMismatchDeployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 	replicaSet := addReplicaSetToDeployment(t, ctx, fakeClient, generationMismatchDeployment)
@@ -1018,7 +1018,7 @@ func TestCheckDeploymentStatus_DeploymentNotProgressing(t *testing.T) {
 
 	deploymentNotProgressing := testDeployment.DeepCopy()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := fakeClient.AppsV1().Deployments("test-namespace").Create(ctx, deploymentNotProgressing, metav1.CreateOptions{})
 	require.NoError(t, err)
 	replicaSet := addReplicaSetToDeployment(t, ctx, fakeClient, deploymentNotProgressing)

--- a/pkg/corerp/handlers/kubernetes_deployment_waiter_test.go
+++ b/pkg/corerp/handlers/kubernetes_deployment_waiter_test.go
@@ -99,7 +99,7 @@ func startInformers(ctx context.Context, clientSet *fake.Clientset) informers.Sh
 	informerFactory.Apps().V1().ReplicaSets().Informer()
 	informerFactory.Core().V1().Pods().Informer()
 
-	informerFactory.Start(context.Background().Done())
+	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
 	return informerFactory
 }
@@ -307,10 +307,10 @@ func TestGetPodsInDeployment(t *testing.T) {
 	}
 
 	// Add the Pod object to the fake Kubernetes clientset
-	_, err := fakeClient.CoreV1().Pods(pod1.Namespace).Create(context.Background(), pod1, metav1.CreateOptions{})
+	_, err := fakeClient.CoreV1().Pods(pod1.Namespace).Create(t.Context(), pod1, metav1.CreateOptions{})
 	require.NoError(t, err, "Failed to create Pod: %v", err)
 
-	_, err = fakeClient.CoreV1().Pods(pod2.Namespace).Create(context.Background(), pod2, metav1.CreateOptions{})
+	_, err = fakeClient.CoreV1().Pods(pod2.Namespace).Create(t.Context(), pod2, metav1.CreateOptions{})
 	require.NoError(t, err, "Failed to create Pod: %v", err)
 
 	// Create a KubernetesHandler object with the fake clientset
@@ -389,15 +389,15 @@ func TestGetCurrentReplicaSetForDeployment(t *testing.T) {
 	}
 
 	// Add the ReplicaSet objects to the fake Kubernetes clientset
-	_, err := fakeClient.AppsV1().ReplicaSets(replicaSet1.Namespace).Create(context.Background(), replicaSet1, metav1.CreateOptions{})
+	_, err := fakeClient.AppsV1().ReplicaSets(replicaSet1.Namespace).Create(t.Context(), replicaSet1, metav1.CreateOptions{})
 	require.NoError(t, err)
-	_, err = fakeClient.AppsV1().ReplicaSets(replicaSet2.Namespace).Create(context.Background(), replicaSet2, metav1.CreateOptions{})
+	_, err = fakeClient.AppsV1().ReplicaSets(replicaSet2.Namespace).Create(t.Context(), replicaSet2, metav1.CreateOptions{})
 	require.NoError(t, err)
-	_, err = fakeClient.AppsV1().ReplicaSets(replicaSet2.Namespace).Create(context.Background(), replicaSet3, metav1.CreateOptions{})
+	_, err = fakeClient.AppsV1().ReplicaSets(replicaSet2.Namespace).Create(t.Context(), replicaSet3, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// Add the Deployment object to the fake Kubernetes clientset
-	_, err = fakeClient.AppsV1().Deployments(deployment.Namespace).Create(context.Background(), deployment, metav1.CreateOptions{})
+	_, err = fakeClient.AppsV1().Deployments(deployment.Namespace).Create(t.Context(), deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// Create a KubernetesHandler object with the fake clientset
@@ -612,7 +612,7 @@ func TestCheckAllPodsReady_Success(t *testing.T) {
 			},
 		},
 	}
-	_, err = clientset.CoreV1().Pods("test-namespace").Create(context.Background(), pod, metav1.CreateOptions{})
+	_, err = clientset.CoreV1().Pods("test-namespace").Create(t.Context(), pod, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	// Create an informer factory and add the deployment and replica set to the cache
@@ -679,7 +679,7 @@ func TestCheckAllPodsReady_Fail(t *testing.T) {
 			},
 		},
 	}
-	_, err = clientset.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	_, err = clientset.CoreV1().Pods(pod.Namespace).Create(t.Context(), pod, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// Create an informer factory and add the deployment and replica set to the cache

--- a/pkg/corerp/handlers/kubernetes_http_proxy_waiter_test.go
+++ b/pkg/corerp/handlers/kubernetes_http_proxy_waiter_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package handlers
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -124,7 +123,7 @@ func TestHTTPProxyWaiter_WaitUntilReadySkipsRouteChild(t *testing.T) {
 		},
 	})
 
-	err := httpProxyWaiter.waitUntilReady(context.Background(), httpProxy)
+	err := httpProxyWaiter.waitUntilReady(t.Context(), httpProxy)
 	require.NoError(t, err)
 }
 
@@ -155,7 +154,7 @@ func TestHTTPProxyWaiter_WaitUntilReadyTimeoutGetsNamespacedHTTPProxy(t *testing
 		httpProxyDeploymentTimeout: 50 * time.Millisecond,
 	}
 
-	err = httpProxyWaiter.waitUntilReady(context.Background(), httpProxy)
+	err = httpProxyWaiter.waitUntilReady(t.Context(), httpProxy)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "HTTP proxy deployment timed out, name: example.com, namespace default, status: still reconciling, reason: Waiting")
 	require.NotContains(t, err.Error(), "not found")
@@ -207,7 +206,7 @@ func TestCheckHTTPProxyStatus_ValidStatus(t *testing.T) {
 	dynamicInformerFactory.WaitForCacheSync(ctx.Done())
 
 	// call the function with the fake clientset, informer factory, logger, object, and done channel
-	go httpProxyWaiter.checkHTTPProxyStatus(context.Background(), dynamicInformerFactory, obj, doneCh)
+	go httpProxyWaiter.checkHTTPProxyStatus(t.Context(), dynamicInformerFactory, obj, doneCh)
 	err = <-doneCh
 	require.NoError(t, err)
 }
@@ -240,11 +239,11 @@ func TestCheckHTTPProxyStatus_ValidRootProxyWithOverriddenLabels(t *testing.T) {
 		dynamicClientSet: fakeClient,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	dynamicInformerFactory.Start(ctx.Done())
 	dynamicInformerFactory.WaitForCacheSync(ctx.Done())
 
-	status := httpProxyWaiter.checkHTTPProxyStatus(context.Background(), dynamicInformerFactory, httpProxy, doneCh)
+	status := httpProxyWaiter.checkHTTPProxyStatus(t.Context(), dynamicInformerFactory, httpProxy, doneCh)
 	err = <-doneCh
 	require.True(t, status)
 	require.NoError(t, err)
@@ -325,7 +324,7 @@ func TestCheckHTTPProxyStatus_InvalidStatusForRootProxy(t *testing.T) {
 	dynamicInformerFactory.WaitForCacheSync(ctx.Done())
 
 	// call the function with the fake clientset, informer factory, logger, object, and done channel
-	go httpProxyWaiter.checkHTTPProxyStatus(context.Background(), dynamicInformerFactory, obj, doneCh)
+	go httpProxyWaiter.checkHTTPProxyStatus(t.Context(), dynamicInformerFactory, obj, doneCh)
 	err = <-doneCh
 	require.EqualError(t, err, "Error - Type: Valid, Status: False, Reason: RouteNotDefined, Message: HTTPProxy is invalid\n")
 }
@@ -369,11 +368,11 @@ func TestCheckHTTPProxyStatus_InvalidStatusForRootProxyWithRoutes(t *testing.T) 
 		dynamicClientSet: fakeClient,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	dynamicInformerFactory.Start(ctx.Done())
 	dynamicInformerFactory.WaitForCacheSync(ctx.Done())
 
-	status := httpProxyWaiter.checkHTTPProxyStatus(context.Background(), dynamicInformerFactory, httpProxy, doneCh)
+	status := httpProxyWaiter.checkHTTPProxyStatus(t.Context(), dynamicInformerFactory, httpProxy, doneCh)
 	err = <-doneCh
 	require.False(t, status)
 	require.EqualError(t, err, "Failed to deploy HTTP proxy. Description: root proxy is invalid")
@@ -459,7 +458,7 @@ func TestCheckHTTPProxyStatus_InvalidStatusForRouteProxy(t *testing.T) {
 	dynamicInformerFactory.WaitForCacheSync(ctx.Done())
 
 	// call the function with the fake clientset, informer factory, logger, object, and done channel
-	go httpProxyWaiter.checkHTTPProxyStatus(context.Background(), dynamicInformerFactory, obj, doneCh)
+	go httpProxyWaiter.checkHTTPProxyStatus(t.Context(), dynamicInformerFactory, obj, doneCh)
 	err = <-doneCh
 	require.NoError(t, err)
 }
@@ -540,7 +539,7 @@ func TestCheckHTTPProxyStatus_WrongName(t *testing.T) {
 	dynamicInformerFactory.WaitForCacheSync(ctx.Done())
 
 	// call the function with the fake clientset, informer factory, logger, object, and done channel
-	status := httpProxyWaiter.checkHTTPProxyStatus(context.Background(), dynamicInformerFactory, obj, doneCh)
+	status := httpProxyWaiter.checkHTTPProxyStatus(t.Context(), dynamicInformerFactory, obj, doneCh)
 	require.False(t, status)
 }
 

--- a/pkg/corerp/handlers/kubernetes_http_proxy_waiter_test.go
+++ b/pkg/corerp/handlers/kubernetes_http_proxy_waiter_test.go
@@ -202,7 +202,7 @@ func TestCheckHTTPProxyStatus_ValidStatus(t *testing.T) {
 		dynamicClientSet: fakeClient,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	dynamicInformerFactory.Start(ctx.Done())
 	dynamicInformerFactory.WaitForCacheSync(ctx.Done())
 
@@ -320,7 +320,7 @@ func TestCheckHTTPProxyStatus_InvalidStatusForRootProxy(t *testing.T) {
 		dynamicClientSet: fakeClient,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	dynamicInformerFactory.Start(ctx.Done())
 	dynamicInformerFactory.WaitForCacheSync(ctx.Done())
 
@@ -454,7 +454,7 @@ func TestCheckHTTPProxyStatus_InvalidStatusForRouteProxy(t *testing.T) {
 		dynamicClientSet: fakeClient,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	dynamicInformerFactory.Start(ctx.Done())
 	dynamicInformerFactory.WaitForCacheSync(ctx.Done())
 
@@ -535,7 +535,7 @@ func TestCheckHTTPProxyStatus_WrongName(t *testing.T) {
 		dynamicClientSet: fakeClient,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	dynamicInformerFactory.Start(ctx.Done())
 	dynamicInformerFactory.WaitForCacheSync(ctx.Done())
 

--- a/pkg/corerp/handlers/kubernetes_test.go
+++ b/pkg/corerp/handlers/kubernetes_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package handlers
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -125,7 +126,7 @@ func TestPut(t *testing.T) {
 }
 
 func TestPut_ContourHTTPProxyRouteChildSkipsWait(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	httpProxy := &contourv1.HTTPProxy{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: contourv1.SchemeGroupVersion.String(),
@@ -174,7 +175,7 @@ func TestPut_ContourHTTPProxyRouteChildSkipsWait(t *testing.T) {
 }
 
 func TestPut_ContourHTTPProxyRootWaits(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	httpProxy := &contourv1.HTTPProxy{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: contourv1.SchemeGroupVersion.String(),
@@ -222,7 +223,7 @@ func TestPut_ContourHTTPProxyRootWaits(t *testing.T) {
 }
 
 func TestPut_NonContourHTTPProxyBypassesWaiter(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	httpProxy := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "networking.example.com/v1",

--- a/pkg/corerp/handlers/kubernetes_test.go
+++ b/pkg/corerp/handlers/kubernetes_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package handlers
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -99,7 +98,7 @@ func TestPut(t *testing.T) {
 
 	for _, tc := range putTests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 
 			clientSet := fake.NewClientset(tc.in.Resource.CreateResource.Data.(runtime.Object))
 			handler := kubernetesHandler{
@@ -261,7 +260,7 @@ func TestPut_NonContourHTTPProxyBypassesWaiter(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	// Create first deployment that will be watched
 	deployment := &v1.Deployment{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/corerp/processors/extenders/processor_test.go
+++ b/pkg/corerp/processors/extenders/processor_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package extenders
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/corerp/datamodel"
@@ -53,7 +52,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, "myBucket", resource.Properties.AdditionalProperties["bucketName"])
@@ -91,7 +90,7 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
-		err := processor.Process(context.Background(), resource, processors.Options{})
+		err := processor.Process(t.Context(), resource, processors.Options{})
 		require.NoError(t, err)
 
 		require.Equal(t, "myBucket", resource.Properties.AdditionalProperties["bucketName"])
@@ -138,7 +137,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, "myBucket2", resource.Properties.AdditionalProperties["bucketName"])
@@ -174,7 +173,7 @@ func Test_Process(t *testing.T) {
 		}
 		options := processors.Options{RecipeOutput: &recipes.RecipeOutput{}}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.Error(t, err)
 		require.IsType(t, &processors.ValidationError{}, err)
 		require.Equal(t, `secret 'databaseSecret' must be of type string`, err.Error())

--- a/pkg/corerp/renderers/container/azure/identity_test.go
+++ b/pkg/corerp/renderers/container/azure/identity_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package azure
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -130,7 +129,7 @@ func TestSetWorkloadIdentityServiceAccount(t *testing.T) {
 	}
 
 	// Transform outputresource
-	err := TransformFederatedIdentitySA(context.Background(), putOptions)
+	err := TransformFederatedIdentitySA(t.Context(), putOptions)
 	require.NoError(t, err)
 	sa := fi.CreateResource.Data.(*corev1.ServiceAccount)
 
@@ -180,7 +179,7 @@ func TestTransformFederatedIdentitySA_Validation(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := TransformFederatedIdentitySA(context.Background(), &handlers.PutOptions{
+			err := TransformFederatedIdentitySA(t.Context(), &handlers.PutOptions{
 				Resource:             &rpv1.OutputResource{CreateResource: &rpv1.Resource{Data: tc.resource}},
 				DependencyProperties: tc.dep,
 			})

--- a/pkg/corerp/renderers/container/azure/keyvaultvolume_test.go
+++ b/pkg/corerp/renderers/container/azure/keyvaultvolume_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package azure
 
 import (
-	"context"
 	"testing"
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
@@ -134,7 +133,7 @@ func TestMakeKeyVaultSecretProviderClass(t *testing.T) {
 						},
 					},
 				}
-				err := TransformSecretProviderClass(context.Background(), putOptions)
+				err := TransformSecretProviderClass(t.Context(), putOptions)
 				require.NoError(t, err)
 				require.Equal(t, tc.afterParams, r.Spec.Parameters)
 			}

--- a/pkg/corerp/renderers/daprextension/renderer_test.go
+++ b/pkg/corerp/renderers/daprextension/renderer_test.go
@@ -86,7 +86,7 @@ func Test_Render_Success(t *testing.T) {
 	resource := makeResource(ctnrProperties)
 	dependencies := map[string]renderers.RendererDependency{}
 
-	output, err := renderer.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies})
+	output, err := renderer.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 1)
 	require.Empty(t, output.SecretValues)

--- a/pkg/corerp/renderers/gateway/render_test.go
+++ b/pkg/corerp/renderers/gateway/render_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package gateway
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -130,7 +129,7 @@ func Test_Render_WithIPAndNoHostname(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions("", testExternalIP, "", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -165,7 +164,7 @@ func Test_Render_WithIPAndPrefix(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions("", testExternalIP, "", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -201,7 +200,7 @@ func Test_Render_WithIPAndFQHostname(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions("", testExternalIP, "", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -236,7 +235,7 @@ func Test_Render_WithFQHostname_OverridesPrefix(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions("", testExternalIP, "", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -264,7 +263,7 @@ func Test_Render_PublicEndpointOverride(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions(testHostname, "", testPort, true, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -297,7 +296,7 @@ func Test_Render_PublicEndpointOverride_OverridesAll(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions(expectedPublicEndpoint, testExternalIP, "", true, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -327,7 +326,7 @@ func Test_Render_PublicEndpointOverride_WithEmptyIP(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions(expectedFQDN, "", "", true, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -357,7 +356,7 @@ func Test_Render_LocalhostPublicEndpointOverride(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions(expectedFQDN, "", testPort, true, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -386,7 +385,7 @@ func Test_Render_Hostname(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions(testHostname, "", "", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -416,7 +415,7 @@ func Test_Render_Hostname_WithPort(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions(expectedFQDN, "", "32434", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -450,7 +449,7 @@ func Test_Render_Hostname_WithPrefix(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions(testHostname, "", "", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -484,7 +483,7 @@ func Test_Render_Hostname_WithPrefixAndPort(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions(testHostname, "", testPort, false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -515,7 +514,7 @@ func Test_Render_WithMissingPublicIP(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions("", "", "", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -554,7 +553,7 @@ func Test_Render_Fails_SSLPassthroughWithRoutePath(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions("", testExternalIP, "", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.Error(t, err)
 	require.Equal(t, err.(*v1.ErrClientRP).Code, v1.CodeInvalid)
 	require.Equal(t, err.(*v1.ErrClientRP).Message, "cannot support `path` or `replacePrefix` in routes with sslPassthrough set to true")
@@ -591,7 +590,7 @@ func Test_Render_Fails_SSLPassthroughWithMultipleRoutes(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions("", testExternalIP, "", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.Error(t, err)
 	require.Equal(t, err.(*v1.ErrClientRP).Code, v1.CodeInvalid)
 	require.Equal(t, err.(*v1.ErrClientRP).Message, "cannot support multiple routes with sslPassthrough set to true")
@@ -626,7 +625,7 @@ func Test_Render_WithTimeoutPolicy(t *testing.T) {
 	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
 	expectedURL := "http://" + expectedHostname
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -685,7 +684,7 @@ func Test_Render_WithUnsetBackendRequestTimeoutPolicy(t *testing.T) {
 	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
 	expectedURL := "http://" + expectedHostname
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -743,7 +742,7 @@ func Test_Render_WithInvalidTimeoutPolicy(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions("", testExternalIP, "", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.Error(t, err)
 	require.Equal(t, err.(*v1.ErrClientRP).Code, v1.CodeInvalid)
 	require.Equal(t, err.(*v1.ErrClientRP).Message, "request timeout must be greater than or equal to backend request timeout")
@@ -764,7 +763,7 @@ func Test_Render_Fails_WithNoRoute(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions("", testExternalIP, "", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.Error(t, err)
 	require.Equal(t, err.(*v1.ErrClientRP).Code, v1.CodeInvalid)
 	require.Equal(t, err.(*v1.ErrClientRP).Message, "must have at least one route when declaring a Gateway resource")
@@ -789,7 +788,7 @@ func Test_Render_FQDNOverride(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions("", testExternalIP, "", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -818,7 +817,7 @@ func Test_Render_Fails_WithoutFQHostnameOrPrefix(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{}
 	environmentOptions := getEnvironmentOptions("", testExternalIP, "", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.Error(t, err)
 	require.Equal(t, "getting hostname failed with error: must provide either prefix or fullyQualifiedHostname if hostname is specified", err.Error())
 	require.Len(t, output.Resources, 0)
@@ -848,7 +847,7 @@ func Test_Render_Single_Route(t *testing.T) {
 	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
 	expectedURL := "http://" + expectedHostname
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -901,7 +900,7 @@ func TestRender_SingleRoute_EnableWebsockets(t *testing.T) {
 	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
 	expectedURL := "http://" + expectedHostname
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -955,7 +954,7 @@ func Test_Render_SSLPassthrough(t *testing.T) {
 	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
 	expectedURL := "https://" + expectedHostname
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -1029,7 +1028,7 @@ func Test_Render_Multiple_Routes(t *testing.T) {
 	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
 	expectedURL := "http://" + expectedHostname
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 3)
 	require.Empty(t, output.SecretValues)
@@ -1091,7 +1090,7 @@ func Test_Render_MultipleRoutes_OrderOutputResourcesDeploysRouteChildrenBeforeRo
 	resource := makeResource(properties)
 	environmentOptions := getEnvironmentOptions("", testExternalIP, "", false, false)
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Environment: environmentOptions})
 	require.NoError(t, err)
 
 	rootHTTPProxy, rootOutputResource := kubernetes.FindContourHTTPProxy(output.Resources)
@@ -1144,7 +1143,7 @@ func Test_Render_Route_WithPrefixRewrite(t *testing.T) {
 	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
 	expectedURL := "http://" + expectedHostname
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -1228,7 +1227,7 @@ func Test_Render_Route_WithMultiplePrefixRewrite(t *testing.T) {
 	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
 	expectedURL := "http://" + expectedHostname
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 3)
 	require.Empty(t, output.SecretValues)
@@ -1342,7 +1341,7 @@ func Test_Render_WithDependencies(t *testing.T) {
 	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
 	expectedURL := "https://" + expectedHostname
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -1397,7 +1396,7 @@ func Test_Render_WithEnvironment_KubernetesMetadata(t *testing.T) {
 	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
 	expectedURL := "http://" + expectedHostname
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -1450,7 +1449,7 @@ func Test_Render_WithEnvironmentApplication_KubernetesMetadata(t *testing.T) {
 	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
 	expectedURL := "http://" + expectedHostname
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions, Application: applicationOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions, Application: applicationOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -1507,7 +1506,7 @@ func Test_RenderDNS_WithEnvironmentApplication_KubernetesMetadata(t *testing.T) 
 	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
 	expectedURL := "http://" + expectedHostname
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions, Application: applicationOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions, Application: applicationOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -1560,7 +1559,7 @@ func Test_RenderDNS_WithEnvironment_KubernetesMetadata(t *testing.T) {
 	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
 	expectedURL := "http://" + expectedHostname
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)
@@ -1632,7 +1631,7 @@ func Test_Render_With_TLSTermination(t *testing.T) {
 		},
 	}
 
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	output, err := r.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 2)
 	require.Empty(t, output.SecretValues)

--- a/pkg/corerp/renderers/kubernetesmetadata/render_test.go
+++ b/pkg/corerp/renderers/kubernetesmetadata/render_test.go
@@ -128,7 +128,7 @@ func TestApplicationDataModelToVersioned(t *testing.T) {
 				}
 			}
 
-			output, err := renderer.Render(context.Background(), resource, options)
+			output, err := renderer.Render(t.Context(), resource, options)
 			require.NoError(t, err)
 			require.Len(t, output.Resources, 1)
 

--- a/pkg/corerp/renderers/manualscale/render_test.go
+++ b/pkg/corerp/renderers/manualscale/render_test.go
@@ -68,7 +68,7 @@ func Test_Render_Success(t *testing.T) {
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
 
-	output, err := renderer.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies})
+	output, err := renderer.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 1)
 
@@ -90,7 +90,7 @@ func Test_Render_CanSpecifyZero(t *testing.T) {
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
 
-	output, err := renderer.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies})
+	output, err := renderer.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 1)
 
@@ -115,7 +115,7 @@ func Test_Render_NoExtension(t *testing.T) {
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
 
-	output, err := renderer.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies})
+	output, err := renderer.Render(t.Context(), resource, renderers.RenderOptions{Dependencies: dependencies})
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 1)
 

--- a/pkg/corerp/renderers/volume/azure/keyvault_test.go
+++ b/pkg/corerp/renderers/volume/azure/keyvault_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package azure
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -193,7 +192,7 @@ func TestGetKeyVaultObjectsSpec(t *testing.T) {
 
 func TestKeyVaultRenderer_Render(t *testing.T) {
 	r := KeyVaultRenderer{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	vol := &datamodel.VolumeResource{}
 	err := json.Unmarshal(testutil.ReadFixture("volume-az-kv-systemassigned.json"), vol)

--- a/pkg/corerp/renderers/volume/render_test.go
+++ b/pkg/corerp/renderers/volume/render_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package volume
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/corerp/datamodel"
@@ -33,7 +32,7 @@ func TestRender_NotSupported(t *testing.T) {
 		},
 	}
 
-	_, err := r.Render(context.Background(), vol, renderers.RenderOptions{
+	_, err := r.Render(t.Context(), vol, renderers.RenderOptions{
 		Environment: renderers.EnvironmentOptions{
 			Namespace: "default",
 		},

--- a/pkg/crypto/encryption/keyprovider_test.go
+++ b/pkg/crypto/encryption/keyprovider_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package encryption
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"strconv"
@@ -52,7 +51,7 @@ func createTestKeyStore(t *testing.T, keys map[int][]byte, currentVersion int) [
 }
 
 func TestKubernetesKeyProvider_GetCurrentKey(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	validKey := make([]byte, KeySize)
 	for i := range validKey {
 		validKey[i] = byte(i)
@@ -255,7 +254,7 @@ func TestKubernetesKeyProvider_GetCurrentKey(t *testing.T) {
 }
 
 func TestKubernetesKeyProvider_GetKeyByVersion(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	key1 := make([]byte, KeySize)
 	key2 := make([]byte, KeySize)
 	for i := range key1 {
@@ -370,7 +369,7 @@ func TestNewKubernetesKeyProvider_DefaultOptions(t *testing.T) {
 }
 
 func TestInMemoryKeyProvider(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	validKey := make([]byte, KeySize)
 	for i := range validKey {
 		validKey[i] = byte(i)
@@ -429,7 +428,7 @@ func TestInMemoryKeyProvider(t *testing.T) {
 }
 
 func TestInMemoryKeyProviderWithVersions(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	key1 := make([]byte, KeySize)
 	key2 := make([]byte, KeySize)
 	for i := range key1 {
@@ -475,7 +474,7 @@ func TestInMemoryKeyProviderWithVersions(t *testing.T) {
 }
 
 func TestInMemoryKeyProvider_AddKeyAndSetVersion(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	key1 := make([]byte, KeySize)
 	key2 := make([]byte, KeySize)
 	for i := range key1 {
@@ -524,7 +523,7 @@ func TestInMemoryKeyProvider_AddKeyAndSetVersion(t *testing.T) {
 }
 
 func TestKeyProviderIntegration(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Generate keys
 	key1, err := GenerateKey()

--- a/pkg/crypto/encryption/sensitive_test.go
+++ b/pkg/crypto/encryption/sensitive_test.go
@@ -408,7 +408,7 @@ func TestSensitiveDataHandler_RoundTrip_ComplexStructure(t *testing.T) {
 }
 
 func TestSensitiveDataHandler_FromProvider(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	key, err := GenerateKey()
 	require.NoError(t, err)
@@ -769,7 +769,7 @@ func TestGetSchemaForPath(t *testing.T) {
 
 // Test versioned key rotation support
 func TestSensitiveDataHandler_VersionedKeyRotation(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Generate two different keys
 	key1, err := GenerateKey()
@@ -828,7 +828,7 @@ func TestSensitiveDataHandler_VersionedKeyRotation(t *testing.T) {
 }
 
 func TestSensitiveDataHandler_DecryptWithOldKeyVersion(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Generate keys
 	key1, err := GenerateKey()
@@ -885,7 +885,7 @@ func TestSensitiveDataHandler_DecryptWithOldKeyVersion(t *testing.T) {
 }
 
 func TestSensitiveDataHandler_DecryptWithMissingKeyVersion(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Generate keys
 	key1, err := GenerateKey()

--- a/pkg/crypto/encryption/sensitive_test.go
+++ b/pkg/crypto/encryption/sensitive_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package encryption
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/schema"
@@ -56,7 +55,7 @@ func TestSensitiveDataHandler_EncryptDecrypt_SimpleField(t *testing.T) {
 	require.Equal(t, "admin", data["username"])
 
 	// Decrypt
-	err = handler.DecryptSensitiveFields(context.Background(), data, []string{"password"}, testResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), data, []string{"password"}, testResourceID)
 	require.NoError(t, err)
 
 	// Verify password is decrypted
@@ -95,7 +94,7 @@ func TestSensitiveDataHandler_EncryptDecrypt_NestedField(t *testing.T) {
 	require.True(t, apiKeyIsEncrypted)
 
 	// Decrypt
-	err = handler.DecryptSensitiveFields(context.Background(), data, []string{"credentials.password", "credentials.apiKey"}, testResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), data, []string{"credentials.password", "credentials.apiKey"}, testResourceID)
 	require.NoError(t, err)
 
 	creds = data["credentials"].(map[string]any)
@@ -134,7 +133,7 @@ func TestSensitiveDataHandler_EncryptDecrypt_ArrayWildcard(t *testing.T) {
 	}
 
 	// Decrypt
-	err = handler.DecryptSensitiveFields(context.Background(), data, []string{"secrets[*].value"}, testResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), data, []string{"secrets[*].value"}, testResourceID)
 	require.NoError(t, err)
 
 	secrets = data["secrets"].([]any)
@@ -172,7 +171,7 @@ func TestSensitiveDataHandler_EncryptDecrypt_MapWildcard(t *testing.T) {
 	}
 
 	// Decrypt
-	err = handler.DecryptSensitiveFields(context.Background(), data, []string{"config[*]"}, testResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), data, []string{"config[*]"}, testResourceID)
 	require.NoError(t, err)
 
 	config = data["config"].(map[string]any)
@@ -212,7 +211,7 @@ func TestSensitiveDataHandler_EncryptDecrypt_ObjectValue(t *testing.T) {
 	require.NotEmpty(t, encData["nonce"])
 
 	// Decrypt
-	err = handler.DecryptSensitiveFields(context.Background(), data, []string{"sensitiveConfig"}, testResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), data, []string{"sensitiveConfig"}, testResourceID)
 	require.NoError(t, err)
 
 	// Verify decrypted object
@@ -240,7 +239,7 @@ func TestSensitiveDataHandler_FieldNotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	// Decrypting non-existent field should be skipped (no error)
-	err = handler.DecryptSensitiveFields(context.Background(), data, []string{"password"}, testResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), data, []string{"password"}, testResourceID)
 	require.NoError(t, err)
 }
 
@@ -280,7 +279,7 @@ func TestSensitiveDataHandler_OptionalSensitiveFields(t *testing.T) {
 	require.False(t, hasCredentials, "credentials should not be added")
 
 	// Decrypt should also succeed
-	err = handler.DecryptSensitiveFields(context.Background(), data, sensitivePaths, testResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), data, sensitivePaths, testResourceID)
 	require.NoError(t, err)
 
 	// Verify decryption worked for the present field
@@ -397,7 +396,7 @@ func TestSensitiveDataHandler_RoundTrip_ComplexStructure(t *testing.T) {
 	require.Equal(t, "visible", data["config"].(map[string]any)["public_setting"])
 
 	// Decrypt
-	err = handler.DecryptSensitiveFields(context.Background(), data, sensitivePaths, testResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), data, sensitivePaths, testResourceID)
 	require.NoError(t, err)
 
 	// Verify values are restored
@@ -466,7 +465,7 @@ func TestSensitiveDataHandler_SpecificIndex(t *testing.T) {
 	require.True(t, isEncrypted)
 
 	// Decrypt
-	err = handler.DecryptSensitiveFields(context.Background(), data, []string{"items[1].value"}, testResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), data, []string{"items[1].value"}, testResourceID)
 	require.NoError(t, err)
 
 	require.Equal(t, "secret", items[1].(map[string]any)["value"])
@@ -525,7 +524,7 @@ func TestSensitiveDataHandler_DecryptWithSchema_IntegerRestoration(t *testing.T)
 	require.True(t, isEncrypted)
 
 	// Decrypt WITH schema
-	err = handler.DecryptSensitiveFieldsWithSchema(context.Background(), data, sensitivePaths, testResourceID, schema)
+	err = handler.DecryptSensitiveFieldsWithSchema(t.Context(), data, sensitivePaths, testResourceID, schema)
 	require.NoError(t, err)
 
 	// Verify types are correctly restored
@@ -604,7 +603,7 @@ func TestSensitiveDataHandler_DecryptWithSchema_NestedObjects(t *testing.T) {
 	err = handler.EncryptSensitiveFields(data, sensitivePaths, testResourceID)
 	require.NoError(t, err)
 
-	err = handler.DecryptSensitiveFieldsWithSchema(context.Background(), data, sensitivePaths, testResourceID, schema)
+	err = handler.DecryptSensitiveFieldsWithSchema(t.Context(), data, sensitivePaths, testResourceID, schema)
 	require.NoError(t, err)
 
 	// Verify nested integers are restored
@@ -657,7 +656,7 @@ func TestSensitiveDataHandler_DecryptWithSchema_ArrayWithIntegers(t *testing.T) 
 	err = handler.EncryptSensitiveFields(data, sensitivePaths, testResourceID)
 	require.NoError(t, err)
 
-	err = handler.DecryptSensitiveFieldsWithSchema(context.Background(), data, sensitivePaths, testResourceID, schema)
+	err = handler.DecryptSensitiveFieldsWithSchema(t.Context(), data, sensitivePaths, testResourceID, schema)
 	require.NoError(t, err)
 
 	config := data["config"].(map[string]any)
@@ -690,7 +689,7 @@ func TestSensitiveDataHandler_DecryptWithoutSchema_NoTypeCoercion(t *testing.T) 
 	require.NoError(t, err)
 
 	// Decrypt WITHOUT schema
-	err = handler.DecryptSensitiveFields(context.Background(), data, sensitivePaths, testResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), data, sensitivePaths, testResourceID)
 	require.NoError(t, err)
 
 	config := data["sensitiveConfig"].(map[string]any)
@@ -940,7 +939,7 @@ func TestSensitiveDataHandler_DecryptWithADMismatch(t *testing.T) {
 
 	// Attempt to decrypt with a DIFFERENT resource ID — the AD hash will not match
 	// and ChaCha20-Poly1305 authentication will reject the ciphertext.
-	err = handler.DecryptSensitiveFields(context.Background(), data, []string{"secret"}, attackerResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), data, []string{"secret"}, attackerResourceID)
 	require.Error(t, err, "decryption must fail when resource ID does not match")
 	require.ErrorIs(t, err, ErrFieldDecryptionFailed)
 
@@ -983,7 +982,7 @@ func TestSensitiveDataHandler_FullDecryptRedactWorkflow(t *testing.T) {
 	recipeProperties := deepCopyMap(dbProperties)
 
 	// Step 3: Decrypt the recipe copy — in-memory only
-	err = handler.DecryptSensitiveFields(context.Background(), recipeProperties, sensitivePaths, testResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), recipeProperties, sensitivePaths, testResourceID)
 	require.NoError(t, err)
 
 	// Verify recipe properties have the decrypted plaintext values
@@ -1034,7 +1033,7 @@ func TestSensitiveDataHandler_DecryptNonEncryptedMap(t *testing.T) {
 	}
 
 	// Attempt to decrypt a map that was never encrypted — should pass through
-	err = handler.DecryptSensitiveFields(context.Background(), data, []string{"config"}, testResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), data, []string{"config"}, testResourceID)
 	require.NoError(t, err)
 
 	config := data["config"].(map[string]any)
@@ -1068,7 +1067,7 @@ func TestSensitiveDataHandler_EncryptDecrypt_BareIntegerField(t *testing.T) {
 	require.Equal(t, "test-resource", data["name"])
 
 	// Decrypt — without schema, JSON unmarshals integers as float64
-	err = handler.DecryptSensitiveFields(context.Background(), data, []string{"secretPort"}, testResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), data, []string{"secretPort"}, testResourceID)
 	require.NoError(t, err)
 
 	// Standard JSON behavior: integers become float64 without schema
@@ -1092,7 +1091,7 @@ func TestSensitiveDataHandler_EncryptDecrypt_BareBooleanField(t *testing.T) {
 	_, isEncrypted := data["secretFlag"].(map[string]any)
 	require.True(t, isEncrypted, "secretFlag should be encrypted")
 
-	err = handler.DecryptSensitiveFields(context.Background(), data, []string{"secretFlag"}, testResourceID)
+	err = handler.DecryptSensitiveFields(t.Context(), data, []string{"secretFlag"}, testResourceID)
 	require.NoError(t, err)
 
 	require.Equal(t, true, data["secretFlag"])

--- a/pkg/daprrp/processors/configurationstores/processor_test.go
+++ b/pkg/daprrp/processors/configurationstores/processor_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package configurationstores
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -86,7 +85,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -108,7 +107,7 @@ func Test_Process(t *testing.T) {
 		components.SetKind("Component")
 
 		// No components created for a recipe
-		err = processor.Client.List(context.Background(), &components,
+		err = processor.Client.List(t.Context(), &components,
 			&client.ListOptions{
 				Namespace: options.RuntimeConfiguration.Kubernetes.Namespace,
 			},
@@ -250,7 +249,7 @@ func Test_Process(t *testing.T) {
 						},
 					},
 				}
-				err := processor.Process(context.Background(), resource, options)
+				err := processor.Process(t.Context(), resource, options)
 				require.NoError(t, err)
 
 				require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -273,7 +272,7 @@ func Test_Process(t *testing.T) {
 				components := unstructured.UnstructuredList{}
 				components.SetAPIVersion("dapr.io/v1alpha1")
 				components.SetKind("Component")
-				err = processor.Client.List(context.Background(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
+				err = processor.Client.List(t.Context(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
 				require.NoError(t, err)
 				require.NotEmpty(t, components.Items)
 				require.Equal(t, []unstructured.Unstructured{*tc.generated}, components.Items)
@@ -320,7 +319,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -367,7 +366,7 @@ func Test_Process(t *testing.T) {
 		components := unstructured.UnstructuredList{}
 		components.SetAPIVersion("dapr.io/v1alpha1")
 		components.SetKind("Component")
-		err = processor.Client.List(context.Background(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
+		err = processor.Client.List(t.Context(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
 		require.NoError(t, err)
 		require.NotEmpty(t, components.Items)
 		require.Equal(t, []unstructured.Unstructured{*generated}, components.Items)
@@ -411,7 +410,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -437,7 +436,7 @@ func Test_Process(t *testing.T) {
 		components := unstructured.UnstructuredList{}
 		components.SetAPIVersion("dapr.io/v1alpha1")
 		components.SetKind("Component")
-		err = processor.Client.List(context.Background(), &components,
+		err = processor.Client.List(t.Context(), &components,
 			&client.ListOptions{
 				Namespace: options.RuntimeConfiguration.Kubernetes.Namespace,
 			},
@@ -498,7 +497,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err = processor.Process(context.Background(), resource, options)
+		err = processor.Process(t.Context(), resource, options)
 		require.Error(t, err)
 		assert.IsType(t, &processors.ValidationError{}, err)
 		assert.Equal(t, fmt.Sprintf("the Dapr component name '\"%s\"' is already in use by another resource. Dapr component and resource names must be unique across all Dapr types (e.g., StateStores, PubSubBrokers, SecretStores, ConfigurationStores, etc.). Please select a new name and try again.", componentName), err.Error())

--- a/pkg/daprrp/processors/pubsubbrokers/processor_test.go
+++ b/pkg/daprrp/processors/pubsubbrokers/processor_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pubsubbrokers
 
 import (
-	"context"
 	"testing"
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
@@ -85,7 +84,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -107,7 +106,7 @@ func Test_Process(t *testing.T) {
 		components.SetKind("Component")
 
 		// No components created for a recipe
-		err = processor.Client.List(context.Background(), &components,
+		err = processor.Client.List(t.Context(), &components,
 			&client.ListOptions{
 				Namespace: options.RuntimeConfiguration.Kubernetes.Namespace,
 			},
@@ -249,7 +248,7 @@ func Test_Process(t *testing.T) {
 						},
 					},
 				}
-				err := processor.Process(context.Background(), resource, options)
+				err := processor.Process(t.Context(), resource, options)
 				require.NoError(t, err)
 
 				require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -272,7 +271,7 @@ func Test_Process(t *testing.T) {
 				components := unstructured.UnstructuredList{}
 				components.SetAPIVersion("dapr.io/v1alpha1")
 				components.SetKind("Component")
-				err = processor.Client.List(context.Background(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
+				err = processor.Client.List(t.Context(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
 				require.NoError(t, err)
 				require.NotEmpty(t, components.Items)
 				require.Equal(t, []unstructured.Unstructured{*tc.generated}, components.Items)
@@ -319,7 +318,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -366,7 +365,7 @@ func Test_Process(t *testing.T) {
 		components := unstructured.UnstructuredList{}
 		components.SetAPIVersion("dapr.io/v1alpha1")
 		components.SetKind("Component")
-		err = processor.Client.List(context.Background(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
+		err = processor.Client.List(t.Context(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
 		require.NoError(t, err)
 		require.NotEmpty(t, components.Items)
 		require.Equal(t, []unstructured.Unstructured{*generated}, components.Items)
@@ -410,7 +409,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -436,7 +435,7 @@ func Test_Process(t *testing.T) {
 		components := unstructured.UnstructuredList{}
 		components.SetAPIVersion("dapr.io/v1alpha1")
 		components.SetKind("Component")
-		err = processor.Client.List(context.Background(), &components,
+		err = processor.Client.List(t.Context(), &components,
 			&client.ListOptions{
 				Namespace: options.RuntimeConfiguration.Kubernetes.Namespace,
 			},
@@ -496,7 +495,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err = processor.Process(context.Background(), resource, options)
+		err = processor.Process(t.Context(), resource, options)
 		require.Error(t, err)
 		assert.IsType(t, &processors.ValidationError{}, err)
 		assert.Equal(t, "the Dapr component name '\"test-dapr-pubsub-broker\"' is already in use by another resource. Dapr component and resource names must be unique across all Dapr types (e.g., StateStores, PubSubBrokers, SecretStores, ConfigurationStores, etc.). Please select a new name and try again.", err.Error())

--- a/pkg/daprrp/processors/secretstores/processor_test.go
+++ b/pkg/daprrp/processors/secretstores/processor_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package secretstores
 
 import (
-	"context"
 	"testing"
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
@@ -80,7 +79,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -102,7 +101,7 @@ func Test_Process(t *testing.T) {
 		components.SetKind("Component")
 
 		// No components created for a recipe
-		err = processor.Client.List(context.Background(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
+		err = processor.Client.List(t.Context(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
 		require.NoError(t, err)
 		require.Empty(t, components.Items)
 	})
@@ -144,7 +143,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -188,7 +187,7 @@ func Test_Process(t *testing.T) {
 		components := unstructured.UnstructuredList{}
 		components.SetAPIVersion("dapr.io/v1alpha1")
 		components.SetKind("Component")
-		err = processor.Client.List(context.Background(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
+		err = processor.Client.List(t.Context(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
 		require.NoError(t, err)
 		require.NotEmpty(t, components.Items)
 		require.Equal(t, []unstructured.Unstructured{*generated}, components.Items)
@@ -231,7 +230,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -275,7 +274,7 @@ func Test_Process(t *testing.T) {
 		components := unstructured.UnstructuredList{}
 		components.SetAPIVersion("dapr.io/v1alpha1")
 		components.SetKind("Component")
-		err = processor.Client.List(context.Background(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
+		err = processor.Client.List(t.Context(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
 		require.NoError(t, err)
 		require.NotEmpty(t, components.Items)
 		require.Equal(t, []unstructured.Unstructured{*generated}, components.Items)
@@ -317,7 +316,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -339,7 +338,7 @@ func Test_Process(t *testing.T) {
 		components := unstructured.UnstructuredList{}
 		components.SetAPIVersion("dapr.io/v1alpha1")
 		components.SetKind("Component")
-		err = processor.Client.List(context.Background(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
+		err = processor.Client.List(t.Context(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
 		require.NoError(t, err)
 		require.Empty(t, components.Items)
 	})
@@ -394,7 +393,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err = processor.Process(context.Background(), resource, options)
+		err = processor.Process(t.Context(), resource, options)
 		require.Error(t, err)
 		assert.IsType(t, &processors.ValidationError{}, err)
 		assert.Equal(t, "the Dapr component name '\"test-component\"' is already in use by another resource. Dapr component and resource names must be unique across all Dapr types (e.g., StateStores, PubSubBrokers, SecretStores, ConfigurationStores, etc.). Please select a new name and try again.", err.Error())

--- a/pkg/daprrp/processors/statestores/processor_test.go
+++ b/pkg/daprrp/processors/statestores/processor_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package statestores
 
 import (
-	"context"
 	"testing"
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
@@ -85,7 +84,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -107,7 +106,7 @@ func Test_Process(t *testing.T) {
 		components.SetKind("Component")
 
 		// No components created for a recipe
-		err = processor.Client.List(context.Background(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
+		err = processor.Client.List(t.Context(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
 		require.NoError(t, err)
 		require.Empty(t, components.Items)
 	})
@@ -243,7 +242,7 @@ func Test_Process(t *testing.T) {
 						},
 					},
 				}
-				err := processor.Process(context.Background(), resource, options)
+				err := processor.Process(t.Context(), resource, options)
 				require.NoError(t, err)
 
 				require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -267,7 +266,7 @@ func Test_Process(t *testing.T) {
 				components := unstructured.UnstructuredList{}
 				components.SetAPIVersion("dapr.io/v1alpha1")
 				components.SetKind("Component")
-				err = processor.Client.List(context.Background(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
+				err = processor.Client.List(t.Context(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
 				require.NoError(t, err)
 				require.NotEmpty(t, components.Items)
 				require.Equal(t, []unstructured.Unstructured{*tc.generated}, components.Items)
@@ -313,7 +312,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -360,7 +359,7 @@ func Test_Process(t *testing.T) {
 		components := unstructured.UnstructuredList{}
 		components.SetAPIVersion("dapr.io/v1alpha1")
 		components.SetKind("Component")
-		err = processor.Client.List(context.Background(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
+		err = processor.Client.List(t.Context(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
 		require.NoError(t, err)
 		require.NotEmpty(t, components.Items)
 		require.Equal(t, []unstructured.Unstructured{*generated}, components.Items)
@@ -403,7 +402,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, componentName, resource.Properties.ComponentName)
@@ -430,7 +429,7 @@ func Test_Process(t *testing.T) {
 		components := unstructured.UnstructuredList{}
 		components.SetAPIVersion("dapr.io/v1alpha1")
 		components.SetKind("Component")
-		err = processor.Client.List(context.Background(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
+		err = processor.Client.List(t.Context(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
 		require.NoError(t, err)
 		require.Empty(t, components.Items)
 	})
@@ -486,7 +485,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err = processor.Process(context.Background(), resource, options)
+		err = processor.Process(t.Context(), resource, options)
 		require.Error(t, err)
 		assert.IsType(t, &processors.ValidationError{}, err)
 		assert.Equal(t, "the Dapr component name '\"test-component\"' is already in use by another resource. Dapr component and resource names must be unique across all Dapr types (e.g., StateStores, PubSubBrokers, SecretStores, ConfigurationStores, etc.). Please select a new name and try again.", err.Error())

--- a/pkg/datastoresrp/frontend/controller/mongodatabases/listsecretsmongodatabase_test.go
+++ b/pkg/datastoresrp/frontend/controller/mongodatabases/listsecretsmongodatabase_test.go
@@ -40,7 +40,7 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 	defer mctrl.Finish()
 
 	databaseClient := database.NewMockClient(mctrl)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, mongoDataModel, _ := getTestModels20231001preview()
 

--- a/pkg/datastoresrp/frontend/controller/rediscaches/listsecretsrediscache_test.go
+++ b/pkg/datastoresrp/frontend/controller/rediscaches/listsecretsrediscache_test.go
@@ -40,7 +40,7 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 	defer mctrl.Finish()
 
 	databaseClient := database.NewMockClient(mctrl)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, redisDataModel, _ := getTestModels20231001preview()
 

--- a/pkg/datastoresrp/frontend/controller/sqldatabases/listsecretssqldatabase_test.go
+++ b/pkg/datastoresrp/frontend/controller/sqldatabases/listsecretssqldatabase_test.go
@@ -44,7 +44,7 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 	defer mctrl.Finish()
 
 	databaseClient := database.NewMockClient(mctrl)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, sqlDataModel, _ := getTestModels20231001preview()
 

--- a/pkg/datastoresrp/processors/mongodatabases/processor_test.go
+++ b/pkg/datastoresrp/processors/mongodatabases/processor_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package mongodatabases
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/datastoresrp/datamodel"
@@ -60,7 +59,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, host, resource.Properties.Host)
@@ -107,7 +106,7 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
-		err := processor.Process(context.Background(), resource, processors.Options{})
+		err := processor.Process(t.Context(), resource, processors.Options{})
 		require.NoError(t, err)
 
 		require.Equal(t, host, resource.Properties.Host)
@@ -177,7 +176,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, host, resource.Properties.Host)
@@ -225,7 +224,7 @@ func Test_Process(t *testing.T) {
 		resource := &datamodel.MongoDatabase{}
 		options := processors.Options{RecipeOutput: &recipes.RecipeOutput{}}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.Error(t, err)
 		require.IsType(t, &processors.ValidationError{}, err)
 		require.Equal(t, `validation returned multiple errors:

--- a/pkg/datastoresrp/processors/rediscaches/processor_test.go
+++ b/pkg/datastoresrp/processors/rediscaches/processor_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rediscaches
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/datastoresrp/datamodel"
@@ -61,7 +60,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, host, resource.Properties.Host)
@@ -113,7 +112,7 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
-		err := processor.Process(context.Background(), resource, processors.Options{})
+		err := processor.Process(t.Context(), resource, processors.Options{})
 		require.NoError(t, err)
 
 		require.Equal(t, host, resource.Properties.Host)
@@ -187,7 +186,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, host, resource.Properties.Host)
@@ -238,7 +237,7 @@ func Test_Process(t *testing.T) {
 		resource := &datamodel.RedisCache{}
 		options := processors.Options{RecipeOutput: &recipes.RecipeOutput{}}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.Error(t, err)
 		require.IsType(t, &processors.ValidationError{}, err)
 		require.Equal(t, `validation returned multiple errors:

--- a/pkg/datastoresrp/processors/sqldatabases/processor_test.go
+++ b/pkg/datastoresrp/processors/sqldatabases/processor_test.go
@@ -6,7 +6,6 @@
 package sqldatabases
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/datastoresrp/datamodel"
@@ -47,7 +46,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, database, resource.Properties.Database)
@@ -94,7 +93,7 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
-		err := processor.Process(context.Background(), resource, processors.Options{})
+		err := processor.Process(t.Context(), resource, processors.Options{})
 		require.NoError(t, err)
 
 		require.Equal(t, database, resource.Properties.Database)
@@ -164,7 +163,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, database, resource.Properties.Database)
@@ -211,7 +210,7 @@ func Test_Process(t *testing.T) {
 		resource := &datamodel.SqlDatabase{}
 		options := processors.Options{RecipeOutput: &recipes.RecipeOutput{}}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.Error(t, err)
 		require.IsType(t, &processors.ValidationError{}, err)
 		require.Equal(t, `validation returned multiple errors:

--- a/pkg/dynamicrp/backend/controller/dynamicresource_test.go
+++ b/pkg/dynamicrp/backend/controller/dynamicresource_test.go
@@ -59,7 +59,7 @@ func Test_DynamicResourceController_selectController(t *testing.T) {
 			OperationType: v1.OperationType{Type: inertResourceType, Method: v1.OperationPut}.String(),
 		}
 
-		selected, err := controller.selectController(context.Background(), request)
+		selected, err := controller.selectController(t.Context(), request)
 		require.NoError(t, err)
 
 		require.IsType(t, &InertPutController{}, selected)
@@ -72,7 +72,7 @@ func Test_DynamicResourceController_selectController(t *testing.T) {
 			OperationType: v1.OperationType{Type: inertResourceType, Method: v1.OperationDelete}.String(),
 		}
 
-		selected, err := controller.selectController(context.Background(), request)
+		selected, err := controller.selectController(t.Context(), request)
 		require.NoError(t, err)
 
 		require.IsType(t, &InertDeleteController{}, selected)
@@ -85,7 +85,7 @@ func Test_DynamicResourceController_selectController(t *testing.T) {
 			OperationType: v1.OperationType{Type: recipeResourceType, Method: v1.OperationPut}.String(),
 		}
 
-		selected, err := controller.selectController(context.Background(), request)
+		selected, err := controller.selectController(t.Context(), request)
 		require.NoError(t, err)
 
 		require.IsType(t, &RecipePutController{}, selected)
@@ -98,7 +98,7 @@ func Test_DynamicResourceController_selectController(t *testing.T) {
 			OperationType: v1.OperationType{Type: recipeResourceType, Method: v1.OperationDelete}.String(),
 		}
 
-		selected, err := controller.selectController(context.Background(), request)
+		selected, err := controller.selectController(t.Context(), request)
 		require.NoError(t, err)
 
 		require.IsType(t, &RecipeDeleteController{}, selected)
@@ -111,7 +111,7 @@ func Test_DynamicResourceController_selectController(t *testing.T) {
 			OperationType: v1.OperationType{Type: inertResourceType, Method: v1.OperationGet}.String(),
 		}
 
-		selected, err := controller.selectController(context.Background(), request)
+		selected, err := controller.selectController(t.Context(), request)
 		require.Error(t, err)
 		require.Equal(t, "unsupported operation type: \"APPLICATIONS.TEST/TESTINERTRESOURCES|GET\"", err.Error())
 		require.Nil(t, selected)
@@ -251,7 +251,7 @@ func Test_DynamicResourceController_fetchResourceTypeDetails(t *testing.T) {
 			id, err := resources.ParseResource(tt.resourceID)
 			require.NoError(t, err)
 
-			resourceType, err := controller.fetchResourceTypeDetails(context.Background(), id)
+			resourceType, err := controller.fetchResourceTypeDetails(t.Context(), id)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errMessage)
@@ -284,7 +284,7 @@ func TestDynamicResourceController_validateRequestSchema(t *testing.T) {
 			OperationType: v1.OperationType{Type: inertResourceType, Method: v1.OperationDelete}.String(),
 		}
 
-		err := controller.validateRequestSchema(context.Background(), request)
+		err := controller.validateRequestSchema(t.Context(), request)
 		require.NoError(t, err) // Should skip validation for DELETE
 	})
 
@@ -295,7 +295,7 @@ func TestDynamicResourceController_validateRequestSchema(t *testing.T) {
 			OperationType: v1.OperationType{Type: inertResourceType, Method: v1.OperationPut}.String(),
 		}
 
-		err := controller.validateRequestSchema(context.Background(), request)
+		err := controller.validateRequestSchema(t.Context(), request)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid resource ID")
 	})

--- a/pkg/dynamicrp/backend/processor/dynamicresource_test.go
+++ b/pkg/dynamicrp/backend/processor/dynamicresource_test.go
@@ -650,7 +650,7 @@ func TestGetSchemaForResourceType(t *testing.T) {
 		clientFactory, err := testUCPClientFactory()
 		require.NoError(t, err)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		resourceType := "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/containers/test-resource"
 		apiVersion := "2023-10-01-preview"
 
@@ -670,7 +670,7 @@ func TestGetSchemaForResourceType(t *testing.T) {
 		clientFactory, err := testUCPClientFactory()
 		require.NoError(t, err)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		resourceType := "invalid-resource-type-format"
 		apiVersion := "2023-10-01-preview"
 
@@ -698,7 +698,7 @@ func TestGetSchemaForResourceType(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		resourceType := "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/containers/test-resource"
 		apiVersion := "nonexistent-version"
 
@@ -733,7 +733,7 @@ func TestGetSchemaForResourceType(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		resourceType := "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/containers/test-resource"
 		apiVersion := "2023-10-01-preview"
 
@@ -747,7 +747,7 @@ func TestGetSchemaForResourceType(t *testing.T) {
 		clientFactory, err := testUCPClientFactory()
 		require.NoError(t, err)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		testCases := []struct {
 			name         string

--- a/pkg/dynamicrp/backend/processor/dynamicresource_test.go
+++ b/pkg/dynamicrp/backend/processor/dynamicresource_test.go
@@ -81,7 +81,7 @@ func Test_Process(t *testing.T) {
 			UcpClient: clientFactory,
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		bs, err := json.Marshal(resource.Properties)
@@ -158,7 +158,7 @@ func Test_Process(t *testing.T) {
 			UcpClient: clientFactory,
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		bs, err := json.Marshal(resource.Properties)
@@ -194,7 +194,7 @@ func Test_Process(t *testing.T) {
 			UcpClient: clientFactory,
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "is not a valid resource id")
 	})
@@ -230,7 +230,7 @@ func Test_Process(t *testing.T) {
 			UcpClient: cf,
 		}
 
-		require.NoError(t, p.Process(context.Background(), resource, options))
+		require.NoError(t, p.Process(t.Context(), resource, options))
 
 		// The managed secret is created with the declared secret data and the owner's environment/application.
 		require.True(t, mat.called)
@@ -290,7 +290,7 @@ func Test_Process(t *testing.T) {
 			UcpClient: cf,
 		}
 
-		require.NoError(t, p.Process(context.Background(), resource, options))
+		require.NoError(t, p.Process(t.Context(), resource, options))
 
 		// Both the declared and the undeclared recipe secret outputs are materialized: the schema's declared
 		// keys document the expected surface but do not filter what is routed to the managed secret, so a
@@ -335,7 +335,7 @@ func Test_Process(t *testing.T) {
 			UcpClient: cf,
 		}
 
-		require.NoError(t, p.Process(context.Background(), resource, options))
+		require.NoError(t, p.Process(t.Context(), resource, options))
 
 		// The declared secret values are stringified and routed to the managed secret, not the owner.
 		require.Equal(t, map[string]string{"port": "1234", "enabled": "true"}, mat.request.Data)
@@ -374,7 +374,7 @@ func Test_Process(t *testing.T) {
 			UcpClient: cf,
 		}
 
-		require.NoError(t, p.Process(context.Background(), resource, options))
+		require.NoError(t, p.Process(t.Context(), resource, options))
 
 		// With only a nil secret value, there is no secret data to materialize.
 		require.False(t, mat.called, "materializer should not be called when there is no secret data")
@@ -412,7 +412,7 @@ func Test_Process(t *testing.T) {
 			UcpClient: cf,
 		}
 
-		require.NoError(t, p.Process(context.Background(), resource, options))
+		require.NoError(t, p.Process(t.Context(), resource, options))
 
 		// The now-stale managed secret is cascade-deleted and the dangling reference is cleared.
 		require.Equal(t, []string{resourceID}, mat.deleted, "the stale managed secret should be deleted")
@@ -451,7 +451,7 @@ func Test_Process(t *testing.T) {
 			UcpClient: cf,
 		}
 
-		require.NoError(t, p.Process(context.Background(), resource, options))
+		require.NoError(t, p.Process(t.Context(), resource, options))
 
 		// Cleanup keys off the owner's reference, not the schema, so the orphan is still reclaimed.
 		require.Equal(t, []string{resourceID}, mat.deleted, "the stale managed secret should be deleted")
@@ -491,7 +491,7 @@ func Test_Process(t *testing.T) {
 			UcpClient: cf,
 		}
 
-		require.NoError(t, p.Process(context.Background(), resource, options))
+		require.NoError(t, p.Process(t.Context(), resource, options))
 
 		// The new secret is dropped (no block), and the prior managed secret is reclaimed rather than
 		// orphaned — even though this update produced secret outputs.
@@ -532,7 +532,7 @@ func Test_Process(t *testing.T) {
 			UcpClient: cf,
 		}
 
-		err = p.Process(context.Background(), resource, options)
+		err = p.Process(t.Context(), resource, options)
 		require.Error(t, err, "a malformed secrets block should fail processing")
 		require.Contains(t, err.Error(), "must be an object")
 		require.False(t, mat.called, "no secret should be materialized for an invalid schema")

--- a/pkg/dynamicrp/backend/secret/materializer_test.go
+++ b/pkg/dynamicrp/backend/secret/materializer_test.go
@@ -97,7 +97,7 @@ func Test_Materialize(t *testing.T) {
 
 	m := NewMaterializer(&arm.ClientOptions{ClientOptions: policy.ClientOptions{Transport: transport}})
 
-	result, err := m.Materialize(context.Background(), Request{
+	result, err := m.Materialize(t.Context(), Request{
 		OwnerResourceID: testOwnerID,
 		EnvironmentID:   "/planes/radius/local/resourceGroups/test-group/providers/Radius.Core/environments/env",
 		ApplicationID:   "/planes/radius/local/resourceGroups/test-group/providers/Radius.Core/applications/app",
@@ -138,7 +138,7 @@ func Test_Materialize_OmitsEmptyApplication(t *testing.T) {
 
 	m := NewMaterializer(&arm.ClientOptions{ClientOptions: policy.ClientOptions{Transport: transport}})
 
-	_, err := m.Materialize(context.Background(), Request{
+	_, err := m.Materialize(t.Context(), Request{
 		OwnerResourceID: testOwnerID,
 		EnvironmentID:   "env",
 		Data:            map[string]string{"connectionString": "abc"},
@@ -151,7 +151,7 @@ func Test_Materialize_OmitsEmptyApplication(t *testing.T) {
 
 func Test_Materialize_InvalidOwnerID(t *testing.T) {
 	m := NewMaterializer(&arm.ClientOptions{})
-	_, err := m.Materialize(context.Background(), Request{OwnerResourceID: "not-an-id", Data: map[string]string{"k": "v"}})
+	_, err := m.Materialize(t.Context(), Request{OwnerResourceID: "not-an-id", Data: map[string]string{"k": "v"}})
 	require.Error(t, err)
 }
 
@@ -194,7 +194,7 @@ func Test_Delete(t *testing.T) {
 
 	m := NewMaterializer(&arm.ClientOptions{ClientOptions: policy.ClientOptions{Transport: transport}})
 
-	require.NoError(t, m.Delete(context.Background(), testOwnerID))
+	require.NoError(t, m.Delete(t.Context(), testOwnerID))
 	ownerID, err := resources.ParseResource(testOwnerID)
 	require.NoError(t, err)
 	require.Equal(t, ManagedSecretName(ownerID), capturedName)
@@ -212,5 +212,5 @@ func Test_Delete_NotFoundIsIgnored(t *testing.T) {
 
 	m := NewMaterializer(&arm.ClientOptions{ClientOptions: policy.ClientOptions{Transport: transport}})
 
-	require.NoError(t, m.Delete(context.Background(), testOwnerID))
+	require.NoError(t, m.Delete(t.Context(), testOwnerID))
 }

--- a/pkg/dynamicrp/frontend/defaultsfilter_test.go
+++ b/pkg/dynamicrp/frontend/defaultsfilter_test.go
@@ -33,7 +33,7 @@ func TestMakeDefaultsFilter_SchemaFetchError(t *testing.T) {
 		Properties: map[string]any{"size": "L"},
 	}
 
-	response, err := makeDefaultsFilter(ucpClient)(createTestContext(), resource, nil, nil)
+	response, err := makeDefaultsFilter(ucpClient)(createTestContext(t), resource, nil, nil)
 	require.NoError(t, err)
 
 	errorResponse, ok := response.(*rest.InternalServerErrorResponse)
@@ -54,7 +54,7 @@ func TestMakeDefaultsFilter_NilProperties(t *testing.T) {
 		require.NoError(t, err)
 
 		resource := &datamodel.DynamicResource{}
-		response, err := makeDefaultsFilter(ucpClient)(createTestContext(), resource, nil, nil)
+		response, err := makeDefaultsFilter(ucpClient)(createTestContext(t), resource, nil, nil)
 		require.NoError(t, err)
 		require.Nil(t, response)
 		require.Equal(t, map[string]any{"size": "S"}, resource.Properties)
@@ -70,7 +70,7 @@ func TestMakeDefaultsFilter_NilProperties(t *testing.T) {
 		require.NoError(t, err)
 
 		resource := &datamodel.DynamicResource{}
-		response, err := makeDefaultsFilter(ucpClient)(createTestContext(), resource, nil, nil)
+		response, err := makeDefaultsFilter(ucpClient)(createTestContext(t), resource, nil, nil)
 		require.NoError(t, err)
 		require.Nil(t, response)
 		require.Nil(t, resource.Properties)
@@ -96,7 +96,7 @@ func TestMakeUpdateFilters_DefaultsBeforeEncryption(t *testing.T) {
 		makeEncryptionFilter(ucpClient, createTestHandler(t)),
 	)
 	for _, filter := range filters {
-		response, err := filter(createTestContext(), resource, nil, nil)
+		response, err := filter(createTestContext(t), resource, nil, nil)
 		require.NoError(t, err)
 		require.Nil(t, response)
 	}

--- a/pkg/dynamicrp/frontend/encryptionfilter_test.go
+++ b/pkg/dynamicrp/frontend/encryptionfilter_test.go
@@ -195,7 +195,7 @@ func TestMakeEncryptionFilter_NestedSensitiveFields(t *testing.T) {
 // Helper functions
 
 func createTestContext() context.Context {
-	ctx := context.Background()
+	ctx := t.Context()
 	// Add ARM request context
 	armCtx := &v1.ARMRequestContext{
 		ResourceID: mustParseResourceID(testResourceID),

--- a/pkg/dynamicrp/frontend/encryptionfilter_test.go
+++ b/pkg/dynamicrp/frontend/encryptionfilter_test.go
@@ -43,7 +43,7 @@ func TestMakeEncryptionFilter_NilHandler(t *testing.T) {
 	// When handler is nil, filter should return an error response
 	filter := makeEncryptionFilter(nil, nil)
 
-	ctx := createTestContext()
+	ctx := createTestContext(t)
 	resource := &datamodel.DynamicResource{
 		Properties: map[string]any{
 			"password": "secret123",
@@ -66,7 +66,7 @@ func TestMakeEncryptionFilter_NoSensitiveFields(t *testing.T) {
 	handler := createTestHandler(t)
 	filter := makeEncryptionFilter(ucpClient, handler)
 
-	ctx := createTestContext()
+	ctx := createTestContext(t)
 	resource := &datamodel.DynamicResource{
 		Properties: map[string]any{
 			"name":  "test",
@@ -91,7 +91,7 @@ func TestMakeEncryptionFilter_WithSensitiveFields(t *testing.T) {
 	handler := createTestHandler(t)
 	filter := makeEncryptionFilter(ucpClient, handler)
 
-	ctx := createTestContext()
+	ctx := createTestContext(t)
 	resource := &datamodel.DynamicResource{
 		Properties: map[string]any{
 			"name":     "test",
@@ -122,7 +122,7 @@ func TestMakeEncryptionFilter_NilProperties(t *testing.T) {
 	handler := createTestHandler(t)
 	filter := makeEncryptionFilter(ucpClient, handler)
 
-	ctx := createTestContext()
+	ctx := createTestContext(t)
 	resource := &datamodel.DynamicResource{
 		Properties: nil,
 	}
@@ -140,7 +140,7 @@ func TestMakeEncryptionFilter_SchemaFetchError(t *testing.T) {
 	handler := createTestHandler(t)
 	filter := makeEncryptionFilter(ucpClient, handler)
 
-	ctx := createTestContext()
+	ctx := createTestContext(t)
 	resource := &datamodel.DynamicResource{
 		Properties: map[string]any{
 			"password": "secret123",
@@ -163,7 +163,7 @@ func TestMakeEncryptionFilter_NestedSensitiveFields(t *testing.T) {
 	handler := createTestHandler(t)
 	filter := makeEncryptionFilter(ucpClient, handler)
 
-	ctx := createTestContext()
+	ctx := createTestContext(t)
 	resource := &datamodel.DynamicResource{
 		Properties: map[string]any{
 			"name": "test",
@@ -194,7 +194,7 @@ func TestMakeEncryptionFilter_NestedSensitiveFields(t *testing.T) {
 
 // Helper functions
 
-func createTestContext() context.Context {
+func createTestContext(t *testing.T) context.Context {
 	ctx := t.Context()
 	// Add ARM request context
 	armCtx := &v1.ARMRequestContext{
@@ -219,7 +219,7 @@ func createTestHandler(t *testing.T) *encryption.SensitiveDataHandler {
 	provider, err := encryption.NewInMemoryKeyProvider(key)
 	require.NoError(t, err)
 
-	handler, err := encryption.NewSensitiveDataHandlerFromProvider(context.Background(), provider)
+	handler, err := encryption.NewSensitiveDataHandlerFromProvider(t.Context(), provider)
 	require.NoError(t, err)
 
 	return handler

--- a/pkg/dynamicrp/integrationtest/dynamic/resource_test.go
+++ b/pkg/dynamicrp/integrationtest/dynamic/resource_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package dynamic
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -360,7 +359,7 @@ func Test_Dynamic_Resource_Recipe_Lifecycle(t *testing.T) {
 }
 
 func createRadiusPlane(server *ucptesthost.TestHost) v20231001preview.RadiusPlanesClientCreateOrUpdateResponse {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	plane := v20231001preview.RadiusPlaneResource{
 		Location: to.Ptr(v1.LocationGlobal),
@@ -383,7 +382,7 @@ func createRadiusPlane(server *ucptesthost.TestHost) v20231001preview.RadiusPlan
 }
 
 func createResourceProvider(server *ucptesthost.TestHost) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	resourceProvider := v20231001preview.ResourceProviderResource{
 		Location:   to.Ptr(v1.LocationGlobal),
@@ -399,7 +398,7 @@ func createResourceProvider(server *ucptesthost.TestHost) {
 }
 
 func createInertResourceType(server *ucptesthost.TestHost) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	resourceType := v20231001preview.ResourceTypeResource{
 		Properties: &v20231001preview.ResourceTypeProperties{
@@ -418,7 +417,7 @@ func createInertResourceType(server *ucptesthost.TestHost) {
 }
 
 func createRecipeResourceType(server *ucptesthost.TestHost) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	resourceType := v20231001preview.ResourceTypeResource{
 		Properties: &v20231001preview.ResourceTypeProperties{},
@@ -433,7 +432,7 @@ func createRecipeResourceType(server *ucptesthost.TestHost) {
 }
 
 func createAPIVersion(server *ucptesthost.TestHost, resourceType string, schema map[string]any) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	apiVersionResource := v20231001preview.APIVersionResource{
 		Properties: &v20231001preview.APIVersionProperties{
@@ -450,7 +449,7 @@ func createAPIVersion(server *ucptesthost.TestHost, resourceType string, schema 
 }
 
 func createLocation(server *ucptesthost.TestHost, resourceType string) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	location := v20231001preview.LocationResource{
 		Properties: &v20231001preview.LocationProperties{
@@ -473,7 +472,7 @@ func createLocation(server *ucptesthost.TestHost, resourceType string) {
 }
 
 func createResourceGroup(server *ucptesthost.TestHost) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	resourceGroup := v20231001preview.ResourceGroupResource{
 		Location:   to.Ptr(v1.LocationGlobal),

--- a/pkg/dynamicrp/integrationtest/dynamic/resource_test.go
+++ b/pkg/dynamicrp/integrationtest/dynamic/resource_test.go
@@ -359,7 +359,7 @@ func Test_Dynamic_Resource_Recipe_Lifecycle(t *testing.T) {
 }
 
 func createRadiusPlane(server *ucptesthost.TestHost) v20231001preview.RadiusPlanesClientCreateOrUpdateResponse {
-	ctx := t.Context()
+	ctx := server.T().Context()
 
 	plane := v20231001preview.RadiusPlaneResource{
 		Location: to.Ptr(v1.LocationGlobal),
@@ -382,7 +382,7 @@ func createRadiusPlane(server *ucptesthost.TestHost) v20231001preview.RadiusPlan
 }
 
 func createResourceProvider(server *ucptesthost.TestHost) {
-	ctx := t.Context()
+	ctx := server.T().Context()
 
 	resourceProvider := v20231001preview.ResourceProviderResource{
 		Location:   to.Ptr(v1.LocationGlobal),
@@ -398,7 +398,7 @@ func createResourceProvider(server *ucptesthost.TestHost) {
 }
 
 func createInertResourceType(server *ucptesthost.TestHost) {
-	ctx := t.Context()
+	ctx := server.T().Context()
 
 	resourceType := v20231001preview.ResourceTypeResource{
 		Properties: &v20231001preview.ResourceTypeProperties{
@@ -417,7 +417,7 @@ func createInertResourceType(server *ucptesthost.TestHost) {
 }
 
 func createRecipeResourceType(server *ucptesthost.TestHost) {
-	ctx := t.Context()
+	ctx := server.T().Context()
 
 	resourceType := v20231001preview.ResourceTypeResource{
 		Properties: &v20231001preview.ResourceTypeProperties{},
@@ -432,7 +432,7 @@ func createRecipeResourceType(server *ucptesthost.TestHost) {
 }
 
 func createAPIVersion(server *ucptesthost.TestHost, resourceType string, schema map[string]any) {
-	ctx := t.Context()
+	ctx := server.T().Context()
 
 	apiVersionResource := v20231001preview.APIVersionResource{
 		Properties: &v20231001preview.APIVersionProperties{
@@ -449,7 +449,7 @@ func createAPIVersion(server *ucptesthost.TestHost, resourceType string, schema 
 }
 
 func createLocation(server *ucptesthost.TestHost, resourceType string) {
-	ctx := t.Context()
+	ctx := server.T().Context()
 
 	location := v20231001preview.LocationResource{
 		Properties: &v20231001preview.LocationProperties{
@@ -472,7 +472,7 @@ func createLocation(server *ucptesthost.TestHost, resourceType string) {
 }
 
 func createResourceGroup(server *ucptesthost.TestHost) {
-	ctx := t.Context()
+	ctx := server.T().Context()
 
 	resourceGroup := v20231001preview.ResourceGroupResource{
 		Location:   to.Ptr(v1.LocationGlobal),

--- a/pkg/dynamicrp/testhost/host.go
+++ b/pkg/dynamicrp/testhost/host.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testhost
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -101,7 +100,7 @@ func Start(t *testing.T, opts ...TestHostOption) (*TestHost, *ucptesthost.TestHo
 		},
 	}
 
-	options, err := dynamicrp.NewOptions(context.Background(), config)
+	options, err := dynamicrp.NewOptions(t.Context(), config)
 	require.NoError(t, err)
 
 	// Set up a fake Kubernetes client with an encryption key secret for testing

--- a/pkg/graph/persistence/git/git_store_test.go
+++ b/pkg/graph/persistence/git/git_store_test.go
@@ -115,7 +115,7 @@ func TestStore_SaveLoadDeleteRoundTrip(t *testing.T) {
 	repoDir := initTestRepo(t)
 	chdir(t, repoDir)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	s, err := NewStore(Options{Branch: "store-" + t.Name()})
 	require.NoError(t, err)
 
@@ -151,7 +151,7 @@ func TestStore_LoadMissingKeyReturnsErrNotFound(t *testing.T) {
 	repoDir := initTestRepo(t)
 	chdir(t, repoDir)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	s, err := NewStore(Options{Branch: "store-" + t.Name()})
 	require.NoError(t, err)
 
@@ -176,7 +176,7 @@ func TestStore_List(t *testing.T) {
 	repoDir := initTestRepo(t)
 	chdir(t, repoDir)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	s, err := NewStore(Options{Branch: "store-" + t.Name()})
 	require.NoError(t, err)
 

--- a/pkg/graph/persistence/git/git_store_test.go
+++ b/pkg/graph/persistence/git/git_store_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package git
 
 import (
-	"context"
 	"errors"
 	"sort"
 	"testing"
@@ -107,7 +106,7 @@ func TestSave_RejectsNilPayload(t *testing.T) {
 	s, err := NewStore(Options{Branch: "store-" + t.Name()})
 	require.NoError(t, err)
 
-	err = s.Save(context.Background(), persistence.Key{Namespace: "ns", Name: "n"}, nil, persistence.SaveOptions{})
+	err = s.Save(t.Context(), persistence.Key{Namespace: "ns", Name: "n"}, nil, persistence.SaveOptions{})
 	require.Error(t, err)
 }
 
@@ -167,7 +166,7 @@ func TestStore_DeleteMissingKeyReturnsErrNotFound(t *testing.T) {
 	s, err := NewStore(Options{Branch: "store-" + t.Name()})
 	require.NoError(t, err)
 
-	err = s.Delete(context.Background(), persistence.Key{Namespace: "ns", Name: "missing"})
+	err = s.Delete(t.Context(), persistence.Key{Namespace: "ns", Name: "missing"})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, persistence.ErrNotFound))
 }
@@ -213,7 +212,7 @@ func TestStore_ListMissingNamespaceReturnsEmpty(t *testing.T) {
 	s, err := NewStore(Options{Branch: "store-" + t.Name()})
 	require.NoError(t, err)
 
-	got, err := s.List(context.Background(), "does-not-exist")
+	got, err := s.List(t.Context(), "does-not-exist")
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -238,7 +237,7 @@ func TestStore_ListRejectsInvalidNamespace(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := s.List(context.Background(), tc.namespace)
+			got, err := s.List(t.Context(), tc.namespace)
 			require.Error(t, err)
 			assert.Nil(t, got)
 		})

--- a/pkg/kubeutil/namespace_test.go
+++ b/pkg/kubeutil/namespace_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubeutil
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/test/k8sutil"
@@ -30,14 +29,14 @@ import (
 func Test_PatchNamespace(t *testing.T) {
 	client := k8sutil.NewFakeKubeClient(scheme.Scheme)
 
-	err := PatchNamespace(context.Background(), client, "test")
+	err := PatchNamespace(t.Context(), client, "test")
 	require.NoError(t, err)
 
 	ns := &unstructured.Unstructured{}
 	ns.SetAPIVersion("v1")
 	ns.SetKind("Namespace")
 
-	err = client.Get(context.Background(), runtime_client.ObjectKey{Name: "test"}, ns)
+	err = client.Get(t.Context(), runtime_client.ObjectKey{Name: "test"}, ns)
 	require.NoError(t, err)
 
 	expected := &unstructured.Unstructured{

--- a/pkg/messagingrp/frontend/controller/rabbitmqqueues/listsecretsrabbitmq_test.go
+++ b/pkg/messagingrp/frontend/controller/rabbitmqqueues/listsecretsrabbitmq_test.go
@@ -38,7 +38,7 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 	defer mctrl.Finish()
 
 	databaseClient := database.NewMockClient(mctrl)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, rabbitMQDataModel, _ := getTest_Model20231001preview()
 

--- a/pkg/messagingrp/processors/rabbitmqqueues/processor_test.go
+++ b/pkg/messagingrp/processors/rabbitmqqueues/processor_test.go
@@ -15,7 +15,6 @@ limitations under the License.
 package rabbitmqqueues
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/messagingrp/datamodel"
@@ -59,7 +58,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, queue, resource.Properties.Queue)
@@ -96,7 +95,7 @@ func Test_Process(t *testing.T) {
 				Username: username,
 			},
 		}
-		err := processor.Process(context.Background(), resource, processors.Options{})
+		err := processor.Process(t.Context(), resource, processors.Options{})
 		require.NoError(t, err)
 
 		require.Equal(t, queue, resource.Properties.Queue)
@@ -141,7 +140,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.NoError(t, err)
 
 		require.Equal(t, "new-queue", resource.Properties.Queue)
@@ -176,7 +175,7 @@ func Test_Process(t *testing.T) {
 		resource := &datamodel.RabbitMQQueue{}
 		options := processors.Options{RecipeOutput: &recipes.RecipeOutput{}}
 
-		err := processor.Process(context.Background(), resource, options)
+		err := processor.Process(t.Context(), resource, options)
 		require.Error(t, err)
 		require.IsType(t, &processors.ValidationError{}, err)
 		require.Equal(t, `validation returned multiple errors:

--- a/pkg/middleware/lowercaseurlpath_test.go
+++ b/pkg/middleware/lowercaseurlpath_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package middleware
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -63,7 +62,7 @@ func TestLowercaseURLPath(t *testing.T) {
 
 		handler := LowercaseURLPath(r)
 
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, testHostname+tt.armid, nil)
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, testHostname+tt.armid, nil)
 		require.NoError(t, err)
 		if tt.refererHeader != "" {
 			req.Header.Add(v1.RefererHeader, tt.refererHeader)

--- a/pkg/middleware/normalizepath_test.go
+++ b/pkg/middleware/normalizepath_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package middleware
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -80,7 +79,7 @@ func TestNormalizePath(t *testing.T) {
 
 		handler := NormalizePath(r)
 
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, tt.armid, nil)
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, tt.armid, nil)
 		require.NoError(t, err)
 		handler.ServeHTTP(w, req)
 

--- a/pkg/middleware/recoverer_test.go
+++ b/pkg/middleware/recoverer_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package middleware
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -42,7 +41,7 @@ func TestRecoverer(t *testing.T) {
 
 	testUrl := testPathBase + "/subscriptions/00001b53-0000-0000-0000-00006235a42c/resourcegroups/radius-test-rg/providers/Applications.Core/environments/env0"
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, testUrl, nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, testUrl, nil)
 	require.NoError(t, err)
 	handler.ServeHTTP(w, req)
 

--- a/pkg/portableresources/backend/controller/createorupdateresource_test.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource_test.go
@@ -473,7 +473,7 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 			genCtrl, err := tt.factory(recipeCfg, opts)
 			require.NoError(t, err)
 
-			res, err := genCtrl.Run(context.Background(), req)
+			res, err := genCtrl.Run(t.Context(), req)
 			switch {
 			case tt.conversionFailure:
 				require.False(t, stillPassing)
@@ -562,7 +562,7 @@ func TestCreateOrUpdateResource_Run_RecipeErrorSurfacedWhenStatusSaveFails(t *te
 	ctrlr, err := NewCreateOrUpdateResource(opts, successProcessorReference, recipeCfg.Engine, recipeCfg.ConfigLoader)
 	require.NoError(t, err)
 
-	res, err := ctrlr.Run(context.Background(), &ctrl.Request{
+	res, err := ctrlr.Run(t.Context(), &ctrl.Request{
 		OperationID:      uuid.New(),
 		OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT",
 		ResourceID:       TestResourceID,
@@ -592,7 +592,7 @@ func TestCreateOrUpdateResource_Run_SensitiveRedaction(t *testing.T) {
 	provider, err := encryption.NewInMemoryKeyProvider(key)
 	require.NoError(t, err)
 
-	handler, err := encryption.NewSensitiveDataHandlerFromProvider(context.Background(), provider)
+	handler, err := encryption.NewSensitiveDataHandlerFromProvider(t.Context(), provider)
 	require.NoError(t, err)
 
 	secretValue := "top-secret"
@@ -709,7 +709,7 @@ func TestCreateOrUpdateResource_Run_SensitiveRedaction(t *testing.T) {
 	ctrlr, err := NewCreateOrUpdateResource(opts, successProcessorReference, recipeCfg.Engine, recipeCfg.ConfigLoader)
 	require.NoError(t, err)
 
-	res, err := ctrlr.Run(context.Background(), &ctrl.Request{
+	res, err := ctrlr.Run(t.Context(), &ctrl.Request{
 		OperationID:      uuid.New(),
 		OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT",
 		ResourceID:       TestResourceID,
@@ -783,7 +783,7 @@ func TestCreateOrUpdateResource_Run_SensitiveMissingKey(t *testing.T) {
 	ctrlr, err := NewCreateOrUpdateResource(opts, successProcessorReference, recipeCfg.Engine, recipeCfg.ConfigLoader)
 	require.NoError(t, err)
 
-	res, err := ctrlr.Run(context.Background(), &ctrl.Request{
+	res, err := ctrlr.Run(t.Context(), &ctrl.Request{
 		OperationID:      uuid.New(),
 		OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT",
 		ResourceID:       TestResourceID,
@@ -895,7 +895,7 @@ func TestCreateOrUpdateResource_Run_SensitiveNilKubeClient(t *testing.T) {
 	ctrlr, err := NewCreateOrUpdateResource(opts, successProcessorReference, recipeCfg.Engine, recipeCfg.ConfigLoader)
 	require.NoError(t, err)
 
-	res, err := ctrlr.Run(context.Background(), &ctrl.Request{
+	res, err := ctrlr.Run(t.Context(), &ctrl.Request{
 		OperationID:      uuid.New(),
 		OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT",
 		ResourceID:       TestResourceID,
@@ -923,7 +923,7 @@ func TestCreateOrUpdateResource_Run_SensitiveRedactionSaveFails(t *testing.T) {
 	provider, err := encryption.NewInMemoryKeyProvider(key)
 	require.NoError(t, err)
 
-	handler, err := encryption.NewSensitiveDataHandlerFromProvider(context.Background(), provider)
+	handler, err := encryption.NewSensitiveDataHandlerFromProvider(t.Context(), provider)
 	require.NoError(t, err)
 
 	properties := map[string]any{
@@ -1010,7 +1010,7 @@ func TestCreateOrUpdateResource_Run_SensitiveRedactionSaveFails(t *testing.T) {
 	ctrlr, err := NewCreateOrUpdateResource(opts, successProcessorReference, recipeCfg.Engine, recipeCfg.ConfigLoader)
 	require.NoError(t, err)
 
-	res, err := ctrlr.Run(context.Background(), &ctrl.Request{
+	res, err := ctrlr.Run(t.Context(), &ctrl.Request{
 		OperationID:      uuid.New(),
 		OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT",
 		ResourceID:       TestResourceID,
@@ -1038,7 +1038,7 @@ func TestCreateOrUpdateResource_Run_SensitiveMultipleFields(t *testing.T) {
 	provider, err := encryption.NewInMemoryKeyProvider(key)
 	require.NoError(t, err)
 
-	handler, err := encryption.NewSensitiveDataHandlerFromProvider(context.Background(), provider)
+	handler, err := encryption.NewSensitiveDataHandlerFromProvider(t.Context(), provider)
 	require.NoError(t, err)
 
 	properties := map[string]any{
@@ -1175,7 +1175,7 @@ func TestCreateOrUpdateResource_Run_SensitiveMultipleFields(t *testing.T) {
 	ctrlr, err := NewCreateOrUpdateResource(opts, successProcessorReference, recipeCfg.Engine, recipeCfg.ConfigLoader)
 	require.NoError(t, err)
 
-	res, err := ctrlr.Run(context.Background(), &ctrl.Request{
+	res, err := ctrlr.Run(t.Context(), &ctrl.Request{
 		OperationID:      uuid.New(),
 		OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT",
 		ResourceID:       TestResourceID,

--- a/pkg/portableresources/backend/controller/deleteresource_test.go
+++ b/pkg/portableresources/backend/controller/deleteresource_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -172,7 +171,7 @@ func TestDeleteResourceRun_20231001Preview(t *testing.T) {
 			ctrl, err := NewDeleteResource(opts, successProcessorReference, eng, configLoader)
 			require.NoError(t, err)
 
-			_, err = ctrl.Run(context.Background(), req)
+			_, err = ctrl.Run(t.Context(), req)
 
 			if tt.getErr != nil || tt.engDelErr != nil || tt.scDelErr != nil {
 				require.Error(t, err)

--- a/pkg/portableresources/handlers/util_test.go
+++ b/pkg/portableresources/handlers/util_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package handlers
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -32,7 +31,7 @@ import (
 func Test_CheckDaprResourceNameUniqueness_NotFound(t *testing.T) {
 	client := k8sutil.NewFakeKubeClient(nil)
 
-	err := CheckDaprResourceNameUniqueness(context.Background(), client, "test-component", "default", "test-resource", dapr_ctrl.DaprStateStoresResourceType)
+	err := CheckDaprResourceNameUniqueness(t.Context(), client, "test-component", "default", "test-resource", dapr_ctrl.DaprStateStoresResourceType)
 	require.NoError(t, err)
 }
 
@@ -41,7 +40,7 @@ func Test_CheckDaprResourceNameUniqueness_SameRadiusResource(t *testing.T) {
 	existing := createUnstructuredComponent("test-component", "default", labels)
 	client := k8sutil.NewFakeKubeClient(nil, existing)
 
-	err := CheckDaprResourceNameUniqueness(context.Background(), client, "test-component", "default", "test-resource", dapr_ctrl.DaprStateStoresResourceType)
+	err := CheckDaprResourceNameUniqueness(t.Context(), client, "test-component", "default", "test-resource", dapr_ctrl.DaprStateStoresResourceType)
 	require.NoError(t, err)
 }
 
@@ -49,7 +48,7 @@ func Test_CheckDaprResourceNameUniqueness_NoLabels(t *testing.T) {
 	existing := createUnstructuredComponent("test-component", "default", nil)
 	client := k8sutil.NewFakeKubeClient(nil, existing)
 
-	err := CheckDaprResourceNameUniqueness(context.Background(), client, "test-component", "default", "test-resource", dapr_ctrl.DaprStateStoresResourceType)
+	err := CheckDaprResourceNameUniqueness(t.Context(), client, "test-component", "default", "test-resource", dapr_ctrl.DaprStateStoresResourceType)
 	require.Error(t, err)
 	require.Equal(t, fmt.Sprintf(daprConflictFmt, "test-component"), err.Error())
 }
@@ -59,7 +58,7 @@ func Test_CheckDaprResourceNameUniqueness_DifferentResourceNames(t *testing.T) {
 	existing := createUnstructuredComponent("test-component", "default", labels)
 	client := k8sutil.NewFakeKubeClient(nil, existing)
 
-	err := CheckDaprResourceNameUniqueness(context.Background(), client, "test-component", "default", "test-resource", dapr_ctrl.DaprStateStoresResourceType)
+	err := CheckDaprResourceNameUniqueness(t.Context(), client, "test-component", "default", "test-resource", dapr_ctrl.DaprStateStoresResourceType)
 	require.Error(t, err)
 	require.Equal(t, fmt.Sprintf(daprConflictFmt, "test-component"), err.Error())
 }
@@ -69,7 +68,7 @@ func Test_CheckDaprResourceNameUniqueness_DifferentResourceTypes(t *testing.T) {
 	existing := createUnstructuredComponent("test-component", "default", labels)
 	client := k8sutil.NewFakeKubeClient(nil, existing)
 
-	err := CheckDaprResourceNameUniqueness(context.Background(), client, "test-component", "default", "test-resource", dapr_ctrl.DaprStateStoresResourceType)
+	err := CheckDaprResourceNameUniqueness(t.Context(), client, "test-component", "default", "test-resource", dapr_ctrl.DaprStateStoresResourceType)
 	require.Error(t, err)
 	require.Equal(t, fmt.Sprintf(daprConflictFmt, "test-component"), err.Error())
 }

--- a/pkg/portableresources/processors/resourceclient_test.go
+++ b/pkg/portableresources/processors/resourceclient_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package processors
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -52,7 +51,7 @@ const (
 
 func Test_Delete_InvalidResourceID(t *testing.T) {
 	c := NewResourceClient(nil, nil, nil)
-	err := c.Delete(context.Background(), "invalid")
+	err := c.Delete(t.Context(), "invalid")
 	require.Error(t, err)
 }
 
@@ -71,7 +70,7 @@ func Test_Delete_ARM(t *testing.T) {
 		c := NewResourceClient(newArmOptions(server.URL), nil, nil)
 		c.armClientOptions = newClientOptions(server.Client(), server.URL)
 
-		err := c.Delete(context.Background(), ARMResourceID)
+		err := c.Delete(t.Context(), ARMResourceID)
 		require.Error(t, err)
 		require.IsType(t, &ResourceError{}, err)
 	})
@@ -99,7 +98,7 @@ func Test_Delete_ARM(t *testing.T) {
 		c := NewResourceClient(newArmOptions(server.URL), nil, nil)
 		c.armClientOptions = newClientOptions(server.Client(), server.URL)
 
-		err := c.Delete(context.Background(), ARMResourceID)
+		err := c.Delete(t.Context(), ARMResourceID)
 		require.NoError(t, err)
 	})
 
@@ -122,7 +121,7 @@ func Test_Delete_ARM(t *testing.T) {
 		c := NewResourceClient(newArmOptions(server.URL), nil, nil)
 		c.armClientOptions = newClientOptions(server.Client(), server.URL)
 
-		err := c.Delete(context.Background(), ARMResourceID)
+		err := c.Delete(t.Context(), ARMResourceID)
 		require.NoError(t, err)
 	})
 
@@ -149,7 +148,7 @@ func Test_Delete_ARM(t *testing.T) {
 		c := NewResourceClient(newArmOptions(server.URL), nil, nil)
 		c.armClientOptions = newClientOptions(server.Client(), server.URL)
 
-		err := c.Delete(context.Background(), ARMResourceID)
+		err := c.Delete(t.Context(), ARMResourceID)
 		require.NoError(t, err)
 	})
 
@@ -163,7 +162,7 @@ func Test_Delete_ARM(t *testing.T) {
 		c := NewResourceClient(newArmOptions(server.URL), nil, nil)
 		c.armClientOptions = newClientOptions(server.Client(), server.URL)
 
-		err := c.Delete(context.Background(), ARMResourceID)
+		err := c.Delete(t.Context(), ARMResourceID)
 		require.Error(t, err)
 		require.IsType(t, &ResourceError{}, err)
 	})
@@ -181,7 +180,7 @@ func Test_Delete_ARM(t *testing.T) {
 		c := NewResourceClient(newArmOptions(server.URL), nil, nil)
 		c.armClientOptions = newClientOptions(server.Client(), server.URL)
 
-		err := c.Delete(context.Background(), ARMResourceID)
+		err := c.Delete(t.Context(), ARMResourceID)
 		require.Error(t, err)
 		require.IsType(t, &ResourceError{}, err)
 		require.Contains(t, err.Error(), "could not find API version for type \"Microsoft.Compute/virtualMachines\", type was not found")
@@ -205,7 +204,7 @@ func Test_Delete_ARM(t *testing.T) {
 		c := NewResourceClient(newArmOptions(server.URL), nil, nil)
 		c.armClientOptions = newClientOptions(server.Client(), server.URL)
 
-		err := c.Delete(context.Background(), ARMResourceID)
+		err := c.Delete(t.Context(), ARMResourceID)
 		require.Error(t, err)
 		require.IsType(t, &ResourceError{}, err)
 		require.Contains(t, err.Error(), "could not find API version for type \"Microsoft.Compute/virtualMachines\", no supported API versions")
@@ -244,7 +243,7 @@ func Test_Delete_Kubernetes(t *testing.T) {
 
 		c := NewResourceClient(nil, nil, kcp)
 
-		err := c.Delete(context.Background(), KubernetesCoreGroupResourceID)
+		err := c.Delete(t.Context(), KubernetesCoreGroupResourceID)
 		require.NoError(t, err)
 	})
 
@@ -276,7 +275,7 @@ func Test_Delete_Kubernetes(t *testing.T) {
 
 		c := NewResourceClient(nil, nil, kcp)
 
-		err := c.Delete(context.Background(), KubernetesCoreGroupResourceID)
+		err := c.Delete(t.Context(), KubernetesCoreGroupResourceID)
 		require.NoError(t, err)
 	})
 
@@ -298,7 +297,7 @@ func Test_Delete_Kubernetes(t *testing.T) {
 
 		c := NewResourceClient(nil, nil, kcp)
 
-		err := c.Delete(context.Background(), KubernetesCoreGroupResourceID)
+		err := c.Delete(t.Context(), KubernetesCoreGroupResourceID)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "could not find API version for type \"core/Secret\", type was not found")
 	})
@@ -317,7 +316,7 @@ func Test_Delete_UCP(t *testing.T) {
 
 		c := NewResourceClient(nil, connection, nil)
 
-		err = c.Delete(context.Background(), AWSResourceID)
+		err = c.Delete(t.Context(), AWSResourceID)
 		require.NoError(t, err)
 	})
 
@@ -333,7 +332,7 @@ func Test_Delete_UCP(t *testing.T) {
 
 		c := NewResourceClient(nil, connection, nil)
 
-		err = c.Delete(context.Background(), AWSResourceID)
+		err = c.Delete(t.Context(), AWSResourceID)
 		require.NoError(t, err)
 	})
 
@@ -353,7 +352,7 @@ func Test_Delete_UCP(t *testing.T) {
 
 		c := NewResourceClient(nil, connection, nil)
 
-		err = c.Delete(context.Background(), AWSResourceID)
+		err = c.Delete(t.Context(), AWSResourceID)
 		require.Error(t, err)
 		require.IsType(t, &ResourceError{}, err)
 	})

--- a/pkg/recipes/configloader/environment_test.go
+++ b/pkg/recipes/configloader/environment_test.go
@@ -558,7 +558,7 @@ func TestGetConfigurationV20250801(t *testing.T) {
 }
 
 func TestGetRecipeDefinitionFromEnvironmentV20250801(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	armOptions := &arm.ClientOptions{}
 
 	envResource := &modelv20250801.EnvironmentResource{

--- a/pkg/recipes/configloader/environment_test.go
+++ b/pkg/recipes/configloader/environment_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package configloader
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -545,7 +544,7 @@ func TestGetConfigurationV20250801(t *testing.T) {
 
 	for _, tc := range configTests {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := getConfigurationV20250801(context.Background(), tc.envResource, &arm.ClientOptions{})
+			result, err := getConfigurationV20250801(t.Context(), tc.envResource, &arm.ClientOptions{})
 			if tc.errString != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errString)

--- a/pkg/recipes/configloader/environment_v20250801_bridge_test.go
+++ b/pkg/recipes/configloader/environment_v20250801_bridge_test.go
@@ -110,7 +110,7 @@ func TestGetConfigurationV20250801_TerraformCredentialsAndEnvAndProviderInstalla
 	// Clear the bicepSettings pointer since we don't want to fetch it in this test.
 	env.Properties.BicepSettings = nil
 
-	cfg, err := getConfigurationV20250801(context.Background(), env, armOpts)
+	cfg, err := getConfigurationV20250801(t.Context(), env, armOpts)
 	require.NoError(t, err)
 
 	// Credentials map is bridged 1:1.
@@ -160,7 +160,7 @@ func TestGetConfigurationV20250801_BicepBasicAuthMapped(t *testing.T) {
 	env := minimalEnv("", bcConfigID)
 	env.Properties.TerraformSettings = nil
 
-	cfg, err := getConfigurationV20250801(context.Background(), env, armOpts)
+	cfg, err := getConfigurationV20250801(t.Context(), env, armOpts)
 	require.NoError(t, err)
 
 	require.Len(t, cfg.RecipeConfig.Bicep.Authentication, 1)
@@ -211,7 +211,7 @@ func TestGetConfigurationV20250801_BicepEntriesWithoutBasicAuthSecretAreSkipped(
 	env := minimalEnv("", bcConfigID)
 	env.Properties.TerraformSettings = nil
 
-	cfg, err := getConfigurationV20250801(context.Background(), env, armOpts)
+	cfg, err := getConfigurationV20250801(t.Context(), env, armOpts)
 	require.NoError(t, err)
 
 	// Only the BasicAuth entry survives.
@@ -255,7 +255,7 @@ func TestGetConfigurationV20250801_BicepAllEntriesSkipped_LeavesAuthNil(t *testi
 	env := minimalEnv("", bcConfigID)
 	env.Properties.TerraformSettings = nil
 
-	cfg, err := getConfigurationV20250801(context.Background(), env, armOpts)
+	cfg, err := getConfigurationV20250801(t.Context(), env, armOpts)
 	require.NoError(t, err)
 
 	require.Empty(t, cfg.RecipeConfig.Bicep.Authentication, "expected no auth map when no usable entries")
@@ -274,7 +274,7 @@ func TestGetConfigurationV20250801_TerraformFetchError_IsWrapped(t *testing.T) {
 	env := minimalEnv(tfConfigID, "")
 	env.Properties.BicepSettings = nil
 
-	_, err := getConfigurationV20250801(context.Background(), env, armOpts)
+	_, err := getConfigurationV20250801(t.Context(), env, armOpts)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to fetch terraformSettings")
 	require.Contains(t, err.Error(), tfConfigID)
@@ -293,7 +293,7 @@ func TestGetConfigurationV20250801_BicepFetchError_IsWrapped(t *testing.T) {
 	env := minimalEnv("", bcConfigID)
 	env.Properties.TerraformSettings = nil
 
-	_, err := getConfigurationV20250801(context.Background(), env, armOpts)
+	_, err := getConfigurationV20250801(t.Context(), env, armOpts)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to fetch bicepSettings")
 	require.Contains(t, err.Error(), bcConfigID)

--- a/pkg/recipes/configloader/security_secrets_test.go
+++ b/pkg/recipes/configloader/security_secrets_test.go
@@ -157,7 +157,7 @@ func Test_findKubernetesSecretOutputResource(t *testing.T) {
 
 func Test_LoadSecrets_UnsupportedType(t *testing.T) {
 	loader := &secretsLoader{}
-	_, err := loader.LoadSecrets(context.Background(), map[string][]string{
+	_, err := loader.LoadSecrets(t.Context(), map[string][]string{
 		"/planes/radius/local/resourceGroups/rg/providers/Applications.Core/gateways/not-a-secret": nil,
 	})
 	require.Error(t, err)
@@ -166,7 +166,7 @@ func Test_LoadSecrets_UnsupportedType(t *testing.T) {
 
 func Test_LoadSecrets_SecuritySecret_NoKubernetesClient(t *testing.T) {
 	loader := &secretsLoader{}
-	_, err := loader.LoadSecrets(context.Background(), map[string][]string{
+	_, err := loader.LoadSecrets(t.Context(), map[string][]string{
 		"/planes/radius/local/resourceGroups/rg/providers/Radius.Security/secrets/my-secret": nil,
 	})
 	require.Error(t, err)
@@ -288,7 +288,7 @@ func Test_loadSecuritySecret(t *testing.T) {
 			id, err := resources.ParseResource(secretResourceID)
 			require.NoError(t, err)
 
-			secretData, err := loader.loadSecuritySecret(context.Background(), id, tt.keysFilter)
+			secretData, err := loader.loadSecuritySecret(t.Context(), id, tt.keysFilter)
 			if tt.expectError {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedErrMsg)

--- a/pkg/recipes/driver/bicep/containerimages.go
+++ b/pkg/recipes/driver/bicep/containerimages.go
@@ -398,10 +398,7 @@ func drainScriptStream(stream io.Reader, logPrefix string, logger logr.Logger, t
 			logFragment = bytes.TrimRight(logFragment, "\r\n")
 		}
 		if len(logFragment) > 0 {
-			remaining := scriptLogLineLimit - len(line)
-			if remaining > len(logFragment) {
-				remaining = len(logFragment)
-			}
+			remaining := min(scriptLogLineLimit-len(line), len(logFragment))
 			line = append(line, logFragment[:remaining]...)
 			lineTruncated = lineTruncated || remaining < len(logFragment)
 		}

--- a/pkg/recipes/driver/terraform/terraform_test.go
+++ b/pkg/recipes/driver/terraform/terraform_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package terraform
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -888,7 +887,7 @@ func Test_Terraform_PrepareRecipeResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			recipeResponse, err := d.prepareRecipeResponse(context.Background(), opts.BaseOptions.Definition, opts.Configuration, tt.state)
+			recipeResponse, err := d.prepareRecipeResponse(t.Context(), opts.BaseOptions.Definition, opts.Configuration, tt.state)
 			require.Equal(t, tt.expectedErr, err)
 			require.Equal(t, tt.expectedResponse, recipeResponse)
 		})
@@ -1068,7 +1067,7 @@ func Test_Terraform_PrepareRecipeResponse_DirectModule(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			recipeResponse, err := d.prepareRecipeResponse(context.Background(), tt.definition, recipes.Configuration{}, tt.state)
+			recipeResponse, err := d.prepareRecipeResponse(t.Context(), tt.definition, recipes.Configuration{}, tt.state)
 			require.Equal(t, tt.expectedErr, err)
 			require.Equal(t, tt.expectedResponse, recipeResponse)
 		})
@@ -1076,7 +1075,7 @@ func Test_Terraform_PrepareRecipeResponse_DirectModule(t *testing.T) {
 }
 
 func Test_FindSecretIDs(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	definition := recipes.EnvironmentDefinition{TemplatePath: "git::https://dev.azure.com/project/module"}
 	_, driver := setup(t)
 

--- a/pkg/recipes/kubernetes/clusteraccess/resolver_test.go
+++ b/pkg/recipes/kubernetes/clusteraccess/resolver_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package clusteraccess
 
 import (
-	"context"
 	"errors"
 	"os"
 	"testing"
@@ -44,7 +43,7 @@ func Test_Resolve_PrefersInjectedKubeconfig(t *testing.T) {
 		},
 	}
 
-	got, err := r.Resolve(context.Background(), &recipes.Configuration{})
+	got, err := r.Resolve(t.Context(), &recipes.Configuration{})
 	require.NoError(t, err)
 	require.Same(t, injectedCfg, got)
 }
@@ -63,7 +62,7 @@ func Test_Resolve_FallsBackToLocalWhenNoInjectedKubeconfig(t *testing.T) {
 		},
 	}
 
-	got, err := r.Resolve(context.Background(), &recipes.Configuration{})
+	got, err := r.Resolve(t.Context(), &recipes.Configuration{})
 	require.NoError(t, err)
 	require.Same(t, localCfg, got)
 }
@@ -84,7 +83,7 @@ func Test_LocalStrategy_UsesInClusterConfigWhenAvailable(t *testing.T) {
 		},
 	}
 
-	got, err := s.restConfig(context.Background(), &recipes.Configuration{})
+	got, err := s.restConfig(t.Context(), &recipes.Configuration{})
 	require.NoError(t, err)
 	require.Same(t, inClusterCfg, got)
 }
@@ -96,7 +95,7 @@ func Test_LocalStrategy_FallsBackToLocalKubeconfigWhenNotInCluster(t *testing.T)
 		localConfig:     func() (*rest.Config, error) { return localCfg, nil },
 	}
 
-	got, err := s.restConfig(context.Background(), &recipes.Configuration{})
+	got, err := s.restConfig(t.Context(), &recipes.Configuration{})
 	require.NoError(t, err)
 	require.Same(t, localCfg, got)
 }
@@ -111,7 +110,7 @@ func Test_LocalStrategy_PropagatesUnexpectedInClusterError(t *testing.T) {
 		},
 	}
 
-	_, err := s.restConfig(context.Background(), &recipes.Configuration{})
+	_, err := s.restConfig(t.Context(), &recipes.Configuration{})
 	require.ErrorIs(t, err, sentinel)
 }
 
@@ -134,7 +133,7 @@ func Test_InjectedKubeconfigStrategy_LoadsConfigFromPath(t *testing.T) {
 		},
 	}
 
-	got, err := s.restConfig(context.Background(), &recipes.Configuration{})
+	got, err := s.restConfig(t.Context(), &recipes.Configuration{})
 	require.NoError(t, err)
 	require.Same(t, want, got)
 	require.Equal(t, "/etc/radius/target-kubeconfig/config", loadedPath)
@@ -146,7 +145,7 @@ func Test_InjectedKubeconfigStrategy_ErrorsWhenKubeconfigUnreadable(t *testing.T
 		loadConfig: func(string) (*rest.Config, error) { return nil, errors.New("no such file") },
 	}
 
-	_, err := s.restConfig(context.Background(), &recipes.Configuration{})
+	_, err := s.restConfig(t.Context(), &recipes.Configuration{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), TargetKubeconfigEnvVar)
 	require.Contains(t, err.Error(), "/missing/kubeconfig")
@@ -168,7 +167,7 @@ func Test_ResolveKubeconfigSource_PrefersInjectedKubeconfig(t *testing.T) {
 		},
 	}
 
-	got, err := r.ResolveKubeconfigSource(context.Background(), &recipes.Configuration{})
+	got, err := r.ResolveKubeconfigSource(t.Context(), &recipes.Configuration{})
 	require.NoError(t, err)
 	require.Equal(t, KubeconfigSource{Path: "/path/to/kubeconfig"}, got)
 }
@@ -183,7 +182,7 @@ func Test_ResolveKubeconfigSource_FallsBackToLocal(t *testing.T) {
 		},
 	}
 
-	got, err := r.ResolveKubeconfigSource(context.Background(), &recipes.Configuration{})
+	got, err := r.ResolveKubeconfigSource(t.Context(), &recipes.Configuration{})
 	require.NoError(t, err)
 	require.Equal(t, KubeconfigSource{Path: clientcmd.RecommendedHomeFile}, got)
 }
@@ -194,7 +193,7 @@ func Test_InjectedKubeconfigStrategy_KubeconfigSourceReturnsEnvPath(t *testing.T
 		statFile: func(string) (os.FileInfo, error) { return nil, nil },
 	}
 
-	got, err := s.kubeconfigSource(context.Background(), &recipes.Configuration{})
+	got, err := s.kubeconfigSource(t.Context(), &recipes.Configuration{})
 	require.NoError(t, err)
 	require.Equal(t, KubeconfigSource{Path: "/etc/radius/target-kubeconfig/config"}, got)
 }
@@ -205,7 +204,7 @@ func Test_InjectedKubeconfigStrategy_KubeconfigSourceErrorsWhenPathUnreadable(t 
 		statFile: func(string) (os.FileInfo, error) { return nil, errors.New("no such file") },
 	}
 
-	_, err := s.kubeconfigSource(context.Background(), &recipes.Configuration{})
+	_, err := s.kubeconfigSource(t.Context(), &recipes.Configuration{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), TargetKubeconfigEnvVar)
 	require.Contains(t, err.Error(), "/missing/kubeconfig")
@@ -216,7 +215,7 @@ func Test_LocalStrategy_KubeconfigSourceInClusterReturnsEmptyPath(t *testing.T) 
 		inClusterConfig: func() (*rest.Config, error) { return &rest.Config{}, nil },
 	}
 
-	got, err := s.kubeconfigSource(context.Background(), &recipes.Configuration{})
+	got, err := s.kubeconfigSource(t.Context(), &recipes.Configuration{})
 	require.NoError(t, err)
 	require.Equal(t, KubeconfigSource{}, got)
 }
@@ -226,7 +225,7 @@ func Test_LocalStrategy_KubeconfigSourceNotInClusterReturnsLocalKubeconfig(t *te
 		inClusterConfig: func() (*rest.Config, error) { return nil, rest.ErrNotInCluster },
 	}
 
-	got, err := s.kubeconfigSource(context.Background(), &recipes.Configuration{})
+	got, err := s.kubeconfigSource(t.Context(), &recipes.Configuration{})
 	require.NoError(t, err)
 	require.Equal(t, KubeconfigSource{Path: clientcmd.RecommendedHomeFile}, got)
 }
@@ -237,6 +236,6 @@ func Test_LocalStrategy_KubeconfigSourcePropagatesUnexpectedError(t *testing.T) 
 		inClusterConfig: func() (*rest.Config, error) { return nil, sentinel },
 	}
 
-	_, err := s.kubeconfigSource(context.Background(), &recipes.Configuration{})
+	_, err := s.kubeconfigSource(t.Context(), &recipes.Configuration{})
 	require.ErrorIs(t, err, sentinel)
 }

--- a/pkg/recipes/terraform/config/backends/kubernetes_test.go
+++ b/pkg/recipes/terraform/config/backends/kubernetes_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package backends
 
 import (
-	"context"
 	"crypto/sha1"
 	"crypto/sha256"
 	"fmt"
@@ -176,7 +175,7 @@ func Test_BuildBackend_ExistingLegacyStateUsesLegacySuffix(t *testing.T) {
 
 	// Simulate a Terraform state secret created by an older version of Radius (legacy SHA-1 suffix).
 	clientset := fake.NewClientset()
-	_, err = clientset.CoreV1().Secrets(RadiusNamespace).Create(context.Background(), &v1.Secret{
+	_, err = clientset.CoreV1().Secrets(RadiusNamespace).Create(t.Context(), &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      KubernetesBackendNamePrefix + legacySuffix,
 			Namespace: RadiusNamespace,
@@ -204,16 +203,16 @@ func Test_ValidateBackendExists(t *testing.T) {
 			"key": []byte("value"),
 		},
 	}
-	_, err := clientset.CoreV1().Secrets(RadiusNamespace).Create(context.Background(), secret, metav1.CreateOptions{})
+	_, err := clientset.CoreV1().Secrets(RadiusNamespace).Create(t.Context(), secret, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	b := NewKubernetesBackend(clientset)
-	exists, err := b.ValidateBackendExists(context.Background(), "test-secret")
+	exists, err := b.ValidateBackendExists(t.Context(), "test-secret")
 	require.NoError(t, err)
 	require.True(t, exists)
 
 	// Validate that the function returns false for a non-existent secret.
-	exists, err = b.ValidateBackendExists(context.Background(), "invalid-secret")
+	exists, err = b.ValidateBackendExists(t.Context(), "invalid-secret")
 	require.NoError(t, err)
 	require.False(t, exists)
 
@@ -221,7 +220,7 @@ func Test_ValidateBackendExists(t *testing.T) {
 	clientset.Fake.PrependReactor("get", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, nil, k8s_errors.NewServerTimeout(schema.GroupResource{Resource: "test-secret"}, "get", 1)
 	})
-	exists, err = b.ValidateBackendExists(context.Background(), "test-secret")
+	exists, err = b.ValidateBackendExists(t.Context(), "test-secret")
 	require.Error(t, err)
 	require.True(t, k8s_errors.IsServerTimeout(err))
 	require.False(t, exists)

--- a/pkg/recipes/terraform/config/config_test.go
+++ b/pkg/recipes/terraform/config/config_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -180,7 +179,7 @@ func Test_NewConfig(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			workingDir := t.TempDir()
 
-			tfconfig, err := New(context.Background(), testRecipeName, tc.envdef, tc.metadata)
+			tfconfig, err := New(t.Context(), testRecipeName, tc.envdef, tc.metadata)
 			require.NoError(t, err)
 
 			// validate generated config
@@ -276,7 +275,7 @@ func Test_AddRecipeContext(t *testing.T) {
 			ctx := t.Context()
 			workingDir := t.TempDir()
 
-			tfconfig, err := New(context.Background(), testRecipeName, tc.envdef, tc.metadata)
+			tfconfig, err := New(t.Context(), testRecipeName, tc.envdef, tc.metadata)
 			require.NoError(t, err)
 			err = tfconfig.AddRecipeContext(ctx, tc.moduleName, tc.recipeContext)
 			if tc.err == "" {
@@ -669,7 +668,7 @@ func Test_AddOutputs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			tfconfig, err := New(context.Background(), testRecipeName, &envRecipe, &resourceRecipe)
+			tfconfig, err := New(t.Context(), testRecipeName, &envRecipe, &resourceRecipe)
 			require.NoError(t, err)
 
 			err = tfconfig.AddOutputs(tc.moduleName)
@@ -784,7 +783,7 @@ func Test_AddMappedOutputs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			tfconfig, err := New(context.Background(), testRecipeName, &envRecipe, &resourceRecipe)
+			tfconfig, err := New(t.Context(), testRecipeName, &envRecipe, &resourceRecipe)
 			require.NoError(t, err)
 
 			err = tfconfig.AddMappedOutputs(tc.moduleName, tc.outputsMap, tc.sensitivity, tc.forceSensitive)
@@ -843,7 +842,7 @@ func Test_AddAllOutputs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			tfconfig, err := New(context.Background(), testRecipeName, &envRecipe, &resourceRecipe)
+			tfconfig, err := New(t.Context(), testRecipeName, &envRecipe, &resourceRecipe)
 			require.NoError(t, err)
 
 			err = tfconfig.AddAllOutputs(tc.moduleName, tc.sensitivity)
@@ -1112,7 +1111,7 @@ func Test_Save_overwrite(t *testing.T) {
 	ctx := t.Context()
 	testDir := t.TempDir()
 	envRecipe, resourceRecipe := getTestInputs()
-	tfconfig, err := New(context.Background(), testRecipeName, &envRecipe, &resourceRecipe)
+	tfconfig, err := New(t.Context(), testRecipeName, &envRecipe, &resourceRecipe)
 	require.NoError(t, err)
 
 	err = tfconfig.Save(ctx, testDir)
@@ -1125,7 +1124,7 @@ func Test_Save_overwrite(t *testing.T) {
 func Test_Save_ConfigFileReadOnly(t *testing.T) {
 	testDir := t.TempDir()
 	envRecipe, resourceRecipe := getTestInputs()
-	tfconfig, err := New(context.Background(), testRecipeName, &envRecipe, &resourceRecipe)
+	tfconfig, err := New(t.Context(), testRecipeName, &envRecipe, &resourceRecipe)
 	require.NoError(t, err)
 
 	// Create a test configuration file with read only permission.
@@ -1142,7 +1141,7 @@ func Test_Save_InvalidWorkingDir(t *testing.T) {
 	testDir := filepath.Join("invalid", uuid.New().String())
 	envRecipe, resourceRecipe := getTestInputs()
 
-	tfconfig, err := New(context.Background(), testRecipeName, &envRecipe, &resourceRecipe)
+	tfconfig, err := New(t.Context(), testRecipeName, &envRecipe, &resourceRecipe)
 	require.NoError(t, err)
 
 	err = tfconfig.Save(t.Context(), testDir)

--- a/pkg/recipes/terraform/config/providers/types_test.go
+++ b/pkg/recipes/terraform/config/providers/types_test.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/corerp/datamodel"
@@ -296,7 +295,7 @@ func Test_GetRecipeProviderConfigs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			result, err := GetRecipeProviderConfigs(context.Background(), tc.envConfig, tc.secrets)
+			result, err := GetRecipeProviderConfigs(t.Context(), tc.envConfig, tc.secrets)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, result)
 		})

--- a/pkg/recipes/terraform/install_test.go
+++ b/pkg/recipes/terraform/install_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package terraform
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -52,7 +51,7 @@ func TestInstall_SuccessfulDownload(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	installer := install.NewInstaller()
 
 	// Call Install function - should download to global location
@@ -94,7 +93,7 @@ func TestInstall_GlobalBinaryReuse(t *testing.T) {
 	// Reset global state for this test
 	resetGlobalStateForTesting()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	installer := install.NewInstaller()
 
 	// First Install call - should download
@@ -152,7 +151,7 @@ func TestInstall_MultipleConcurrentCallsUseSameBinary(t *testing.T) {
 	// Reset global state for this test
 	resetGlobalStateForTesting()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	installer := install.NewInstaller()
 
 	// Create temporary execution directories
@@ -220,7 +219,7 @@ func TestInstall_GlobalBinaryConcurrency(t *testing.T) {
 	resetGlobalStateForTesting()
 
 	// Test that multiple concurrent Install calls use the same binary without race conditions
-	ctx := context.Background()
+	ctx := t.Context()
 	installer := install.NewInstaller()
 
 	// Create multiple execution directories (as would happen in production)

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -61,7 +61,7 @@ func TestNewRetryer(t *testing.T) {
 
 func TestRetryer_RetryFunc(t *testing.T) {
 	retryer := NewDefaultRetryer()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Test successful function
 	err := retryer.RetryFunc(ctx, func(ctx context.Context) error {

--- a/pkg/rp/frontend/validator_test.go
+++ b/pkg/rp/frontend/validator_test.go
@@ -31,13 +31,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func newTestARMContext() context.Context {
-	return v1.WithARMRequestContext(context.Background(), &v1.ARMRequestContext{})
+func newTestARMContext(t *testing.T) context.Context {
+	return v1.WithARMRequestContext(t.Context(), &v1.ARMRequestContext{})
 }
 
 func TestPrepareRadiusResource_OldResource_Nil(t *testing.T) {
 	newResource := &TestResourceDataModel{}
-	resp, err := PrepareRadiusResource(newTestARMContext(), newResource, nil, &controller.Options{})
+	resp, err := PrepareRadiusResource(newTestARMContext(t), newResource, nil, &controller.Options{})
 
 	require.Nil(t, resp)
 	require.NoError(t, err)
@@ -57,13 +57,13 @@ func TestPrepareRadiusResource_UnmatchedLinks(t *testing.T) {
 		},
 	}}
 
-	resp, err := PrepareRadiusResource(newTestARMContext(), newResource, oldResource, &controller.Options{})
+	resp, err := PrepareRadiusResource(newTestARMContext(t), newResource, oldResource, &controller.Options{})
 	require.NoError(t, err)
 	require.Nil(t, resp)
 
 	// Ensure that unmatched application id returns the error.
 	newResource.Properties.BasicResourceProperties.Application = "invalid"
-	resp, err = PrepareRadiusResource(newTestARMContext(), newResource, oldResource, &controller.Options{})
+	resp, err = PrepareRadiusResource(newTestARMContext(t), newResource, oldResource, &controller.Options{})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 }
@@ -88,7 +88,7 @@ func TestPrepareRadiusResource_DeepCopy(t *testing.T) {
 			Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
 		},
 	}}
-	resp, err := PrepareRadiusResource(newTestARMContext(), newResource, oldResource, &controller.Options{})
+	resp, err := PrepareRadiusResource(newTestARMContext(t), newResource, oldResource, &controller.Options{})
 	require.NoError(t, err)
 	require.Nil(t, resp)
 	require.Equal(t, "testID", newResource.Properties.BasicResourceProperties.Status.OutputResources[0].LocalID)
@@ -123,7 +123,7 @@ func TestPrepareDaprResource(t *testing.T) {
 		},
 	}}
 	expectedResp := rest.NewDependencyMissingResponse(datamodel.DaprMissingError)
-	resp, err := PrepareDaprResource(newTestARMContext(), newResource, oldResource, &controller.Options{KubeClient: client})
+	resp, err := PrepareDaprResource(newTestARMContext(t), newResource, oldResource, &controller.Options{KubeClient: client})
 	require.NoError(t, err)
 	require.Equal(t, expectedResp, resp)
 

--- a/pkg/rp/kube/resources_test.go
+++ b/pkg/rp/kube/resources_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kube
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -91,7 +90,7 @@ func TestFindNamespaceByEnvID(t *testing.T) {
 			mockSC := database.NewMockClient(mctrl)
 			mockSC.EXPECT().Get(gomock.Any(), tc.id, gomock.Any()).Return(fakeStoreObject(envdm), nil).Times(1)
 
-			ns, err := FindNamespaceByEnvID(context.Background(), mockSC, testAppCoreEnvID)
+			ns, err := FindNamespaceByEnvID(t.Context(), mockSC, testAppCoreEnvID)
 			require.NoError(t, err)
 			require.Equal(t, tc.out, ns)
 		})
@@ -211,7 +210,7 @@ func TestFindNamespaceByEnvID_V20250801Preview(t *testing.T) {
 			mockSC := database.NewMockClient(mctrl)
 			mockSC.EXPECT().Get(gomock.Any(), testRadiusCoreEnvID, gomock.Any()).Return(fakeStoreObject(tc.environment), nil).Times(1)
 
-			ns, err := FindNamespaceByEnvID(context.Background(), mockSC, testRadiusCoreEnvID)
+			ns, err := FindNamespaceByEnvID(t.Context(), mockSC, testRadiusCoreEnvID)
 			if tc.expectedError != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.expectedError)
@@ -229,7 +228,7 @@ func TestFindNamespaceByEnvID_InvalidResourceType(t *testing.T) {
 
 	invalidEnvID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Invalid.Type/environments/env"
 
-	_, err := FindNamespaceByEnvID(context.Background(), mockSC, invalidEnvID)
+	_, err := FindNamespaceByEnvID(t.Context(), mockSC, invalidEnvID)
 	require.Error(t, err)
 	require.Equal(t, "invalid environment resource id - must be Applications.Core/environments or Radius.Core/environments", err.Error())
 }
@@ -248,7 +247,7 @@ func TestFindNamespaceByEnvID_NonKubernetesEnvironment(t *testing.T) {
 	mockSC := database.NewMockClient(mctrl)
 	mockSC.EXPECT().Get(gomock.Any(), testAppCoreEnvID, gomock.Any()).Return(fakeStoreObject(envdm), nil).Times(1)
 
-	_, err := FindNamespaceByEnvID(context.Background(), mockSC, testAppCoreEnvID)
+	_, err := FindNamespaceByEnvID(t.Context(), mockSC, testAppCoreEnvID)
 	require.Error(t, err)
 	require.Equal(t, ErrNonKubernetesEnvironment, err)
 }

--- a/pkg/rp/util/authclient/types_test.go
+++ b/pkg/rp/util/authclient/types_test.go
@@ -80,14 +80,15 @@ func Test_getRegistryAuthClient(t *testing.T) {
 		},
 	}
 
+	ctx := t.Context()
 	for _, tc := range testset {
 		ctrl := gomock.NewController(t)
 		newClient, err := GetNewRegistryAuthClient(tc.secrets)
 		require.NoError(t, err)
 		require.Equal(t, tc.expNewAuthClient, newClient)
 		mClient := NewMockAuthClient(ctrl)
-		mClient.EXPECT().GetAuthClient(t.Context(), tc.templatePath).Times(1).Return(tc.expAuthClient, nil)
-		ac, err := mClient.GetAuthClient(t.Context(), tc.templatePath)
+		mClient.EXPECT().GetAuthClient(ctx, tc.templatePath).Times(1).Return(tc.expAuthClient, nil)
+		ac, err := mClient.GetAuthClient(ctx, tc.templatePath)
 		require.NoError(t, err)
 		require.Equal(t, ac, tc.expAuthClient)
 	}

--- a/pkg/rp/util/authclient/types_test.go
+++ b/pkg/rp/util/authclient/types_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package authclient
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -87,8 +86,8 @@ func Test_getRegistryAuthClient(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, tc.expNewAuthClient, newClient)
 		mClient := NewMockAuthClient(ctrl)
-		mClient.EXPECT().GetAuthClient(context.Background(), templatePath).Times(1).Return(tc.expAuthClient, nil)
-		ac, err := mClient.GetAuthClient(context.Background(), tc.templatePath)
+		mClient.EXPECT().GetAuthClient(t.Context(), templatePath).Times(1).Return(tc.expAuthClient, nil)
+		ac, err := mClient.GetAuthClient(t.Context(), tc.templatePath)
 		require.NoError(t, err)
 		require.Equal(t, ac, tc.expAuthClient)
 	}

--- a/pkg/rp/util/authclient/types_test.go
+++ b/pkg/rp/util/authclient/types_test.go
@@ -86,7 +86,7 @@ func Test_getRegistryAuthClient(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, tc.expNewAuthClient, newClient)
 		mClient := NewMockAuthClient(ctrl)
-		mClient.EXPECT().GetAuthClient(t.Context(), templatePath).Times(1).Return(tc.expAuthClient, nil)
+		mClient.EXPECT().GetAuthClient(t.Context(), tc.templatePath).Times(1).Return(tc.expAuthClient, nil)
 		ac, err := mClient.GetAuthClient(t.Context(), tc.templatePath)
 		require.NoError(t, err)
 		require.Equal(t, ac, tc.expAuthClient)

--- a/pkg/schema/annotations_test.go
+++ b/pkg/schema/annotations_test.go
@@ -434,7 +434,7 @@ func TestExtractSensitiveFieldPaths_WithPrefix(t *testing.T) {
 }
 
 func TestGetSensitiveFieldPaths(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("nil client returns nil", func(t *testing.T) {
 		result, err := GetSensitiveFieldPaths(ctx, nil, "/planes/radius/local/resourceGroups/test/providers/Foo.Bar/myResources/test", "Foo.Bar/myResources", "2024-01-01")
@@ -511,7 +511,7 @@ func TestGetSensitiveFieldPaths(t *testing.T) {
 }
 
 func TestGetSchema(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("nil client returns nil", func(t *testing.T) {
 		result, err := GetSchema(ctx, nil, "/planes/radius/local/resourceGroups/test/providers/Foo.Bar/myResources/test", "Foo.Bar/myResources", "2024-01-01")

--- a/pkg/schema/annotations_test.go
+++ b/pkg/schema/annotations_test.go
@@ -575,7 +575,7 @@ func TestGetSensitiveFieldPaths_InvalidResourceID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = GetSensitiveFieldPaths(
-		context.Background(),
+		t.Context(),
 		clientFactory,
 		"invalid-resource-id",
 		"Foo.Bar/myResources",

--- a/pkg/schema/validator_test.go
+++ b/pkg/schema/validator_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package schema
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -33,7 +32,7 @@ func TestNewValidator(t *testing.T) {
 
 func TestValidator_ValidateSchema(t *testing.T) {
 	validator := NewValidator()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("nil schema", func(t *testing.T) {
 		err := validator.ValidateSchema(ctx, nil)
@@ -76,7 +75,7 @@ func TestValidator_ValidateSchema(t *testing.T) {
 
 func TestValidator_ValidateSchema_PlatformOptionsTypeAny(t *testing.T) {
 	validator := NewValidator()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("platformOptions additionalProperties type any succeeds", func(t *testing.T) {
 		schema := &openapi3.Schema{
@@ -1447,7 +1446,7 @@ func TestValidator_validateSchemaWithOpenAPI(t *testing.T) {
 
 func TestValidator_ValidateSchema_EdgeCases(t *testing.T) {
 	validator := NewValidator()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("schema with empty object", func(t *testing.T) {
 		schema := &openapi3.Schema{
@@ -1938,7 +1937,7 @@ func TestValidator_checkReservedProperties(t *testing.T) {
 
 func TestValidator_ValidateSchema_MultipleErrors(t *testing.T) {
 	validator := NewValidator()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("always collects all errors", func(t *testing.T) {
 		schema := &openapi3.Schema{
@@ -2001,7 +2000,7 @@ func TestValidator_ValidateSchema_MultipleErrors(t *testing.T) {
 }
 
 func TestValidateResourceAgainstSchema(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("nil schema returns nil", func(t *testing.T) {
 		resourceData := map[string]any{
@@ -2367,7 +2366,7 @@ func TestValidator_checkSensitiveAnnotation(t *testing.T) {
 
 func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 	validator := NewValidator()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("valid string with x-radius-sensitive", func(t *testing.T) {
 		schema := &openapi3.Schema{
@@ -3043,7 +3042,7 @@ func TestNormalizeSensitiveFieldTypes(t *testing.T) {
 }
 
 func TestValidateResourceAgainstSchema_EncryptedSensitiveFields(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("encrypted sensitive string field passes validation", func(t *testing.T) {
 		schema := map[string]any{

--- a/pkg/server/asyncworker_test.go
+++ b/pkg/server/asyncworker_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,7 +52,7 @@ func Test_deploymentTargetClients_NoEnvVar_ReturnsControlPlane(t *testing.T) {
 	w := &AsyncWorker{}
 	controlPlane := &kubeutil.Clients{}
 
-	got, err := w.deploymentTargetClients(context.Background(), controlPlane)
+	got, err := w.deploymentTargetClients(t.Context(), controlPlane)
 	require.NoError(t, err)
 	require.Same(t, controlPlane, got, "with no target kubeconfig the control-plane clients must be returned unchanged")
 }
@@ -67,7 +66,7 @@ func Test_deploymentTargetClients_ValidKubeconfig_ReturnsTargetClients(t *testin
 	w := &AsyncWorker{}
 	controlPlane := &kubeutil.Clients{}
 
-	got, err := w.deploymentTargetClients(context.Background(), controlPlane)
+	got, err := w.deploymentTargetClients(t.Context(), controlPlane)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.NotSame(t, controlPlane, got, "with a target kubeconfig set, distinct target clients must be returned")
@@ -79,7 +78,7 @@ func Test_deploymentTargetClients_UnreadableKubeconfig_ReturnsError(t *testing.T
 
 	w := &AsyncWorker{}
 
-	_, err := w.deploymentTargetClients(context.Background(), &kubeutil.Clients{})
+	_, err := w.deploymentTargetClients(t.Context(), &kubeutil.Clients{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), kubeutil.TargetKubeconfigEnvVar)
 	require.Contains(t, err.Error(), missingPath)

--- a/pkg/statearchive/factory/factory_test.go
+++ b/pkg/statearchive/factory/factory_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package factory
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/statearchive/oci"
@@ -58,7 +57,7 @@ func TestNewGraphArchive_InvalidBackendFailsOnOpen(t *testing.T) {
 	t.Setenv(BackendEnvVar, "filesystem")
 
 	archive := NewGraphArchive("")
-	_, err := archive.Open(context.Background(), "radius-graph")
+	_, err := archive.Open(t.Context(), "radius-graph")
 	require.ErrorContains(t, err, "invalid "+BackendEnvVar)
 }
 
@@ -74,7 +73,7 @@ func TestNewStateArchive_DefaultWithoutRegistryFailsOnOpen(t *testing.T) {
 	t.Setenv("DOCKER_CONFIG", t.TempDir())
 
 	archive := NewStateArchive("")
-	_, err := archive.Open(context.Background(), "radius-state")
+	_, err := archive.Open(t.Context(), "radius-state")
 	require.ErrorContains(t, err, "repository is not configured")
 }
 
@@ -90,7 +89,7 @@ func TestNewStateArchive_ExplicitOCIWithoutRegistryFailsOnOpen(t *testing.T) {
 	t.Setenv("DOCKER_CONFIG", t.TempDir())
 
 	archive := NewStateArchive("")
-	_, err := archive.Open(context.Background(), "radius-state")
+	_, err := archive.Open(t.Context(), "radius-state")
 	require.ErrorContains(t, err, "repository is not configured")
 }
 
@@ -106,6 +105,6 @@ func TestNewStateArchive_InvalidBackendFailsOnOpen(t *testing.T) {
 	t.Setenv(BackendEnvVar, "filesystem")
 
 	archive := NewStateArchive("")
-	_, err := archive.Open(context.Background(), "radius-state")
+	_, err := archive.Open(t.Context(), "radius-state")
 	require.ErrorContains(t, err, "invalid "+BackendEnvVar)
 }

--- a/pkg/statearchive/git/git_test.go
+++ b/pkg/statearchive/git/git_test.go
@@ -100,7 +100,7 @@ func TestOpen_CreatesOrphanBranchAndIsolatesState(t *testing.T) {
 	root := initTestRepo(t)
 	chdir(t, root)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	branch := "radius-state-test"
 	s, err := NewGitArchive().Open(ctx, branch)
 	require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestOpen_RestoresPreviousState(t *testing.T) {
 	root := initTestRepo(t)
 	chdir(t, root)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	b := NewGitArchive()
 
 	// First session writes state and commits it.
@@ -147,7 +147,7 @@ func TestOpen_ReusesBranch(t *testing.T) {
 	root := initTestRepo(t)
 	chdir(t, root)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	b := NewGitArchive()
 	branch := "radius-state-test"
 
@@ -164,7 +164,7 @@ func TestOpen_ReusesBranch(t *testing.T) {
 
 func TestOpen_UsesRemoteBranch(t *testing.T) {
 	sourceDir, remoteDir := initTestRepoWithOrigin(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	branch := "radius-state-test"
 
 	chdir(t, sourceDir)
@@ -190,7 +190,7 @@ func TestCommit_NoRemoteIsNotAnError(t *testing.T) {
 	root := initTestRepo(t)
 	chdir(t, root)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	s, err := NewGitArchive().Open(ctx, "radius-state-test")
 	require.NoError(t, err)
 	defer s.Close(ctx)
@@ -204,7 +204,7 @@ func TestCommit_NoChangesIsNoOp(t *testing.T) {
 	root := initTestRepo(t)
 	chdir(t, root)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	s, err := NewGitArchive().Open(ctx, "radius-state-test")
 	require.NoError(t, err)
 	defer s.Close(ctx)
@@ -218,7 +218,7 @@ func TestCommit_NoChangesDoesNotPush(t *testing.T) {
 	repoDir, _ := initTestRepoWithOrigin(t)
 	chdir(t, repoDir)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	branch := "radius-state-test"
 	s, err := NewGitArchive().Open(ctx, branch)
 	require.NoError(t, err)
@@ -237,7 +237,7 @@ func TestCommit_PushesToRemote(t *testing.T) {
 	repoDir, _ := initTestRepoWithOrigin(t)
 	chdir(t, repoDir)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	branch := "radius-state-test"
 	s, err := NewGitArchive().Open(ctx, branch)
 	require.NoError(t, err)
@@ -254,7 +254,7 @@ func TestCommit_ReturnsErrorWhenPushFails(t *testing.T) {
 	repoDir, _ := initTestRepoWithOrigin(t)
 	chdir(t, repoDir)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	s, err := NewGitArchive().Open(ctx, "radius-state-test")
 	require.NoError(t, err)
 	defer s.Close(ctx)
@@ -281,7 +281,7 @@ func TestCommit_CommitsWithoutConfiguredIdentity(t *testing.T) {
 	runGit(t, root, "git", "config", "--unset", "user.email")
 	chdir(t, root)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	s, err := NewGitArchive().Open(ctx, "radius-state-test")
 	require.NoError(t, err)
 	defer s.Close(ctx)
@@ -307,7 +307,7 @@ func TestCommit_CommitsWithOnlyEmailConfigured(t *testing.T) {
 	runGit(t, root, "git", "config", "--unset", "user.name")
 	chdir(t, root)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	s, err := NewGitArchive().Open(ctx, "radius-state-test")
 	require.NoError(t, err)
 	defer s.Close(ctx)
@@ -360,7 +360,7 @@ func TestOpen_SerializesSessionsPerBranch(t *testing.T) {
 	root := initTestRepo(t)
 	chdir(t, root)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	b := NewGitArchive()
 	const branch = "radius-state-test"
 

--- a/pkg/statearchive/git/git_test.go
+++ b/pkg/statearchive/git/git_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package git
 
 import (
-	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -330,9 +329,9 @@ func TestOpen_UnreachableRemoteFailsLoudly(t *testing.T) {
 	chdir(t, root)
 
 	branch := "radius-state-test"
-	_, err := NewGitArchive().Open(context.Background(), branch)
+	_, err := NewGitArchive().Open(t.Context(), branch)
 	require.Error(t, err, "Open must fail when the configured remote is unreachable")
-	require.False(t, branchExists(context.Background(), root, branch),
+	require.False(t, branchExists(t.Context(), root, branch),
 		"Open must not create a local branch when it cannot confirm remote state")
 }
 
@@ -347,7 +346,7 @@ func TestOpen_OutsideGitRepositoryReturnsError(t *testing.T) {
 	// A bare temp dir with no "git init" is not inside any repository.
 	chdir(t, t.TempDir())
 
-	_, err := NewGitArchive().Open(context.Background(), "radius-state-test")
+	_, err := NewGitArchive().Open(t.Context(), "radius-state-test")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to determine git repo root")
 }

--- a/pkg/statearchive/oci/ghcr_test.go
+++ b/pkg/statearchive/oci/ghcr_test.go
@@ -82,7 +82,7 @@ func TestGHCRPackageClient_Visibility(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			visibility, err := client.Visibility(context.Background())
+			visibility, err := client.Visibility(t.Context())
 			require.NoError(t, err)
 			require.Equal(t, test.visibility, visibility)
 			require.Equal(t, 2, requests)
@@ -94,7 +94,7 @@ func TestGHCRPackageClient_VisibilityReturnsNotFound(t *testing.T) {
 	server := newGHCRTestServer(t, "Organization", http.StatusNotFound, "")
 	client := newTestGHCRPackageClient(t, server)
 
-	_, err := client.Visibility(context.Background())
+	_, err := client.Visibility(t.Context())
 	require.ErrorIs(t, err, errGHCRPackageNotFound)
 }
 
@@ -110,7 +110,7 @@ func TestGHCRPackageClient_VisibilityFailsClosed(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		_, err = client.Visibility(context.Background())
+		_, err = client.Visibility(t.Context())
 		require.ErrorContains(t, err, "credential unavailable")
 	})
 
@@ -123,7 +123,7 @@ func TestGHCRPackageClient_VisibilityFailsClosed(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		_, err = client.Visibility(context.Background())
+		_, err = client.Visibility(t.Context())
 		require.ErrorContains(t, err, "do not include a token")
 	})
 
@@ -166,7 +166,7 @@ func TestGHCRPackageClient_VisibilityFailsClosed(t *testing.T) {
 			server := newGHCRTestServer(t, test.accountType, test.packageStatus, test.packageBody)
 			client := newTestGHCRPackageClient(t, server)
 
-			_, err := client.Visibility(context.Background())
+			_, err := client.Visibility(t.Context())
 			require.ErrorContains(t, err, test.errorContains)
 		})
 	}
@@ -179,7 +179,7 @@ func TestGHCRPackageClient_VisibilityReturnsOwnerErrors(t *testing.T) {
 	t.Cleanup(server.Close)
 	client := newTestGHCRPackageClient(t, server)
 
-	_, err := client.Visibility(context.Background())
+	_, err := client.Visibility(t.Context())
 	require.ErrorContains(t, err, "returned Service Unavailable")
 }
 

--- a/pkg/statearchive/oci/oci_test.go
+++ b/pkg/statearchive/oci/oci_test.go
@@ -44,7 +44,7 @@ import (
 
 func TestOCIArchive_CommitRoundTrip(t *testing.T) {
 	archive, target := newTestArchive(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	session, err := archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
@@ -142,7 +142,7 @@ func TestOCIArchive_CommitEnforcesGHCRVisibility(t *testing.T) {
 				return test.visibility, nil
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			session, err := archive.Open(ctx, "radius-state")
 			require.NoError(t, err)
 			t.Cleanup(func() { session.Close(ctx) })
@@ -203,7 +203,7 @@ func TestOCIArchive_CommitBootstrapsMissingGHCRPackage(t *testing.T) {
 			}}
 			archive.checkPackageVisibility = visibility.Check
 
-			ctx := context.Background()
+			ctx := t.Context()
 			session, err := archive.Open(ctx, "radius-state")
 			require.NoError(t, err)
 			require.NoError(t, os.WriteFile(filepath.Join(session.Path(), "state.txt"), []byte("sensitive state"), 0o644))
@@ -236,7 +236,7 @@ func TestOCIArchive_CommitBootstrapsMissingGHCRPackage(t *testing.T) {
 
 func TestOCIArchive_BootstrapDoesNotOverwriteConcurrentState(t *testing.T) {
 	archive, target := newTestArchive(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	checks := 0
 	archive.checkPackageVisibility = func(context.Context) (packageVisibility, error) {
 		checks++
@@ -272,7 +272,7 @@ func TestOCIArchive_BootstrapDoesNotOverwriteConcurrentState(t *testing.T) {
 
 func TestOCIArchive_PublicPackageAllowsStateDeletion(t *testing.T) {
 	archive, target := newTestArchive(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	archive.checkPackageVisibility = func(context.Context) (packageVisibility, error) {
 		return packageVisibilityPrivate, nil
 	}
@@ -308,7 +308,7 @@ func TestOCIArchive_CommitReturnsVisibilityErrorBeforeUpload(t *testing.T) {
 		return "", errors.New("visibility unavailable")
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	session, err := archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
 	t.Cleanup(func() { session.Close(ctx) })
@@ -328,7 +328,7 @@ func TestOCIArchive_CommitReturnsBootstrapUploadError(t *testing.T) {
 		return "", errGHCRPackageNotFound
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	session, err := archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
 	t.Cleanup(func() { session.Close(ctx) })
@@ -347,7 +347,7 @@ func TestOCIArchive_EmptyNewArchiveSkipsVisibilityCheck(t *testing.T) {
 		return packageVisibilityPublic, nil
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	session, err := archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
 	t.Cleanup(func() { session.Close(ctx) })
@@ -359,7 +359,7 @@ func TestOCIArchive_EmptyNewArchiveSkipsVisibilityCheck(t *testing.T) {
 
 func TestOCIArchive_CommitPersistsDeletion(t *testing.T) {
 	archive, target := newTestArchive(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	session, err := archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
@@ -386,7 +386,7 @@ func TestOCIArchive_CommitPersistsDeletion(t *testing.T) {
 
 func TestOCIArchive_EmptyNewArchiveIsNoOp(t *testing.T) {
 	archive, target := newTestArchive(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	session, err := archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
@@ -405,7 +405,7 @@ func TestOCIArchive_EmptyNewArchiveIsNoOp(t *testing.T) {
 
 func TestOCIArchive_CommitRejectsConcurrentTagUpdate(t *testing.T) {
 	archive, target := newTestArchive(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	session, err := archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
@@ -456,7 +456,7 @@ func TestCreateLayerRejectsSymbolicLinks(t *testing.T) {
 }
 
 func TestCreateArtifactUsesCompatibleManifestAndCleansUp(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(root, "state.txt"), []byte("state"), 0o644))
 
@@ -543,7 +543,7 @@ func TestUnpackArchiveEntriesRejectsNonRegularEntries(t *testing.T) {
 }
 
 func TestUnpackArchiveRejectsInvalidArtifacts(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("malformed manifest", func(t *testing.T) {
 		target := memory.New()

--- a/pkg/statearchive/oci/oci_test.go
+++ b/pkg/statearchive/oci/oci_test.go
@@ -80,22 +80,22 @@ func TestOCIArchive_UsesOCIStorageForGraphs(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, store.Save(context.Background(), key, graph, persistence.SaveOptions{}))
+	require.NoError(t, store.Save(t.Context(), key, graph, persistence.SaveOptions{}))
 
-	got, err := store.Load(context.Background(), key)
+	got, err := store.Load(t.Context(), key)
 	require.NoError(t, err)
 	require.Len(t, got.Resources, 1)
 	require.Equal(t, "frontend", *got.Resources[0].Name)
 
-	require.NoError(t, store.Delete(context.Background(), key))
-	_, err = store.Load(context.Background(), key)
+	require.NoError(t, store.Delete(t.Context(), key))
+	_, err = store.Load(t.Context(), key)
 	require.ErrorIs(t, err, persistence.ErrNotFound)
 }
 
 func TestOCIArchive_OpenRejectsEmptyName(t *testing.T) {
 	archive, _ := newTestArchive(t)
 
-	_, err := archive.Open(context.Background(), "")
+	_, err := archive.Open(t.Context(), "")
 	require.ErrorContains(t, err, "OCI archive name must not be empty")
 }
 
@@ -105,7 +105,7 @@ func TestOCIArchive_OpenReturnsTargetError(t *testing.T) {
 		return nil, errors.New("registry unavailable")
 	}
 
-	_, err := archive.Open(context.Background(), "radius-state")
+	_, err := archive.Open(t.Context(), "radius-state")
 	require.ErrorContains(t, err, "registry unavailable")
 }
 
@@ -115,12 +115,13 @@ func TestOCIArchive_CommitReturnsTargetError(t *testing.T) {
 		return failedPushTarget{}, nil
 	}
 
-	session, err := archive.Open(context.Background(), "radius-state")
+	session, err := archive.Open(t.Context(), "radius-state")
 	require.NoError(t, err)
+	// Use a fresh context because t.Context() is cancelled before cleanup runs.
 	t.Cleanup(func() { session.Close(context.Background()) })
 	require.NoError(t, os.WriteFile(filepath.Join(session.Path(), "state.txt"), []byte("state"), 0o644))
 
-	err = session.Commit(context.Background(), "ignored message")
+	err = session.Commit(t.Context(), "ignored message")
 	require.ErrorContains(t, err, "push failed")
 }
 
@@ -435,7 +436,7 @@ func TestOCIArchive_OpenRemoteTargetConfiguresPlainHTTP(t *testing.T) {
 	t.Setenv("DOCKER_CONFIG", t.TempDir())
 	archive := NewOCIArchive(Options{Repository: "localhost:5000/radius-state", PlainHTTP: true})
 
-	target, err := archive.openRemoteTarget(context.Background())
+	target, err := archive.openRemoteTarget(t.Context())
 	require.NoError(t, err)
 	repository, ok := target.(*remote.Repository)
 	require.True(t, ok)
@@ -579,7 +580,7 @@ func pushTestManifest(t *testing.T, target oras.Target, manifest ocispec.Manifes
 
 	data, err := json.Marshal(manifest)
 	require.NoError(t, err)
-	desc, err := pushBlob(context.Background(), target, ocispec.MediaTypeImageManifest, data)
+	desc, err := pushBlob(t.Context(), target, ocispec.MediaTypeImageManifest, data)
 	require.NoError(t, err)
 	return desc
 }

--- a/pkg/statearchive/oci/oci_test.go
+++ b/pkg/statearchive/oci/oci_test.go
@@ -32,6 +32,7 @@ import (
 	corerpv20250801preview "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
 	"github.com/radius-project/radius/pkg/graph/persistence"
 	graphstore "github.com/radius-project/radius/pkg/graph/persistence/git"
+	"github.com/radius-project/radius/pkg/statearchive"
 	"github.com/radius-project/radius/pkg/to"
 	"github.com/stretchr/testify/require"
 	"oras.land/oras-go/v2"
@@ -55,7 +56,7 @@ func TestOCIArchive_CommitRoundTrip(t *testing.T) {
 
 	session, err = archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
-	t.Cleanup(func() { session.Close(ctx) })
+	closeOnCleanup(t, session)
 
 	data, err := os.ReadFile(filepath.Join(session.Path(), "nested", "state.txt"))
 	require.NoError(t, err)
@@ -117,8 +118,7 @@ func TestOCIArchive_CommitReturnsTargetError(t *testing.T) {
 
 	session, err := archive.Open(t.Context(), "radius-state")
 	require.NoError(t, err)
-	// Use a fresh context because t.Context() is cancelled before cleanup runs.
-	t.Cleanup(func() { session.Close(context.Background()) }) //nolint:usetesting
+	closeOnCleanup(t, session)
 	require.NoError(t, os.WriteFile(filepath.Join(session.Path(), "state.txt"), []byte("state"), 0o644))
 
 	err = session.Commit(t.Context(), "ignored message")
@@ -146,7 +146,7 @@ func TestOCIArchive_CommitEnforcesGHCRVisibility(t *testing.T) {
 			ctx := t.Context()
 			session, err := archive.Open(ctx, "radius-state")
 			require.NoError(t, err)
-			t.Cleanup(func() { session.Close(ctx) })
+			closeOnCleanup(t, session)
 			require.NoError(t, os.WriteFile(filepath.Join(session.Path(), "state.txt"), []byte("state"), 0o644))
 
 			err = session.Commit(ctx, "ignored message")
@@ -221,7 +221,7 @@ func TestOCIArchive_CommitBootstrapsMissingGHCRPackage(t *testing.T) {
 
 			session, err = archive.Open(ctx, "radius-state")
 			require.NoError(t, err)
-			t.Cleanup(func() { session.Close(ctx) })
+			closeOnCleanup(t, session)
 			if test.errorContains == "" {
 				data, err := os.ReadFile(filepath.Join(session.Path(), "state.txt"))
 				require.NoError(t, err)
@@ -265,7 +265,7 @@ func TestOCIArchive_BootstrapDoesNotOverwriteConcurrentState(t *testing.T) {
 
 	session, err = archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
-	t.Cleanup(func() { session.Close(ctx) })
+	closeOnCleanup(t, session)
 	data, err := os.ReadFile(filepath.Join(session.Path(), "state.txt"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("external state"), data)
@@ -297,7 +297,7 @@ func TestOCIArchive_PublicPackageAllowsStateDeletion(t *testing.T) {
 
 	session, err = archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
-	t.Cleanup(func() { session.Close(ctx) })
+	closeOnCleanup(t, session)
 	entries, err := os.ReadDir(session.Path())
 	require.NoError(t, err)
 	require.Empty(t, entries)
@@ -312,7 +312,7 @@ func TestOCIArchive_CommitReturnsVisibilityErrorBeforeUpload(t *testing.T) {
 	ctx := t.Context()
 	session, err := archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
-	t.Cleanup(func() { session.Close(ctx) })
+	closeOnCleanup(t, session)
 	require.NoError(t, os.WriteFile(filepath.Join(session.Path(), "state.txt"), []byte("state"), 0o644))
 
 	err = session.Commit(ctx, "ignored message")
@@ -332,7 +332,7 @@ func TestOCIArchive_CommitReturnsBootstrapUploadError(t *testing.T) {
 	ctx := t.Context()
 	session, err := archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
-	t.Cleanup(func() { session.Close(ctx) })
+	closeOnCleanup(t, session)
 	require.NoError(t, os.WriteFile(filepath.Join(session.Path(), "state.txt"), []byte("state"), 0o644))
 
 	err = session.Commit(ctx, "ignored message")
@@ -351,7 +351,7 @@ func TestOCIArchive_EmptyNewArchiveSkipsVisibilityCheck(t *testing.T) {
 	ctx := t.Context()
 	session, err := archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
-	t.Cleanup(func() { session.Close(ctx) })
+	closeOnCleanup(t, session)
 
 	require.NoError(t, session.Commit(ctx, "ignored message"))
 	require.Equal(t, 0, checks)
@@ -378,7 +378,7 @@ func TestOCIArchive_CommitPersistsDeletion(t *testing.T) {
 
 	session, err = archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
-	t.Cleanup(func() { session.Close(ctx) })
+	closeOnCleanup(t, session)
 
 	entries, err := os.ReadDir(session.Path())
 	require.NoError(t, err)
@@ -398,7 +398,7 @@ func TestOCIArchive_EmptyNewArchiveIsNoOp(t *testing.T) {
 
 	session, err = archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
-	t.Cleanup(func() { session.Close(ctx) })
+	closeOnCleanup(t, session)
 	entries, err := os.ReadDir(session.Path())
 	require.NoError(t, err)
 	require.Empty(t, entries)
@@ -426,7 +426,7 @@ func TestOCIArchive_CommitRejectsConcurrentTagUpdate(t *testing.T) {
 
 	session, err = archive.Open(ctx, "radius-state")
 	require.NoError(t, err)
-	t.Cleanup(func() { session.Close(ctx) })
+	closeOnCleanup(t, session)
 	data, err := os.ReadFile(filepath.Join(session.Path(), "state.txt"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("external state"), data)
@@ -596,6 +596,13 @@ func newTestArchive(t *testing.T) (*OCIArchive, *countingTarget) {
 		return target, nil
 	}
 	return archive, target
+}
+
+// closeOnCleanup closes the session once the test ends. It uses a fresh context because
+// t.Context() is cancelled before cleanup runs.
+func closeOnCleanup(t *testing.T, session statearchive.Session) {
+	t.Helper()
+	t.Cleanup(func() { session.Close(context.Background()) }) //nolint:usetesting
 }
 
 type countingTarget struct {

--- a/pkg/statearchive/oci/oci_test.go
+++ b/pkg/statearchive/oci/oci_test.go
@@ -118,7 +118,7 @@ func TestOCIArchive_CommitReturnsTargetError(t *testing.T) {
 	session, err := archive.Open(t.Context(), "radius-state")
 	require.NoError(t, err)
 	// Use a fresh context because t.Context() is cancelled before cleanup runs.
-	t.Cleanup(func() { session.Close(context.Background()) })
+	t.Cleanup(func() { session.Close(context.Background()) }) //nolint:usetesting
 	require.NoError(t, os.WriteFile(filepath.Join(session.Path(), "state.txt"), []byte("state"), 0o644))
 
 	err = session.Commit(t.Context(), "ignored message")

--- a/pkg/ucp/aws/servicecontext/awsrequestcontext_test.go
+++ b/pkg/ucp/aws/servicecontext/awsrequestcontext_test.go
@@ -33,7 +33,7 @@ func TestFromContext(t *testing.T) {
 	require.NoError(t, err)
 	serviceCtx, err := v1.FromARMRequest(req, "", v1.LocationGlobal)
 	require.NoError(t, err)
-	ctx := context.Background()
+	ctx := t.Context()
 	newCtx := v1.WithARMRequestContext(ctx, serviceCtx)
 
 	sCtx := AWSRequestContextFromContext(newCtx)

--- a/pkg/ucp/aws/servicecontext/awsrequestcontext_test.go
+++ b/pkg/ucp/aws/servicecontext/awsrequestcontext_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package servicecontext
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"os"
@@ -29,7 +28,7 @@ import (
 )
 
 func TestFromContext(t *testing.T) {
-	req, err := getTestHTTPRequest("./testdata/armrpcheaders.json")
+	req, err := getTestHTTPRequest(t, "./testdata/armrpcheaders.json")
 	require.NoError(t, err)
 	serviceCtx, err := v1.FromARMRequest(req, "", v1.LocationGlobal)
 	require.NoError(t, err)
@@ -42,7 +41,7 @@ func TestFromContext(t *testing.T) {
 	require.Equal(t, "AWS::Kinesis::Stream", sCtx.ResourceTypeInAWSFormat())
 }
 
-func getTestHTTPRequest(headerFile string) (*http.Request, error) {
+func getTestHTTPRequest(t *testing.T, headerFile string) (*http.Request, error) {
 	jsonData, err := os.ReadFile(headerFile)
 	if err != nil {
 		return nil, err
@@ -53,7 +52,7 @@ func getTestHTTPRequest(headerFile string) (*http.Request, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, strings.ToLower(parsed["Referer"]), nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, strings.ToLower(parsed["Referer"]), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ucp/aws/ucpcredentialprovider_test.go
+++ b/pkg/ucp/aws/ucpcredentialprovider_test.go
@@ -78,14 +78,14 @@ func TestRetrieve(t *testing.T) {
 		cp := NewUCPCredentialProvider(p, DefaultExpireDuration)
 		p.fakeCredential.AccessKeyCredential.AccessKeyID = ""
 
-		_, err := cp.Retrieve(context.TODO())
+		_, err := cp.Retrieve(t.Context())
 		require.Error(t, err)
 
 		p = newMockProviderIRSA()
 		cp = NewUCPCredentialProvider(p, DefaultExpireDuration)
 		p.fakeCredential.IRSACredential.RoleARN = ""
 
-		_, err = cp.Retrieve(context.TODO())
+		_, err = cp.Retrieve(t.Context())
 		require.Error(t, err)
 	})
 
@@ -94,7 +94,7 @@ func TestRetrieve(t *testing.T) {
 		cp := NewUCPCredentialProvider(p, DefaultExpireDuration)
 
 		expectedExpiry := time.Now().UTC().Add(DefaultExpireDuration)
-		cred, err := cp.Retrieve(context.TODO())
+		cred, err := cp.Retrieve(t.Context())
 		require.NoError(t, err)
 
 		require.Equal(t, "fakeid", cred.AccessKeyID)

--- a/pkg/ucp/backend/controller/resourceproviders/util_test.go
+++ b/pkg/ucp/backend/controller/resourceproviders/util_test.go
@@ -192,7 +192,7 @@ func Test_UpdateResourceProviderSummaryWithETag(t *testing.T) {
 				})
 			}
 
-			err := updateResourceProviderSummaryWithETag(context.Background(), client, tt.summaryID, tt.policy, tt.updateFunc)
+			err := updateResourceProviderSummaryWithETag(t.Context(), client, tt.summaryID, tt.policy, tt.updateFunc)
 			if tt.expectedErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/ucp/datamodel/icon_validation.go
+++ b/pkg/ucp/datamodel/icon_validation.go
@@ -258,11 +258,11 @@ func validateURLBearingValue(elementName, attrName, value string) error {
 			return nil
 		}
 		after := remaining[i+len("url("):]
-		j := strings.Index(after, ")")
-		if j < 0 {
+		before, after0, ok := strings.Cut(after, ")")
+		if !ok {
 			return fmt.Errorf("icon <%s> element attribute %q has malformed url(...) value %q", elementName, attrName, value)
 		}
-		target := strings.TrimSpace(after[:j])
+		target := strings.TrimSpace(before)
 		if len(target) >= 2 {
 			first, last := target[0], target[len(target)-1]
 			if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
@@ -272,6 +272,6 @@ func validateURLBearingValue(elementName, attrName, value string) error {
 		if !strings.HasPrefix(target, "#") {
 			return fmt.Errorf("icon <%s> element attribute %q references external resource %q via url(); only intra-document fragments (url(#...)) are allowed", elementName, attrName, value)
 		}
-		remaining = after[j+1:]
+		remaining = after0
 	}
 }

--- a/pkg/ucp/frontend/controller/credentials/aws/createorupdateawscredential_test.go
+++ b/pkg/ucp/frontend/controller/credentials/aws/createorupdateawscredential_test.go
@@ -128,7 +128,7 @@ func Test_AWS_Credential(t *testing.T) {
 			err = json.Unmarshal(credentialInput, credentialVersionedInput)
 			require.NoError(t, err)
 
-			request, err := rpctest.NewHTTPRequestFromJSON(context.Background(), http.MethodPut, tt.headerfile, credentialVersionedInput)
+			request, err := rpctest.NewHTTPRequestFromJSON(t.Context(), http.MethodPut, tt.headerfile, credentialVersionedInput)
 			require.NoError(t, err)
 
 			ctx := rpctest.NewARMRequestContext(request)

--- a/pkg/ucp/frontend/controller/credentials/aws/deleteawscredential_test.go
+++ b/pkg/ucp/frontend/controller/credentials/aws/deleteawscredential_test.go
@@ -111,7 +111,7 @@ func Test_Credential_Delete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.fn(*mockDatabaseClient, *mockSecretClient)
-			request, err := rpctest.NewHTTPRequestFromJSON(context.Background(), http.MethodDelete, tt.headerfile, nil)
+			request, err := rpctest.NewHTTPRequestFromJSON(t.Context(), http.MethodDelete, tt.headerfile, nil)
 			require.NoError(t, err)
 			ctx := rpctest.NewARMRequestContext(request)
 			response, err := credentialCtrl.Run(ctx, nil, request)

--- a/pkg/ucp/frontend/controller/credentials/azure/createorupdateazurecredential_test.go
+++ b/pkg/ucp/frontend/controller/credentials/azure/createorupdateazurecredential_test.go
@@ -129,7 +129,7 @@ func Test_Azure_Credential(t *testing.T) {
 			err = json.Unmarshal(credentialInput, credentialVersionedInput)
 			require.NoError(t, err)
 
-			request, err := rpctest.NewHTTPRequestFromJSON(context.Background(), http.MethodPut, tt.headerfile, credentialVersionedInput)
+			request, err := rpctest.NewHTTPRequestFromJSON(t.Context(), http.MethodPut, tt.headerfile, credentialVersionedInput)
 			require.NoError(t, err)
 
 			ctx := rpctest.NewARMRequestContext(request)

--- a/pkg/ucp/frontend/controller/credentials/azure/deleteazurecredential_test.go
+++ b/pkg/ucp/frontend/controller/credentials/azure/deleteazurecredential_test.go
@@ -112,7 +112,7 @@ func Test_Credential_Delete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.fn(*mockDatabaseClient, *mockSecretClient)
-			request, err := rpctest.NewHTTPRequestFromJSON(context.Background(), http.MethodDelete, tt.headerfile, nil)
+			request, err := rpctest.NewHTTPRequestFromJSON(t.Context(), http.MethodDelete, tt.headerfile, nil)
 			require.NoError(t, err)
 
 			ctx := rpctest.NewARMRequestContext(request)

--- a/pkg/ucp/frontend/controller/resourceproviders/geticon_test.go
+++ b/pkg/ucp/frontend/controller/resourceproviders/geticon_test.go
@@ -85,12 +85,12 @@ func TestGetIcon_Success(t *testing.T) {
 	mockDB.EXPECT().Get(gomock.Any(), testIconResourceTypeID).Return(&database.Object{Data: rt}, nil)
 
 	req := newIconRequest(t, testIconHash)
-	resp, err := ctrl.Run(context.Background(), nil, req)
+	resp, err := ctrl.Run(t.Context(), nil, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
 	rec := httptest.NewRecorder()
-	require.NoError(t, resp.Apply(context.Background(), rec, req))
+	require.NoError(t, resp.Apply(t.Context(), rec, req))
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, "image/svg+xml; charset=utf-8", rec.Header().Get("Content-Type"))
@@ -112,7 +112,7 @@ func TestGetIcon_HashMismatch(t *testing.T) {
 	mockDB.EXPECT().Get(gomock.Any(), testIconResourceTypeID).Return(&database.Object{Data: rt}, nil)
 
 	req := newIconRequest(t, "deadbeef")
-	resp, err := ctrl.Run(context.Background(), nil, req)
+	resp, err := ctrl.Run(t.Context(), nil, req)
 	require.NoError(t, err)
 
 	notFound, ok := resp.(*armrpc_rest.NotFoundResponse)
@@ -141,7 +141,7 @@ func TestGetIcon_IntegrityCheckFails(t *testing.T) {
 	mockDB.EXPECT().Get(gomock.Any(), testIconResourceTypeID).Return(&database.Object{Data: rt}, nil)
 
 	req := newIconRequest(t, testIconHash)
-	resp, err := ctrl.Run(context.Background(), nil, req)
+	resp, err := ctrl.Run(t.Context(), nil, req)
 	require.NoError(t, err)
 
 	notFound, ok := resp.(*armrpc_rest.NotFoundResponse)
@@ -180,7 +180,7 @@ func TestGetIcon_NoIcon(t *testing.T) {
 			mockDB.EXPECT().Get(gomock.Any(), testIconResourceTypeID).Return(&database.Object{Data: rt}, nil)
 
 			req := newIconRequest(t, testIconHash)
-			resp, err := ctrl.Run(context.Background(), nil, req)
+			resp, err := ctrl.Run(t.Context(), nil, req)
 			require.NoError(t, err)
 
 			notFound, ok := resp.(*armrpc_rest.NotFoundResponse)
@@ -211,12 +211,12 @@ func TestGetIcon_DefaultHashServesEmbeddedBytes(t *testing.T) {
 	mockDB.EXPECT().Get(gomock.Any(), testIconResourceTypeID).Return(&database.Object{Data: rt}, nil)
 
 	req := newIconRequest(t, defaultIcon.Hash)
-	resp, err := ctrl.Run(context.Background(), nil, req)
+	resp, err := ctrl.Run(t.Context(), nil, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
 	rec := httptest.NewRecorder()
-	require.NoError(t, resp.Apply(context.Background(), rec, req))
+	require.NoError(t, resp.Apply(t.Context(), rec, req))
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, "image/svg+xml; charset=utf-8", rec.Header().Get("Content-Type"))
@@ -229,7 +229,7 @@ func TestGetIcon_ResourceTypeNotFound(t *testing.T) {
 	mockDB.EXPECT().Get(gomock.Any(), testIconResourceTypeID).Return(nil, &database.ErrNotFound{ID: testIconResourceTypeID})
 
 	req := newIconRequest(t, testIconHash)
-	resp, err := ctrl.Run(context.Background(), nil, req)
+	resp, err := ctrl.Run(t.Context(), nil, req)
 	require.NoError(t, err)
 
 	notFound, ok := resp.(*armrpc_rest.NotFoundResponse)

--- a/pkg/ucp/initializer/service_test.go
+++ b/pkg/ucp/initializer/service_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package initializer
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
@@ -45,11 +44,11 @@ func Test_registerResourceProviderDirect(t *testing.T) {
 		dbClient := inmemory.NewClient()
 
 		rp := createTestResourceProvider()
-		err := registerResourceProviderDirect(context.Background(), dbClient, "local", rp)
+		err := registerResourceProviderDirect(t.Context(), dbClient, "local", rp)
 		require.NoError(t, err)
 
 		// Verify resource provider was saved
-		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources")
+		obj, err := dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources")
 		require.NoError(t, err)
 
 		rpModel := &datamodel.ResourceProvider{}
@@ -60,7 +59,7 @@ func Test_registerResourceProviderDirect(t *testing.T) {
 		assert.Equal(t, "global", rpModel.Location)
 
 		// Verify resource type was saved
-		obj, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/resourceTypes/widgets")
+		obj, err = dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/resourceTypes/widgets")
 		require.NoError(t, err)
 
 		rtModel := &datamodel.ResourceType{}
@@ -70,7 +69,7 @@ func Test_registerResourceProviderDirect(t *testing.T) {
 		assert.Equal(t, v1.ProvisioningStateSucceeded, rtModel.InternalMetadata.AsyncProvisioningState)
 
 		// Verify API version was saved
-		obj, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/resourceTypes/widgets/apiVersions/2023-10-01-preview")
+		obj, err = dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/resourceTypes/widgets/apiVersions/2023-10-01-preview")
 		require.NoError(t, err)
 
 		avModel := &datamodel.APIVersion{}
@@ -79,7 +78,7 @@ func Test_registerResourceProviderDirect(t *testing.T) {
 		assert.Equal(t, datamodel.APIVersionResourceType, avModel.Type)
 
 		// Verify location was saved
-		obj, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/locations/global")
+		obj, err = dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/locations/global")
 		require.NoError(t, err)
 
 		locModel := &datamodel.Location{}
@@ -90,7 +89,7 @@ func Test_registerResourceProviderDirect(t *testing.T) {
 		assert.Contains(t, locModel.Properties.ResourceTypes["widgets"].APIVersions, "2023-10-01-preview")
 
 		// Verify summary was saved
-		obj, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviderSummaries/MyCompany.Resources")
+		obj, err = dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviderSummaries/MyCompany.Resources")
 		require.NoError(t, err)
 
 		summaryModel := &datamodel.ResourceProviderSummary{}
@@ -105,23 +104,23 @@ func Test_registerResourceProviderDirect(t *testing.T) {
 		dbClient := inmemory.NewClient()
 
 		rp := createTestResourceProviderMultiType()
-		err := registerResourceProviderDirect(context.Background(), dbClient, "local", rp)
+		err := registerResourceProviderDirect(t.Context(), dbClient, "local", rp)
 		require.NoError(t, err)
 
 		// Verify both resource types exist
 		for _, typeName := range []string{"typeA", "typeB"} {
-			_, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Multi.Provider/resourceTypes/"+typeName)
+			_, err := dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/Multi.Provider/resourceTypes/"+typeName)
 			require.NoError(t, err, "expected resource type %s to exist", typeName)
 		}
 
 		// Verify typeA has two API versions
 		for _, version := range []string{"2023-01-01", "2024-01-01"} {
-			_, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Multi.Provider/resourceTypes/typeA/apiVersions/"+version)
+			_, err := dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/Multi.Provider/resourceTypes/typeA/apiVersions/"+version)
 			require.NoError(t, err, "expected API version %s to exist for typeA", version)
 		}
 
 		// Verify summary has both types
-		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviderSummaries/Multi.Provider")
+		obj, err := dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviderSummaries/Multi.Provider")
 		require.NoError(t, err)
 
 		summaryModel := &datamodel.ResourceProviderSummary{}
@@ -137,11 +136,11 @@ func Test_registerResourceProviderDirect(t *testing.T) {
 
 		rp := createTestResourceProvider()
 		rp.Location = nil
-		err := registerResourceProviderDirect(context.Background(), dbClient, "local", rp)
+		err := registerResourceProviderDirect(t.Context(), dbClient, "local", rp)
 		require.NoError(t, err)
 
 		// Location should default to "global"
-		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/locations/global")
+		obj, err := dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/locations/global")
 		require.NoError(t, err)
 
 		locModel := &datamodel.Location{}
@@ -157,14 +156,14 @@ func Test_registerResourceProviderDirect(t *testing.T) {
 		rp := createTestResourceProvider()
 
 		// Register twice
-		err := registerResourceProviderDirect(context.Background(), dbClient, "local", rp)
+		err := registerResourceProviderDirect(t.Context(), dbClient, "local", rp)
 		require.NoError(t, err)
 
-		err = registerResourceProviderDirect(context.Background(), dbClient, "local", rp)
+		err = registerResourceProviderDirect(t.Context(), dbClient, "local", rp)
 		require.NoError(t, err)
 
 		// Should still be readable
-		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources")
+		obj, err := dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources")
 		require.NoError(t, err)
 		require.NotNil(t, obj)
 	})
@@ -177,14 +176,14 @@ func Test_Run(t *testing.T) {
 	t.Run("no manifest directory skips initialization", func(t *testing.T) {
 		t.Parallel()
 		svc := newTestService("")
-		err := svc.Run(context.Background())
+		err := svc.Run(t.Context())
 		require.NoError(t, err)
 	})
 
 	t.Run("missing manifest directory returns error", func(t *testing.T) {
 		t.Parallel()
 		svc := newTestService("/nonexistent/path")
-		err := svc.Run(context.Background())
+		err := svc.Run(t.Context())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "manifest directory does not exist")
 	})
@@ -208,14 +207,14 @@ types:
 		require.NoError(t, err)
 
 		svc := newTestService(tempDir)
-		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
+		dbClient, err := svc.options.DatabaseProvider.GetClient(t.Context())
 		require.NoError(t, err)
 
-		err = svc.Run(context.Background())
+		err = svc.Run(t.Context())
 		require.NoError(t, err)
 
 		// Verify the resource provider was registered
-		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Test.Provider")
+		obj, err := dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/Test.Provider")
 		require.NoError(t, err)
 		require.NotNil(t, obj)
 	})
@@ -248,7 +247,7 @@ types:
 		require.NoError(t, err)
 
 		svc := newTestService(tempDir)
-		err = svc.Run(context.Background())
+		err = svc.Run(t.Context())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "duplicate resource type Radius.Compute/containers")
 	})
@@ -280,20 +279,20 @@ types:
 		require.NoError(t, err)
 
 		svc := newTestService(tempDir)
-		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
+		dbClient, err := svc.options.DatabaseProvider.GetClient(t.Context())
 		require.NoError(t, err)
 
-		err = svc.Run(context.Background())
+		err = svc.Run(t.Context())
 		require.NoError(t, err)
 
 		// Verify both types are registered under the same namespace.
-		_, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Radius.Compute/resourceTypes/containers")
+		_, err = dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/Radius.Compute/resourceTypes/containers")
 		require.NoError(t, err)
-		_, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Radius.Compute/resourceTypes/routes")
+		_, err = dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/Radius.Compute/resourceTypes/routes")
 		require.NoError(t, err)
 
 		// Verify the location contains both types.
-		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Radius.Compute/locations/global")
+		obj, err := dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/Radius.Compute/locations/global")
 		require.NoError(t, err)
 		location := &datamodel.Location{}
 		require.NoError(t, obj.As(location))
@@ -312,13 +311,13 @@ types:
 		require.NoError(t, err)
 
 		svc := newTestService(tempDir)
-		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
+		dbClient, err := svc.options.DatabaseProvider.GetClient(t.Context())
 		require.NoError(t, err)
 
-		err = svc.Run(context.Background())
+		err = svc.Run(t.Context())
 		require.NoError(t, err)
 
-		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviderSummaries/Radius.Core")
+		obj, err := dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviderSummaries/Radius.Core")
 		require.NoError(t, err)
 
 		summaryModel := &datamodel.ResourceProviderSummary{}
@@ -393,7 +392,7 @@ types:
 		assert.NotContains(t, registryAuthenticationsProperty, "$ref")
 		assert.Equal(t, "object", registryAuthenticationsProperty["type"])
 
-		obj, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Radius.Core/resourceTypes/applications/apiVersions/2025-08-01-preview")
+		obj, err = dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/Radius.Core/resourceTypes/applications/apiVersions/2025-08-01-preview")
 		require.NoError(t, err)
 
 		apiVersionModel := &datamodel.APIVersion{}
@@ -474,10 +473,10 @@ func Test_saveResource(t *testing.T) {
 		},
 	}
 
-	err := saveResource(context.Background(), dbClient, data.ID, data)
+	err := saveResource(t.Context(), dbClient, data.ID, data)
 	require.NoError(t, err)
 
-	obj, err := dbClient.Get(context.Background(), data.ID)
+	obj, err := dbClient.Get(t.Context(), data.ID)
 	require.NoError(t, err)
 
 	result := &datamodel.ResourceProvider{}
@@ -704,13 +703,13 @@ func Test_Run_Icons(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(tempDir, "widgets.svg"), validIconSVG, 0600))
 
 		svc := newTestService(tempDir)
-		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
+		dbClient, err := svc.options.DatabaseProvider.GetClient(t.Context())
 		require.NoError(t, err)
 
-		require.NoError(t, svc.Run(context.Background()))
+		require.NoError(t, svc.Run(t.Context()))
 
 		// Verify the resource type record carries the icon and hash.
-		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Test.Provider/resourceTypes/widgets")
+		obj, err := dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/Test.Provider/resourceTypes/widgets")
 		require.NoError(t, err)
 
 		rt := &datamodel.ResourceType{}
@@ -721,7 +720,7 @@ func Test_Run_Icons(t *testing.T) {
 		assert.Equal(t, expectedHashHex, *rt.Properties.IconHash)
 
 		// Verify the summary mirrors the same icon and hash.
-		obj, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviderSummaries/Test.Provider")
+		obj, err = dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviderSummaries/Test.Provider")
 		require.NoError(t, err)
 
 		summary := &datamodel.ResourceProviderSummary{}
@@ -742,13 +741,13 @@ func Test_Run_Icons(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(tempDir, "widgets.svg"), validIconSVG, 0600))
 
 		svc := newTestService(tempDir)
-		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
+		dbClient, err := svc.options.DatabaseProvider.GetClient(t.Context())
 		require.NoError(t, err)
 
-		require.NoError(t, svc.Run(context.Background()))
+		require.NoError(t, svc.Run(t.Context()))
 
 		// widgets got the icon.
-		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Test.Provider/resourceTypes/widgets")
+		obj, err := dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/Test.Provider/resourceTypes/widgets")
 		require.NoError(t, err)
 		widgets := &datamodel.ResourceType{}
 		require.NoError(t, obj.As(widgets))
@@ -760,7 +759,7 @@ func Test_Run_Icons(t *testing.T) {
 		// gadgets did NOT get the sibling icon bytes, but registration-time
 		// hash substitution fills in the product default icon's hash so every
 		// registered type has a non-nil IconHash.
-		obj, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Test.Provider/resourceTypes/gadgets")
+		obj, err = dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/Test.Provider/resourceTypes/gadgets")
 		require.NoError(t, err)
 		gadgets := &datamodel.ResourceType{}
 		require.NoError(t, obj.As(gadgets))
@@ -776,12 +775,12 @@ func Test_Run_Icons(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(tempDir, "widgets.yaml"), []byte(iconManifestYAML), 0600))
 
 		svc := newTestService(tempDir)
-		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
+		dbClient, err := svc.options.DatabaseProvider.GetClient(t.Context())
 		require.NoError(t, err)
 
-		require.NoError(t, svc.Run(context.Background()))
+		require.NoError(t, svc.Run(t.Context()))
 
-		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Test.Provider/resourceTypes/widgets")
+		obj, err := dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/Test.Provider/resourceTypes/widgets")
 		require.NoError(t, err)
 
 		// Icon bytes are not stored on the record (kept in the binary via
@@ -802,7 +801,7 @@ func Test_Run_Icons(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(tempDir, "orphan.svg"), validIconSVG, 0600))
 
 		svc := newTestService(tempDir)
-		require.NoError(t, svc.Run(context.Background()))
+		require.NoError(t, svc.Run(t.Context()))
 	})
 
 	t.Run("invalid <typeName>.svg fails startup", func(t *testing.T) {
@@ -813,7 +812,7 @@ func Test_Run_Icons(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(tempDir, "widgets.svg"), invalidIconSVG, 0600))
 
 		svc := newTestService(tempDir)
-		err := svc.Run(context.Background())
+		err := svc.Run(t.Context())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid icon file")
 	})
@@ -830,10 +829,10 @@ func Test_registerResourceProviderDirect_Icon(t *testing.T) {
 	rp := createTestResourceProvider()
 	rp.Types["widgets"].Icon = to.Ptr(svg)
 
-	require.NoError(t, registerResourceProviderDirect(context.Background(), dbClient, "local", rp))
+	require.NoError(t, registerResourceProviderDirect(t.Context(), dbClient, "local", rp))
 
 	// The resource type record carries the icon and its server-computed SHA-256 hash.
-	obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/resourceTypes/widgets")
+	obj, err := dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/resourceTypes/widgets")
 	require.NoError(t, err)
 
 	rt := &datamodel.ResourceType{}
@@ -844,7 +843,7 @@ func Test_registerResourceProviderDirect_Icon(t *testing.T) {
 	assert.Equal(t, expectedHashHex, *rt.Properties.IconHash)
 
 	// The summary mirror carries the same icon and hash.
-	obj, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviderSummaries/MyCompany.Resources")
+	obj, err = dbClient.Get(t.Context(), "/planes/radius/local/providers/System.Resources/resourceProviderSummaries/MyCompany.Resources")
 	require.NoError(t, err)
 
 	summary := &datamodel.ResourceProviderSummary{}

--- a/pkg/ucp/integrationtests/aws/createresource_test.go
+++ b/pkg/ucp/integrationtests/aws/createresource_test.go
@@ -62,7 +62,7 @@ func Test_CreateAWSResource(t *testing.T) {
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	createRequest, err := rpctest.NewHTTPRequestWithContent(context.Background(), http.MethodPut, ucp.BaseURL()+testProxyRequestAWSPath, body)
+	createRequest, err := rpctest.NewHTTPRequestWithContent(t.Context(), http.MethodPut, ucp.BaseURL()+testProxyRequestAWSPath, body)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := rpctest.NewARMRequestContext(createRequest)

--- a/pkg/ucp/integrationtests/aws/createresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/createresourcewithpost_test.go
@@ -80,7 +80,7 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	createRequest, err := rpctest.NewHTTPRequestWithContent(context.Background(), http.MethodPost, ucp.BaseURL()+testProxyRequestAWSCollectionPath+"/:put", body)
+	createRequest, err := rpctest.NewHTTPRequestWithContent(t.Context(), http.MethodPost, ucp.BaseURL()+testProxyRequestAWSCollectionPath+"/:put", body)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := rpctest.NewARMRequestContext(createRequest)

--- a/pkg/ucp/integrationtests/aws/deleteresource_test.go
+++ b/pkg/ucp/integrationtests/aws/deleteresource_test.go
@@ -45,7 +45,7 @@ func Test_DeleteAWSResource(t *testing.T) {
 		return &output, nil
 	})
 
-	deleteRequest, err := rpctest.NewHTTPRequestWithContent(context.Background(), http.MethodDelete, ucp.BaseURL()+testProxyRequestAWSPath, nil)
+	deleteRequest, err := rpctest.NewHTTPRequestWithContent(t.Context(), http.MethodDelete, ucp.BaseURL()+testProxyRequestAWSPath, nil)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := rpctest.NewARMRequestContext(deleteRequest)

--- a/pkg/ucp/integrationtests/aws/deleteresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/deleteresourcewithpost_test.go
@@ -72,7 +72,7 @@ func Test_DeleteAWSResourceWithPost(t *testing.T) {
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	deleteRequest, err := rpctest.NewHTTPRequestWithContent(context.Background(), http.MethodPost, ucp.BaseURL()+testProxyRequestAWSCollectionPath+"/:delete", body)
+	deleteRequest, err := rpctest.NewHTTPRequestWithContent(t.Context(), http.MethodPost, ucp.BaseURL()+testProxyRequestAWSCollectionPath+"/:delete", body)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := rpctest.NewARMRequestContext(deleteRequest)

--- a/pkg/ucp/integrationtests/aws/getresource_test.go
+++ b/pkg/ucp/integrationtests/aws/getresource_test.go
@@ -53,7 +53,7 @@ func Test_GetAWSResource(t *testing.T) {
 		return &output, nil
 	})
 
-	getRequest, err := rpctest.NewHTTPRequestWithContent(context.Background(), http.MethodGet, ucp.BaseURL()+testProxyRequestAWSPath, nil)
+	getRequest, err := rpctest.NewHTTPRequestWithContent(t.Context(), http.MethodGet, ucp.BaseURL()+testProxyRequestAWSPath, nil)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := rpctest.NewARMRequestContext(getRequest)

--- a/pkg/ucp/integrationtests/aws/getresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/getresourcewithpost_test.go
@@ -79,7 +79,7 @@ func Test_GetAWSResourceWithPost(t *testing.T) {
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	getRequest, err := rpctest.NewHTTPRequestWithContent(context.Background(), http.MethodPost, ucp.BaseURL()+testProxyRequestAWSCollectionPath+"/:get", body)
+	getRequest, err := rpctest.NewHTTPRequestWithContent(t.Context(), http.MethodPost, ucp.BaseURL()+testProxyRequestAWSCollectionPath+"/:get", body)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := rpctest.NewARMRequestContext(getRequest)

--- a/pkg/ucp/integrationtests/aws/listresources_test.go
+++ b/pkg/ucp/integrationtests/aws/listresources_test.go
@@ -57,7 +57,7 @@ func Test_ListAWSResources(t *testing.T) {
 		return &output, nil
 	})
 
-	listRequest, err := rpctest.NewHTTPRequestWithContent(context.Background(), http.MethodGet, ucp.BaseURL()+testProxyRequestAWSListPath, nil)
+	listRequest, err := rpctest.NewHTTPRequestWithContent(t.Context(), http.MethodGet, ucp.BaseURL()+testProxyRequestAWSListPath, nil)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := rpctest.NewARMRequestContext(listRequest)

--- a/pkg/ucp/integrationtests/aws/operationresults_test.go
+++ b/pkg/ucp/integrationtests/aws/operationresults_test.go
@@ -45,7 +45,7 @@ func Test_GetOperationResults(t *testing.T) {
 		return &output, nil
 	})
 
-	operationResultsRequest, err := rpctest.NewHTTPRequestWithContent(context.Background(), http.MethodGet, ucp.BaseURL()+testProxyRequestAWSAsyncPath+"/operationResults/"+strings.ToLower(testAWSRequestToken), nil)
+	operationResultsRequest, err := rpctest.NewHTTPRequestWithContent(t.Context(), http.MethodGet, ucp.BaseURL()+testProxyRequestAWSAsyncPath+"/operationResults/"+strings.ToLower(testAWSRequestToken), nil)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := rpctest.NewARMRequestContext(operationResultsRequest)

--- a/pkg/ucp/integrationtests/aws/operationstatuses_test.go
+++ b/pkg/ucp/integrationtests/aws/operationstatuses_test.go
@@ -47,7 +47,7 @@ func Test_GetOperationStatuses(t *testing.T) {
 		return &output, nil
 	})
 
-	operationResultsRequest, err := rpctest.NewHTTPRequestWithContent(context.Background(), http.MethodGet, ucp.BaseURL()+testProxyRequestAWSAsyncPath+"/operationStatuses/"+strings.ToLower(testAWSRequestToken), nil)
+	operationResultsRequest, err := rpctest.NewHTTPRequestWithContent(t.Context(), http.MethodGet, ucp.BaseURL()+testProxyRequestAWSAsyncPath+"/operationStatuses/"+strings.ToLower(testAWSRequestToken), nil)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := rpctest.NewARMRequestContext(operationResultsRequest)

--- a/pkg/ucp/integrationtests/aws/updateresource_test.go
+++ b/pkg/ucp/integrationtests/aws/updateresource_test.go
@@ -93,7 +93,7 @@ func Test_UpdateAWSResource(t *testing.T) {
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	updateRequest, err := rpctest.NewHTTPRequestWithContent(context.Background(), http.MethodPut, ucp.BaseURL()+testProxyRequestAWSPath, body)
+	updateRequest, err := rpctest.NewHTTPRequestWithContent(t.Context(), http.MethodPut, ucp.BaseURL()+testProxyRequestAWSPath, body)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := rpctest.NewARMRequestContext(updateRequest)

--- a/pkg/ucp/integrationtests/aws/updateresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/updateresourcewithpost_test.go
@@ -89,7 +89,7 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	updateRequest, err := rpctest.NewHTTPRequestWithContent(context.Background(), http.MethodPost, ucp.BaseURL()+testProxyRequestAWSCollectionPath+"/:put", body)
+	updateRequest, err := rpctest.NewHTTPRequestWithContent(t.Context(), http.MethodPost, ucp.BaseURL()+testProxyRequestAWSCollectionPath+"/:put", body)
 	require.NoError(t, err, "update request failed")
 
 	ctx := rpctest.NewARMRequestContext(updateRequest)

--- a/pkg/ucp/testhost/host.go
+++ b/pkg/ucp/testhost/host.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testhost
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -177,7 +176,7 @@ func Start(t *testing.T, opts ...TestHostOption) *TestHost {
 		},
 	}
 
-	options, err := ucp.NewOptions(context.Background(), config)
+	options, err := ucp.NewOptions(t.Context(), config)
 	require.NoError(t, err)
 
 	for _, opt := range opts {

--- a/pkg/upgrade/preflight/config_check_test.go
+++ b/pkg/upgrade/preflight/config_check_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package preflight
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -103,7 +102,7 @@ func TestCustomConfigValidationCheck_BasicValidation(t *testing.T) {
 			// Override the default chart path to skip chart validation for basic tests
 			check.chartPath = ""
 
-			pass, msg, err := check.Run(context.Background())
+			pass, msg, err := check.Run(t.Context())
 
 			require.NoError(t, err)
 			assert.Equal(t, !tt.shouldFail, pass)
@@ -208,7 +207,7 @@ func TestCustomConfigValidationCheck_ChartValidation(t *testing.T) {
 			// Use the real chart path and OS filesystem for chart loading
 			check := NewCustomConfigValidationCheck(tt.setParams, setFileParams, realChartPath, nil)
 
-			pass, msg, err := check.Run(context.Background())
+			pass, msg, err := check.Run(t.Context())
 
 			require.NoError(t, err)
 			assert.Equal(t, !tt.shouldFail, pass)
@@ -296,7 +295,7 @@ func TestCustomConfigValidationCheck_ErrorHandling(t *testing.T) {
 				check.fs = mockFS
 			}
 
-			pass, msg, err := check.Run(context.Background())
+			pass, msg, err := check.Run(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, !tt.shouldFail, pass)
 			if tt.expectError != "" {

--- a/pkg/upgrade/preflight/helm_check_test.go
+++ b/pkg/upgrade/preflight/helm_check_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package preflight
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -129,7 +128,7 @@ func TestHelmConnectivityCheck_Run(t *testing.T) {
 			tt.setupMock(mockHelm)
 
 			check := NewHelmConnectivityCheck(mockHelm, "test-context")
-			pass, message, err := check.Run(context.Background())
+			pass, message, err := check.Run(t.Context())
 
 			assert.Equal(t, tt.expectPass, pass)
 			assert.Contains(t, message, tt.expectMessage)

--- a/pkg/upgrade/preflight/installation_check_test.go
+++ b/pkg/upgrade/preflight/installation_check_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package preflight
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -85,7 +84,7 @@ func TestRadiusInstallationCheck_Run(t *testing.T) {
 
 			check := NewRadiusInstallationCheck(mockHelm, "test-context")
 
-			success, message, err := check.Run(context.Background())
+			success, message, err := check.Run(t.Context())
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/pkg/upgrade/preflight/kubernetes_check_test.go
+++ b/pkg/upgrade/preflight/kubernetes_check_test.go
@@ -45,7 +45,7 @@ func TestKubernetesConnectivityCheck_WithClientset(t *testing.T) {
 }
 
 func TestKubernetesConnectivityCheck_Run(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("successful connection with permissions", func(t *testing.T) {
 		// Setup: namespace exists, deployments can be listed

--- a/pkg/upgrade/preflight/kubernetes_check_test.go
+++ b/pkg/upgrade/preflight/kubernetes_check_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package preflight
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -119,7 +118,7 @@ func TestKubernetesConnectivityCheck_NoClientset(t *testing.T) {
 	// In a test environment, this should fail to create a client
 	check := NewKubernetesConnectivityCheck("nonexistent-context")
 
-	pass, _, err := check.Run(context.Background())
+	pass, _, err := check.Run(t.Context())
 
 	require.Error(t, err)
 	assert.False(t, pass)

--- a/pkg/upgrade/preflight/registry_test.go
+++ b/pkg/upgrade/preflight/registry_test.go
@@ -69,7 +69,7 @@ func TestRegistry_RunChecks_EmptyRegistry(t *testing.T) {
 	mockOutput := &output.MockOutput{}
 	registry := NewRegistry(mockOutput)
 
-	results, err := registry.RunChecks(context.Background())
+	results, err := registry.RunChecks(t.Context())
 
 	require.NoError(t, err)
 	assert.Empty(t, results)
@@ -95,7 +95,7 @@ func TestRegistry_RunChecks_AllSuccess(t *testing.T) {
 	registry.AddCheck(check1)
 	registry.AddCheck(check2)
 
-	results, err := registry.RunChecks(context.Background())
+	results, err := registry.RunChecks(t.Context())
 
 	require.NoError(t, err)
 	assert.Len(t, results, 2)
@@ -142,7 +142,7 @@ func TestRegistry_RunChecks_ErrorSeverityFails(t *testing.T) {
 	registry.AddCheck(check2)
 	registry.AddCheck(check3)
 
-	results, err := registry.RunChecks(context.Background())
+	results, err := registry.RunChecks(t.Context())
 
 	// Should fail immediately on error severity check
 	require.Error(t, err)
@@ -174,7 +174,7 @@ func TestRegistry_RunChecks_WarningSeverityDoesNotFail(t *testing.T) {
 	registry.AddCheck(check1)
 	registry.AddCheck(check2)
 
-	results, err := registry.RunChecks(context.Background())
+	results, err := registry.RunChecks(t.Context())
 
 	// Should succeed even with failed warning check
 	require.NoError(t, err)
@@ -200,7 +200,7 @@ func TestRegistry_RunChecks_CheckReturnsError(t *testing.T) {
 
 	registry.AddCheck(check1)
 
-	results, err := registry.RunChecks(context.Background())
+	results, err := registry.RunChecks(t.Context())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pre-flight check 'Error Check' failed")

--- a/pkg/upgrade/preflight/resource_check_test.go
+++ b/pkg/upgrade/preflight/resource_check_test.go
@@ -47,7 +47,7 @@ func TestKubernetesResourceCheck_WithClientset(t *testing.T) {
 }
 
 func TestKubernetesResourceCheck_Run(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("sufficient resources", func(t *testing.T) {
 		clientset := createClientsetWithResources(

--- a/pkg/upgrade/preflight/resource_check_test.go
+++ b/pkg/upgrade/preflight/resource_check_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package preflight
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -171,7 +170,7 @@ func TestKubernetesResourceCheck_EstimatedUsage(t *testing.T) {
 func TestKubernetesResourceCheck_NoClientset(t *testing.T) {
 	check := NewKubernetesResourceCheck("nonexistent-context")
 
-	pass, _, err := check.Run(context.Background())
+	pass, _, err := check.Run(t.Context())
 
 	require.Error(t, err)
 	assert.False(t, pass)

--- a/pkg/upgrade/preflight/version_check_test.go
+++ b/pkg/upgrade/preflight/version_check_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package preflight
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -94,7 +93,7 @@ func TestVersionCompatibilityCheck_Run(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			check := NewVersionCompatibilityCheck(tt.currentVersion, tt.targetVersion)
 
-			success, message, err := check.Run(context.Background())
+			success, message, err := check.Run(t.Context())
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectSuccess, success)

--- a/pkg/upgrade/preupgrade/preupgrade_test.go
+++ b/pkg/upgrade/preupgrade/preupgrade_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package preupgrade
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -64,7 +63,7 @@ func TestRunPreflightChecks_Success(t *testing.T) {
 		CurrentVersion: "",
 	}
 
-	err := RunPreflightChecks(context.Background(), config, options)
+	err := RunPreflightChecks(t.Context(), config, options)
 	require.NoError(t, err)
 }
 
@@ -96,7 +95,7 @@ func TestRunPreflightChecks_AllNewChecks(t *testing.T) {
 		CurrentVersion: "0.28.0",
 	}
 
-	err := RunPreflightChecks(context.Background(), config, options)
+	err := RunPreflightChecks(t.Context(), config, options)
 	// Note: This will fail because kubernetes checks need actual client
 	// But it validates that the checks are being registered
 	assert.Error(t, err) // Expected since we don't have actual k8s client
@@ -124,7 +123,7 @@ func TestRunPreflightChecks_UnknownCheck(t *testing.T) {
 		CurrentVersion: "0.28.0",
 	}
 
-	err := RunPreflightChecks(context.Background(), config, options)
+	err := RunPreflightChecks(t.Context(), config, options)
 	require.NoError(t, err)
 }
 
@@ -150,7 +149,7 @@ func TestRunPreflightChecks_EmptyCheckNames(t *testing.T) {
 		CurrentVersion: "0.28.0",
 	}
 
-	err := RunPreflightChecks(context.Background(), config, options)
+	err := RunPreflightChecks(t.Context(), config, options)
 	require.NoError(t, err)
 }
 
@@ -188,7 +187,7 @@ func TestRunPreflightChecks_MultipleChecks(t *testing.T) {
 		TargetVersion: "0.29.0",
 	}
 
-	err := RunPreflightChecks(context.Background(), config, options)
+	err := RunPreflightChecks(t.Context(), config, options)
 	require.NoError(t, err)
 }
 
@@ -226,7 +225,7 @@ func TestRunPreflightChecks_WithSpacesInCheckNames(t *testing.T) {
 		TargetVersion: "0.29.0",
 	}
 
-	err := RunPreflightChecks(context.Background(), config, options)
+	err := RunPreflightChecks(t.Context(), config, options)
 	require.NoError(t, err)
 }
 
@@ -255,7 +254,7 @@ func TestRunPreflightChecks_HelmCheckError(t *testing.T) {
 		CurrentVersion: "",
 	}
 
-	err := RunPreflightChecks(context.Background(), config, options)
+	err := RunPreflightChecks(t.Context(), config, options)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to check current Radius installation")
 	assert.Contains(t, err.Error(), "failed to connect to kubernetes")
@@ -282,7 +281,7 @@ func TestRunPreflightChecks_UnknownCheckName(t *testing.T) {
 		TargetVersion: "0.29.0",
 	}
 
-	err := RunPreflightChecks(context.Background(), config, options)
+	err := RunPreflightChecks(t.Context(), config, options)
 	// Should no longer error since we skip unknown checks
 	require.NoError(t, err)
 }
@@ -310,7 +309,7 @@ func TestRunPreflightChecks_EmptyChecksList(t *testing.T) {
 		TargetVersion: "0.29.0",
 	}
 
-	err := RunPreflightChecks(context.Background(), config, options)
+	err := RunPreflightChecks(t.Context(), config, options)
 	require.NoError(t, err)
 }
 
@@ -346,7 +345,7 @@ func TestRunPreflightChecks_PreflightCheckFailure(t *testing.T) {
 		CurrentVersion: "",
 	}
 
-	err := RunPreflightChecks(context.Background(), config, options)
+	err := RunPreflightChecks(t.Context(), config, options)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pre-flight check")
 	assert.Contains(t, err.Error(), "failed")
@@ -388,6 +387,6 @@ func TestRunPreflightChecks_WithTimeout(t *testing.T) {
 		Timeout:        10 * time.Second, // Custom timeout
 	}
 
-	err := RunPreflightChecks(context.Background(), config, options)
+	err := RunPreflightChecks(t.Context(), config, options)
 	require.NoError(t, err)
 }

--- a/pkg/validator/apivalidator_test.go
+++ b/pkg/validator/apivalidator_test.go
@@ -18,7 +18,6 @@ package validator
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -65,7 +64,7 @@ func Test_APIValidator_UCPID(t *testing.T) {
 
 func runTest(t *testing.T, resourceIDUrl, targetScope, planeRootScope string, prefixes []string) {
 	// Load OpenAPI Spec for applications.core provider.
-	l, err := LoadSpec(context.Background(), "applications.core", swagger.SpecFiles, prefixes, "rootScope")
+	l, err := LoadSpec(t.Context(), "applications.core", swagger.SpecFiles, prefixes, "rootScope")
 
 	require.NoError(t, err)
 
@@ -507,7 +506,7 @@ func runTest(t *testing.T, resourceIDUrl, targetScope, planeRootScope string, pr
 				tc.url += "?api-version=" + tc.apiVersion
 			}
 
-			req, err := http.NewRequestWithContext(context.Background(), tc.method, tc.url, bytes.NewBuffer(body))
+			req, err := http.NewRequestWithContext(t.Context(), tc.method, tc.url, bytes.NewBuffer(body))
 			require.NoError(t, err)
 			r.ServeHTTP(w, req)
 

--- a/pkg/validator/loader_test.go
+++ b/pkg/validator/loader_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package validator
 
 import (
-	"context"
 	"testing"
 
 	"github.com/radius-project/radius/swagger"
@@ -73,7 +72,7 @@ func Test_ParseSpecFilePath(t *testing.T) {
 }
 
 func Test_Loader(t *testing.T) {
-	l, err := LoadSpec(context.Background(), "applications.core", swagger.SpecFiles, []string{"{rootScope:.*}"}, "rootScope")
+	l, err := LoadSpec(t.Context(), "applications.core", swagger.SpecFiles, []string{"{rootScope:.*}"}, "rootScope")
 	require.NoError(t, err)
 	v, ok := l.GetValidator("applications.core/environments", "2023-10-01-preview")
 	require.True(t, ok)

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func Test_FindParam(t *testing.T) {
-	l, err := LoadSpec(context.Background(), "applications.core", swagger.SpecFiles, []string{"/subscriptions/{subscriptionID}/resourceGroups/{rgName}"}, "rootScope")
+	l, err := LoadSpec(t.Context(), "applications.core", swagger.SpecFiles, []string{"/subscriptions/{subscriptionID}/resourceGroups/{rgName}"}, "rootScope")
 	require.NoError(t, err)
 	v, ok := l.GetValidator("applications.core/environments", "2023-10-01-preview")
 	require.True(t, ok)

--- a/test/functional-portable/cli/noncloud/env_delete_test.go
+++ b/test/functional-portable/cli/noncloud/env_delete_test.go
@@ -50,7 +50,7 @@ func Test_EnvDelete(t *testing.T) {
 	t.Cleanup(func() {
 		// Try to delete the test group if it still exists
 		// Ignore errors as the group might have been successfully deleted
-		_ = cli.GroupDelete(context.Background(), uniqueGroupName, radcli.DeleteOptions{Confirm: true})
+		_ = cli.GroupDelete(t.Context(), uniqueGroupName, radcli.DeleteOptions{Confirm: true})
 	})
 
 	// Create the unique resource group

--- a/test/functional-portable/cli/noncloud/env_delete_test.go
+++ b/test/functional-portable/cli/noncloud/env_delete_test.go
@@ -49,8 +49,9 @@ func Test_EnvDelete(t *testing.T) {
 	// Ensure cleanup even if test fails
 	t.Cleanup(func() {
 		// Try to delete the test group if it still exists
-		// Ignore errors as the group might have been successfully deleted
-		_ = cli.GroupDelete(t.Context(), uniqueGroupName, radcli.DeleteOptions{Confirm: true})
+		// Ignore errors as the group might have been successfully deleted.
+		// Use a fresh context because t.Context() is cancelled before cleanup runs.
+		_ = cli.GroupDelete(context.Background(), uniqueGroupName, radcli.DeleteOptions{Confirm: true}) //nolint:usetesting
 	})
 
 	// Create the unique resource group

--- a/test/functional-portable/cli/noncloud/env_deploy_test.go
+++ b/test/functional-portable/cli/noncloud/env_deploy_test.go
@@ -52,12 +52,12 @@ func Test_DeployEnvironmentTemplate(t *testing.T) {
 
 	// Ensure cleanup even if test fails
 	t.Cleanup(func() {
-		deleteKubernetesNamespace(context.Background(), t, options, envNamespace)
+		deleteKubernetesNamespace(t.Context(), t, options, envNamespace)
 	})
 	t.Cleanup(func() {
 		// Try to delete the test group if it still exists
 		// Ignore errors as the group might have been successfully deleted
-		_ = cli.GroupDelete(context.Background(), uniqueGroupName, radcli.DeleteOptions{Confirm: true})
+		_ = cli.GroupDelete(t.Context(), uniqueGroupName, radcli.DeleteOptions{Confirm: true})
 	})
 
 	// Create the unique resource group

--- a/test/functional-portable/cli/noncloud/env_deploy_test.go
+++ b/test/functional-portable/cli/noncloud/env_deploy_test.go
@@ -52,12 +52,13 @@ func Test_DeployEnvironmentTemplate(t *testing.T) {
 
 	// Ensure cleanup even if test fails
 	t.Cleanup(func() {
-		deleteKubernetesNamespace(t.Context(), t, options, envNamespace)
+		// Use a fresh context because t.Context() is cancelled before cleanup runs.
+		deleteKubernetesNamespace(context.Background(), t, options, envNamespace) //nolint:usetesting
 	})
 	t.Cleanup(func() {
 		// Try to delete the test group if it still exists
 		// Ignore errors as the group might have been successfully deleted
-		_ = cli.GroupDelete(t.Context(), uniqueGroupName, radcli.DeleteOptions{Confirm: true})
+		_ = cli.GroupDelete(context.Background(), uniqueGroupName, radcli.DeleteOptions{Confirm: true}) //nolint:usetesting
 	})
 
 	// Create the unique resource group

--- a/test/functional-portable/cli/noncloud/group_delete_test.go
+++ b/test/functional-portable/cli/noncloud/group_delete_test.go
@@ -49,8 +49,9 @@ func Test_GroupDelete(t *testing.T) {
 	// Ensure cleanup even if test fails
 	t.Cleanup(func() {
 		// Try to delete the test group if it still exists
-		// Ignore errors as the group might have been successfully deleted
-		_ = cli.GroupDelete(t.Context(), uniqueGroupName, radcli.DeleteOptions{Confirm: true})
+		// Ignore errors as the group might have been successfully deleted.
+		// Use a fresh context because t.Context() is cancelled before cleanup runs.
+		_ = cli.GroupDelete(context.Background(), uniqueGroupName, radcli.DeleteOptions{Confirm: true}) //nolint:usetesting
 	})
 
 	// Create the unique resource group

--- a/test/functional-portable/cli/noncloud/group_delete_test.go
+++ b/test/functional-portable/cli/noncloud/group_delete_test.go
@@ -50,7 +50,7 @@ func Test_GroupDelete(t *testing.T) {
 	t.Cleanup(func() {
 		// Try to delete the test group if it still exists
 		// Ignore errors as the group might have been successfully deleted
-		_ = cli.GroupDelete(context.Background(), uniqueGroupName, radcli.DeleteOptions{Confirm: true})
+		_ = cli.GroupDelete(t.Context(), uniqueGroupName, radcli.DeleteOptions{Confirm: true})
 	})
 
 	// Create the unique resource group

--- a/test/functional-portable/corerp/noncloud/api_test.go
+++ b/test/functional-portable/corerp/noncloud/api_test.go
@@ -48,7 +48,7 @@ func Test_ResourceList(t *testing.T) {
 
 	resourceGroupScope := parsed.String()
 
-	resourceTypesList, err := options.ManagementClient.(*clients.UCPApplicationsManagementClient).ListAllResourceTypesNames(context.Background(), "local")
+	resourceTypesList, err := options.ManagementClient.(*clients.UCPApplicationsManagementClient).ListAllResourceTypesNames(t.Context(), "local")
 	require.NoError(t, err)
 	resourceTypes := []string{"Applications.Core/applications", "Applications.Core/environments", "Radius.Core/applications", "Radius.Core/environments"}
 	resourceTypes = append(resourceTypes, resourceTypesList...)

--- a/test/functional-portable/corerp/noncloud/resources/kubemetadata_cascade_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/kubemetadata_cascade_test.go
@@ -111,7 +111,7 @@ func Test_KubeMetadataCascade(t *testing.T) {
 				require.True(t, testutil.IsMapNonIntersecting(notExpectedLabels, pod.Labels))
 
 				// Verify deployment labels and annotations
-				deployments, err := test.Options.K8sClient.AppsV1().Deployments(appNamespace).List(context.Background(), metav1.ListOptions{
+				deployments, err := test.Options.K8sClient.AppsV1().Deployments(appNamespace).List(t.Context(), metav1.ListOptions{
 					LabelSelector: label,
 				})
 				require.NoError(t, err)

--- a/test/functional-portable/corerp/noncloud/resources/kubemetadata_container_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/kubemetadata_container_test.go
@@ -85,7 +85,7 @@ func Test_KubeMetadataContainer(t *testing.T) {
 				require.True(t, testutil.IsMapSubSet(expectedLabels, pod.Labels))
 
 				// Verify deployment labels and annotations
-				deployments, err := test.Options.K8sClient.AppsV1().Deployments(appNamespace).List(context.Background(), metav1.ListOptions{
+				deployments, err := test.Options.K8sClient.AppsV1().Deployments(appNamespace).List(t.Context(), metav1.ListOptions{
 					LabelSelector: label,
 				})
 				require.NoError(t, err)

--- a/test/functional-portable/dynamicrp/noncloud/resources/dynamicrp_test.go
+++ b/test/functional-portable/dynamicrp/noncloud/resources/dynamicrp_test.go
@@ -272,7 +272,7 @@ func Test_Postgres_EnvScoped_ExistingResource(t *testing.T) {
 			},
 			PostStepVerify: func(ctx context.Context, t *testing.T, ct rp.RPTest) {
 				// Verify that the environment namespace is created.
-				_, err := ct.Options.K8sClient.CoreV1().Namespaces().Get(context.Background(), name, metav1.GetOptions{})
+				_, err := ct.Options.K8sClient.CoreV1().Namespaces().Get(t.Context(), name, metav1.GetOptions{})
 				require.NoError(t, err)
 			},
 		},

--- a/test/functional-portable/statestore/noncloud/statestore_lifecycle_test.go
+++ b/test/functional-portable/statestore/noncloud/statestore_lifecycle_test.go
@@ -264,14 +264,14 @@ func TestRegistryManifestExists(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	registry := strings.TrimPrefix(server.URL, "http://")
-	require.True(t, registryManifestExists(context.Background(), registry, "radius-state", "radius-state"))
+	require.True(t, registryManifestExists(t.Context(), registry, "radius-state", "radius-state"))
 }
 
 // Test_StateStore_ShutdownStartup_TerraformCrossDeploy exercises every state path:
 // install, deploy a Terraform resource, shut down (backup), tear down, start up (restore), then
 // deploy an update to the same resource.
 func Test_StateStore_ShutdownStartup_TerraformCrossDeploy(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Minute)
 	defer cancel()
 
 	cli := radcli.NewCLI(t, "")
@@ -313,6 +313,7 @@ func Test_StateStore_ShutdownStartup_TerraformCrossDeploy(t *testing.T) {
 
 	// 1. Fresh install with the PostgreSQL state backend.
 	installRadius(ctx, t, cli)
+	// Use a fresh context because t.Context() is cancelled before cleanup runs.
 	t.Cleanup(func() { uninstallRadius(context.Background(), t, cli) })
 
 	// Create the workspace and resource group the test deploys into (the shared CI "Install Radius"

--- a/test/functional-portable/statestore/noncloud/statestore_lifecycle_test.go
+++ b/test/functional-portable/statestore/noncloud/statestore_lifecycle_test.go
@@ -314,7 +314,7 @@ func Test_StateStore_ShutdownStartup_TerraformCrossDeploy(t *testing.T) {
 	// 1. Fresh install with the PostgreSQL state backend.
 	installRadius(ctx, t, cli)
 	// Use a fresh context because t.Context() is cancelled before cleanup runs.
-	t.Cleanup(func() { uninstallRadius(context.Background(), t, cli) })
+	t.Cleanup(func() { uninstallRadius(context.Background(), t, cli) }) //nolint:usetesting
 
 	// Create the workspace and resource group the test deploys into (the shared CI "Install Radius"
 	// step is skipped for this leg, so the test owns this setup).

--- a/test/functional-portable/ucp/cloud/aws_test.go
+++ b/test/functional-portable/ucp/cloud/aws_test.go
@@ -168,7 +168,8 @@ func setupTestAWSResource(t *testing.T, ctx context.Context, resourceName string
 
 	t.Cleanup(func() {
 		// Use a fresh context because t.Context() is cancelled before cleanup runs.
-		cleanupCtx := t.Context()
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
 
 		// Check if resource exists before issuing a delete because the AWS SDK async delete operation
 		// seems to fail if the resource does not exist

--- a/test/functional-portable/ucp/cloud/aws_test.go
+++ b/test/functional-portable/ucp/cloud/aws_test.go
@@ -168,7 +168,7 @@ func setupTestAWSResource(t *testing.T, ctx context.Context, resourceName string
 
 	t.Cleanup(func() {
 		// Use a fresh context because t.Context() is cancelled before cleanup runs.
-		cleanupCtx := context.Background()
+		cleanupCtx := t.Context()
 
 		// Check if resource exists before issuing a delete because the AWS SDK async delete operation
 		// seems to fail if the resource does not exist

--- a/test/functional-portable/ucp/cloud/aws_test.go
+++ b/test/functional-portable/ucp/cloud/aws_test.go
@@ -168,7 +168,7 @@ func setupTestAWSResource(t *testing.T, ctx context.Context, resourceName string
 
 	t.Cleanup(func() {
 		// Use a fresh context because t.Context() is cancelled before cleanup runs.
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute) //nolint:usetesting
 		defer cancel()
 
 		// Check if resource exists before issuing a delete because the AWS SDK async delete operation

--- a/test/radcli/shared.go
+++ b/test/radcli/shared.go
@@ -18,7 +18,6 @@ package radcli
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -146,7 +145,7 @@ func SharedValidateValidation(t *testing.T, factory func(framework framework.Fac
 
 			cmd, runner := factory(framework)
 			cmd.SetArgs(testcase.Input)
-			cmd.SetContext(context.Background())
+			cmd.SetContext(t.Context())
 
 			err := cmd.ParseFlags(testcase.Input)
 			require.NoError(t, err, "flag parsing failed")

--- a/test/rp/rptest.go
+++ b/test/rp/rptest.go
@@ -375,9 +375,9 @@ func DeploymentTargetK8sClient(options RPTestOptions) (k8sclient.Interface, erro
 }
 
 // Method CleanUpExtensionResources deletes all resources in the given slice of unstructured objects.
-func (ct RPTest) CleanUpExtensionResources(resources []unstructured.Unstructured) {
+func (ct RPTest) CleanUpExtensionResources(ctx context.Context, resources []unstructured.Unstructured) {
 	for i := len(resources) - 1; i >= 0; i-- {
-		_ = ct.Options.Client.Delete(context.TODO(), &resources[i])
+		_ = ct.Options.Client.Delete(ctx, &resources[i])
 	}
 }
 
@@ -481,7 +481,7 @@ func (ct RPTest) Test(t *testing.T) {
 	// Inside the integration test code we rely on the context for timeout/cancellation functionality.
 	// We expect the caller to wire this out to the test timeout system, or a stricter timeout if desired.
 	require.GreaterOrEqual(t, len(ct.Steps), 1, "at least one step is required")
-	defer ct.CleanUpExtensionResources(ct.InitialResources)
+	defer ct.CleanUpExtensionResources(ctx, ct.InitialResources)
 	err := ct.CreateInitialResources(ctx)
 	require.NoError(t, err, "failed to create initial resources")
 
@@ -492,7 +492,7 @@ func (ct RPTest) Test(t *testing.T) {
 	success := true
 	for i, step := range ct.Steps {
 		success = t.Run(step.Executor.GetDescription(), func(t *testing.T) {
-			defer ct.CleanUpExtensionResources(step.K8sOutputResources)
+			defer ct.CleanUpExtensionResources(ctx, step.K8sOutputResources)
 			if !success {
 				t.Skip("skipping due to previous step failure")
 				return

--- a/test/rp/rptest.go
+++ b/test/rp/rptest.go
@@ -619,7 +619,7 @@ func (ct RPTest) Test(t *testing.T) {
 				go func(r validation.RPResource) {
 					// Use a background context that won't be canceled when the test finishes
 					// Use silent deletion to avoid "Log in goroutine after test has completed" panics
-					bgCtx := context.Background()
+					bgCtx := context.Background() //nolint:usetesting
 					_ = validation.DeleteRPResourceSilent(bgCtx, cli, ct.Options.ManagementClient, r)
 					// Errors are ignored in fast cleanup mode since it's best-effort
 				}(resource)

--- a/test/step/deployexecutor_test.go
+++ b/test/step/deployexecutor_test.go
@@ -35,7 +35,7 @@ func Test_ExecuteWithRetry_SucceedsOnFirstAttempt(t *testing.T) {
 	var calls atomic.Int32
 	d := NewDeployExecutor("test.bicep").WithRetry(2, 10*time.Millisecond, func(error) bool { return true })
 
-	err := d.executeWithRetry(context.Background(), t, func() error {
+	err := d.executeWithRetry(t.Context(), t, func() error {
 		calls.Add(1)
 		return nil
 	})
@@ -52,7 +52,7 @@ func Test_ExecuteWithRetry_RetriesOnTransientThenSucceeds(t *testing.T) {
 		return err.Error() == "ManagedServiceIdentityNotFound"
 	})
 
-	err := d.executeWithRetry(context.Background(), t, func() error {
+	err := d.executeWithRetry(t.Context(), t, func() error {
 		n := calls.Add(1)
 		if n == 1 {
 			return transientErr
@@ -71,7 +71,7 @@ func Test_ExecuteWithRetry_DoesNotRetryNonTransientError(t *testing.T) {
 		return err.Error() == "transient"
 	})
 
-	err := d.executeWithRetry(context.Background(), t, func() error {
+	err := d.executeWithRetry(t.Context(), t, func() error {
 		calls.Add(1)
 		return errors.New("permanent failure")
 	})
@@ -86,7 +86,7 @@ func Test_ExecuteWithRetry_ExhaustsAllRetries(t *testing.T) {
 	var calls atomic.Int32
 	d := NewDeployExecutor("test.bicep").WithRetry(2, 10*time.Millisecond, func(error) bool { return true })
 
-	err := d.executeWithRetry(context.Background(), t, func() error {
+	err := d.executeWithRetry(t.Context(), t, func() error {
 		calls.Add(1)
 		return errors.New("always fails")
 	})
@@ -103,7 +103,7 @@ func Test_ExecuteWithRetry_DefaultDoesNotRetryNonTransientError(t *testing.T) {
 	// non-transient error must not be retried.
 	d := NewDeployExecutor("test.bicep")
 
-	err := d.executeWithRetry(context.Background(), t, func() error {
+	err := d.executeWithRetry(t.Context(), t, func() error {
 		calls.Add(1)
 		return errors.New("fails")
 	})
@@ -120,7 +120,7 @@ func Test_ExecuteWithRetry_DefaultRetriesTransientImagePullError(t *testing.T) {
 	d := NewDeployExecutor("test.bicep")
 	d.RetryDelay = 10 * time.Millisecond // shorten the delay for the test
 
-	err := d.executeWithRetry(context.Background(), t, func() error {
+	err := d.executeWithRetry(t.Context(), t, func() error {
 		n := calls.Add(1)
 		if n < 2 {
 			return errors.New("Reason: ErrImagePull, net/http: timeout awaiting response headers")
@@ -140,7 +140,7 @@ func Test_ExecuteWithRetry_DefaultRetriesTransientConnectionError(t *testing.T) 
 	d := NewDeployExecutor("test.bicep")
 	d.RetryDelay = 10 * time.Millisecond // shorten the delay for the test
 
-	err := d.executeWithRetry(context.Background(), t, func() error {
+	err := d.executeWithRetry(t.Context(), t, func() error {
 		n := calls.Add(1)
 		if n < 2 {
 			return errors.New(`command 'rad deploy' had non-zero exit code: exit status 1
@@ -156,7 +156,7 @@ Error: Get "https://127.0.0.1:37481/apis/api.ucp.dev/v1alpha3/.../operationStatu
 func Test_ExecuteWithRetry_ContextCancelledDuringDelay(t *testing.T) {
 	t.Parallel()
 	var calls atomic.Int32
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	d := NewDeployExecutor("test.bicep").WithRetry(2, 5*time.Second, func(error) bool { return true })
 
 	// Cancel context immediately after first deploy attempt
@@ -181,7 +181,7 @@ func Test_ExecuteWithRetry_NilShouldRetryDisablesRetries(t *testing.T) {
 	d.MaxRetries = 3
 	d.ShouldRetry = nil // nil predicate
 
-	err := d.executeWithRetry(context.Background(), t, func() error {
+	err := d.executeWithRetry(t.Context(), t, func() error {
 		calls.Add(1)
 		return errors.New("fails")
 	})

--- a/test/testutil/portforward_test.go
+++ b/test/testutil/portforward_test.go
@@ -57,7 +57,7 @@ func TestRunPortForward_ContextCanceledBeforeReadyReportsError(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	stopChan := make(chan struct{})
 	readyChan := make(chan struct{})
 	portChan := make(chan int)
@@ -105,7 +105,7 @@ func TestRunPortForward_ContextCanceledBeforePortReportsError(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	stopChan := make(chan struct{})
 	readyChan := make(chan struct{})
 	close(readyChan)
@@ -156,7 +156,7 @@ func TestRunPortForward_GetPortsErrorAfterContextCanceledReportsError(t *testing
 		},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	stopChan := make(chan struct{})
 	readyChan := make(chan struct{})
 	close(readyChan)
@@ -206,7 +206,7 @@ func TestRunPortForward_ForwardPortsNilReportsError(t *testing.T) {
 	errorChan := make(chan error)
 	done := make(chan struct{})
 	go func() {
-		runPortForward(context.Background(), forwarder, stopChan, readyChan, portChan, errorChan)
+		runPortForward(t.Context(), forwarder, stopChan, readyChan, portChan, errorChan)
 		close(done)
 	}()
 
@@ -252,7 +252,7 @@ func TestRunPortForward_GetPortsErrorDoesNotBlockOnForwardResult(t *testing.T) {
 	errorChan := make(chan error)
 	done := make(chan struct{})
 	go func() {
-		runPortForward(context.Background(), forwarder, stopChan, readyChan, portChan, errorChan)
+		runPortForward(t.Context(), forwarder, stopChan, readyChan, portChan, errorChan)
 		close(done)
 	}()
 
@@ -297,7 +297,7 @@ func TestRunPortForward_ForwardsRuntimeError(t *testing.T) {
 	stopChan := make(chan struct{})
 	portChan := make(chan int)
 	errorChan := make(chan error)
-	go runPortForward(context.Background(), forwarder, stopChan, readyChan, portChan, errorChan)
+	go runPortForward(t.Context(), forwarder, stopChan, readyChan, portChan, errorChan)
 
 	select {
 	case port := <-portChan:

--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -370,7 +370,7 @@ func ValidateObjectsRunning(ctx context.Context, t *testing.T, k8s *kubernetes.C
 func ValidateNoPodsInApplication(ctx context.Context, t *testing.T, k8s *kubernetes.Clientset, namespace string, application string) {
 	labelset := kuberneteskeys.MakeSelectorLabels(application, "")
 
-	actualPods, err := k8s.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
+	actualPods, err := k8s.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labelset).String(),
 	})
 	assert.NoErrorf(t, err, "failed to list pods in namespace %s", namespace)
@@ -392,7 +392,7 @@ func ValidateNoPodsInApplication(ctx context.Context, t *testing.T, k8s *kuberne
 		case <-time.After(IntervalForPodShutdown):
 			t.Logf("at %s waiting for pods in namespace %s for application %s to shut down.. ", time.Now().Format("2006-01-02 15:04:05"), namespace, application)
 
-			actualPods, err := listPodsWithRetries(t, k8s, labelset, namespace, application)
+			actualPods, err := listPodsWithRetries(ctx, t, k8s, labelset, namespace, application)
 			assert.NoError(t, err)
 
 			logPods(t, actualPods.Items)
@@ -404,11 +404,11 @@ func ValidateNoPodsInApplication(ctx context.Context, t *testing.T, k8s *kuberne
 	}
 }
 
-func listPodsWithRetries(t *testing.T, k8s *kubernetes.Clientset, labelset map[string]string, namespace, application string) (*corev1.PodList, error) {
+func listPodsWithRetries(ctx context.Context, t *testing.T, k8s *kubernetes.Clientset, labelset map[string]string, namespace, application string) (*corev1.PodList, error) {
 	// Need to retry because of AKS error: https://github.com/radius-project/radius/issues/2484
 	retries := 3
 	for i := 1; i <= retries; i++ {
-		actualPods, err := k8s.CoreV1().Pods(namespace).List(t.Context(), metav1.ListOptions{
+		actualPods, err := k8s.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labels.SelectorFromSet(labelset).String(),
 		})
 		if err == nil {

--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -408,7 +408,7 @@ func listPodsWithRetries(t *testing.T, k8s *kubernetes.Clientset, labelset map[s
 	// Need to retry because of AKS error: https://github.com/radius-project/radius/issues/2484
 	retries := 3
 	for i := 1; i <= retries; i++ {
-		actualPods, err := k8s.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
+		actualPods, err := k8s.CoreV1().Pods(namespace).List(t.Context(), metav1.ListOptions{
 			LabelSelector: labels.SelectorFromSet(labelset).String(),
 		})
 		if err == nil {


### PR DESCRIPTION
## Summary

Replaces many `context.Background()` usages in tests with `t.Context()` to align test context lifecycle with each test and reduce detached background contexts.

## Reason for change

Test-scoped contexts improve cancellation behavior and make tests more idiomatic with modern Go test APIs.

Fixes #<!-- issue number (optional) -->

## How to test

- Run targeted tests for changed packages, for example:
  - `go test ./pkg/...`
  - `go test ./test/functional-portable/ucp/cloud -run AWS`
- Confirm updated tests pass using `t.Context()` instead of `context.Background()`.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `pkg/**/**_test.go` (43 files) | Replaced `context.Background()` with `t.Context()` in unit/integration tests across ARMRPC, CLI, core RP, dynamic RP, crypto, recipes, schema, state archive, and upgrade preflight test suites. |
| `test/functional-portable/ucp/cloud/aws_test.go` | Updated functional AWS cloud test to use `t.Context()` for request/test context handling. |