### PR TITLE
Enhance bicep-types doc emitter to render CLI-style resource references

### DIFF
--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/emitter.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/emitter.ts
@@ -14,7 +14,7 @@
 // limitations under the License.
 // ------------------------------------------------------------.
 
-import { EmitContext, emitFile, resolvePath } from "@typespec/compiler";
+import { EmitContext, emitFile, getDoc, resolvePath } from "@typespec/compiler";
 import {
   ResourceType,
   TypeBaseKind,
@@ -71,6 +71,18 @@ export async function $onEmit(
       buildResourceType(context.program, factory, resource, cache);
     }
 
+    // Capture the resource-level `@doc` for each resource so the reference docs
+    // can render a description block. The description is authored on the body
+    // model and is not serialized into types.json, so it is read here from the
+    // TypeSpec program and keyed by the resource type name.
+    const descriptions = new Map<string, string | undefined>();
+    for (const resource of group) {
+      descriptions.set(
+        resource.resourceTypeName,
+        getDoc(context.program, resource.bodyModel)
+      );
+    }
+
     const apiVersion = group[0].apiVersion;
     const outFolder = `${namespace}/${apiVersion}`.toLowerCase();
 
@@ -100,7 +112,11 @@ export async function $onEmit(
           "docs",
           `${filename}.md`
         ),
-        content: writeTableMarkdown([resourceType], factory.types)
+        content: writeTableMarkdown(
+          [resourceType],
+          factory.types,
+          descriptions.get(resourceType.name)
+        )
       });
     }
   }

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
@@ -450,7 +450,8 @@ function getPropertyType(types: BicepType[], reference: TypeReference): string {
 /** Renders an array as `<scalar> array`, or `array` when the element is complex. */
 function getArrayType(types: BicepType[], type: ArrayType): string {
   const element = getPropertyType(types, type.itemType);
-  return /^[a-z]+$/.test(element) ? `${element} array` : "array";
+  const scalars = new Set(["string", "integer", "boolean", "null"]);
+  return scalars.has(element) ? `${element} array` : "array";
 }
 
 /**

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
@@ -281,7 +281,11 @@ function writeTable(
     );
   }
 
-  if (section.additionalProperties) {
+  // Only surface the `*` additionalProperties row for pure maps (objects with
+  // no named properties). Objects that both declare named properties and allow
+  // arbitrary keys (models that `extends Record<T>`) omit it, matching `rad
+  // resource-type show`, which lists only named properties.
+  if (section.additionalProperties && names.length === 0) {
     const type = getPropertyType(types, section.additionalProperties);
     lines.push(
       `| \`*\` | ${type} | false | false | Additional properties keyed by name. |`

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
@@ -532,6 +532,7 @@ function getBuiltInType(kind: BuiltInTypeKind): string {
 function sanitizeCell(text: string): string {
   return text
     .replace(/\r?\n/g, " ")
+    .replace(/\\/g, "\\\\")
     .replace(/\|/g, "\\|")
     .replace(/\s+/g, " ")
     .trim();

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
@@ -127,7 +127,8 @@ function getTopLevelProperties(
     if (bag) {
       return {
         properties: bag.properties,
-        additionalProperties: bag.additionalProperties
+        additionalProperties: bag.additionalProperties,
+        discriminator: bag.discriminator
       };
     }
   }

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
@@ -331,7 +331,8 @@ function getLinkedType(
  * Enums (unions of string literals) render their allowed values, for example
  * `'terraform' \| 'bicep'`.
  */
-function getPropertyType(types: BicepType[], reference: TypeReference): string {  const type = types[reference.index];
+function getPropertyType(types: BicepType[], reference: TypeReference): string {
+  const type = types[reference.index];
   switch (type.type) {
     case TypeBaseKind.ObjectType:
     case TypeBaseKind.DiscriminatedObjectType:

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
@@ -331,7 +331,8 @@ function resolveSection(
       };
     }
     if (objectType.additionalProperties) {
-      return resolveSection(types, objectType.additionalProperties);
+      const target = resolveLinkTarget(types, objectType.additionalProperties);
+      return target ? target.section : undefined;
     }
     return undefined;
   }

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
@@ -264,9 +264,9 @@ function writeTable(
     const property = section.properties[name];
     const enumValues = getEnumValues(types, property.type);
     const type =
-      enumValues ?
-        "string"
-      : getLinkedType(types, property.type, childAnchors.get(name));
+      enumValues ? "string" : (
+        getLinkedType(types, property.type, childAnchors.get(name))
+      );
     const required = (property.flags & ObjectTypePropertyFlags.Required) !== 0;
     const readOnly = (property.flags & ObjectTypePropertyFlags.ReadOnly) !== 0;
     let description = sanitizeCell(property.description ?? "");

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
@@ -50,12 +50,27 @@ const ENVELOPE_PROPERTIES = new Set([
 interface PropertyBag {
   properties: Record<string, ObjectTypeProperty>;
   additionalProperties?: TypeReference;
+  /**
+   * Discriminated-union metadata, present when the object selects its shape via
+   * a discriminator property. Each element is documented as its own variant
+   * section and the discriminator row links to them.
+   */
+  discriminator?: {
+    propertyName: string;
+    elements: Record<string, TypeReference>;
+  };
 }
 
 /** A pending object section to render, keyed by its dotted-path heading. */
 interface Section extends PropertyBag {
   heading: string;
-  index?: number;
+  /**
+   * Type indices of the sections on the path from the root to this one
+   * (inclusive of this section's own type). Distinct paths that share a type
+   * are each expanded into their own section (matching the CLI), while this set
+   * guards against genuinely recursive types producing an unbounded traversal.
+   */
+  ancestors: Set<number>;
 }
 
 /**
@@ -136,29 +151,67 @@ function writeResource(
   types: BicepType[],
   topLevel: PropertyBag
 ): void {
-  const queue: Section[] = [{ heading: "", ...topLevel }];
-  const visited = new Set<number>();
-  const anchorsByIndex = new Map<number, string>();
+  const queue: Section[] = [
+    { heading: "", ancestors: new Set<number>(), ...topLevel }
+  ];
   let state: "none" | "top-level" | "object" = "none";
 
   while (queue.length > 0) {
     const section = queue.shift() as Section;
     const names = sortedKeys(section.properties);
 
-    // Enqueue nested sections before emitting this section's heading so child
-    // headings are derived from the current traversal state, matching the CLI:
-    // top-level object properties are keyed by name, deeper ones by path. Object
-    // properties, map value types, and array-element objects each expand into
-    // their own section, and the anchor map records each section's heading so
-    // the Type column can link to it. The visited set guards against recursive
-    // schemas producing an unbounded traversal.
+    // Expand each nested object into its own section keyed by dotted path, so a
+    // type shared across several paths is documented once per path (matching
+    // the CLI, which walks an inlined JSON schema). Child anchors are recorded
+    // per property name for this section's Type-cell links. The ancestors set
+    // guards against genuinely recursive types without collapsing distinct
+    // paths. Top-level object properties are keyed by name, deeper ones by path.
+    const childAnchors = new Map<string, string>();
+    const childHeading = (key: string): string =>
+      state === "none" ? key : `${section.heading}.${key}`;
+
     for (const name of names) {
       const target = resolveLinkTarget(types, section.properties[name].type);
-      if (target && !visited.has(target.section.index)) {
-        visited.add(target.section.index);
-        const heading = state === "none" ? name : `${section.heading}.${name}`;
-        anchorsByIndex.set(target.section.index, anchor(heading));
-        queue.push({ heading, ...target.section });
+      if (!target || section.ancestors.has(target.section.index)) {
+        continue;
+      }
+      const heading = childHeading(name);
+      childAnchors.set(name, anchor(heading));
+      queue.push({
+        heading,
+        ancestors: new Set(section.ancestors).add(target.section.index),
+        ...target.section
+      });
+    }
+
+    // Document each discriminated-union variant as its own section, dropping the
+    // discriminator literal from the variant table since it is already shown on
+    // the parent's discriminator row.
+    if (section.discriminator) {
+      const { propertyName, elements } = section.discriminator;
+      for (const value of sortedKeys(elements)) {
+        const ref = elements[value];
+        const elementType = types[ref.index];
+        if (
+          elementType.type !== TypeBaseKind.ObjectType ||
+          section.ancestors.has(ref.index)
+        ) {
+          continue;
+        }
+        const properties: Record<string, ObjectTypeProperty> = {};
+        for (const [key, prop] of Object.entries(
+          (elementType as ObjectType).properties
+        )) {
+          if (key !== propertyName) {
+            properties[key] = prop;
+          }
+        }
+        queue.push({
+          heading: childHeading(value),
+          ancestors: new Set(section.ancestors).add(ref.index),
+          properties,
+          additionalProperties: (elementType as ObjectType).additionalProperties
+        });
       }
     }
 
@@ -178,7 +231,7 @@ function writeResource(
       }
     }
 
-    writeTable(lines, types, section, anchorsByIndex);
+    writeTable(lines, types, section, childAnchors);
     lines.push("");
   }
 }
@@ -187,11 +240,15 @@ function writeResource(
 function writeTable(
   lines: string[],
   types: BicepType[],
-  section: PropertyBag,
-  anchorsByIndex: Map<number, string>
+  section: Section,
+  childAnchors: Map<string, string>
 ): void {
   const names = sortedKeys(section.properties);
-  if (names.length === 0 && !section.additionalProperties) {
+  if (
+    names.length === 0 &&
+    !section.additionalProperties &&
+    !section.discriminator
+  ) {
     lines.push("_No properties._");
     return;
   }
@@ -199,13 +256,17 @@ function writeTable(
   lines.push("| Property | Type | Required | Read-Only | Description |");
   lines.push("|----------|------|----------|-----------|-------------|");
 
+  if (section.discriminator) {
+    lines.push(writeDiscriminatorRow(section));
+  }
+
   for (const name of names) {
     const property = section.properties[name];
     const enumValues = getEnumValues(types, property.type);
     const type =
       enumValues ?
         "string"
-      : getLinkedType(types, property.type, anchorsByIndex);
+      : getLinkedType(types, property.type, childAnchors.get(name));
     const required = (property.flags & ObjectTypePropertyFlags.Required) !== 0;
     const readOnly = (property.flags & ObjectTypePropertyFlags.ReadOnly) !== 0;
     let description = sanitizeCell(property.description ?? "");
@@ -225,6 +286,23 @@ function writeTable(
       `| \`*\` | ${type} | false | false | Additional properties keyed by name. |`
     );
   }
+}
+
+/**
+ * Renders the discriminator property row for a discriminated-union section. The
+ * allowed values link to each variant's section so readers can jump to the
+ * shape selected by that value.
+ */
+function writeDiscriminatorRow(section: Section): string {
+  const { propertyName, elements } = section.discriminator!;
+  const allowed = sortedKeys(elements)
+    .map((value) => {
+      const path = section.heading ? `${section.heading}.${value}` : value;
+      return `[\`${value}\`](#${anchor(path)})`;
+    })
+    .join(", ");
+  const description = `Discriminator property that selects the variant. Allowed values: ${allowed}.`;
+  return `| \`${propertyName}\` | string | true | false | ${description} |`;
 }
 
 /** A resolved object section together with the index of its source type. */
@@ -258,9 +336,14 @@ function resolveSection(
     return undefined;
   }
   if (type.type === TypeBaseKind.DiscriminatedObjectType) {
+    const discriminated = type as DiscriminatedObjectType;
     return {
       index: reference.index,
-      properties: (type as DiscriminatedObjectType).baseProperties
+      properties: discriminated.baseProperties,
+      discriminator: {
+        propertyName: discriminated.discriminator,
+        elements: discriminated.elements
+      }
     };
   }
   return undefined;
@@ -312,13 +395,12 @@ function anchor(headingPath: string): string {
 function getLinkedType(
   types: BicepType[],
   reference: TypeReference,
-  anchorsByIndex: Map<number, string>
+  anchorId: string | undefined
 ): string {
-  const target = resolveLinkTarget(types, reference);
-  if (target) {
-    const id = anchorsByIndex.get(target.section.index);
-    if (id) {
-      const link = `[object](#${id})`;
+  if (anchorId) {
+    const target = resolveLinkTarget(types, reference);
+    if (target) {
+      const link = `[object](#${anchorId})`;
       return target.isArray ? `${link}[]` : link;
     }
   }

--- a/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts
@@ -15,377 +15,443 @@
 // ------------------------------------------------------------.
 import {
   ArrayType,
+  BicepType,
   BuiltInType,
+  BuiltInTypeKind,
   DiscriminatedObjectType,
-  getBuiltInTypeKindLabel,
-  getObjectTypePropertyFlagsLabels,
-  ObjectTypeProperty,
   ObjectType,
-  ResourceFunctionType,
+  ObjectTypeProperty,
+  ObjectTypePropertyFlags,
   ResourceType,
   StringLiteralType,
-  BicepType,
   TypeBaseKind,
   TypeReference,
-  UnionType,
-  IntegerType,
-  StringType
+  UnionType
 } from "bicep-types";
 
+/**
+ * ARM envelope properties that are not authored on the resource and are hidden
+ * from the reference docs so the output focuses on the resource-specific
+ * properties, matching `rad resource-type show`. The resource-specific
+ * properties live under the envelope's `properties` object, which this writer
+ * descends into for the top-level table.
+ */
+const ENVELOPE_PROPERTIES = new Set([
+  "id",
+  "name",
+  "type",
+  "apiversion",
+  "location",
+  "tags",
+  "systemdata"
+]);
+
+/** The set of properties displayed for an object, plus any map value type. */
+interface PropertyBag {
+  properties: Record<string, ObjectTypeProperty>;
+  additionalProperties?: TypeReference;
+}
+
+/** A pending object section to render, keyed by its dotted-path heading. */
+interface Section extends PropertyBag {
+  heading: string;
+  index?: number;
+}
+
+/**
+ * Renders one resource type as reference markdown that mirrors the layout of
+ * `rad resource-type show`: an optional description block, a `Top-Level
+ * Properties` table, and an `Object Properties` section with one dotted-path
+ * table per nested object.
+ *
+ * The document body starts at heading level 2. The docs pipeline
+ * (`generate_resource_references.py` in the docs repo) wraps this content with
+ * Hugo front matter, so this writer owns every heading below the page title.
+ *
+ * @param resourceTypes The resource types to render (the emitter passes one).
+ * @param types The full Bicep type graph the resource types index into.
+ * @param description The resource-level TypeSpec `@doc`, when authored.
+ */
 export function writeTableMarkdown(
   resourceTypes: ResourceType[],
-  types: BicepType[]
-) {
-  let output = "";
+  types: BicepType[],
+  description?: string
+): string {
+  const lines: string[] = [];
 
-  function getTypeName(
-    types: BicepType[],
-    typeReference: TypeReference
-  ): string {
-    const type = types[typeReference.index];
-    switch (type.type) {
-      case TypeBaseKind.BuiltInType:
-        return getBuiltInTypeKindLabel(
-          (type as BuiltInType).kind
-        ).toLowerCase();
-      case TypeBaseKind.ObjectType:
-        return generateAnchorLink((type as ObjectType).name);
-      case TypeBaseKind.ArrayType:
-        return getArrayTypeName(types, type as ArrayType);
-      case TypeBaseKind.ResourceType:
-        return (type as ResourceType).name;
-      case TypeBaseKind.ResourceFunctionType: {
-        const functionType = type as ResourceFunctionType;
-        return `${functionType.name} (${functionType.resourceType}@${functionType.apiVersion})`;
+  if (description && description.trim().length > 0) {
+    lines.push("## Description", "", description.trim(), "");
+  }
+
+  for (const resourceType of resourceTypes) {
+    const topLevel = getTopLevelProperties(types, resourceType);
+    writeResource(lines, types, topLevel);
+  }
+
+  return lines.join("\n").replace(/\n+$/, "\n");
+}
+
+/**
+ * Resolves the resource-specific properties shown as the top-level table. These
+ * live under the envelope's `properties` object; if that is absent, the envelope
+ * properties are used with the ARM envelope keys filtered out.
+ */
+function getTopLevelProperties(
+  types: BicepType[],
+  resourceType: ResourceType
+): PropertyBag {
+  const body = types[resourceType.body.index];
+  if (body.type !== TypeBaseKind.ObjectType) {
+    return { properties: {} };
+  }
+
+  const envelope = body as ObjectType;
+  const propertiesRef = envelope.properties["properties"];
+  if (propertiesRef) {
+    const bag = resolveSection(types, propertiesRef.type);
+    if (bag) {
+      return {
+        properties: bag.properties,
+        additionalProperties: bag.additionalProperties
+      };
+    }
+  }
+
+  const filtered: Record<string, ObjectTypeProperty> = {};
+  for (const [name, property] of Object.entries(envelope.properties)) {
+    if (!ENVELOPE_PROPERTIES.has(name.toLowerCase())) {
+      filtered[name] = property;
+    }
+  }
+  return { properties: filtered };
+}
+
+/**
+ * Walks the resource's properties breadth-first, emitting the top-level table
+ * followed by one table per nested object under dotted-path headings. This
+ * mirrors the traversal in the `rad resource-type show` display.
+ */
+function writeResource(
+  lines: string[],
+  types: BicepType[],
+  topLevel: PropertyBag
+): void {
+  const queue: Section[] = [{ heading: "", ...topLevel }];
+  const visited = new Set<number>();
+  const anchorsByIndex = new Map<number, string>();
+  let state: "none" | "top-level" | "object" = "none";
+
+  while (queue.length > 0) {
+    const section = queue.shift() as Section;
+    const names = sortedKeys(section.properties);
+
+    // Enqueue nested sections before emitting this section's heading so child
+    // headings are derived from the current traversal state, matching the CLI:
+    // top-level object properties are keyed by name, deeper ones by path. Object
+    // properties, map value types, and array-element objects each expand into
+    // their own section, and the anchor map records each section's heading so
+    // the Type column can link to it. The visited set guards against recursive
+    // schemas producing an unbounded traversal.
+    for (const name of names) {
+      const target = resolveLinkTarget(types, section.properties[name].type);
+      if (target && !visited.has(target.section.index)) {
+        visited.add(target.section.index);
+        const heading = state === "none" ? name : `${section.heading}.${name}`;
+        anchorsByIndex.set(target.section.index, anchor(heading));
+        queue.push({ heading, ...target.section });
       }
-      case TypeBaseKind.UnionType: {
-        const elements = (type as UnionType).elements.map((x) =>
-          getTypeName(types, x)
+    }
+
+    if (state === "none") {
+      state = "top-level";
+      lines.push("## Top-Level Properties", "");
+    } else {
+      if (state === "top-level") {
+        lines.push("## Object Properties", "");
+      }
+      state = "object";
+      if (section.heading) {
+        lines.push(
+          `### \`${section.heading}\` {#${anchor(section.heading)}}`,
+          ""
         );
-        return elements.sort().join(" | ");
-      }
-      case TypeBaseKind.StringLiteralType:
-        return `'${(type as StringLiteralType).value}'`;
-      case TypeBaseKind.DiscriminatedObjectType:
-        return generateAnchorLink((type as DiscriminatedObjectType).name);
-      case TypeBaseKind.AnyType:
-        return "any";
-      case TypeBaseKind.NullType:
-        return "null";
-      case TypeBaseKind.BooleanType:
-        return "bool";
-      case TypeBaseKind.IntegerType:
-        return `int${getIntegerModifiers(type as IntegerType)}`;
-      case TypeBaseKind.StringType:
-        return `string${getStringModifiers(type as StringType)}`;
-      default:
-        throw new Error("Unrecognized type");
-    }
-  }
-
-  function getArrayTypeName(types: BicepType[], type: ArrayType): string {
-    let itemTypeName = getTypeName(types, type.itemType);
-    if (itemTypeName.includes(" ")) {
-      itemTypeName = `(${itemTypeName})`;
-    }
-
-    return `${itemTypeName}[]${formatModifiers(type.minLength !== undefined ? `minLength: ${type.minLength}` : undefined, type.maxLength !== undefined ? `maxLength: ${type.maxLength}` : undefined)}`;
-  }
-
-  function generateAnchorLink(name: string) {
-    return `[${name}](#${name.replace(/[^a-zA-Z0-9-]/g, "").toLowerCase()})`;
-  }
-
-  function writeTypeProperty(
-    types: BicepType[],
-    name: string,
-    property: ObjectTypeProperty
-  ) {
-    const flagsString =
-      property.flags ?
-        `${getObjectTypePropertyFlagsLabels(property.flags).join(", ")}`
-      : "";
-    const descriptionString = property.description ? property.description : "";
-    writeTableEntry(
-      name,
-      getTypeName(types, property.type),
-      flagsString,
-      descriptionString
-    );
-  }
-
-  function writeTableHeading() {
-    output += `| Property | Type | Description |\n`;
-    output += `|----------|------|-------------|\n`;
-  }
-
-  function writeTableEntry(
-    name: string,
-    type: string,
-    flags: string,
-    description: string
-  ) {
-    const flagString = flags ? `<br />_(${flags})_ ` : "";
-    output += `| **${name}** | ${type} | ${description} ${flagString}|\n`;
-  }
-
-  function writeHeading(nesting: number, message: string) {
-    output += `${"#".repeat(nesting)} ${message}`;
-    writeNewLine();
-  }
-
-  function writeBullet(key: string, value: string) {
-    output += `* **${key}**`;
-    if (value !== "") {
-      output += `: ${value}`;
-    }
-    writeNewLine();
-  }
-
-  function writeNewLine() {
-    output += "\n";
-  }
-
-  function findTypesToWrite(
-    types: BicepType[],
-    typesToWrite: BicepType[],
-    typeReference: TypeReference
-  ) {
-    function processTypeLinks(
-      typeReference: TypeReference,
-      skipParent: boolean
-    ) {
-      // this is needed to avoid circular type references causing stack overflows
-      if (!typesToWrite.includes(types[typeReference.index])) {
-        if (!skipParent) {
-          typesToWrite.push(types[typeReference.index]);
-        }
-
-        findTypesToWrite(types, typesToWrite, typeReference);
       }
     }
 
-    const type = types[typeReference.index];
-    switch (type.type) {
-      case TypeBaseKind.ArrayType: {
-        const arrayType = type as ArrayType;
-        processTypeLinks(arrayType.itemType, false);
-
-        return;
-      }
-      case TypeBaseKind.ObjectType: {
-        const objectType = type as ObjectType;
-
-        for (const key of sortedKeys(objectType.properties)) {
-          processTypeLinks(objectType.properties[key].type, false);
-        }
-
-        if (objectType.additionalProperties) {
-          processTypeLinks(objectType.additionalProperties, false);
-        }
-
-        return;
-      }
-      case TypeBaseKind.DiscriminatedObjectType: {
-        const discriminatedObjectType = type as DiscriminatedObjectType;
-
-        for (const key of sortedKeys(discriminatedObjectType.baseProperties)) {
-          processTypeLinks(
-            discriminatedObjectType.baseProperties[key].type,
-            false
-          );
-        }
-
-        for (const key of sortedKeys(discriminatedObjectType.elements)) {
-          const element = discriminatedObjectType.elements[key];
-          // Don't display discriminated object elements as individual types
-          processTypeLinks(element, true);
-        }
-
-        return;
-      }
-    }
+    writeTable(lines, types, section, anchorsByIndex);
+    lines.push("");
   }
-
-  function sortedKeys<T>(dictionary: Record<string, T>) {
-    return orderBy(Object.keys(dictionary), (k) => k.toLowerCase());
-  }
-
-  function writeComplexType(
-    types: BicepType[],
-    type: BicepType,
-    nesting: number,
-    includeHeader: boolean
-  ) {
-    switch (type.type) {
-      case TypeBaseKind.ResourceType: {
-        const resourceType = type as ResourceType;
-        writeHeading(nesting, `Top-Level Resource`);
-        // temporarily removing scope as it's not applicable
-        // writeBullet("Valid Scope(s)", `${getScopeTypeLabels(resourceType.ScopeType).join(', ') || 'Unknown'}`);
-        writeComplexType(types, types[resourceType.body.index], nesting, false);
-
-        return;
-      }
-      case TypeBaseKind.ResourceFunctionType: {
-        const resourceFunctionType = type as ResourceFunctionType;
-        writeHeading(
-          nesting,
-          `Function ${resourceFunctionType.name} (${resourceFunctionType.resourceType}@${resourceFunctionType.apiVersion})`
-        );
-        writeNewLine();
-        writeBullet("Resource", resourceFunctionType.resourceType);
-        writeBullet("ApiVersion", resourceFunctionType.apiVersion);
-        if (resourceFunctionType.input) {
-          writeBullet("Input", getTypeName(types, resourceFunctionType.input));
-        }
-        writeBullet("Output", getTypeName(types, resourceFunctionType.output));
-
-        writeNewLine();
-        return;
-      }
-      case TypeBaseKind.ObjectType: {
-        const objectType = type as ObjectType;
-        if (includeHeader) {
-          writeHeading(nesting, objectType.name);
-        }
-
-        writeNewLine();
-        writeHeading(nesting + 1, "Properties");
-        writeNewLine();
-
-        if (Object.keys(objectType.properties).length === 0) {
-          writeBullet("none", "");
-          writeNewLine();
-        } else {
-          writeTableHeading();
-          for (const key of sortedKeys(objectType.properties)) {
-            writeTypeProperty(types, key, objectType.properties[key]);
-          }
-        }
-
-        if (objectType.additionalProperties) {
-          writeHeading(nesting + 1, "Additional Properties");
-          writeNewLine();
-          writeBullet(
-            "Additional Properties Type",
-            getTypeName(types, objectType.additionalProperties)
-          );
-        }
-
-        writeNewLine();
-        return;
-      }
-      case TypeBaseKind.DiscriminatedObjectType: {
-        const discriminatedObjectType = type as DiscriminatedObjectType;
-        if (includeHeader) {
-          writeHeading(nesting, discriminatedObjectType.name);
-          writeNewLine();
-        }
-
-        writeBullet("Discriminator", discriminatedObjectType.discriminator);
-        writeNewLine();
-
-        writeHeading(nesting + 1, "Base Properties");
-        writeNewLine();
-        if (Object.keys(discriminatedObjectType.baseProperties).length === 0) {
-          writeBullet("none", "");
-          writeNewLine();
-        } else {
-          writeTableHeading();
-          for (const propertyName of sortedKeys(
-            discriminatedObjectType.baseProperties
-          )) {
-            writeTypeProperty(
-              types,
-              propertyName,
-              discriminatedObjectType.baseProperties[propertyName]
-            );
-          }
-        }
-
-        writeNewLine();
-
-        for (const key of sortedKeys(discriminatedObjectType.elements)) {
-          const element = discriminatedObjectType.elements[key];
-          writeComplexType(types, types[element.index], nesting + 1, true);
-        }
-
-        writeNewLine();
-        return;
-      }
-    }
-  }
-
-  function generateMarkdown(types: BicepType[]) {
-    const resourceFunctionTypes = orderBy(
-      types.filter(
-        (t) => t.type === TypeBaseKind.ResourceFunctionType
-      ) as ResourceFunctionType[],
-      (x) => x.name.split("@")[0].toLowerCase()
-    );
-    const filteredFunctionTypes = resourceFunctionTypes.filter((x) =>
-      resourceTypes.some(
-        (y) =>
-          x.resourceType.toLowerCase() === y.name.split("@")[0].toLowerCase()
-      )
-    );
-    const typesToWrite: BicepType[] = [
-      ...resourceTypes,
-      ...filteredFunctionTypes
-    ];
-
-    for (const resourceType of resourceTypes) {
-      findTypesToWrite(types, typesToWrite, resourceType.body);
-    }
-
-    for (const resourceFunctionType of filteredFunctionTypes) {
-      if (resourceFunctionType.input) {
-        typesToWrite.push(types[resourceFunctionType.input.index]);
-        findTypesToWrite(types, typesToWrite, resourceFunctionType.input);
-      }
-      typesToWrite.push(types[resourceFunctionType.output.index]);
-      findTypesToWrite(types, typesToWrite, resourceFunctionType.output);
-    }
-
-    for (const type of typesToWrite) {
-      writeComplexType(types, type, 3, true);
-    }
-
-    return output;
-  }
-
-  return generateMarkdown(types);
 }
 
-function getIntegerModifiers(type: IntegerType): string {
-  return formatModifiers(
-    type.minValue !== undefined ? `minValue: ${type.minValue}` : undefined,
-    type.maxValue !== undefined ? `maxValue: ${type.maxValue}` : undefined
+/** Emits a property table for a single object section. */
+function writeTable(
+  lines: string[],
+  types: BicepType[],
+  section: PropertyBag,
+  anchorsByIndex: Map<number, string>
+): void {
+  const names = sortedKeys(section.properties);
+  if (names.length === 0 && !section.additionalProperties) {
+    lines.push("_No properties._");
+    return;
+  }
+
+  lines.push("| Property | Type | Required | Read-Only | Description |");
+  lines.push("|----------|------|----------|-----------|-------------|");
+
+  for (const name of names) {
+    const property = section.properties[name];
+    const enumValues = getEnumValues(types, property.type);
+    const type =
+      enumValues ?
+        "string"
+      : getLinkedType(types, property.type, anchorsByIndex);
+    const required = (property.flags & ObjectTypePropertyFlags.Required) !== 0;
+    const readOnly = (property.flags & ObjectTypePropertyFlags.ReadOnly) !== 0;
+    let description = sanitizeCell(property.description ?? "");
+    if (enumValues) {
+      const allowed = enumValues.map((value) => `\`${value}\``).join(", ");
+      const sentence = `Allowed values: ${allowed}.`;
+      description = description ? `${description}<br />${sentence}` : sentence;
+    }
+    lines.push(
+      `| \`${name}\` | ${type} | ${required} | ${readOnly} | ${description} |`
+    );
+  }
+
+  if (section.additionalProperties) {
+    const type = getPropertyType(types, section.additionalProperties);
+    lines.push(
+      `| \`*\` | ${type} | false | false | Additional properties keyed by name. |`
+    );
+  }
+}
+
+/** A resolved object section together with the index of its source type. */
+type ResolvedSection = PropertyBag & { index: number };
+
+/**
+ * Resolves the object section a property should document. Named objects and
+ * discriminated objects resolve to their own properties. A map/`Record` (an
+ * object with no named properties) unwraps to its value type, so a
+ * `map<RecipeDefinition>` documents the RecipeDefinition shape rather than an
+ * empty section. Scalar-valued maps and non-object types resolve to nothing and
+ * are surfaced inline on the parent row instead.
+ */
+function resolveSection(
+  types: BicepType[],
+  reference: TypeReference
+): ResolvedSection | undefined {
+  const type = types[reference.index];
+  if (type.type === TypeBaseKind.ObjectType) {
+    const objectType = type as ObjectType;
+    if (Object.keys(objectType.properties).length > 0) {
+      return {
+        index: reference.index,
+        properties: objectType.properties,
+        additionalProperties: objectType.additionalProperties
+      };
+    }
+    if (objectType.additionalProperties) {
+      return resolveSection(types, objectType.additionalProperties);
+    }
+    return undefined;
+  }
+  if (type.type === TypeBaseKind.DiscriminatedObjectType) {
+    return {
+      index: reference.index,
+      properties: (type as DiscriminatedObjectType).baseProperties
+    };
+  }
+  return undefined;
+}
+
+/** A resolved section together with whether the property is an array of it. */
+interface LinkTarget {
+  section: ResolvedSection;
+  isArray: boolean;
+}
+
+/**
+ * Resolves the object section a property (or its array element / map value)
+ * expands to, so the Type column can link to it. Arrays set `isArray` so the
+ * Type renders `[object](#anchor)[]`. Returns undefined when nothing expands.
+ */
+function resolveLinkTarget(
+  types: BicepType[],
+  reference: TypeReference
+): LinkTarget | undefined {
+  const type = types[reference.index];
+  if (type.type === TypeBaseKind.ArrayType) {
+    const inner = resolveLinkTarget(types, (type as ArrayType).itemType);
+    return inner ? { section: inner.section, isArray: true } : undefined;
+  }
+  const section = resolveSection(types, reference);
+  return section ? { section, isArray: false } : undefined;
+}
+
+/**
+ * Builds a deterministic heading anchor from a dotted section path. Section
+ * paths are unique, so the slug is collision-free. Emitting an explicit `{#id}`
+ * on each heading avoids depending on Hugo's auto-slugger and its `-1`/`-2`
+ * dedup behavior, keeping the Type-column links stable.
+ */
+function anchor(headingPath: string): string {
+  return headingPath
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+/**
+ * Renders a property's Type cell. Object-valued properties (including maps and
+ * arrays of objects) link to the `### <path>` section that expands them, so
+ * `object` becomes a jump link and arrays render `[object](#anchor)[]`. Types
+ * without an expanded section fall back to their plain type name.
+ */
+function getLinkedType(
+  types: BicepType[],
+  reference: TypeReference,
+  anchorsByIndex: Map<number, string>
+): string {
+  const target = resolveLinkTarget(types, reference);
+  if (target) {
+    const id = anchorsByIndex.get(target.section.index);
+    if (id) {
+      const link = `[object](#${id})`;
+      return target.isArray ? `${link}[]` : link;
+    }
+  }
+  return getPropertyType(types, reference);
+}
+
+/**
+ * Maps a Bicep type to a JSON-schema-style type name (`string`, `integer`,
+ * `boolean`, `object`, `array`, `any`) to match the CLI's property tables.
+ * Enums (unions of string literals) render their allowed values, for example
+ * `'terraform' \| 'bicep'`.
+ */
+function getPropertyType(types: BicepType[], reference: TypeReference): string {  const type = types[reference.index];
+  switch (type.type) {
+    case TypeBaseKind.ObjectType:
+    case TypeBaseKind.DiscriminatedObjectType:
+      return "object";
+    case TypeBaseKind.ArrayType:
+      return getArrayType(types, type as ArrayType);
+    case TypeBaseKind.BooleanType:
+      return "boolean";
+    case TypeBaseKind.IntegerType:
+      return "integer";
+    case TypeBaseKind.StringType:
+    case TypeBaseKind.StringLiteralType:
+      return "string";
+    case TypeBaseKind.AnyType:
+      return "any";
+    case TypeBaseKind.NullType:
+      return "null";
+    case TypeBaseKind.UnionType:
+      return getUnionType(types, type as UnionType);
+    case TypeBaseKind.BuiltInType:
+      return getBuiltInType((type as BuiltInType).kind);
+    default:
+      return "string";
+  }
+}
+
+/** Renders an array as `<scalar> array`, or `array` when the element is complex. */
+function getArrayType(types: BicepType[], type: ArrayType): string {
+  const element = getPropertyType(types, type.itemType);
+  return /^[a-z]+$/.test(element) ? `${element} array` : "array";
+}
+
+/**
+ * Returns the sorted allowed values of an enum (a union whose elements are all
+ * string literals), or undefined for any other type. Used to move enum values
+ * out of the Type column and into the Description.
+ */
+function getEnumValues(
+  types: BicepType[],
+  reference: TypeReference
+): string[] | undefined {
+  const type = types[reference.index];
+  if (type.type !== TypeBaseKind.UnionType) {
+    return undefined;
+  }
+  const values: string[] = [];
+  for (const element of (type as UnionType).elements) {
+    const elementType = types[element.index];
+    if (elementType.type !== TypeBaseKind.StringLiteralType) {
+      return undefined; // not a pure string-literal enum
+    }
+    values.push((elementType as StringLiteralType).value);
+  }
+  return values.length > 0 ? values.sort() : undefined;
+}
+
+/**
+ * Renders a union. Enums (unions of string literals) list their allowed values
+ * as `'a' \| 'b'`, with the pipe escaped so the value stays inside one table
+ * cell. Non-literal unions collapse to their underlying type(s).
+ */
+function getUnionType(types: BicepType[], type: UnionType): string {
+  const literals: string[] = [];
+  let allLiterals = true;
+  for (const element of type.elements) {
+    const elementType = types[element.index];
+    if (elementType.type === TypeBaseKind.StringLiteralType) {
+      literals.push(`'${(elementType as StringLiteralType).value}'`);
+    } else {
+      allLiterals = false;
+      break;
+    }
+  }
+  if (allLiterals && literals.length > 0) {
+    return literals.sort().join(" \\| ");
+  }
+
+  const kinds = new Set(
+    type.elements.map((element) => getPropertyType(types, element))
   );
+  if (kinds.size === 1) {
+    return [...kinds][0];
+  }
+  return [...kinds].sort().join(" or ");
 }
 
-function getStringModifiers(type: StringType): string {
-  return formatModifiers(
-    type.sensitive ? "sensitive" : undefined,
-    type.minLength !== undefined ? `minLength: ${type.minLength}` : undefined,
-    type.maxLength !== undefined ? `maxLength: ${type.maxLength}` : undefined,
-    type.pattern !== undefined ?
-      `pattern: ${JSON.stringify(type.pattern)}`
-    : undefined
-  );
+/** Maps a built-in type kind to its JSON-schema-style name. */
+function getBuiltInType(kind: BuiltInTypeKind): string {
+  switch (kind) {
+    case BuiltInTypeKind.Bool:
+      return "boolean";
+    case BuiltInTypeKind.Int:
+      return "integer";
+    case BuiltInTypeKind.String:
+      return "string";
+    case BuiltInTypeKind.Object:
+      return "object";
+    case BuiltInTypeKind.Array:
+      return "array";
+    case BuiltInTypeKind.Null:
+      return "null";
+    default:
+      return "any";
+  }
 }
 
-function formatModifiers(...modifiers: Array<string | undefined>): string {
-  const modifierString = modifiers.filter((modifier) => !!modifier).join(", ");
-  return modifierString.length > 0 ? ` {${modifierString}}` : modifierString;
+/** Flattens a property description to a single table-cell-safe line. */
+function sanitizeCell(text: string): string {
+  return text
+    .replace(/\r?\n/g, " ")
+    .replace(/\|/g, "\\|")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
-/** Stable ascending sort by a string selector (replaces lodash `orderBy`). */
-function orderBy<T>(items: readonly T[], selector: (item: T) => string): T[] {
-  return [...items].sort((a, b) => {
-    const ka = selector(a);
-    const kb = selector(b);
+/** Returns the keys of a record sorted case-insensitively and ascending. */
+function sortedKeys(record: Record<string, unknown>): string[] {
+  return Object.keys(record).sort((a, b) => {
+    const ka = a.toLowerCase();
+    const kb = b.toLowerCase();
     return (
       ka < kb ? -1
       : ka > kb ? 1

--- a/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
@@ -95,11 +95,77 @@ function buildResource(): { factory: TypeFactory; resourceType: ResourceType } {
   });
   const extensionsArrayRef = factory.addArrayType(extensionRef);
 
+  // A discriminated union (like EnvironmentCompute): a `kind` discriminator with
+  // shared base properties plus per-variant properties. The variant objects
+  // carry the discriminator literal, which the writer omits from their tables.
+  const computeRef = factory.addDiscriminatedObjectType(
+    "EnvironmentCompute",
+    "kind",
+    {
+      resourceId: createObjectProperty(
+        stringRef,
+        ObjectTypePropertyFlags.None,
+        "(Optional) The compute resource id."
+      )
+    },
+    {
+      kubernetes: factory.addObjectType("KubernetesCompute", {
+        kind: createObjectProperty(
+          factory.addStringLiteralType("kubernetes"),
+          ObjectTypePropertyFlags.Required,
+          "Discriminator value."
+        ),
+        namespace: createObjectProperty(
+          stringRef,
+          ObjectTypePropertyFlags.Required,
+          "(Required) The Kubernetes namespace."
+        )
+      }),
+      aci: factory.addObjectType("ACICompute", {
+        kind: createObjectProperty(
+          factory.addStringLiteralType("aci"),
+          ObjectTypePropertyFlags.Required,
+          "Discriminator value."
+        ),
+        resourceGroup: createObjectProperty(
+          stringRef,
+          ObjectTypePropertyFlags.Required,
+          "(Required) The ACI resource group."
+        )
+      })
+    }
+  );
+
+  // A shared object type referenced from two properties to prove each path is
+  // expanded into its own section rather than de-duplicated by type identity.
+  const endpointRef = factory.addObjectType("EndpointInfo", {
+    host: createObjectProperty(
+      stringRef,
+      ObjectTypePropertyFlags.Required,
+      "(Required) The endpoint host."
+    )
+  });
+
   const propertiesRef = factory.addObjectType("EnvironmentProperties", {
     providers: createObjectProperty(
       providersRef,
       ObjectTypePropertyFlags.None,
       "(Optional) Target compute platform."
+    ),
+    compute: createObjectProperty(
+      computeRef,
+      ObjectTypePropertyFlags.None,
+      "(Optional) The compute platform."
+    ),
+    primaryEndpoint: createObjectProperty(
+      endpointRef,
+      ObjectTypePropertyFlags.None,
+      "(Optional) The primary endpoint."
+    ),
+    secondaryEndpoint: createObjectProperty(
+      endpointRef,
+      ObjectTypePropertyFlags.None,
+      "(Optional) The secondary endpoint."
     ),
     recipes: createObjectProperty(
       recipesMapRef,
@@ -268,5 +334,43 @@ describe("writeTableMarkdown", () => {
     // ...and the element object (Extension) is expanded as its own section.
     expect(markdown).toContain("### `extensions` {#extensions}\n");
     expect(markdown).toContain("| `manifest` | string | false | false |");
+  });
+
+  it("expands a shared object type into a separate section per path", () => {
+    const { factory, resourceType } = buildResource();
+
+    const markdown = writeTableMarkdown([resourceType], factory.types);
+
+    // Both properties reference the same EndpointInfo type but each links to
+    // its own dotted-path section rather than collapsing to a shared one.
+    expect(markdown).toContain(
+      "| `primaryEndpoint` | [object](#primaryendpoint) | false | false |"
+    );
+    expect(markdown).toContain(
+      "| `secondaryEndpoint` | [object](#secondaryendpoint) | false | false |"
+    );
+    expect(markdown).toContain("### `primaryEndpoint` {#primaryendpoint}\n");
+    expect(markdown).toContain("### `secondaryEndpoint` {#secondaryendpoint}\n");
+    // The shared property is documented under each path.
+    const primary = markdown.split("### `primaryEndpoint`")[1].split("###")[0];
+    expect(primary).toContain("| `host` | string | true | false |");
+  });
+
+  it("expands discriminated unions into a discriminator row and variant sections", () => {
+    const { factory, resourceType } = buildResource();
+
+    const markdown = writeTableMarkdown([resourceType], factory.types);
+
+    // The discriminated property's section leads with a discriminator row whose
+    // allowed values link to each variant section.
+    expect(markdown).toContain(
+      "| `kind` | string | true | false | Discriminator property that selects the variant. Allowed values: [`aci`](#compute-aci), [`kubernetes`](#compute-kubernetes). |"
+    );
+    // Each variant is expanded into its own section with the discriminator
+    // literal omitted (shown only once on the parent row).
+    expect(markdown).toContain("### `compute.kubernetes` {#compute-kubernetes}\n");
+    expect(markdown).toContain("### `compute.aci` {#compute-aci}\n");
+    expect(markdown).toContain("| `namespace` | string | true | false |");
+    expect(markdown).toContain("| `resourceGroup` | string | true | false |");
   });
 });

--- a/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
@@ -111,6 +111,12 @@ function buildResource(): { factory: TypeFactory; resourceType: ResourceType } {
   });
   const extensionsArrayRef = factory.addArrayType(extensionRef);
 
+  // An array whose element object does not expand into a section (it has no
+  // named properties and no additional properties). Its Type cell must render
+  // `array`, not `object array`.
+  const logEntryRef = factory.addObjectType("LogEntry", {});
+  const logsArrayRef = factory.addArrayType(logEntryRef);
+
   // A discriminated union (like EnvironmentCompute): a `kind` discriminator with
   // shared base properties plus per-variant properties. The variant objects
   // carry the discriminator literal, which the writer omits from their tables.
@@ -217,6 +223,11 @@ function buildResource(): { factory: TypeFactory; resourceType: ResourceType } {
       extensionsArrayRef,
       ObjectTypePropertyFlags.None,
       "(Optional) Extensions applied to the Environment."
+    ),
+    logs: createObjectProperty(
+      logsArrayRef,
+      ObjectTypePropertyFlags.None,
+      "(Optional) Log entries."
     ),
     simulated: createObjectProperty(
       boolRef,
@@ -404,6 +415,17 @@ describe("writeTableMarkdown", () => {
     // ...and the element object (Extension) is expanded as its own section.
     expect(markdown).toContain("### `extensions` {#extensions}\n");
     expect(markdown).toContain("| `manifest` | string | false | false |");
+  });
+
+  it("renders arrays of non-expanding objects as `array`, not `object array`", () => {
+    const { factory, resourceType } = buildResource();
+
+    const markdown = writeTableMarkdown([resourceType], factory.types);
+
+    // LogEntry has no properties so it does not expand; the array Type cell must
+    // be `array` rather than `object array`.
+    expect(markdown).toContain("| `logs` | array | false | false |");
+    expect(markdown).not.toContain("object array");
   });
 
   it("expands a shared object type into a separate section per path", () => {

--- a/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
@@ -414,4 +414,81 @@ describe("writeTableMarkdown", () => {
     expect(markdown).toContain("| `namespace` | string | true | false |");
     expect(markdown).toContain("| `resourceGroup` | string | true | false |");
   });
+
+  it("renders the discriminator row and variants when properties is a discriminated union", () => {
+    const factory = new TypeFactory();
+    const stringRef = factory.addStringType();
+
+    const propertiesRef = factory.addDiscriminatedObjectType(
+      "GatewayProperties",
+      "mode",
+      {
+        hostname: createObjectProperty(
+          stringRef,
+          ObjectTypePropertyFlags.None,
+          "(Optional) The gateway hostname."
+        )
+      },
+      {
+        http: factory.addObjectType("HttpGateway", {
+          mode: createObjectProperty(
+            factory.addStringLiteralType("http"),
+            ObjectTypePropertyFlags.Required,
+            "Discriminator value."
+          ),
+          port: createObjectProperty(
+            stringRef,
+            ObjectTypePropertyFlags.Required,
+            "(Required) The HTTP port."
+          )
+        }),
+        tcp: factory.addObjectType("TcpGateway", {
+          mode: createObjectProperty(
+            factory.addStringLiteralType("tcp"),
+            ObjectTypePropertyFlags.Required,
+            "Discriminator value."
+          ),
+          endpoint: createObjectProperty(
+            stringRef,
+            ObjectTypePropertyFlags.Required,
+            "(Required) The TCP endpoint."
+          )
+        })
+      }
+    );
+
+    const bodyRef = factory.addObjectType("Radius.Core/gateways", {
+      name: createObjectProperty(
+        stringRef,
+        ObjectTypePropertyFlags.Required,
+        "The resource name"
+      ),
+      properties: createObjectProperty(
+        propertiesRef,
+        ObjectTypePropertyFlags.Required,
+        "The resource-specific properties for this resource."
+      )
+    });
+
+    const resourceRef = factory.addResourceType(
+      "Radius.Core/gateways@2025-08-01-preview",
+      bodyRef,
+      ScopeType.ResourceGroup,
+      ScopeType.ResourceGroup
+    );
+    const resourceType = factory.lookupType(resourceRef) as ResourceType;
+
+    const markdown = writeTableMarkdown([resourceType], factory.types);
+
+    // The discriminator row appears in the top-level table with links to each
+    // variant section...
+    expect(markdown).toContain(
+      "| `mode` | string | true | false | Discriminator property that selects the variant. Allowed values: [`http`](#http), [`tcp`](#tcp). |"
+    );
+    // ...and each variant is expanded as its own section.
+    expect(markdown).toContain("### `http` {#http}\n");
+    expect(markdown).toContain("### `tcp` {#tcp}\n");
+    expect(markdown).toContain("| `port` | string | true | false |");
+    expect(markdown).toContain("| `endpoint` | string | true | false |");
+  });
 });

--- a/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
@@ -84,6 +84,22 @@ function buildResource(): { factory: TypeFactory; resourceType: ResourceType } {
     recipeDefinitionRef
   );
 
+  // A map whose value type is an array of objects (map<ProviderConfig[]>). The
+  // element object shape must still expand into its own linked section even
+  // though the map value is an ArrayType rather than an ObjectType.
+  const providerConfigRef = factory.addObjectType("ProviderConfig", {
+    name: createObjectProperty(
+      stringRef,
+      ObjectTypePropertyFlags.Required,
+      "(Required) The provider config name."
+    )
+  });
+  const providerConfigsMapRef = factory.addObjectType(
+    "ProviderConfigMap",
+    {},
+    factory.addArrayType(providerConfigRef)
+  );
+
   // An array<Extension>: the element object is documented as its own section
   // and the Type column links to it as `[object](#extensions)[]`.
   const extensionRef = factory.addObjectType("Extension", {
@@ -171,6 +187,11 @@ function buildResource(): { factory: TypeFactory; resourceType: ResourceType } {
       recipesMapRef,
       ObjectTypePropertyFlags.None,
       "(Optional) Recipes keyed by name."
+    ),
+    providerConfigs: createObjectProperty(
+      providerConfigsMapRef,
+      ObjectTypePropertyFlags.None,
+      "(Optional) Provider configs keyed by name."
     ),
     extensions: createObjectProperty(
       extensionsArrayRef,
@@ -308,6 +329,20 @@ describe("writeTableMarkdown", () => {
       "| `kind` | string | true | false | (Required) The kind of recipe.<br />Allowed values: `bicep`, `terraform`. |"
     );
     expect(markdown).toContain("| `source` | string | true | false |");
+  });
+
+  it("documents map values that are arrays of objects as their own section", () => {
+    const { factory, resourceType } = buildResource();
+
+    const markdown = writeTableMarkdown([resourceType], factory.types);
+
+    // The map value is an array of objects (map<ProviderConfig[]>); the element
+    // object must still expand into its own linked section.
+    expect(markdown).toContain(
+      "| `providerConfigs` | [object](#providerconfigs) | false | false |"
+    );
+    expect(markdown).toContain("### `providerConfigs` {#providerconfigs}\n");
+    expect(markdown).toContain("| `name` | string | true | false |");
   });
 
   it("flattens nested objects into dotted-path sections", () => {

--- a/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
@@ -428,6 +428,42 @@ describe("writeTableMarkdown", () => {
     expect(markdown).not.toContain("object array");
   });
 
+  it("escapes backslashes and pipes in description cells", () => {
+    const factory = new TypeFactory();
+    const stringRef = factory.addStringType();
+    const propsRef = factory.addObjectType("Props", {
+      pattern: createObjectProperty(
+        stringRef,
+        ObjectTypePropertyFlags.None,
+        "Escape sequence \\n or the pipe | character."
+      )
+    });
+    const bodyRef = factory.addObjectType("Body", {
+      properties: createObjectProperty(
+        propsRef,
+        ObjectTypePropertyFlags.None,
+        "The resource properties."
+      )
+    });
+    const resource = factory.addResourceType(
+      "Test/resource@2025-01-01",
+      bodyRef,
+      ScopeType.ResourceGroup,
+      ScopeType.ResourceGroup
+    );
+
+    const markdown = writeTableMarkdown(
+      [factory.lookupType(resource) as ResourceType],
+      factory.types
+    );
+
+    // The backslash is escaped before the pipe, so both survive as literals in
+    // the table cell without corrupting the column structure.
+    expect(markdown).toContain(
+      "| `pattern` | string | false | false | Escape sequence \\\\n or the pipe \\| character. |"
+    );
+  });
+
   it("expands a shared object type into a separate section per path", () => {
     const { factory, resourceType } = buildResource();
 

--- a/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
@@ -298,7 +298,9 @@ describe("writeTableMarkdown", () => {
     const markdown = writeTableMarkdown([resourceType], factory.types);
 
     // The map property appears in the top-level table as a linked object...
-    expect(markdown).toContain("| `recipes` | [object](#recipes) | false | false |");
+    expect(markdown).toContain(
+      "| `recipes` | [object](#recipes) | false | false |"
+    );
     // ...and its value type (RecipeDefinition) is documented under its path,
     // including the enum allowed values in the nested property's description.
     expect(markdown).toContain("### `recipes` {#recipes}\n");
@@ -350,7 +352,9 @@ describe("writeTableMarkdown", () => {
       "| `secondaryEndpoint` | [object](#secondaryendpoint) | false | false |"
     );
     expect(markdown).toContain("### `primaryEndpoint` {#primaryendpoint}\n");
-    expect(markdown).toContain("### `secondaryEndpoint` {#secondaryendpoint}\n");
+    expect(markdown).toContain(
+      "### `secondaryEndpoint` {#secondaryendpoint}\n"
+    );
     // The shared property is documented under each path.
     const primary = markdown.split("### `primaryEndpoint`")[1].split("###")[0];
     expect(primary).toContain("| `host` | string | true | false |");
@@ -368,7 +372,9 @@ describe("writeTableMarkdown", () => {
     );
     // Each variant is expanded into its own section with the discriminator
     // literal omitted (shown only once on the parent row).
-    expect(markdown).toContain("### `compute.kubernetes` {#compute-kubernetes}\n");
+    expect(markdown).toContain(
+      "### `compute.kubernetes` {#compute-kubernetes}\n"
+    );
     expect(markdown).toContain("### `compute.aci` {#compute-aci}\n");
     expect(markdown).toContain("| `namespace` | string | true | false |");
     expect(markdown).toContain("| `resourceGroup` | string | true | false |");

--- a/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
@@ -1,0 +1,272 @@
+// ------------------------------------------------------------
+// Copyright 2023 The Radius Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------.
+
+import { describe, expect, it } from "vitest";
+import {
+  ObjectTypePropertyFlags,
+  ResourceType,
+  ScopeType,
+  TypeFactory,
+  createObjectProperty
+} from "../src/bicep.js";
+import { writeTableMarkdown } from "../src/writers/markdown-table.js";
+
+/**
+ * Builds a small resource type graph shaped like a real ARM resource: an
+ * envelope with the standardized properties plus a `properties` object holding
+ * the resource-specific fields, one of which nests another object
+ * (`providers` -> `providers.azure`).
+ */
+function buildResource(): { factory: TypeFactory; resourceType: ResourceType } {
+  const factory = new TypeFactory();
+  const stringRef = factory.addStringType();
+  const boolRef = factory.addBooleanType();
+  const stringArrayRef = factory.addArrayType(factory.addStringType());
+  const enumRef = factory.addUnionType([
+    factory.addStringLiteralType("Succeeded"),
+    factory.addStringLiteralType("Failed")
+  ]);
+
+  const azureRef = factory.addObjectType("ProvidersAzure", {
+    subscriptionId: createObjectProperty(
+      stringRef,
+      ObjectTypePropertyFlags.Required,
+      "(Required) ID of the Azure subscription."
+    ),
+    resourceGroupName: createObjectProperty(
+      stringRef,
+      ObjectTypePropertyFlags.None,
+      "(Optional) Name of the Azure resource group."
+    )
+  });
+
+  const providersRef = factory.addObjectType("Providers", {
+    azure: createObjectProperty(
+      azureRef,
+      ObjectTypePropertyFlags.None,
+      "(Optional) Configuration for deploying resources to Azure."
+    )
+  });
+
+  // A map<RecipeDefinition>: an object with no named properties whose value
+  // type is documented as its own section.
+  const recipeDefinitionRef = factory.addObjectType("RecipeDefinition", {
+    kind: createObjectProperty(
+      factory.addUnionType([
+        factory.addStringLiteralType("bicep"),
+        factory.addStringLiteralType("terraform")
+      ]),
+      ObjectTypePropertyFlags.Required,
+      "(Required) The kind of recipe."
+    ),
+    source: createObjectProperty(
+      stringRef,
+      ObjectTypePropertyFlags.Required,
+      "(Required) The source of the recipe."
+    )
+  });
+  const recipesMapRef = factory.addObjectType(
+    "RecipeDefinitionMap",
+    {},
+    recipeDefinitionRef
+  );
+
+  // An array<Extension>: the element object is documented as its own section
+  // and the Type column links to it as `[object](#extensions)[]`.
+  const extensionRef = factory.addObjectType("Extension", {
+    manifest: createObjectProperty(
+      stringRef,
+      ObjectTypePropertyFlags.None,
+      "(Optional) The extension manifest."
+    )
+  });
+  const extensionsArrayRef = factory.addArrayType(extensionRef);
+
+  const propertiesRef = factory.addObjectType("EnvironmentProperties", {
+    providers: createObjectProperty(
+      providersRef,
+      ObjectTypePropertyFlags.None,
+      "(Optional) Target compute platform."
+    ),
+    recipes: createObjectProperty(
+      recipesMapRef,
+      ObjectTypePropertyFlags.None,
+      "(Optional) Recipes keyed by name."
+    ),
+    extensions: createObjectProperty(
+      extensionsArrayRef,
+      ObjectTypePropertyFlags.None,
+      "(Optional) Extensions applied to the Environment."
+    ),
+    simulated: createObjectProperty(
+      boolRef,
+      ObjectTypePropertyFlags.None,
+      "(Optional) When true, the Environment is simulated."
+    ),
+    provisioningState: createObjectProperty(
+      enumRef,
+      ObjectTypePropertyFlags.ReadOnly,
+      "(Read Only) The status of the Environment."
+    ),
+    recipePacks: createObjectProperty(
+      stringArrayRef,
+      ObjectTypePropertyFlags.None,
+      "(Optional) Resource IDs of the Recipe Packs."
+    )
+  });
+
+  const bodyRef = factory.addObjectType("Radius.Core/environments", {
+    id: createObjectProperty(
+      stringRef,
+      ObjectTypePropertyFlags.ReadOnly |
+        ObjectTypePropertyFlags.DeployTimeConstant,
+      "The resource id"
+    ),
+    name: createObjectProperty(
+      factory.addStringType(),
+      ObjectTypePropertyFlags.Required,
+      "The resource name"
+    ),
+    type: createObjectProperty(
+      factory.addStringLiteralType("Radius.Core/environments"),
+      ObjectTypePropertyFlags.ReadOnly,
+      "The resource type"
+    ),
+    apiVersion: createObjectProperty(
+      factory.addStringLiteralType("2025-08-01-preview"),
+      ObjectTypePropertyFlags.ReadOnly,
+      "The resource api version"
+    ),
+    tags: createObjectProperty(
+      factory.addStringType(),
+      ObjectTypePropertyFlags.None,
+      "Resource tags."
+    ),
+    properties: createObjectProperty(
+      propertiesRef,
+      ObjectTypePropertyFlags.Required,
+      "The resource-specific properties for this resource."
+    )
+  });
+
+  const resourceRef = factory.addResourceType(
+    "Radius.Core/environments@2025-08-01-preview",
+    bodyRef,
+    ScopeType.ResourceGroup,
+    ScopeType.ResourceGroup
+  );
+
+  return {
+    factory,
+    resourceType: factory.lookupType(resourceRef) as ResourceType
+  };
+}
+
+describe("writeTableMarkdown", () => {
+  it("renders the resource description block, preserving multi-line markdown", () => {
+    const { factory, resourceType } = buildResource();
+    const description = "An Environment.\n\n## Notes\n\nUse `rad deploy`.";
+
+    const markdown = writeTableMarkdown(
+      [resourceType],
+      factory.types,
+      description
+    );
+
+    expect(markdown).toContain(`## Description\n\n${description}\n`);
+  });
+
+  it("omits the description block when no description is provided", () => {
+    const { factory, resourceType } = buildResource();
+
+    const markdown = writeTableMarkdown([resourceType], factory.types);
+
+    expect(markdown).not.toContain("## Description");
+    expect(markdown.startsWith("## Top-Level Properties")).toBe(true);
+  });
+
+  it("hides ARM envelope properties and lists resource-specific properties", () => {
+    const { factory, resourceType } = buildResource();
+
+    const markdown = writeTableMarkdown([resourceType], factory.types);
+    const topLevel = markdown.split("## Object Properties")[0];
+
+    expect(topLevel).toContain(
+      "| `providers` | [object](#providers) | false | false |"
+    );
+    expect(topLevel).toContain("| `simulated` | boolean | false | false |");
+    expect(topLevel).not.toContain("`id`");
+    expect(topLevel).not.toContain("`apiVersion`");
+    expect(topLevel).not.toContain("`tags`");
+  });
+
+  it("derives Required and Read-Only columns and lists enum and array types", () => {
+    const { factory, resourceType } = buildResource();
+
+    const markdown = writeTableMarkdown([resourceType], factory.types);
+
+    expect(markdown).toContain(
+      "| `provisioningState` | string | false | true | (Read Only) The status of the Environment.<br />Allowed values: `Failed`, `Succeeded`. |"
+    );
+    expect(markdown).toContain(
+      "| `recipePacks` | string array | false | false |"
+    );
+  });
+
+  it("documents map value types as their own section", () => {
+    const { factory, resourceType } = buildResource();
+
+    const markdown = writeTableMarkdown([resourceType], factory.types);
+
+    // The map property appears in the top-level table as a linked object...
+    expect(markdown).toContain("| `recipes` | [object](#recipes) | false | false |");
+    // ...and its value type (RecipeDefinition) is documented under its path,
+    // including the enum allowed values in the nested property's description.
+    expect(markdown).toContain("### `recipes` {#recipes}\n");
+    expect(markdown).toContain(
+      "| `kind` | string | true | false | (Required) The kind of recipe.<br />Allowed values: `bicep`, `terraform`. |"
+    );
+    expect(markdown).toContain("| `source` | string | true | false |");
+  });
+
+  it("flattens nested objects into dotted-path sections", () => {
+    const { factory, resourceType } = buildResource();
+
+    const markdown = writeTableMarkdown([resourceType], factory.types);
+
+    expect(markdown).toContain("## Object Properties");
+    expect(markdown).toContain("### `providers` {#providers}\n");
+    expect(markdown).toContain("### `providers.azure` {#providers-azure}\n");
+    expect(markdown).toContain(
+      "| `azure` | [object](#providers-azure) | false | false |"
+    );
+    expect(markdown).toContain("| `subscriptionId` | string | true | false |");
+  });
+
+  it("links array-of-object types and expands their element sections", () => {
+    const { factory, resourceType } = buildResource();
+
+    const markdown = writeTableMarkdown([resourceType], factory.types);
+
+    // The array property links to the element object's section, suffixed `[]`.
+    expect(markdown).toContain(
+      "| `extensions` | [object](#extensions)[] | false | false |"
+    );
+    // ...and the element object (Extension) is expanded as its own section.
+    expect(markdown).toContain("### `extensions` {#extensions}\n");
+    expect(markdown).toContain("| `manifest` | string | false | false |");
+  });
+});

--- a/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts
@@ -162,6 +162,21 @@ function buildResource(): { factory: TypeFactory; resourceType: ResourceType } {
     )
   });
 
+  // An object that both declares named properties and allows arbitrary keys
+  // (models that `extends Record<T>`). The `*` additionalProperties row must be
+  // omitted here to match `rad resource-type show`.
+  const metadataRef = factory.addObjectType(
+    "ResourceMetadata",
+    {
+      owner: createObjectProperty(
+        stringRef,
+        ObjectTypePropertyFlags.Required,
+        "(Required) The owner of the resource."
+      )
+    },
+    stringRef
+  );
+
   const propertiesRef = factory.addObjectType("EnvironmentProperties", {
     providers: createObjectProperty(
       providersRef,
@@ -192,6 +207,11 @@ function buildResource(): { factory: TypeFactory; resourceType: ResourceType } {
       providerConfigsMapRef,
       ObjectTypePropertyFlags.None,
       "(Optional) Provider configs keyed by name."
+    ),
+    metadata: createObjectProperty(
+      metadataRef,
+      ObjectTypePropertyFlags.None,
+      "(Optional) Resource metadata."
     ),
     extensions: createObjectProperty(
       extensionsArrayRef,
@@ -343,6 +363,19 @@ describe("writeTableMarkdown", () => {
     );
     expect(markdown).toContain("### `providerConfigs` {#providerconfigs}\n");
     expect(markdown).toContain("| `name` | string | true | false |");
+  });
+
+  it("omits the additionalProperties row for objects that also have named properties", () => {
+    const { factory, resourceType } = buildResource();
+
+    const markdown = writeTableMarkdown([resourceType], factory.types);
+
+    // ResourceMetadata declares `owner` and extends Record<string>. The named
+    // property is listed but the `*` row is omitted to match the CLI.
+    expect(markdown).toContain("### `metadata` {#metadata}\n");
+    const metadata = markdown.split("### `metadata`")[1].split("###")[0];
+    expect(metadata).toContain("| `owner` | string | true | false |");
+    expect(metadata).not.toContain("| `*` |");
   });
 
   it("flattens nested objects into dotted-path sections", () => {


### PR DESCRIPTION
## Summary

Reworks the TypeSpec bicep-types doc emitter so the generated `docs/<resource>.md` reads like `rad resource-type show`. Each document now has a Description prose block, a Top-Level Properties table, and per-object Object Properties sections with dotted-path headings, code-formatted heading text, explicit `{#anchor}` IDs, and cross-links from object-valued Type cells to the sections that expand them.

## Reason for change

The previous emitter produced a flat schema dump that didn't match the CLI's `resource-type show` output that contributors and the docs site rely on. Enum allowed values were crammed into the narrow Type column (causing wrapping and escaped pipes), map value types and array-of-object element types were dropped entirely, and there was no way to navigate from a property to the object it references.

Fixes #12554

## How to test

1. Build the emitter and run its unit tests:

       cd hack/bicep-types-radius/src/typespec-bicep-types
       pnpm run build && pnpm test   # build is clean and 26 vitest tests pass

2. Regenerate the bicep types and docs from the repo root:

       make generate-bicep-types-core

3. Clone the docs repo next to this one (skip if you already have it). The commands below assume `radius` and `docs` share a parent directory:

       cd ..
       git clone https://github.com/radius-project/docs.git
       cd docs

4. Convert the generated docs into the docs-site reference content (run from the `docs` repo checkout):

       cd docs
       python3 .github/scripts/generate_resource_references.py \
         ../radius/hack/bicep-types-radius/generated/ \
         docs/content/reference/resources

5. Start Hugo:

       cd docs
       npm start

6. Browse to the updated page and verify the rendering:

   <http://localhost:1313/reference/resources/radius.core/2025-08-01-preview/applications/>

   - The Description block, Top-Level Properties table, and per-object Object Properties sections render like `rad resource-type show`.
   - Object-valued Type cells are links that jump to their `### <path>` sections (arrays of objects render as `[object](#...)[]`).
   - Enum properties show `string` in the Type column with `Allowed values: ...` on a new line in the Description.

## File change summary

- `hack/bicep-types-radius/src/typespec-bicep-types/src/emitter.ts`: Pass each resource's authored `@doc` (via `getDoc`) into the markdown writer so the Description block can be rendered. 
- `hack/bicep-types-radius/src/typespec-bicep-types/src/writers/markdown-table.ts`: Rewrote the doc writer to mirror `rad resource-type show`:
  - `## Description` prose block when the resource has a `@doc`.
  - `## Top-Level Properties` table (Property | Type | Required | Read-Only | Description), ARM envelope props hidden.
  - `## Object Properties` sections via BFS, one per nested object, keyed by dotted path.
  - Enum allowed values moved out of the Type column into the Description as `Allowed values: ...` on a new line; Type shows `string`.
  - Map value types and array-of-object element types expanded into their own sections (resolveLinkTarget / resolveSection).
  - Object Properties headings code-formatted with explicit IDs: `### `path` {#anchor}`.
  - Object-valued Type cells linked to their sections: `[object](#anchor)`; arrays of objects `[object](#anchor)[]`. 
- `hack/bicep-types-radius/src/typespec-bicep-types/test/markdown-table.test.ts`: New vitest golden test covering the Description block, envelope hiding, enum/array rendering, map and array-of-object sections, dotted-path headings, and Type-cell links. 