### PR TITLE
fix(buildkit): bounded concurrency for in-cluster image builds

### DIFF
--- a/deploy/Chart/README.md
+++ b/deploy/Chart/README.md
@@ -17,6 +17,21 @@ helm upgrade --wait --install radius deploy/Chart -n radius-system
 
 ## Configuration Options
 
+### In-Cluster Container Image Builds
+
+The `Radius.Compute/containerImages` resource type requires the opt-in rootless BuildKit sidecar:
+
+```console
+rad install kubernetes \
+  --set dynamicrp.buildkit.enabled=true
+```
+
+BuildKit defaults to one parallel OCI worker step across all image builds sharing the `dynamic-rp` Pod. This protects the sidecar's memory limit when multiple `containerImages` resources are deployed together. `dynamicrp.buildkit.maxParallelism` must be an integer between `1` and `2147483647`; BuildKit treats non-positive values as unlimited, so the chart rejects them before rendering the daemon configuration.
+
+Increase `dynamicrp.buildkit.maxParallelism` only after profiling representative cold builds. Size `dynamicrp.buildkit.resources.requests` for the sustained working set and `dynamicrp.buildkit.resources.limits` with enough headroom for the configured parallelism. The limit bounds concurrent build steps but cannot make an individual build fit within an undersized memory limit.
+
+Do not lower the global `workerServer.maxOperationConcurrency` to control image-build memory. That setting governs every Dynamic RP operation and does not constrain parallel steps within a single BuildKit solve.
+
 ### Custom Container Registry
 
 By default, Radius pulls container images from GitHub Container Registry (ghcr.io). For air-gapped environments or when using private registries, you can configure a custom container registry using the `global.imageRegistry` parameter.
@@ -119,7 +134,7 @@ kubectl create secret docker-registry regcred \
   -n radius-system
 ```
 
-2. Reference the secret in your Helm values:
+1. Reference the secret in your Helm values:
 
 ```console
 helm upgrade --wait --install radius deploy/Chart -n radius-system \
@@ -134,7 +149,7 @@ helm upgrade --wait --install radius deploy/Chart -n radius-system \
 #     - name: regcred
 ```
 
-3. With rad CLI:
+1. With rad CLI:
 
 ```console
 rad install kubernetes \

--- a/deploy/Chart/templates/dynamic-rp/buildkit-config.yaml
+++ b/deploy/Chart/templates/dynamic-rp/buildkit-config.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.dynamicrp.buildkit.enabled }}
+{{- $maxParallelism := .Values.dynamicrp.buildkit.maxParallelism }}
+{{- $maxParallelismError := "dynamicrp.buildkit.maxParallelism must be an integer between 1 and 2147483647" }}
+{{- if not (or (kindIs "int" $maxParallelism) (kindIs "int64" $maxParallelism) (kindIs "float64" $maxParallelism)) }}
+{{- fail $maxParallelismError }}
+{{- end }}
+{{- $maxParallelismFloat := float64 $maxParallelism }}
+{{- if or (lt $maxParallelismFloat 1.0) (gt $maxParallelismFloat 2147483647.0) (ne $maxParallelismFloat (floor $maxParallelismFloat)) }}
+{{- fail $maxParallelismError }}
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dynamic-rp-buildkit-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: dynamic-rp
+    app.kubernetes.io/part-of: radius
+data:
+  buildkitd.toml: |-
+    [worker.oci]
+      max-parallelism = {{ int64 $maxParallelism }}
+{{- end }}

--- a/deploy/Chart/templates/dynamic-rp/deployment.yaml
+++ b/deploy/Chart/templates/dynamic-rp/deployment.yaml
@@ -25,12 +25,15 @@ spec:
         {{- if eq .Values.global.azureWorkloadIdentity.enabled true }}
         azure.workload.identity/use: "true"
         {{- end }}
-      {{- if or (eq .Values.global.prometheus.enabled true) (and .Values.dynamicrp.buildkit.enabled (not (semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version))) }}
+      {{- if or (eq .Values.global.prometheus.enabled true) .Values.dynamicrp.buildkit.enabled }}
       annotations:
         {{- if eq .Values.global.prometheus.enabled true }}
         prometheus.io/path: "{{ .Values.global.prometheus.path }}"
         prometheus.io/port: "{{ .Values.global.prometheus.port }}"
         prometheus.io/scrape: "{{ .Values.global.prometheus.enabled }}"
+        {{- end }}
+        {{- if .Values.dynamicrp.buildkit.enabled }}
+        checksum/buildkit-config: {{ include (print $.Template.BasePath "/dynamic-rp/buildkit-config.yaml") . | sha256sum }}
         {{- end }}
         {{- if and .Values.dynamicrp.buildkit.enabled (not (semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version)) }}
         # Pre-K8s 1.30 fallback: securityContext.appArmorProfile was added
@@ -80,11 +83,11 @@ spec:
           echo "Terraform init container starting..."
           echo "Running on architecture: $(uname -m)"
           echo "Alpine version: $(cat /etc/alpine-release)"
-          
+
           # Create terraform directory
           mkdir -p "{{ .Values.dynamicrp.terraform.path }}"
           echo "Created directory: {{ .Values.dynamicrp.terraform.path }}"
-          
+
           # Detect architecture for terraform download
           ARCH=$(uname -m)
           case $ARCH in
@@ -93,13 +96,13 @@ spec:
             *) echo "ERROR: Unsupported architecture: $ARCH"; exit 1 ;;
           esac
           echo "Terraform architecture: $TERRAFORM_ARCH"
-          
+
           # Install wget and unzip if not available (Alpine doesn't include them by default)
           if ! which wget >/dev/null 2>&1 || ! which unzip >/dev/null 2>&1; then
             echo "Installing wget and unzip..."
             apk add --no-cache wget unzip || { echo "ERROR: Failed to install wget/unzip"; exit 3; }
           fi
-          
+
           # Determine download URL
           TERRAFORM_URL="{{ .Values.global.terraform.downloadUrl }}"
 
@@ -117,9 +120,9 @@ spec:
             echo "Pinned Terraform version: $TERRAFORM_VERSION"
             TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TERRAFORM_ARCH}.zip"
           fi
-          
+
           echo "Download URL: $TERRAFORM_URL"
-          
+
           # Basic connectivity and environment info
           echo "Environment debug info:"
           echo "- Date: $(date)"
@@ -130,10 +133,10 @@ spec:
           cd /tmp
           echo "Downloading terraform using wget..."
           wget "${TERRAFORM_URL}" -O terraform.zip || { echo "ERROR: Failed to download terraform"; exit 4; }
-          
+
           echo "Extracting terraform using unzip..."
           unzip terraform.zip || { echo "ERROR: Failed to extract terraform"; exit 5; }
-          
+
           echo "Installing terraform binary..."
           # Path/marker MUST match constants in
           # pkg/recipes/terraform/install.go (defaultGlobalTerraformBinary,
@@ -153,7 +156,7 @@ spec:
           cp terraform "{{ .Values.dynamicrp.terraform.path }}/terraform" || { echo "ERROR: Failed to copy terraform"; exit 6; }
           chmod +x "{{ .Values.dynamicrp.terraform.path }}/terraform" || { echo "ERROR: Failed to make terraform executable"; exit 7; }
           echo "pre-mounted" > "{{ .Values.dynamicrp.terraform.path }}/.terraform-source"
-          
+
           echo "Terraform binary successfully pre-downloaded and installed"
         volumeMounts:
         - name: terraform
@@ -307,6 +310,8 @@ spec:
       - name: buildkitd
         image: "{{ .Values.dynamicrp.buildkit.image }}"
         args:
+        - --config
+        - /etc/radius/buildkit/buildkitd.toml
         - --addr
         - tcp://127.0.0.1:1234
         - --oci-worker-no-process-sandbox
@@ -342,6 +347,9 @@ spec:
           # allowPrivilegeEscalation: false).
           allowPrivilegeEscalation: true
         volumeMounts:
+        - name: buildkit-config
+          mountPath: /etc/radius/buildkit
+          readOnly: true
         - name: buildkit-state
           mountPath: /home/user/.local/share/buildkit
         {{- with .Values.dynamicrp.buildkit.resources }}
@@ -369,6 +377,9 @@ spec:
             secretName: radius-encryption-key
             defaultMode: 0400
         {{- if .Values.dynamicrp.buildkit.enabled }}
+        - name: buildkit-config
+          configMap:
+            name: dynamic-rp-buildkit-config
         - name: buildctl-bin
           emptyDir: {}
         - name: buildkit-state

--- a/deploy/Chart/tests/buildkit_config_test.yaml
+++ b/deploy/Chart/tests/buildkit_config_test.yaml
@@ -1,0 +1,145 @@
+suite: test BuildKit concurrency configuration
+templates:
+  - dynamic-rp/buildkit-config.yaml
+  - dynamic-rp/deployment.yaml
+release:
+  name: radius
+  namespace: radius-system
+tests:
+  - it: omits BuildKit configuration when the sidecar is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: dynamic-rp/buildkit-config.yaml
+      - notExists:
+          path: spec.template.metadata.annotations["checksum/buildkit-config"]
+        template: dynamic-rp/deployment.yaml
+
+  - it: limits BuildKit to one parallel OCI worker step by default
+    set:
+      dynamicrp.buildkit.enabled: true
+    asserts:
+      - equal:
+          path: data["buildkitd.toml"]
+          value: |-
+            [worker.oci]
+              max-parallelism = 1
+        template: dynamic-rp/buildkit-config.yaml
+      - equal:
+          path: spec.template.metadata.annotations["checksum/buildkit-config"]
+          value: 95a0c8f8af5511090090ab0079d285e12a7761f634954f5303676996506b9ea4
+        template: dynamic-rp/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[1].args
+          value:
+            - --config
+            - /etc/radius/buildkit/buildkitd.toml
+            - --addr
+            - tcp://127.0.0.1:1234
+            - --oci-worker-no-process-sandbox
+        template: dynamic-rp/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: buildkit-config
+            mountPath: /etc/radius/buildkit
+            readOnly: true
+        template: dynamic-rp/deployment.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: buildkit-config
+            configMap:
+              name: dynamic-rp-buildkit-config
+        template: dynamic-rp/deployment.yaml
+
+  - it: renders an operator-provided parallelism limit
+    set:
+      dynamicrp.buildkit.enabled: true
+      dynamicrp.buildkit.maxParallelism: 3
+    asserts:
+      - equal:
+          path: data["buildkitd.toml"]
+          value: |-
+            [worker.oci]
+              max-parallelism = 3
+        template: dynamic-rp/buildkit-config.yaml
+      - equal:
+          path: spec.template.metadata.annotations["checksum/buildkit-config"]
+          value: 3dcf331b86546ad0afe422f0c3f70f514a4ef953e279a4b480e79015aaf7b5b0
+        template: dynamic-rp/deployment.yaml
+
+  - it: rejects zero parallelism because BuildKit treats zero as unlimited
+    set:
+      dynamicrp.buildkit.enabled: true
+      dynamicrp.buildkit.maxParallelism: 0
+    asserts:
+      - failedTemplate:
+          errorMessage: dynamicrp.buildkit.maxParallelism must be an integer between 1 and 2147483647
+        template: dynamic-rp/deployment.yaml
+
+  - it: rejects negative parallelism
+    set:
+      dynamicrp.buildkit.enabled: true
+      dynamicrp.buildkit.maxParallelism: -1
+    asserts:
+      - failedTemplate:
+          errorMessage: dynamicrp.buildkit.maxParallelism must be an integer between 1 and 2147483647
+        template: dynamic-rp/deployment.yaml
+
+  - it: rejects fractional parallelism
+    set:
+      dynamicrp.buildkit.enabled: true
+      dynamicrp.buildkit.maxParallelism: 1.5
+    asserts:
+      - failedTemplate:
+          errorMessage: dynamicrp.buildkit.maxParallelism must be an integer between 1 and 2147483647
+        template: dynamic-rp/deployment.yaml
+
+  - it: rejects string parallelism instead of coercing it
+    set:
+      dynamicrp.buildkit.enabled: true
+      dynamicrp.buildkit.maxParallelism: "1"
+    asserts:
+      - failedTemplate:
+          errorMessage: dynamicrp.buildkit.maxParallelism must be an integer between 1 and 2147483647
+        template: dynamic-rp/deployment.yaml
+
+  - it: accepts the maximum portable integer value
+    set:
+      dynamicrp.buildkit.enabled: true
+      dynamicrp.buildkit.maxParallelism: 2147483647
+    asserts:
+      - equal:
+          path: data["buildkitd.toml"]
+          value: |-
+            [worker.oci]
+              max-parallelism = 2147483647
+        template: dynamic-rp/buildkit-config.yaml
+
+  - it: rejects a value immediately above the portable integer range
+    set:
+      dynamicrp.buildkit.enabled: true
+      dynamicrp.buildkit.maxParallelism: 2147483648
+    asserts:
+      - failedTemplate:
+          errorMessage: dynamicrp.buildkit.maxParallelism must be an integer between 1 and 2147483647
+        template: dynamic-rp/deployment.yaml
+
+  - it: rejects values outside the portable integer range before conversion
+    set:
+      dynamicrp.buildkit.enabled: true
+      dynamicrp.buildkit.maxParallelism: 9223372036854775808
+    asserts:
+      - failedTemplate:
+          errorMessage: dynamicrp.buildkit.maxParallelism must be an integer between 1 and 2147483647
+        template: dynamic-rp/deployment.yaml
+
+  - it: rejects large fractional values before conversion
+    set:
+      dynamicrp.buildkit.enabled: true
+      dynamicrp.buildkit.maxParallelism: 2147483646.5
+    asserts:
+      - failedTemplate:
+          errorMessage: dynamicrp.buildkit.maxParallelism must be an integer between 1 and 2147483647
+        template: dynamic-rp/deployment.yaml

--- a/deploy/Chart/tests/helpers_test.yaml
+++ b/deploy/Chart/tests/helpers_test.yaml
@@ -5,6 +5,7 @@ templates:
   - ucp/deployment.yaml
   - rp/deployment.yaml
   - dynamic-rp/deployment.yaml
+  - dynamic-rp/buildkit-config.yaml
   - dynamic-rp/secret.yaml
   - dynamic-rp/serviceaccount.yaml
   - de/deployment.yaml
@@ -912,7 +913,7 @@ tests:
       # Verify valid base64 format (base64-encoded JSON)
       - matchRegex:
           path: data["keys.json"]
-          pattern: '^[A-Za-z0-9+/]+=*$'
+          pattern: "^[A-Za-z0-9+/]+=*$"
         documentIndex: 0
       # Ensure no typos or old field names
       - isNull:
@@ -1043,7 +1044,7 @@ tests:
             name: encryption-secret
             secret:
               secretName: radius-encryption-key
-              defaultMode: 256  # 0400 in octal = 256 in decimal (read-only for owner)
+              defaultMode: 256 # 0400 in octal = 256 in decimal (read-only for owner)
 
   - it: should reference exact secret name radius-encryption-key in deployment volume
     set:
@@ -1479,7 +1480,7 @@ tests:
       # Verify it's a valid base64 value (base64-encoded JSON)
       - matchRegex:
           path: data["keys.json"]
-          pattern: '^[A-Za-z0-9+/]+=*$'
+          pattern: "^[A-Za-z0-9+/]+=*$"
         documentIndex: 0
       # The secrets.lookup helper in the template ensures that:
       # - On fresh install: generates new versioned key store with version 1
@@ -1500,7 +1501,7 @@ tests:
       # The key store must be properly encoded (base64-encoded JSON)
       - matchRegex:
           path: data["keys.json"]
-          pattern: '^[A-Za-z0-9+/]+=*$'
+          pattern: "^[A-Za-z0-9+/]+=*$"
         documentIndex: 0
       # BEHAVIOR: secrets.lookup helper checks for existing secret first
       # - If secret exists in cluster: returns existing value (preserves all keys)

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -161,6 +161,10 @@ dynamicrp:
     enabled: false
     # Pinned rootless BuildKit image.
     image: "moby/buildkit:v0.13.2-rootless"
+    # Limit concurrent OCI worker steps across all builds sharing the
+    # BuildKit sidecar. Increase only after profiling representative cold
+    # builds and sizing the resources below with sufficient headroom.
+    maxParallelism: 1
     # Default limits suit small/medium image builds; raise for large
     # contexts or memory-heavy compilations.
     resources:

--- a/docs/architecture/dynamic-rp.md
+++ b/docs/architecture/dynamic-rp.md
@@ -17,30 +17,30 @@ generic provider model.
 
 ## Quick Reference
 
-| Topic | Start Here |
-| --- | --- |
-| Startup | `cmd/dynamic-rp/cmd/root.go` |
-| Host composition | `pkg/dynamicrp/server/server.go` |
-| API service | `pkg/dynamicrp/frontend/service.go` |
-| Route wiring | `pkg/dynamicrp/frontend/routes.go` |
-| Async backend | `pkg/dynamicrp/backend/service.go` |
+| Topic            | Start Here                          |
+|------------------|-------------------------------------|
+| Startup          | `cmd/dynamic-rp/cmd/root.go`        |
+| Host composition | `pkg/dynamicrp/server/server.go`    |
+| API service      | `pkg/dynamicrp/frontend/service.go` |
+| Route wiring     | `pkg/dynamicrp/frontend/routes.go`  |
+| Async backend    | `pkg/dynamicrp/backend/service.go`  |
 
-| Test Focus | Packages |
-| --- | --- |
-| Frontend/read-path behavior | `./pkg/dynamicrp/frontend/...` |
-| Backend/processor behavior | `./pkg/dynamicrp/backend/...` |
-| Integration coverage | `./pkg/dynamicrp/integrationtest/...` |
-| Broad safety check | `./pkg/dynamicrp/...` |
+| Test Focus                  | Packages                              |
+|-----------------------------|---------------------------------------|
+| Frontend/read-path behavior | `./pkg/dynamicrp/frontend/...`        |
+| Backend/processor behavior  | `./pkg/dynamicrp/backend/...`         |
+| Integration coverage        | `./pkg/dynamicrp/integrationtest/...` |
+| Broad safety check          | `./pkg/dynamicrp/...`                 |
 
 ## Core Packages
 
-| Package | Responsibility |
-| --- | --- |
-| `pkg/dynamicrp/frontend` | request handling and API surface |
-| `pkg/dynamicrp/backend` | backend processing and async work |
+| Package                   | Responsibility                     |
+|---------------------------|------------------------------------|
+| `pkg/dynamicrp/frontend`  | request handling and API surface   |
+| `pkg/dynamicrp/backend`   | backend processing and async work  |
 | `pkg/dynamicrp/datamodel` | dynamic resource persistence model |
-| `pkg/dynamicrp/api` | versioned API types |
-| `pkg/dynamicrp/server` | process bootstrap and hosting |
+| `pkg/dynamicrp/api`       | versioned API types                |
+| `pkg/dynamicrp/server`    | process bootstrap and hosting      |
 
 ## How It Works
 
@@ -71,6 +71,12 @@ type authoring patterns.
 The Bicep driver has a hook used only by `Radius.Compute/containerImages`. When a recipe returns an `imageBuild` object, the driver loads the script embedded in the recipe, adds the operator-configured registry, passes the object's fields as command-line flags, and waits for the script to push the image. The script and `imageBuild` output can change together without a Radius driver change. Other resource types ignore this output, and recipe parameters cannot provide the script.
 
 ARM/Bicep cannot call BuildKit directly, so `dynamic-rp` runs the script where the in-Pod BuildKit endpoint is available. The registry and credential Secret name come from the registered Recipe, which prevents developer overrides from redirecting credentials. Radius reads the Secret from the recipe runtime namespace on the selected cluster, including `RADIUS_TARGET_KUBECONFIG`, and does not fall back when that target is invalid. The build runs on every recipe execution and stores no state.
+
+### Shared BuildKit Capacity
+
+All `containerImages` operations in one `dynamic-rp` Pod share its BuildKit sidecar and memory cgroup. The chart configures BuildKit's native OCI worker scheduler through `dynamicrp.buildkit.maxParallelism`, which defaults to one concurrent build step across all active solves. A generated `buildkitd.toml` carries the setting, and its Pod-template checksum restarts `dynamic-rp` when the value changes because BuildKit reads daemon configuration only at startup.
+
+Keep this limit independent from `workerServer.maxOperationConcurrency`. The worker setting bounds all Dynamic RP operations, while BuildKit's scheduler bounds the memory-intensive execution steps within and across image builds. Increasing BuildKit parallelism requires profiling representative cold builds and sizing the sidecar's memory request and limit with sufficient headroom. This is a concurrency boundary, not per-build isolation: one build can still exceed the configured memory limit.
 
 ### Packages That Usually Move Together
 


### PR DESCRIPTION
## Summary

- Bounds rootless BuildKit OCI worker concurrency across all in-cluster image builds, defaulting to one parallel step.
- Renders and mounts a validated `buildkitd.toml`, with a Pod-template checksum so configuration changes restart `dynamic-rp`.
- Adds focused Helm regression coverage and documents safe concurrency and resource tuning.

## Reason for change

Concurrent `Radius.Compute/containerImages` builds share the BuildKit sidecar in the `dynamic-rp` Pod. With up to ten Dynamic RP operations admitted concurrently and a 4 GiB BuildKit memory limit, real multi-architecture .NET builds can OOM-kill the daemon and surface gRPC `Unavailable`/`EOF` errors. BuildKit-native `max-parallelism` applies backpressure at the failing shared resource while preserving concurrency for unrelated Dynamic RP operations.

Fixes #12542

## How to test

- `make test-helm` (116 tests pass)
- `helm lint deploy/Chart --strict`
- `helm lint deploy/Chart --strict --set dynamicrp.buildkit.enabled=true`
- `pnpm exec markdown-table-formatter "deploy/Chart/README.md" "docs/architecture/dynamic-rp.md" --check`
- `pnpm exec markdownlint-cli2 "deploy/Chart/README.md" "docs/architecture/dynamic-rp.md" --config "./.github/linters/.markdownlint-cli2.yaml"`
- `make spellcheck`

A live nine-image eShop deployment was not run locally because it requires a configured Kubernetes control plane and image registry.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `deploy/Chart/values.yaml` | Adds the conservative `dynamicrp.buildkit.maxParallelism` default. |
| `deploy/Chart/templates/dynamic-rp/buildkit-config.yaml` | Renders the validated BuildKit OCI worker concurrency configuration. |
| `deploy/Chart/templates/dynamic-rp/deployment.yaml` | Mounts the BuildKit config, passes `--config`, and adds rollout checksum handling. |
| `deploy/Chart/tests/buildkit_config_test.yaml` | Covers defaults, overrides, rollout checksums, disabled behavior, and invalid numeric boundaries. |
| `deploy/Chart/tests/helpers_test.yaml` | Loads the BuildKit ConfigMap in the existing chart test suite. |
| `deploy/Chart/README.md` | Documents BuildKit concurrency and resource-sizing guidance. |
| `docs/architecture/dynamic-rp.md` | Records the shared BuildKit capacity boundary and its separation from global worker concurrency. |