### PR TITLE
exclude containerImages from graph

### DIFF
--- a/pkg/cli/graph/modeled_test.go
+++ b/pkg/cli/graph/modeled_test.go
@@ -94,6 +94,8 @@ func TestBuildModeledGraph_SkipsContainersAndRecipePacks(t *testing.T) {
 			map[string]any{"type": "Radius.Core/environments", "name": "myradenv"},
 			// Recipe catalog resource — never a graph member.
 			map[string]any{"type": "Radius.Core/recipePacks", "name": "mypack"},
+			// Container image — build-time artifact, never a graph node.
+			map[string]any{"type": "Radius.Compute/containerImages", "name": "frontendimage"},
 			// The one resource that should appear.
 			map[string]any{"type": "Applications.Core/containers", "name": "frontend",
 				"properties": map[string]any{"image": "nginx"}},

--- a/pkg/corerp/frontend/controller/applications/v20250801preview/graph_util.go
+++ b/pkg/corerp/frontend/controller/applications/v20250801preview/graph_util.go
@@ -332,6 +332,14 @@ func computeGraph(applicationResources []generated.GenericResource, environmentR
 	resourcesByIDInApplication := map[string]bool{}
 
 	for _, resource := range applicationResources {
+		// Skip resources whose type is on the shared exclusion list.
+		// These are structural containers or build-time artifacts that
+		// must not appear as graph nodes; the CLI static-graph builder
+		// applies the same rule so the two graphs stay in sync. See
+		// edges.ExcludedResourceTypes.
+		if _, excluded := edges.ExcludedResourceTypes[to.String(resource.Type)]; excluded {
+			continue
+		}
 		resources = append(resources, resource)
 
 		// Application-scoped resources are by definition "in" the application
@@ -339,6 +347,12 @@ func computeGraph(applicationResources []generated.GenericResource, environmentR
 	}
 
 	for _, resource := range environmentResources {
+		// Same exclusion rule for environment-scoped resources (e.g. a
+		// recipe pack tagged with the environment ID must not appear
+		// as a graph node).
+		if _, excluded := edges.ExcludedResourceTypes[to.String(resource.Type)]; excluded {
+			continue
+		}
 		_, found := resourcesByIDInApplication[to.String(resource.ID)]
 		if found {
 			// Appears in both application and environment lists, avoid duplicates.

--- a/pkg/corerp/frontend/controller/applications/v20250801preview/graph_util_test.go
+++ b/pkg/corerp/frontend/controller/applications/v20250801preview/graph_util_test.go
@@ -163,3 +163,54 @@ func Test_computeGraph_MergesDependsOnEdges(t *testing.T) {
 		}
 	})
 }
+
+// Test_computeGraph_ExcludesContainerImageNodes verifies that
+// Radius.Compute/containerImages resources are dropped at node-emission
+// time, matching the CLI static graph behaviour. containerImages are
+// build-time artifacts referenced via imageReference, not runtime graph
+// endpoints.
+func Test_computeGraph_ExcludesContainerImageNodes(t *testing.T) {
+	t.Parallel()
+
+	const (
+		appID       = "/planes/radius/local/resourceGroups/default/providers/Radius.Core/applications/myapp"
+		containerID = "/planes/radius/local/resourceGroups/default/providers/Radius.Compute/containers/web"
+		imageID     = "/planes/radius/local/resourceGroups/default/providers/Radius.Compute/containerImages/frontend"
+	)
+
+	container := generated.GenericResource{
+		ID:   to.Ptr(containerID),
+		Name: to.Ptr("web"),
+		Type: to.Ptr("Radius.Compute/containers"),
+		Properties: map[string]any{
+			"application": appID,
+		},
+	}
+	image := generated.GenericResource{
+		ID:   to.Ptr(imageID),
+		Name: to.Ptr("frontend"),
+		Type: to.Ptr("Radius.Compute/containerImages"),
+		Properties: map[string]any{
+			"application": appID,
+		},
+	}
+
+	graph := computeGraph(
+		[]generated.GenericResource{container, image},
+		nil,
+		"",
+		nil,
+	)
+
+	for _, r := range graph.Resources {
+		if r == nil || r.ID == nil {
+			continue
+		}
+		assert.NotEqual(t, imageID, *r.ID,
+			"containerImages resource must not appear as a graph node")
+		if r.Type != nil {
+			assert.NotEqual(t, "Radius.Compute/containerImages", *r.Type,
+				"no node of type Radius.Compute/containerImages should be emitted")
+		}
+	}
+}

--- a/pkg/graph/edges/edges.go
+++ b/pkg/graph/edges/edges.go
@@ -24,12 +24,21 @@ import (
 	"github.com/radius-project/radius/pkg/to"
 )
 
-// ExcludedResourceTypes lists resource types that are never valid
-// endpoints for a Dependency edge. Both the CLI static-graph builder
-// (pkg/cli/graph) and the Radius.Core preview runtime handler
-// (pkg/corerp/frontend/controller/applications/v20250801preview) share
-// this policy so the two graphs surface an identical set of edges for
-// the same input.
+// ExcludedResourceTypes lists resource types that must not appear as
+// graph nodes or as endpoints of any graph edge (Connection or
+// Dependency). It is consumed in two places:
+//
+//   - Node emission. The CLI static-graph builder
+//     (pkg/cli/graph, isExcludedResourceType) skips resources of these
+//     types when materializing ApplicationGraphResource nodes, and the
+//     Radius.Core preview runtime handler
+//     (pkg/corerp/frontend/controller/applications/v20250801preview,
+//     computeGraph) applies the same rule to the application-scoped
+//     and environment-scoped resource lists it fetches from UCP.
+//   - Dependency edge merging. MergeDependencyEdges (this file) drops
+//     any Dependency edge whose source or target Type is on this list,
+//     so both graphs surface an identical set of edges for the same
+//     input.
 //
 // The types listed here fall into two buckets:
 //
@@ -42,6 +51,12 @@ import (
 //     than a runtime component. Application containers reference the
 //     resulting `imageReference` string, not the artifact resource, so
 //     the artifact does not belong on the runtime graph.
+//
+// Add a new entry only when the type meets both criteria: it must not
+// belong on any application graph as a node, AND it must not be a
+// valid edge endpoint. Changing the semantics of this list (for
+// example, splitting it into node-only and edge-only sets) requires
+// updating every consumer above.
 var ExcludedResourceTypes = map[string]struct{}{
 	"Applications.Core/applications": {},
 	"Applications.Core/environments": {},

--- a/pkg/graph/edges/edges.go
+++ b/pkg/graph/edges/edges.go
@@ -31,16 +31,24 @@ import (
 // this policy so the two graphs surface an identical set of edges for
 // the same input.
 //
-// The types listed here are structural containers (applications,
-// environments, recipe packs) — Bicep authors typically write
-// `dependsOn` against them incidentally, but they are not resources
-// the graph is meant to visualise as endpoints.
+// The types listed here fall into two buckets:
+//
+//   - Structural containers (applications, environments, recipe packs)
+//     — Bicep authors typically write `dependsOn` against them
+//     incidentally, but they are not resources the graph is meant to
+//     visualise as endpoints.
+//   - Build-time artifacts (container images) — resources that model an
+//     artifact produced by a recipe (e.g. a pushed OCI image) rather
+//     than a runtime component. Application containers reference the
+//     resulting `imageReference` string, not the artifact resource, so
+//     the artifact does not belong on the runtime graph.
 var ExcludedResourceTypes = map[string]struct{}{
 	"Applications.Core/applications": {},
 	"Applications.Core/environments": {},
 	"Radius.Core/applications":       {},
 	"Radius.Core/environments":       {},
 	"Radius.Core/recipePacks":        {},
+	"Radius.Compute/containerImages": {},
 }
 
 // MergeDependencyEdges overlays caller-supplied Dependency edges onto

--- a/pkg/graph/edges/edges_test.go
+++ b/pkg/graph/edges/edges_test.go
@@ -29,11 +29,13 @@ const (
 	rabbitmqID  = "/planes/radius/local/resourcegroups/default/providers/Radius.Messaging/rabbitMQ/rabbitmq"
 	appsecretID = "/planes/radius/local/resourcegroups/default/providers/Radius.Security/secrets/appsecret"
 	appScopeID  = "/planes/radius/local/resourcegroups/default/providers/Radius.Core/applications/rabbitmq-app"
+	imageID     = "/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containerImages/frontend"
 
 	containerType = "Radius.Compute/containers"
 	queueType     = "Radius.Messaging/rabbitMQ"
 	secretType    = "Radius.Security/secrets"
 	appScopeType  = "Radius.Core/applications"
+	imageType     = "Radius.Compute/containerImages"
 )
 
 // static builder and the Radius.Core preview runtime handler.
@@ -179,6 +181,37 @@ func TestMergeDependencyEdges_ExcludedTargetDropsEdge(t *testing.T) {
 		"excluded target must not receive a mirrored inbound entry")
 }
 
+// TestMergeDependencyEdges_ExcludedContainerImage covers the
+// Radius.Compute/containerImages entry in ExcludedResourceTypes. Container
+// images are build-time artifacts referenced by their imageReference
+// string, not runtime graph endpoints, so both directions of a
+// dependency edge involving one must be dropped.
+func TestMergeDependencyEdges_ExcludedContainerImage(t *testing.T) {
+	t.Parallel()
+
+	graph := &corerpv20250801preview.ApplicationGraphResponse{
+		Resources: []*corerpv20250801preview.ApplicationGraphResource{
+			resource(consumerID, containerType),
+			resource(imageID, imageType),
+			resource(rabbitmqID, queueType),
+		},
+	}
+	// Two nonsensical edges the caller might emit from a raw dependsOn
+	// scan: consumer -> image (excluded target) and image -> rabbitmq
+	// (excluded source). Both must vanish.
+	MergeDependencyEdges(graph, map[string][]*corerpv20250801preview.ApplicationGraphConnection{
+		consumerID: {dep(imageID)},
+		imageID:    {dep(rabbitmqID)},
+	})
+
+	require.Empty(t, findResource(t, graph, consumerID).Connections,
+		"edge to excluded containerImages target must be dropped")
+	require.Empty(t, findResource(t, graph, imageID).Connections,
+		"edges sourced from excluded containerImages must be dropped and no mirror written")
+	require.Empty(t, findResource(t, graph, rabbitmqID).Connections,
+		"target of edge from excluded containerImages source must not receive a mirror")
+}
+
 func TestMergeDependencyEdges_UnknownEndpointIsDropped(t *testing.T) {
 	t.Parallel()
 
@@ -262,7 +295,7 @@ func TestMergeDependencyEdges_MalformedInputEntriesAreSkipped(t *testing.T) {
 	}
 	MergeDependencyEdges(graph, map[string][]*corerpv20250801preview.ApplicationGraphConnection{
 		consumerID: {
-			nil, // nil entry
+			nil,                      // nil entry
 			{ID: to.Ptr(rabbitmqID)}, // missing Direction and Kind
 			{ID: to.Ptr(rabbitmqID), Direction: to.Ptr(corerpv20250801preview.DirectionInbound), Kind: to.Ptr(corerpv20250801preview.ConnectionKindDependency)},  // wrong Direction
 			{ID: to.Ptr(rabbitmqID), Direction: to.Ptr(corerpv20250801preview.DirectionOutbound), Kind: to.Ptr(corerpv20250801preview.ConnectionKindConnection)}, // wrong Kind

--- a/specs/004-graph-dependency-edges/plan.md
+++ b/specs/004-graph-dependency-edges/plan.md
@@ -10,7 +10,7 @@
 Phase 1 of a two-phase change to the Radius application graph, scoped to the `Radius.Core/2025-08-01-preview` API surface.
 
 - **Static graph builder** (`pkg/cli/graph/modeled.go`) gains a second edge source: Bicep's compiled `dependsOn` array. Edges are tagged `kind: Connection` (from `properties.connections`) or `kind: Dependency` (from `dependsOn`). Connection wins when both sources signal the same source-target pair.
-- **Exclusion list**: `Radius.Core/applications`, `Radius.Core/environments`, `Radius.Core/recipePacks`, `Applications.Core/applications`, `Applications.Core/environments`. Members are never graph nodes and never edge targets.
+- **Exclusion list**: `Radius.Core/applications`, `Radius.Core/environments`, `Radius.Core/recipePacks`, `Radius.Compute/containerImages`, `Applications.Core/applications`, `Applications.Core/environments`. Members are never graph nodes and never edge targets.
 - **Wire model**: `ApplicationGraphConnection` on `Radius.Core/2025-08-01-preview` gains a `kind` field. `Applications.Core` TypeSpec, generated code, handlers, and tests are untouched.
 - **Runtime handler** (Radius.Core preview): sets `kind: Connection` on every edge it emits. `Dependency` edges at runtime are Phase 2.
 - **Shared primitives**: extraction, resolution, exclusion, mirroring, and Connection-wins de-dup live in a new neutral package `pkg/graph/edges/` so Phase 2's runtime dependency scan is a wiring change, not a re-implementation.


### PR DESCRIPTION

## Summary

removing containerImages from graph to reduce noise. 
A successful container deploy should indicate the image is built successfully. 

## Reason for change

<!--
Explain why this change is needed. If it addresses a GitHub issue, link it
below so it is automatically closed when this PR merges (optional).
-->

Fixes #<!-- issue number (optional) -->

## How to test

<!-- Describe the steps a reviewer can take to verify these changes. -->

## File change summary

<!-- Summarize the change made in each file that was modified. -->

| File | Summary of change |
| ---- | ----------------- |
|      |                   |
