### PR TITLE
Generate reference docs for RRTs in bicep extension

### DIFF
--- a/build/generate.mk
+++ b/build/generate.mk
@@ -212,11 +212,13 @@ generate-yq-installed:
 .PHONY: generate-bicep-types-contrib
 generate-bicep-types-contrib: generate-yq-installed ## Generates Bicep types.json files for default contrib namespaces from defaults.yaml.
 	@echo "$(ARROW) Generating Bicep types for default contrib resource type namespaces..."
+	@test -f $(BICEP_TYPES_EMITTER_DIR)/dist/src/cmd/generate-contrib-docs.js || $(MAKE) generate-bicep-types-emitter
 	build/scripts/generate-bicep-types-contrib.sh \
 		"$(DEFAULTS_YAML)" \
 		"$(BICEP_TYPES_CONTRIB_MANIFEST_DIR)" \
 		"$(BICEP_TYPES_OUTPUT_BASE)" \
-		"$(BICEP_TYPES_CONTRIB_API_VERSION)"
+		"$(BICEP_TYPES_CONTRIB_API_VERSION)" \
+		"$(BICEP_TYPES_EMITTER_DIR)"
 
 # rebuild-bicep-types-index rebuilds the unified index from the per-namespace
 # types.json files. It builds the emitter only when it is not already built (e.g.

--- a/build/scripts/generate-bicep-types-contrib.sh
+++ b/build/scripts/generate-bicep-types-contrib.sh
@@ -5,18 +5,28 @@ set -euo pipefail
 # Each entry in defaults.yaml uses <namespace>/<typeName> format (e.g. Radius.Compute/containers).
 # Per-type manifest files live under the manifest dir as individual YAML files.
 #
-# Usage: generate-bicep-types-contrib.sh <defaults_yaml> <manifest_dir> <output_base> <api_version>
+# Usage: generate-bicep-types-contrib.sh <defaults_yaml> <manifest_dir> <output_base> <api_version> <emitter_dir>
 #
 # Arguments:
 #   defaults_yaml  - Path to defaults.yaml listing default resource type registrations.
 #   manifest_dir   - Directory containing per-type manifest YAML files.
 #   output_base    - Base output directory for generated Bicep types.
 #   api_version    - API version string to use for the output directory name.
+#   emitter_dir    - Directory of the built TypeSpec Bicep emitter package (provides
+#                    dist/src/cmd/generate-contrib-docs.js for reference-doc generation).
 
 DEFAULTS_YAML="${1:?defaults_yaml argument is required}"
 BICEP_TYPES_CONTRIB_MANIFEST_DIR="${2:?manifest_dir argument is required}"
 BICEP_TYPES_OUTPUT_BASE="${3:?output_base argument is required}"
 BICEP_TYPES_CONTRIB_API_VERSION="${4:?api_version argument is required}"
+BICEP_TYPES_EMITTER_DIR="${5:?emitter_dir argument is required}"
+
+GENERATE_DOCS_JS="${BICEP_TYPES_EMITTER_DIR}/dist/src/cmd/generate-contrib-docs.js"
+if [[ ! -f "${GENERATE_DOCS_JS}" ]]; then
+    echo "ERROR: Reference-doc generator not found: ${GENERATE_DOCS_JS}"
+    echo "Build the emitter first (make generate-bicep-types-emitter)."
+    exit 1
+fi
 
 NAMESPACES=$(yq '.defaultRegistration[]' "$DEFAULTS_YAML" | sed 's|/.*||' | sort -u)
 for ns in $NAMESPACES; do
@@ -34,5 +44,5 @@ for ns in $NAMESPACES; do
     done
     echo "  -> $ns ($manifest_args) -> $out_dir"
     go run ./bicep-tools/cmd/manifest-to-bicep generate $manifest_args "$out_dir"
-    mkdir -p "$out_dir/docs"
+    node "${GENERATE_DOCS_JS}" --types-json "$out_dir/types.json" --out-dir "$out_dir/docs"
 done

--- a/build/scripts/generate-bicep-types-contrib.sh
+++ b/build/scripts/generate-bicep-types-contrib.sh
@@ -46,5 +46,26 @@ for ns in $NAMESPACES; do
     done
     echo "  -> $ns ($manifest_args) -> $out_dir"
     go run ./bicep-tools/cmd/manifest-to-bicep generate $manifest_args "$out_dir"
-    node "${GENERATE_DOCS_JS}" --types-json "$out_dir/types.json" --out-dir "$out_dir/docs"
+
+    # Resource-level descriptions are authored in the manifests but cannot be carried in
+    # types.json: the bicep-types schema has no description field on ResourceType or
+    # ObjectType, only on individual properties. Side-channel them to the doc generator as
+    # a { "<Namespace>/<typeName>": "<description>" } map, mirroring how the TypeSpec
+    # emitter reads @doc from the compiler rather than from types.json.
+    #
+    # Only the first document of each manifest is read, because manifest-to-bicep parses
+    # with yaml.Unmarshal and silently ignores any later documents. Reading them here too
+    # would describe types the converter never emitted.
+    descriptions_json="$out_dir/descriptions.json"
+    # shellcheck disable=SC2016 # $ns is a yq variable, so the expression must not be expanded by the shell.
+    yq -o=json eval-all \
+        '[select(document_index == 0) | .namespace as $ns | .types | to_entries[] | select(.value.description != null) | {"key": ($ns + "/" + .key), "value": .value.description}] | from_entries' \
+        $manifest_args > "$descriptions_json"
+
+    node "${GENERATE_DOCS_JS}" \
+        --types-json "$out_dir/types.json" \
+        --out-dir "$out_dir/docs" \
+        --descriptions "$descriptions_json"
+
+    rm -f "$descriptions_json"
 done

--- a/build/scripts/generate-bicep-types-contrib.sh
+++ b/build/scripts/generate-bicep-types-contrib.sh
@@ -33,7 +33,9 @@ for ns in $NAMESPACES; do
     ns_lower=$(echo "$ns" | tr '[:upper:]' '[:lower:]')
     out_dir="$BICEP_TYPES_OUTPUT_BASE/$ns_lower/$BICEP_TYPES_CONTRIB_API_VERSION"
     manifest_args=""
-    for entry in $(yq '.defaultRegistration[]' "$DEFAULTS_YAML" | grep "^$ns/"); do
+    for entry in $(yq '.defaultRegistration[]' "$DEFAULTS_YAML"); do
+        # Literal namespace prefix match; namespaces contain '.', which grep would treat as a wildcard.
+        [ "${entry%%/*}" = "$ns" ] || continue
         type_name=$(echo "$entry" | cut -d'/' -f2)
         manifest="$BICEP_TYPES_CONTRIB_MANIFEST_DIR/$type_name.yaml"
         if [ ! -f "$manifest" ]; then

--- a/docs/contributing/contributing-code/contributing-code-schema-changes/README.md
+++ b/docs/contributing/contributing-code/contributing-code-schema-changes/README.md
@@ -71,7 +71,7 @@ To confirm your schema compiles in a Bicep template, publish the generated Bicep
    make generate-bicep-types
    ```
 
-   This writes the type files under `hack/bicep-types-radius/generated/` and rebuilds the unified index at `hack/bicep-types-radius/generated/index.json`.
+   This writes the type files under `hack/bicep-types-radius/generated/` and rebuilds the unified index at `hack/bicep-types-radius/generated/index.json`. It also writes one reference doc per resource type to `<namespace>/<apiVersion>/docs/`, for both the TypeSpec-generated and the manifest-generated (contrib) namespaces. Those docs are build artifacts, not checked in, and are published to the docs repo by the `publish-docs` workflow.
 3. Publish the unified `radius` extension to a target of your choice (a local file path or an OCI registry):
 
    ```bash
@@ -121,3 +121,4 @@ To confirm your schema compiles in a Bicep template, publish the generated Bicep
 - **Generated files keep reappearing as changes.** Generated `zz_generated_*.go` and `openapi.json` files are committed artifacts. Run `make generate`, then commit the regenerated output so it matches your TypeSpec.
 - **`make publish-bicep-extension` errors that the index does not exist.** Run `make generate-bicep-types` first; the target publishes `hack/bicep-types-radius/generated/index.json`, which that command creates.
 - **`make publish-bicep-extension` cannot find `bicep`.** Install the [Bicep CLI](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/install) and ensure it is on your `PATH`, or use the binary at `~/.rad/bin/bicep` from a Radius CLI install.
+- **`Reference-doc generator not found`.** The contrib namespaces render their reference docs with the compiled TypeSpec emitter. Run `make generate-bicep-types-emitter` to build it, then re-run `make generate-bicep-types-contrib`.

--- a/hack/bicep-types-radius/src/typespec-bicep-types/package.json
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/package.json
@@ -26,6 +26,7 @@
     "typecheck": "tsc -p . --noEmit",
     "compile-projects": "node dist/src/cmd/compile-projects.js",
     "rebuild-index": "node dist/src/cmd/rebuild-index.js",
+    "generate-contrib-docs": "node dist/src/cmd/generate-contrib-docs.js",
     "clean": "rimraf dist"
   },
   "author": "The Radius Authors",

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/cmd/generate-contrib-docs.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/cmd/generate-contrib-docs.ts
@@ -53,7 +53,9 @@ if (!typesJsonArg || !outDirArg) {
 const typesJsonPath = resolve(process.cwd(), typesJsonArg);
 const outDir = resolve(process.cwd(), outDirArg);
 
-const types = readTypesJson(await readFile(typesJsonPath, { encoding: "utf8" }));
+const types = readTypesJson(
+  await readFile(typesJsonPath, { encoding: "utf8" })
+);
 const resourceTypes = filterResourceTypes(types);
 
 if (resourceTypes.length === 0) {

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/cmd/generate-contrib-docs.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/cmd/generate-contrib-docs.ts
@@ -23,12 +23,13 @@
 //
 // Usage:
 //   node dist/src/cmd/generate-contrib-docs.js \
-//     --types-json <namespace>/<apiVersion>/types.json \
-//     --out-dir    <namespace>/<apiVersion>/docs
+//     --types-json    <namespace>/<apiVersion>/types.json \
+//     --out-dir       <namespace>/<apiVersion>/docs \
+//     [--descriptions <path to { "<Namespace>/<typeName>": "<description>" } JSON>]
 
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
-import { readTypesJson } from "../bicep.js";
+import { readTypesJson, writeMarkdown } from "../bicep.js";
 import {
   buildResourceDocs,
   filterResourceTypes
@@ -42,6 +43,7 @@ function getArg(name: string): string | undefined {
 
 const typesJsonArg = getArg("types-json");
 const outDirArg = getArg("out-dir");
+const descriptionsArg = getArg("descriptions");
 
 if (!typesJsonArg || !outDirArg) {
   console.error(
@@ -79,7 +81,41 @@ if (resourceTypes.length === 0) {
   process.exit(1);
 }
 
-const docs = buildResourceDocs(resourceTypes, types);
+// Resource-level descriptions are authored in the source manifests but cannot be
+// carried in types.json: the bicep-types schema exposes `description` only on
+// individual object properties, not on ResourceType or ObjectType. The generation
+// script extracts them with yq and passes them here, keyed by `<Namespace>/<typeName>`
+// without the API version.
+const descriptions = new Map<string, string>();
+if (descriptionsArg) {
+  const parsed: unknown = JSON.parse(
+    await readFile(resolve(process.cwd(), descriptionsArg), {
+      encoding: "utf8"
+    })
+  );
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    console.error(
+      `--descriptions must contain a JSON object mapping resource type names to descriptions; got ${descriptionsArg}.`
+    );
+    process.exit(1);
+  }
+  for (const [name, description] of Object.entries(parsed)) {
+    // A non-string value means the manifest authored something unexpected. The Go
+    // converter ignores the resource-level description entirely, so nothing upstream
+    // catches it; fail here rather than silently publishing a doc without it.
+    if (typeof description !== "string") {
+      console.error(
+        `Description for '${name}' in ${descriptionsArg} must be a string; got ${typeof description}.`
+      );
+      process.exit(1);
+    }
+    descriptions.set(name, description);
+  }
+}
+
+const docs = buildResourceDocs(resourceTypes, types, (resourceType) =>
+  descriptions.get(resourceType.name.split("@")[0])
+);
 
 // Regenerate from scratch so docs for renamed/removed resources do not linger
 // and get republished by the docs-repo consumer.
@@ -91,6 +127,21 @@ await Promise.all(
   docs.map((doc) => writeFile(resolve(outDir, doc.filename), doc.content))
 );
 
+// The generated index.md links every resource to `types.md#resource-...`, and the
+// TypeSpec path writes that file alongside types.json. Emit it here too so the
+// contrib namespaces have the same layout and those links resolve.
+const [namespace, apiVersion] = splitResourceTypeName(resourceTypes[0].name);
+await writeFile(
+  resolve(dirname(typesJsonPath), "types.md"),
+  writeMarkdown(types, `${namespace} @ ${apiVersion}`)
+);
+
 console.log(
   `Generated ${docs.length} reference doc(s) from ${typesJsonArg} into ${outDirArg}`
 );
+
+/** Splits `Namespace/type@apiVersion` into its namespace and API version. */
+function splitResourceTypeName(name: string): [string, string] {
+  const [typePath, apiVersion = ""] = name.split("@");
+  return [typePath.split("/")[0], apiVersion];
+}

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/cmd/generate-contrib-docs.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/cmd/generate-contrib-docs.ts
@@ -27,7 +27,7 @@
 //     --out-dir    <namespace>/<apiVersion>/docs
 
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { readTypesJson } from "../bicep.js";
 import {
   buildResourceDocs,
@@ -52,6 +52,19 @@ if (!typesJsonArg || !outDirArg) {
 
 const typesJsonPath = resolve(process.cwd(), typesJsonArg);
 const outDir = resolve(process.cwd(), outDirArg);
+
+// The stale-doc cleanup below removes every *.md in the output directory, so
+// require the output to be the `docs/` directory alongside the supplied
+// types.json. A looser check (for example, only requiring the directory to be
+// named `docs`) would allow an unrelated docs directory to be wiped.
+const expectedOutDir = resolve(dirname(typesJsonPath), "docs");
+if (outDir !== expectedOutDir) {
+  console.error(
+    `--out-dir must be the 'docs' directory next to --types-json; got '${outDirArg}' ` +
+      `(resolved to '${outDir}'), expected '${expectedOutDir}'.`
+  );
+  process.exit(1);
+}
 
 const types = readTypesJson(
   await readFile(typesJsonPath, { encoding: "utf8" })

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/cmd/generate-contrib-docs.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/cmd/generate-contrib-docs.ts
@@ -1,0 +1,81 @@
+// ------------------------------------------------------------
+// Copyright 2023 The Radius Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------.
+//
+// Standalone CLI that generates per-resource reference docs (`docs/<resource>.md`)
+// for a contrib namespace produced by the Go `manifest-to-bicep generate`
+// command. That command emits only `types.json`; this reuses the shared
+// `writeTableMarkdown()` markdown so contrib namespaces (Radius.Compute,
+// Radius.Data, Radius.Security, ...) get the same reference docs as the
+// TypeSpec-generated core namespaces, without reimplementing the renderer in Go.
+//
+// Usage:
+//   node dist/src/cmd/generate-contrib-docs.js \
+//     --types-json <namespace>/<apiVersion>/types.json \
+//     --out-dir    <namespace>/<apiVersion>/docs
+
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { readTypesJson } from "../bicep.js";
+import {
+  buildResourceDocs,
+  filterResourceTypes
+} from "../writers/resource-docs.js";
+
+function getArg(name: string): string | undefined {
+  const flagIndex = process.argv.indexOf(`--${name}`);
+  const value = flagIndex >= 0 ? process.argv[flagIndex + 1] : undefined;
+  return value && !value.startsWith("--") ? value : undefined;
+}
+
+const typesJsonArg = getArg("types-json");
+const outDirArg = getArg("out-dir");
+
+if (!typesJsonArg || !outDirArg) {
+  console.error(
+    "Usage: generate-contrib-docs --types-json <path> --out-dir <docsDir>"
+  );
+  process.exit(1);
+}
+
+const typesJsonPath = resolve(process.cwd(), typesJsonArg);
+const outDir = resolve(process.cwd(), outDirArg);
+
+const types = readTypesJson(await readFile(typesJsonPath, { encoding: "utf8" }));
+const resourceTypes = filterResourceTypes(types);
+
+if (resourceTypes.length === 0) {
+  console.error(
+    `No resource types found in ${typesJsonArg}; refusing to generate empty docs. ` +
+      "This usually means the manifest-to-bicep conversion produced no resources."
+  );
+  process.exit(1);
+}
+
+const docs = buildResourceDocs(resourceTypes, types);
+
+// Regenerate from scratch so docs for renamed/removed resources do not linger
+// and get republished by the docs-repo consumer.
+await mkdir(outDir, { recursive: true });
+const stale = (await readdir(outDir)).filter((name) => name.endsWith(".md"));
+await Promise.all(stale.map((name) => rm(resolve(outDir, name))));
+
+await Promise.all(
+  docs.map((doc) => writeFile(resolve(outDir, doc.filename), doc.content))
+);
+
+console.log(
+  `Generated ${docs.length} reference doc(s) from ${typesJsonArg} into ${outDirArg}`
+);

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/emitter.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/emitter.ts
@@ -16,15 +16,16 @@
 
 import { EmitContext, emitFile, getDoc, resolvePath } from "@typespec/compiler";
 import {
-  ResourceType,
-  TypeBaseKind,
   TypeFactory,
   writeMarkdown,
   writeTypesJson
 } from "./bicep.js";
 import { discoverResources, DiscoveredResource } from "./resource-discovery.js";
 import { buildResourceType, newTranslationCache } from "./type-translator.js";
-import { writeTableMarkdown } from "./writers/markdown-table.js";
+import {
+  buildResourceDocs,
+  filterResourceTypes
+} from "./writers/resource-docs.js";
 import type { BicepEmitterOptions } from "./lib.js";
 
 /**
@@ -97,26 +98,20 @@ export async function $onEmit(
     });
 
     // One reference doc per resource type under docs/<resource>.md.
-    const resourceTypes = factory.types.filter(
-      (type) => type.type === TypeBaseKind.ResourceType
-    ) as ResourceType[];
-    for (const resourceType of resourceTypes) {
-      const filename = resourceType.name
-        .split("/")[1]
-        .split("@")[0]
-        .toLowerCase();
+    const docs = buildResourceDocs(
+      filterResourceTypes(factory.types),
+      factory.types,
+      (resourceType) => descriptions.get(resourceType.name)
+    );
+    for (const doc of docs) {
       await emitFile(context.program, {
         path: resolvePath(
           context.emitterOutputDir,
           outFolder,
           "docs",
-          `${filename}.md`
+          doc.filename
         ),
-        content: writeTableMarkdown(
-          [resourceType],
-          factory.types,
-          descriptions.get(resourceType.name)
-        )
+        content: doc.content
       });
     }
   }

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/emitter.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/emitter.ts
@@ -15,11 +15,7 @@
 // ------------------------------------------------------------.
 
 import { EmitContext, emitFile, getDoc, resolvePath } from "@typespec/compiler";
-import {
-  TypeFactory,
-  writeMarkdown,
-  writeTypesJson
-} from "./bicep.js";
+import { TypeFactory, writeMarkdown, writeTypesJson } from "./bicep.js";
 import { discoverResources, DiscoveredResource } from "./resource-discovery.js";
 import { buildResourceType, newTranslationCache } from "./type-translator.js";
 import {

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/resource-docs.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/resource-docs.ts
@@ -44,10 +44,45 @@ export function buildResourceDocs(
   types: BicepType[],
   describe?: (resourceType: ResourceType) => string | undefined
 ): ResourceDoc[] {
-  return resourceTypes.map((resourceType) => ({
+  const docs = resourceTypes.map((resourceType) => ({
     filename: `${resourceDocFilename(resourceType)}.md`,
     content: writeTableMarkdown([resourceType], types, describe?.(resourceType))
   }));
+
+  assertUniqueFilenames(resourceTypes, docs);
+  return docs;
+}
+
+/**
+ * Fails when two resource types map to the same file name. The file name drops
+ * the API version, so a `types.json` holding several API versions of one
+ * resource type would otherwise write both docs to the same path and silently
+ * publish whichever finished last. Nested names joined with `-` can collide the
+ * same way. Callers should split the input by API version rather than letting
+ * one overwrite the other.
+ */
+function assertUniqueFilenames(
+  resourceTypes: ResourceType[],
+  docs: ResourceDoc[]
+): void {
+  const owners = new Map<string, string[]>();
+  docs.forEach((doc, index) => {
+    const names = owners.get(doc.filename) ?? [];
+    names.push(resourceTypes[index].name);
+    owners.set(doc.filename, names);
+  });
+
+  const collisions = [...owners.entries()].filter(
+    ([, names]) => names.length > 1
+  );
+  if (collisions.length > 0) {
+    const detail = collisions
+      .map(([filename, names]) => `${filename} <- ${names.join(", ")}`)
+      .join("; ");
+    throw new Error(
+      `Resource types map to the same reference doc file name: ${detail}`
+    );
+  }
 }
 
 /**

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/resource-docs.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/resource-docs.ts
@@ -1,0 +1,75 @@
+// ------------------------------------------------------------
+// Copyright 2023 The Radius Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------.
+
+import { BicepType, ResourceType, TypeBaseKind } from "../bicep.js";
+import { writeTableMarkdown } from "./markdown-table.js";
+
+/**
+ * A single generated reference document: the target file name (without a
+ * directory, e.g. `containers.md`) and its markdown content.
+ */
+export interface ResourceDoc {
+  filename: string;
+  content: string;
+}
+
+/**
+ * Builds the per-resource reference docs (`docs/<resource>.md`) for a namespace.
+ *
+ * For every {@link ResourceType} it derives the file name from the resource
+ * name (`Namespace/type@version` -> `type.md`, lowercased) and renders the
+ * markdown table with the shared {@link writeTableMarkdown}. This is the single
+ * source of truth for the `docs/*.md` layout so the TypeSpec emitter and the
+ * contrib (Go manifest) path produce identical output.
+ *
+ * `describe` supplies the optional resource description rendered above the
+ * property tables. The TypeSpec emitter resolves it from `@doc`; the contrib
+ * path has no equivalent metadata in `types.json` and omits it.
+ */
+export function buildResourceDocs(
+  resourceTypes: ResourceType[],
+  types: BicepType[],
+  describe?: (resourceType: ResourceType) => string | undefined
+): ResourceDoc[] {
+  return resourceTypes.map((resourceType) => ({
+    filename: `${resourceDocFilename(resourceType)}.md`,
+    content: writeTableMarkdown([resourceType], types, describe?.(resourceType))
+  }));
+}
+
+/**
+ * Derives the doc file stem from a resource name. Bicep resource names are
+ * `Namespace/type@version` (and, for nested types, `Namespace/parent/child@version`).
+ * Everything after the namespace and before `@` is used, joined with `-`, so
+ * nested types get a distinct, collision-free name.
+ */
+function resourceDocFilename(resourceType: ResourceType): string {
+  const [typePath] = resourceType.name.split("@");
+  const segments = typePath.split("/");
+  if (segments.length < 2) {
+    throw new Error(
+      `Unexpected resource type name '${resourceType.name}'; expected 'Namespace/type@version'`
+    );
+  }
+  return segments.slice(1).join("-").toLowerCase();
+}
+
+/** Returns the {@link ResourceType}s from a flat list of Bicep types. */
+export function filterResourceTypes(types: BicepType[]): ResourceType[] {
+  return types.filter(
+    (type): type is ResourceType => type.type === TypeBaseKind.ResourceType
+  );
+}

--- a/hack/bicep-types-radius/src/typespec-bicep-types/test/contrib-docs.test.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/test/contrib-docs.test.ts
@@ -1,0 +1,91 @@
+// ------------------------------------------------------------
+// Copyright 2023 The Radius Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------.
+
+import { describe, expect, it } from "vitest";
+import {
+  ObjectTypePropertyFlags,
+  ScopeType,
+  TypeFactory,
+  createObjectProperty,
+  writeMarkdown
+} from "../src/bicep.js";
+import {
+  buildResourceDocs,
+  filterResourceTypes
+} from "../src/writers/resource-docs.js";
+
+const RESOURCE_NAME = "Radius.Compute/containers@2025-08-01-preview";
+
+function buildFactory(): TypeFactory {
+  const factory = new TypeFactory();
+  const stringRef = factory.addStringType();
+  const bodyRef = factory.addObjectType(RESOURCE_NAME, {
+    application: createObjectProperty(
+      stringRef,
+      ObjectTypePropertyFlags.Required,
+      "(Required) The Radius Application ID."
+    )
+  });
+  factory.addResourceType(
+    RESOURCE_NAME,
+    bodyRef,
+    ScopeType.ResourceGroup,
+    ScopeType.ResourceGroup
+  );
+  return factory;
+}
+
+/** GitHub-style heading slug, matching how the rendered types.md anchors resolve. */
+function headingSlug(heading: string): string {
+  return heading
+    .toLowerCase()
+    .replace(/[^a-z0-9 -]/g, "")
+    .trim()
+    .replace(/ /g, "-");
+}
+
+describe("contrib reference docs", () => {
+  it("leads with the description block when the manifest supplies one", () => {
+    const factory = buildFactory();
+
+    const [doc] = buildResourceDocs(
+      filterResourceTypes(factory.types),
+      factory.types,
+      () => "Runs one or more containers."
+    );
+
+    expect(doc.filename).toBe("containers.md");
+    expect(doc.content.startsWith("## Description")).toBe(true);
+    expect(doc.content).toContain("Runs one or more containers.");
+  });
+
+  it("emits a types.md anchor matching the link format used by index.md", () => {
+    const factory = buildFactory();
+
+    const typesMarkdown = writeMarkdown(
+      factory.types,
+      "Radius.Compute @ 2025-08-01-preview"
+    );
+
+    // The generated index.md links to `types.md#resource-<name with separators stripped>`.
+    const indexLinkAnchor = `resource-${RESOURCE_NAME.toLowerCase().replace(/[^a-z0-9-]/g, "")}`;
+    const anchors = [...typesMarkdown.matchAll(/^#+\s+(.*)$/gm)].map(
+      ([, heading]) => headingSlug(heading)
+    );
+
+    expect(anchors).toContain(indexLinkAnchor);
+  });
+});

--- a/hack/bicep-types-radius/src/typespec-bicep-types/test/resource-docs.test.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/test/resource-docs.test.ts
@@ -144,4 +144,26 @@ describe("buildResourceDocs", () => {
       buildResourceDocs(filterResourceTypes(factory.types), factory.types)
     ).toThrow(/expected 'Namespace\/type@version'/);
   });
+
+  it("rejects two API versions of one resource type, which share a file name", () => {
+    const factory = buildTypes([
+      "Radius.Compute/containers@2025-08-01-preview",
+      "Radius.Compute/containers@2026-01-01"
+    ]);
+
+    expect(() =>
+      buildResourceDocs(filterResourceTypes(factory.types), factory.types)
+    ).toThrow(/same reference doc file name.*containers\.md/s);
+  });
+
+  it("rejects nested resource types that collapse to the same hyphenated name", () => {
+    const factory = buildTypes([
+      "Radius.Compute/containers-sidecars@2025-08-01-preview",
+      "Radius.Compute/containers/sidecars@2025-08-01-preview"
+    ]);
+
+    expect(() =>
+      buildResourceDocs(filterResourceTypes(factory.types), factory.types)
+    ).toThrow(/same reference doc file name/);
+  });
 });

--- a/hack/bicep-types-radius/src/typespec-bicep-types/test/resource-docs.test.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/test/resource-docs.test.ts
@@ -1,0 +1,147 @@
+// ------------------------------------------------------------
+// Copyright 2023 The Radius Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------.
+
+import { describe, expect, it } from "vitest";
+import {
+  ObjectTypePropertyFlags,
+  ScopeType,
+  TypeFactory,
+  createObjectProperty
+} from "../src/bicep.js";
+import {
+  buildResourceDocs,
+  filterResourceTypes
+} from "../src/writers/resource-docs.js";
+
+/**
+ * Builds a factory containing one resource type per supplied name, plus the
+ * non-resource types they reference, so the helper can be exercised against the
+ * same flat `BicepType[]` shape that `types.json` deserializes into.
+ */
+function buildTypes(names: string[]): TypeFactory {
+  const factory = new TypeFactory();
+  const stringRef = factory.addStringType();
+
+  for (const name of names) {
+    const bodyRef = factory.addObjectType(name, {
+      name: createObjectProperty(
+        stringRef,
+        ObjectTypePropertyFlags.Required,
+        "The resource name."
+      )
+    });
+    factory.addResourceType(
+      name,
+      bodyRef,
+      ScopeType.ResourceGroup,
+      ScopeType.ResourceGroup
+    );
+  }
+
+  return factory;
+}
+
+describe("filterResourceTypes", () => {
+  it("returns only the resource types from a flat type list", () => {
+    const factory = buildTypes([
+      "Radius.Compute/containers@2025-08-01-preview"
+    ]);
+
+    const resourceTypes = filterResourceTypes(factory.types);
+
+    expect(resourceTypes.map((resourceType) => resourceType.name)).toEqual([
+      "Radius.Compute/containers@2025-08-01-preview"
+    ]);
+  });
+
+  it("returns an empty list when there are no resource types", () => {
+    const factory = new TypeFactory();
+    factory.addStringType();
+
+    expect(filterResourceTypes(factory.types)).toEqual([]);
+  });
+});
+
+describe("buildResourceDocs", () => {
+  it("derives the file name from the resource type name", () => {
+    const factory = buildTypes([
+      "Radius.Compute/containers@2025-08-01-preview"
+    ]);
+
+    const docs = buildResourceDocs(
+      filterResourceTypes(factory.types),
+      factory.types
+    );
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].filename).toBe("containers.md");
+  });
+
+  it("joins nested resource type segments so child types get distinct names", () => {
+    const factory = buildTypes([
+      "Radius.Compute/containers/sidecars@2025-08-01-preview"
+    ]);
+
+    const docs = buildResourceDocs(
+      filterResourceTypes(factory.types),
+      factory.types
+    );
+
+    expect(docs[0].filename).toBe("containers-sidecars.md");
+  });
+
+  it("renders the description when a lookup supplies one", () => {
+    const factory = buildTypes([
+      "Radius.Compute/containers@2025-08-01-preview"
+    ]);
+
+    const docs = buildResourceDocs(
+      filterResourceTypes(factory.types),
+      factory.types,
+      () => "Runs a containerized workload."
+    );
+
+    expect(docs[0].content).toContain("Runs a containerized workload.");
+  });
+
+  it("omits the description block when no lookup is supplied", () => {
+    const factory = buildTypes([
+      "Radius.Compute/containers@2025-08-01-preview"
+    ]);
+
+    const docs = buildResourceDocs(
+      filterResourceTypes(factory.types),
+      factory.types
+    );
+
+    expect(docs[0].content).not.toContain("## Description");
+  });
+
+  it("rejects a resource type name without a namespace segment", () => {
+    const factory = new TypeFactory();
+    const bodyRef = factory.addObjectType("Malformed", {});
+    factory.addResourceType(
+      "malformed@2025-08-01-preview",
+      bodyRef,
+      ScopeType.ResourceGroup,
+      ScopeType.ResourceGroup
+    );
+
+    expect(() =>
+      buildResourceDocs(filterResourceTypes(factory.types), factory.types)
+    ).toThrow(/expected 'Namespace\/type@version'/);
+  });
+});


### PR DESCRIPTION

## Summary
Contrib resource-type namespaces ( Radius.Compute ,  Radius.Data ,  Radius.Security ,  Radius.AI ,  Radius.Messaging ,  Radius.Storage ) shipped in the unified  radius  Bicep extension had no resource-type reference documentation. Core/TypeSpec namespaces generate per-resource  docs/<resource>.md  via the emitter's  writeTableMarkdown() , but the Go  manifest-to-bicep generate  command emits only  types.json . As a workaround,  generate-bicep-types-contrib.sh  created empty  docs/  directories so the docs-repo publish script wouldn't crash — leaving these namespaces with zero published reference pages.

## Reason for change

Fixes #11918 

## How to test
1. Build + unit-test the emitter package
cd hack/bicep-types-radius/src/typespec-bicep-types
pnpm install && pnpm build && pnpm test          # expect: 19/19 pass

2. End-to-end generation for all contrib namespaces
cd -                                              # repo root
make generate-bicep-types-contrib                 # expect: "Generated N reference doc(s)" per namespace

3. Verify docs are populated (were empty before)
ls hack/bicep-types-radius/generated/radius/radius.compute/2025-08-01-preview/docs
 -> containerimages.md  containers.md  persistentvolumes.md  routes.md

4. Verify every table row is well-formed (exactly 4 unescaped pipes = 3 cells)
find hack/bicep-types-radius/generated/radius -path '*/docs/*.md' -exec \
  perl -ne 'if(/^\| \*\*/){my $n=0;$n++ while /(?<!\\)\|/g;print "$ARGV:$.\n" if $n!=4}' {} +
  -> no output means all rows are valid

Expected results (verified locally): build clean, 19/19 tests pass, 15 docs generated across all 6 namespaces (AI 2, Compute 4, Data 5, Messaging 2, Security 1, Storage 1), union types render as escaped single cells, zero malformed rows.


## File change summary

| File | Change |
|------|--------|
| `hack/bicep-types-radius/src/typespec-bicep-types/src/writers/resource-docs.ts` _(new)_ | Shared `buildResourceDocs()` + `filterResourceTypes()` — single source of truth for `docs/<resource>.md`; collision-safe filename derivation for nested resource names. |
| `hack/bicep-types-radius/src/typespec-bicep-types/src/cmd/generate-contrib-docs.ts` _(new)_ | Standalone Node CLI (`--types-json`/`--out-dir`): reads a namespace `types.json`, renders per-resource docs, cleans stale `*.md`, fails fast on zero resource types. |
| `hack/bicep-types-radius/src/typespec-bicep-types/src/emitter.ts` | Refactored to call the shared helpers (core output unchanged). |
| `hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts` | `sanitizeTableCell()` now applied to **both** the type and description columns — escapes `\|` (fixes union types breaking table rows) and collapses embedded newlines. |
| `hack/bicep-types-radius/src/typespec-bicep-types/package.json` | Added `generate-contrib-docs` npm script. |
| `build/scripts/generate-bicep-types-contrib.sh` | Takes an `emitter_dir` arg, validates the built CLI exists, and invokes it instead of creating empty `docs/` dirs. |
| `build/generate.mk` | `generate-bicep-types-contrib` conditionally builds the emitter (guard mirrors `rebuild-bicep-types-index`) and passes the emitter dir. |

