### PR TITLE
Fix rad init progress display and Ctrl-C handling

### DIFF
--- a/pkg/cli/cmd/radinit/common/display.go
+++ b/pkg/cli/cmd/radinit/common/display.go
@@ -19,6 +19,8 @@ package common
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -152,13 +154,36 @@ func ConfirmOptions(ctx context.Context, prompter prompt.Interface, options Disp
 	}
 }
 
+// RedirectStdout redirects the process's stdout to the null device and returns the previous
+// stdout writer along with a restore function. Callers render the progress UI to the returned
+// writer so that stray writes to os.Stdout during installation (for example Helm's install
+// logs) cannot corrupt the display. If the null device cannot be opened, stdout is left
+// unchanged. The returned restore function is safe to call via defer.
+func RedirectStdout() (out io.Writer, restore func()) {
+	real := os.Stdout
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		return real, func() {}
+	}
+
+	os.Stdout = devNull
+	return real, func() {
+		os.Stdout = real
+		_ = devNull.Close()
+	}
+}
+
 // ShowProgress shows an updating progress display while the user's selections are being applied.
 //
 // This function should be called from a goroutine while installation proceeds in the background.
 // Progress updates are received on progressChan; the loop also exits when ctx is canceled.
-func ShowProgress(ctx context.Context, prompter prompt.Interface, options DisplayOptions, progressChan <-chan ProgressMsg) error {
+//
+// The display is rendered to out rather than to os.Stdout directly. Callers redirect the
+// process's stdout elsewhere while this UI runs so that stray writes (for example Helm's
+// install logs) cannot corrupt the rendered output.
+func ShowProgress(ctx context.Context, prompter prompt.Interface, options DisplayOptions, progressChan <-chan ProgressMsg, out io.Writer) error {
 	model := NewProgressModel(options)
-	program := tea.NewProgram(model, tea.WithContext(ctx))
+	program := tea.NewProgram(model, tea.WithContext(ctx), tea.WithOutput(out))
 
 	go func() {
 		for {
@@ -177,7 +202,16 @@ func ShowProgress(ctx context.Context, prompter prompt.Interface, options Displa
 		}
 	}()
 
-	_, err := prompter.RunProgram(program)
+	finalModel, err := prompter.RunProgram(program)
+
+	// If the user pressed Ctrl+C, abort rad init immediately. The installation steps run
+	// in another goroutine and may be blocked in a call (such as a Helm install) that
+	// cannot be canceled cooperatively, so terminate the process the way Helm does on
+	// interrupt. The terminal has already been restored by Bubble Tea at this point.
+	if pm, ok := finalModel.(*ProgressModel); ok && pm.Interrupted {
+		os.Exit(130)
+	}
+
 	return err
 }
 
@@ -288,6 +322,9 @@ type ProgressModel struct {
 	spinner  spinner.Model
 	style    lipgloss.Style
 
+	// Interrupted is set when the user cancels the progress display with Ctrl+C.
+	Interrupted bool
+
 	// SuppressSpinner is used to suppress the ticking of the spinner for testing.
 	SuppressSpinner bool
 	width           int
@@ -305,6 +342,12 @@ func (m *ProgressModel) Init() tea.Cmd {
 // Update implements tea.Model. It updates the model state on progress updates and spinner ticks.
 func (m *ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		if msg.String() == "ctrl+c" {
+			m.Interrupted = true
+			return m, tea.Quit
+		}
+		return m, nil
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		return m, nil

--- a/pkg/cli/cmd/radinit/common/display.go
+++ b/pkg/cli/cmd/radinit/common/display.go
@@ -189,11 +189,11 @@ func ShowProgress(ctx context.Context, prompter prompt.Interface, options Displa
 		for {
 			select {
 			case <-ctx.Done():
-				program.Send(tea.Quit)
+				program.Quit()
 				return
 			case msg, ok := <-progressChan:
 				if !ok {
-					program.Send(tea.Quit)
+					program.Quit()
 					return
 				}
 
@@ -209,7 +209,7 @@ func ShowProgress(ctx context.Context, prompter prompt.Interface, options Displa
 	// cannot be canceled cooperatively, so terminate the process the way Helm does on
 	// interrupt. The terminal has already been restored by Bubble Tea at this point.
 	if pm, ok := finalModel.(*ProgressModel); ok && pm.Interrupted {
-		os.Exit(130)
+		os.Exit(130) //nolint:forbidigo // Intentional: match Helm's behavior and abort rad init on Ctrl+C.
 	}
 
 	return err

--- a/pkg/cli/cmd/radinit/common/display_test.go
+++ b/pkg/cli/cmd/radinit/common/display_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_RedirectStdout(t *testing.T) {
+	original := os.Stdout
+
+	out, restore := RedirectStdout()
+	// Ensure the original stdout is restored even if an assertion fails.
+	defer restore()
+
+	// The returned writer is the original stdout so the progress UI can keep
+	// rendering to the real terminal.
+	require.Same(t, original, out)
+
+	// The process's global stdout is redirected away from the terminal so stray
+	// writes during installation are discarded instead of corrupting the UI.
+	require.NotSame(t, original, os.Stdout)
+
+	// Restoring puts the original stdout back in place.
+	restore()
+	require.Same(t, original, os.Stdout)
+}

--- a/pkg/cli/cmd/radinit/common/display_test.go
+++ b/pkg/cli/cmd/radinit/common/display_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,8 +28,15 @@ func Test_RedirectStdout(t *testing.T) {
 	original := os.Stdout
 
 	out, restore := RedirectStdout()
-	// Ensure the original stdout is restored even if an assertion fails.
-	defer restore()
+
+	// Restore the original stdout on failure, but only if the explicit restore
+	// below did not already run, so restore is called exactly once.
+	restored := false
+	defer func() {
+		if !restored {
+			restore()
+		}
+	}()
 
 	// The returned writer is the original stdout so the progress UI can keep
 	// rendering to the real terminal.
@@ -40,5 +48,21 @@ func Test_RedirectStdout(t *testing.T) {
 
 	// Restoring puts the original stdout back in place.
 	restore()
+	restored = true
 	require.Same(t, original, os.Stdout)
+}
+
+func Test_ProgressModel_Update_CtrlC(t *testing.T) {
+	model := NewProgressModel(DisplayOptions{})
+
+	updated, cmd := model.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+
+	// Ctrl+C marks the model as interrupted so the caller can abort rad init.
+	pm, ok := updated.(*ProgressModel)
+	require.True(t, ok)
+	require.True(t, pm.Interrupted)
+
+	// The returned command quits the Bubble Tea program.
+	require.NotNil(t, cmd)
+	require.IsType(t, tea.QuitMsg{}, cmd())
 }

--- a/pkg/cli/cmd/radinit/display.go
+++ b/pkg/cli/cmd/radinit/display.go
@@ -18,6 +18,7 @@ package radinit
 
 import (
 	"context"
+	"io"
 
 	"github.com/radius-project/radius/pkg/cli/cmd/radinit/common"
 )
@@ -30,8 +31,10 @@ func (r *Runner) confirmOptions(ctx context.Context, options *initOptions) (bool
 // showProgress shows an updating progress display while the user's selections are being applied.
 //
 // This function should be called from a goroutine while installation proceeds in the background.
-func (r *Runner) showProgress(ctx context.Context, options *initOptions, progressChan <-chan common.ProgressMsg) error {
-	return common.ShowProgress(ctx, r.Prompter, toDisplayOptions(options), progressChan)
+// The display is rendered to out, which must be the real stdout captured before the caller
+// redirects os.Stdout for the duration of the installation.
+func (r *Runner) showProgress(ctx context.Context, options *initOptions, progressChan <-chan common.ProgressMsg, out io.Writer) error {
+	return common.ShowProgress(ctx, r.Prompter, toDisplayOptions(options), progressChan, out)
 }
 
 // toDisplayOptions converts the package-local initOptions into the common

--- a/pkg/cli/cmd/radinit/init.go
+++ b/pkg/cli/cmd/radinit/init.go
@@ -234,9 +234,15 @@ func (r *Runner) Run(ctx context.Context) error {
 	progressCompleteChan := make(chan error)
 	progress := common.ProgressMsg{}
 
+	// Redirect stdout to the null device while the progress UI owns the terminal so that
+	// stray writes from the installation steps (for example Helm's install logs) cannot
+	// corrupt the rendered output. The UI is given the real stdout explicitly.
+	progressOut, restoreStdout := common.RedirectStdout()
+	defer restoreStdout()
+
 	go func() {
 		// Show dynamic UI.
-		err := r.showProgress(ctx, r.Options, progressChan)
+		err := r.showProgress(ctx, r.Options, progressChan, progressOut)
 		if err != nil {
 			progressCompleteChan <- err
 		}

--- a/pkg/cli/cmd/radinit/init.go
+++ b/pkg/cli/cmd/radinit/init.go
@@ -231,6 +231,7 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	// Use this channel to send progress updates to the UI.
 	progressChan := make(chan common.ProgressMsg)
+	defer close(progressChan)
 	progressCompleteChan := make(chan error)
 	progress := common.ProgressMsg{}
 

--- a/pkg/cli/cmd/radinit/preview/display.go
+++ b/pkg/cli/cmd/radinit/preview/display.go
@@ -18,7 +18,7 @@ package preview
 
 import (
 	"context"
-	"path/filepath"
+	"io"
 
 	"github.com/radius-project/radius/pkg/cli/cmd/radinit/common"
 )
@@ -31,8 +31,10 @@ func (r *Runner) confirmOptions(ctx context.Context, options *initOptions) (bool
 // showProgress shows an updating progress display while the user's selections are being applied.
 //
 // This function should be called from a goroutine while installation proceeds in the background.
-func (r *Runner) showProgress(ctx context.Context, options *initOptions, progressChan <-chan common.ProgressMsg) error {
-	return common.ShowProgress(ctx, r.Prompter, toDisplayOptions(options), progressChan)
+// The display is rendered to out, which must be the real stdout captured before the caller
+// redirects os.Stdout for the duration of the installation.
+func (r *Runner) showProgress(ctx context.Context, options *initOptions, progressChan <-chan common.ProgressMsg, out io.Writer) error {
+	return common.ShowProgress(ctx, r.Prompter, toDisplayOptions(options), progressChan, out)
 }
 
 // toDisplayOptions converts the package-local initOptions into the common
@@ -45,7 +47,7 @@ func toDisplayOptions(options *initOptions) common.DisplayOptions {
 
 	var scaffoldFiles []string
 	if options.Application.Scaffold {
-		scaffoldFiles = []string{"app.bicep", "bicepconfig.json", filepath.Join(".rad", "rad.yaml")}
+		scaffoldFiles = []string{"app.bicep", "bicepconfig.json"}
 	}
 
 	return common.DisplayOptions{

--- a/pkg/cli/cmd/radinit/preview/display.go
+++ b/pkg/cli/cmd/radinit/preview/display.go
@@ -42,7 +42,7 @@ func (r *Runner) showProgress(ctx context.Context, options *initOptions, progres
 func toDisplayOptions(options *initOptions) common.DisplayOptions {
 	recipePackLabel := ""
 	if options.Recipes.DefaultRecipePack {
-		recipePackLabel = "default recipe pack"
+		recipePackLabel = "default"
 	}
 
 	var scaffoldFiles []string

--- a/pkg/cli/cmd/radinit/preview/init.go
+++ b/pkg/cli/cmd/radinit/preview/init.go
@@ -196,9 +196,15 @@ func (r *Runner) Run(ctx context.Context) error {
 	progressCompleteChan := make(chan error)
 	progress := common.ProgressMsg{}
 
+	// Redirect stdout to the null device while the progress UI owns the terminal so that
+	// stray writes from the installation steps (for example Helm's install logs) cannot
+	// corrupt the rendered output. The UI is given the real stdout explicitly.
+	progressOut, restoreStdout := common.RedirectStdout()
+	defer restoreStdout()
+
 	go func() {
 		// Show dynamic UI.
-		err := r.showProgress(ctx, r.Options, progressChan)
+		err := r.showProgress(ctx, r.Options, progressChan, progressOut)
 		if err != nil {
 			progressCompleteChan <- err
 		}


### PR DESCRIPTION
## Summary

Cleans up the `rad init` progress experience by fixing three related defects in the shared and preview init flows:

- The progress display no longer prints a duplicated "Initializing Radius..." heading or garbled output.
- Ctrl-C now interrupts `rad init` promptly instead of being swallowed by the progress UI.
- The preview scaffold summary lists only the files that are actually created (`app.bicep` and `bicepconfig.json`).

## Reason for change

While the Bubble Tea progress UI is rendering, Helm's install logs (for example `Installing Contour...`) were written directly to `os.Stdout`, corrupting the inline renderer's cursor tracking and duplicating the heading. Additionally, Bubble Tea puts the terminal in raw mode (ISIG disabled), so Ctrl-C arrived as a key event that the progress model ignored, leaving the install uninterruptible. Finally, the preview summary advertised a `.rad/rad.yaml` file that `ScaffoldApplication` never creates.

Fixes #12537
Fixes #12538
Fixes #12539

## How to test

1. Build the CLI: `go build -o ./raddev ./cmd/rad`.
2. Run `./raddev init --preview` against a Kubernetes cluster.
3. Verify the progress output shows a single "Initializing Radius..." heading with no stray/garbled terminal characters.
4. Verify the scaffold summary lists only `app.bicep` and `bicepconfig.json`.
5. During installation, press Ctrl-C and confirm `rad init` aborts promptly (exit code 130), matching Helm's interrupt behavior.
6. Run `go test ./pkg/cli/cmd/radinit/...` (optionally with `-race`).

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `pkg/cli/cmd/radinit/common/display.go` | Added `RedirectStdout` helper; `ShowProgress` now renders to an explicit `io.Writer` via `tea.WithOutput`; added `Interrupted` field to `ProgressModel` with Ctrl-C handling that exits with code 130. |
| `pkg/cli/cmd/radinit/init.go` | Redirect `os.Stdout` to the null device during install and pass the real stdout to the progress UI. |
| `pkg/cli/cmd/radinit/display.go` | Updated `showProgress` wrapper to forward the output writer. |
| `pkg/cli/cmd/radinit/preview/init.go` | Same stdout redirection wiring for the preview flow. |
| `pkg/cli/cmd/radinit/preview/display.go` | Updated `showProgress` wrapper and corrected the scaffold file list to `app.bicep` and `bicepconfig.json`. |