### PR TITLE
Fix deploy parameter injection for templates without image parameters

### DIFF
--- a/.github/extension/README.md
+++ b/.github/extension/README.md
@@ -42,10 +42,10 @@ Each workflow runs on `ubuntu-latest`. No long-lived cloud secrets are stored �
 
 The workflows read only GitHub Actions **variables** (`vars`), never secrets. Configure these on the target GitHub Environment:
 
-| Provider | Variables |
-|---|---|
-| Azure | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_RESOURCE_GROUP`, `AZURE_AKS_CLUSTER_NAME` |
-| AWS | `AWS_ROLE_ARN`, `AWS_REGION`, `AWS_EKS_CLUSTER_NAME` |
+| Provider | Variables                                                                                                       |
+|----------|-----------------------------------------------------------------------------------------------------------------|
+| Azure    | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_RESOURCE_GROUP`, `AZURE_AKS_CLUSTER_NAME` |
+| AWS      | `AWS_ROLE_ARN`, `AWS_REGION`, `AWS_EKS_CLUSTER_NAME`                                                            |
 
 ### Prerequisites on the cloud side
 
@@ -77,7 +77,6 @@ Radius deletes a deployed application or an environment with the same ephemeral-
 
 The `delete-resource` composite action runs `rad app delete <name> --yes --preview` or `rad env delete <name> --yes --preview` (`--preview` selects the Radius.Core surface the deploy flow provisions) and writes a `rad-delete-result` artifact — a JSON document with `outcome`, `exitCode`, `resourceType`, `name`, and the command `output`.
 
-
 ### What it does
 
 The dispatcher routes to the matching provider workflow, which runs on `ubuntu-latest`. It stands up an ephemeral [k3d](https://k3d.io) cluster to host the Radius control plane on the runner, points that control plane at the user's existing EKS/AKS cluster, and deploys the application there. The control-plane setup, state restore, and run/teardown phases below run from the shared composite actions; the OIDC login, cluster connection, token projection, credential registration, and recipe-pack creation are the provider-specific steps. When a provider's identifying variable is empty, its steps are skipped and resources deploy to the ephemeral control-plane cluster instead of an external target.
@@ -94,7 +93,7 @@ The dispatcher routes to the matching provider workflow, which runs on `ubuntu-l
 10. **Register cloud credentials.** Registers the cloud identity with `rad credential register azure wi` / `aws irsa` so Radius holds the identity selector and reads the projected token at runtime.
 11. **Create the Radius environment and recipe pack.** `rad deploy`s a `radius-env.bicep` that defines a `Radius.Core/recipePacks` resource and the `Radius.Core/environments` resource that references it. Azure downloads the `azure-avm` pack (Azure Verified Modules) from [resource-types-contrib](https://github.com/radius-project/resource-types-contrib); AWS generates an inline `aws-terraform` pack. `radius-env.bicep` is written to the app file's directory (e.g. `.radius/`) and deployed from there, so `rad deploy` resolves the repo's own `bicepconfig.json` (which declares the `radius` extension) — bicep resolves the config nearest the `.bicep` file. The `Radius.Compute/containerImages` type ships with the Radius extension, so no separate resource-type registration is needed.
 12. **Register custom types and apply custom recipe pack.** When the app's `.radius/` folder carries a `custom-types.yaml` file, the shared `apply-custom-recipe-packs` action registers those resource types with `rad resource-type create --from-file` (skipped when absent). When it carries a `custom-recipe-pack.bicep` file, the action snapshots the recipe-pack IDs before and after `rad deploy`ing that pack to identify the newly-created pack(s), reads the environment's existing `recipePacks` with `rad env show --preview`, and runs `rad env update <env> --recipe-packs <existing ∪ new> --preview` so the environment keeps the default provider pack and gains the custom pack — without pulling in unrelated packs the control plane may know about (skipped when absent). When neither file exists this step is a no-op and the default pack stays in place.
-13. **Run the requested rad commands.** Validates each command in `rad_commands` against the allowed-command set, then runs them in order (stopping on the first failure) and writes a combined `rad-commands-result` artifact. When `rad_commands` is empty it runs the default `rad deploy <app-file> --environment <env>`, passing the `image` parameter (the `image` input, defaulting to `github.sha`), any application parameters from the `RADIUS_DEPLOY_PARAMS` secret, and the registry push/pull credentials as `registryUsername` (`github.actor`) and `registryPassword` (the built-in `GITHUB_TOKEN`). Those feed the app's `Radius.Security/secrets` resource (`radius-ghcr-registry-creds`), which materializes the registry Secret on the target cluster so the containerImages recipe's in-pod BuildKit can push the application image. The secret value is passed via an argv array and never written into the recorded command string.
+13. **Run the requested rad commands.** Validates each command in `rad_commands` against the allowed-command set, then runs them in order (stopping on the first failure) and writes a combined `rad-commands-result` artifact. Before deploying the app, the shared action compiles its Bicep file once and reads the declared ARM parameters. It passes each extension-generated parameter only when the template declares it: `image` (the workflow input, defaulting to `github.sha`), `registryUsername` (`github.actor`), and `registryPassword` (the built-in `GITHUB_TOKEN`). Caller-configured application parameters from the `RADIUS_DEPLOY_PARAMS` secret remain strict and are passed unchanged. The registry parameters feed the app's `Radius.Security/secrets` resource (`radius-ghcr-registry-creds`), when present, so the containerImages recipe's in-pod BuildKit can push the application image. Secret values are passed via an argv array and never written into the recorded command string.
 14. **Persist state (`rad shutdown`).** Backs the control-plane databases and Terraform recipe-state Secrets up to the state archive — the OCI-backed archive by default (pushed to GHCR, selected by the `RADIUS_STATE_*` variables), or the `radius-state` git orphan branch when `RADIUS_STATE_BACKEND=git`. This runs even when the deploy fails (`if: always()`), so a partially-applied Terraform run is not lost.
 15. **Tear down.** Runs `rad app list`, and always deletes the ephemeral `radius-cp` cluster. On failure, Radius and application logs are collected and uploaded as the `radius-logs` artifact (three-day retention).
 
@@ -107,11 +106,11 @@ Triggers and permissions live on the **dispatcher** (`run-rad-commands.yml`); th
   - `workflow_run` after the `Radius - Verify Credentials` workflow completes. The `detect` job runs only when the upstream verify run concluded `success`, so a successful credential check auto-triggers a deploy.
 - **Inputs:**
 
-  | Input | Required | Description |
-  |---|---|---|
-  | `environment` | Yes | The GitHub Environment name, used as the Radius environment. |
-  | `image` | No | Container image for the application, passed to the default deploy as the `image` parameter. Defaults to the commit SHA (`github.sha`) when unset. |
-  | `rad_commands` | No | A single `rad` command string, or a JSON array of command strings run in order (the `rad` prefix omitted, e.g. `["deploy .radius/app.bicep --environment dev", "app graph my-app -o json"]`). Each command is validated against the allowed-command set. Falls back to the `RADIUS_RAD_COMMANDS` variable. When empty, the workflow runs its default `rad deploy` of the app bicep. |
+  | Input          | Required | Description                                                                                                                                                                                                                                                                                                                                                                         |
+  |----------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  | `environment`  | Yes      | The GitHub Environment name, used as the Radius environment.                                                                                                                                                                                                                                                                                                                        |
+  | `image`        | No       | Container image for the application. Defaults to the commit SHA (`github.sha`) when unset and is passed only when the application template declares the `image` parameter.                                                                                                                                                                                                          |
+  | `rad_commands` | No       | A single `rad` command string, or a JSON array of command strings run in order (the `rad` prefix omitted, e.g. `["deploy .radius/app.bicep --environment dev", "app graph my-app -o json"]`). Each command is validated against the allowed-command set. Falls back to the `RADIUS_RAD_COMMANDS` variable. When empty, the workflow runs its default `rad deploy` of the app bicep. |
 
 - **Outputs:** a combined `rad-commands-result` artifact — a JSON document with a top-level `outcome`/`exitCode` and a `commands` array (one entry per command, in input order, with each command's exit code and output).
 - **Permissions:** `id-token: write` (required for OIDC), `contents: write` (so `rad shutdown` can push the `radius-state` branch when the git state backend is selected), and `packages: write` (to push the OCI-backed state archive to GHCR and the application image built by the containerImages recipe).
@@ -120,19 +119,19 @@ Triggers and permissions live on the **dispatcher** (`run-rad-commands.yml`); th
 
 The workflow reads cloud and cluster configuration from GitHub Actions **variables** (`vars`). Configure the relevant provider's set on the target GitHub Environment:
 
-| Provider | Variables |
-|---|---|
-| Common | `KUBERNETES_NAMESPACE` (default `default`), `RADIUS_BUILD_REGISTRY` (default `ghcr.io/<owner>/<repo>`), `RADIUS_RAD_COMMANDS` (optional fallback for `rad_commands`) |
-| Azure (`run-rad-commands-azure.yml`) | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_RESOURCE_GROUP`, `AZURE_AKS_CLUSTER_NAME` |
-| AWS (`run-rad-commands-aws.yml`) | `AWS_ROLE_ARN`, `AWS_REGION`, `AWS_ACCOUNT_ID`, `AWS_EKS_CLUSTER_NAME`, `RADIUS_VPC_ID`, `RADIUS_SUBNET_IDS` |
+| Provider                             | Variables                                                                                                                                                            |
+|--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Common                               | `KUBERNETES_NAMESPACE` (default `default`), `RADIUS_BUILD_REGISTRY` (default `ghcr.io/<owner>/<repo>`), `RADIUS_RAD_COMMANDS` (optional fallback for `rad_commands`) |
+| Azure (`run-rad-commands-azure.yml`) | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_RESOURCE_GROUP`, `AZURE_AKS_CLUSTER_NAME`                                                      |
+| AWS (`run-rad-commands-aws.yml`)     | `AWS_ROLE_ARN`, `AWS_REGION`, `AWS_ACCOUNT_ID`, `AWS_EKS_CLUSTER_NAME`, `RADIUS_VPC_ID`, `RADIUS_SUBNET_IDS`                                                         |
 
 The provider steps run only when the identifying variable (`AZURE_CLIENT_ID` or `AWS_ROLE_ARN`) is non-empty. When it is unset, resources deploy to the ephemeral control-plane cluster instead of an external target.
 
 This workflow also reads GitHub Actions **secrets** for image push and application configuration:
 
-| Secret | Purpose |
-|---|---|
-| `GITHUB_TOKEN` | Built-in. Used with `github.actor` to authenticate the containerImages recipe's image push to GHCR. |
+| Secret                 | Purpose                                                                                                                                                  |
+|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `GITHUB_TOKEN`         | Built-in. Used with `github.actor` to authenticate the containerImages recipe's image push to GHCR.                                                      |
 | `RADIUS_DEPLOY_PARAMS` | Optional. A JSON object of application parameters (`{"password":"…","apiKey":"…"}`) expanded into `--parameters name=value` pairs on the default deploy. |
 
 ### State persistence (`rad startup` / `rad shutdown`)

--- a/.github/extension/actions/run-rad-commands/action.yml
+++ b/.github/extension/actions/run-rad-commands/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: Application bicep file to deploy by default.
     required: true
   app-image:
-    description: Container image passed to the default deploy as the image parameter.
+    description: Container image passed when the application template declares the image parameter.
     required: false
     default: ""
   namespace:
@@ -30,10 +30,10 @@ inputs:
     required: false
     default: ""
   registry-username:
-    description: Username passed to the app deploy as the registryUsername parameter (feeds the app's Radius.Security/secrets registry Secret).
+    description: Username passed when the app declares the registryUsername parameter (feeds its Radius.Security/secrets registry Secret).
     required: true
   registry-password:
-    description: Password/token passed to the app deploy as the registryPassword parameter (feeds the app's Radius.Security/secrets registry Secret).
+    description: Password/token passed when the app declares the registryPassword parameter (feeds its Radius.Security/secrets registry Secret).
     required: true
 
 runs:
@@ -60,14 +60,13 @@ runs:
         ENVIRONMENT: ${{ inputs.environment }}
         APP_FILE: ${{ inputs.app-file }}
         APP_IMAGE: ${{ inputs.app-image }}
-        # Registry push/pull credentials for the app deploy. These are passed to
-        # the app file's `rad deploy` as the registryUsername/registryPassword
-        # parameters, which feed the app's Radius.Security/secrets resource
-        # (`radius-ghcr-registry-creds`). That resource materializes the registry Secret
-        # on the TARGET cluster, where the containerImages recipe reads it by the
-        # name the recipe pack registers. Read via the environment (not inlined
-        # into the script) so the secret value can't break the shell or be
-        # word-split, and is never written into the recorded command string.
+        # Registry push/pull credentials for the app deploy. When the app declares
+        # registryUsername/registryPassword, these feed its Radius.Security/secrets
+        # resource (`radius-ghcr-registry-creds`). That resource materializes the
+        # registry Secret on the TARGET cluster, where the containerImages recipe
+        # reads it by the name the recipe pack registers. Read via the environment
+        # (not inlined into the script) so the secret value can't break the shell or
+        # be word-split, and is never written into the recorded command string.
         REGISTRY_USERNAME: ${{ inputs.registry-username }}
         REGISTRY_PASSWORD: ${{ inputs.registry-password }}
         # Pass caller input through the environment to avoid command injection.
@@ -170,6 +169,11 @@ runs:
           [ -n "$DEPLOY_PARAMS_JSON" ] || return 1
           printf '%s' "$DEPLOY_PARAMS_JSON" | jq -e --arg k "$1" 'has($k) and (.[$k] != null) and (.[$k] != "")' >/dev/null 2>&1
         }
+
+        # Compile the app once and use its ARM parameter keys to avoid supplying
+        # extension-generated parameters that the template does not declare.
+        # shellcheck source=deploy-parameters.sh
+        source "$GITHUB_ACTION_PATH/deploy-parameters.sh"
 
         # Secret values that must never reach the logs or the uploaded artifact:
         # the registry password (the runner GITHUB_TOKEN) and every value in the
@@ -324,26 +328,19 @@ runs:
                 printf '%s' "$t"
               }
               if [ "$(normalize_target "$DEPLOY_TARGET")" = "$(normalize_target "$APP_FILE")" ]; then
-                if [ -n "$APP_IMAGE" ]; then
-                  EXTRA_PARAMS+=(--parameters "image=$APP_IMAGE")
+                if ! load_declared_app_params "$APP_FILE"; then
+                  OVERALL_OUTCOME="command_failed"
+                  OVERALL_EXIT=1
+                  exit 1
                 fi
+                append_generated_app_params
+                EXTRA_PARAMS+=("${GENERATED_APP_PARAMS[@]}")
                 if [ -n "$DEPLOY_PARAMS_JSON" ]; then
                   while IFS= read -r _pname; do
                     [ -z "$_pname" ] && continue
                     _pval=$(printf '%s' "$DEPLOY_PARAMS_JSON" | jq -r --arg k "$_pname" '.[$k]' 2>/dev/null)
                     EXTRA_PARAMS+=(--parameters "$_pname=$_pval")
                   done < <(printf '%s' "$DEPLOY_PARAMS_JSON" | jq -r 'keys_unsorted[]' 2>/dev/null)
-                fi
-                # Registry credentials for the app's Radius.Security/secrets
-                # resource. Appended to the argv array so the secret value is never
-                # word-split or written into the recorded command string. Skipped
-                # when the params secret already supplies the key, so the same
-                # --parameters is never passed twice.
-                if [ -n "$REGISTRY_USERNAME" ] && ! deploy_params_has_key registryUsername; then
-                  EXTRA_PARAMS+=(--parameters "registryUsername=$REGISTRY_USERNAME")
-                fi
-                if [ -n "$REGISTRY_PASSWORD" ] && ! deploy_params_has_key registryPassword; then
-                  EXTRA_PARAMS+=(--parameters "registryPassword=$REGISTRY_PASSWORD")
                 fi
               fi
               if ! record "$idx" "$cmd" rad "${CMD_ARGV[@]}" "${EXTRA_PARAMS[@]}"; then
@@ -370,9 +367,13 @@ runs:
           # so values with special characters are not mangled by the shell.
           REQUESTED=1
           DEPLOY_PARAMS=()
-          if [ -n "$APP_IMAGE" ]; then
-            DEPLOY_PARAMS+=(--parameters "image=$APP_IMAGE")
+          if ! load_declared_app_params "$APP_FILE"; then
+            OVERALL_OUTCOME="command_failed"
+            OVERALL_EXIT=1
+            exit 1
           fi
+          append_generated_app_params
+          DEPLOY_PARAMS+=("${GENERATED_APP_PARAMS[@]}")
           # Expand the application parameters JSON ({"name":"value", …}) into
           # --parameters name=value pairs. Each value is read back from the JSON
           # by key with jq so embedded '=', spaces, or newlines are preserved and
@@ -383,17 +384,6 @@ runs:
               _pval=$(printf '%s' "$DEPLOY_PARAMS_JSON" | jq -r --arg k "$_pname" '.[$k]' 2>/dev/null)
               DEPLOY_PARAMS+=(--parameters "$_pname=$_pval")
             done < <(printf '%s' "$DEPLOY_PARAMS_JSON" | jq -r 'keys_unsorted[]' 2>/dev/null)
-          fi
-          # Registry credentials for the app's Radius.Security/secrets resource
-          # (`radius-ghcr-registry-creds`). Appended to the argv array so the secret
-          # value is never word-split or written into the recorded command string.
-          # Skipped when the params secret already supplies the key, so the same
-          # --parameters is never passed twice.
-          if [ -n "$REGISTRY_USERNAME" ] && ! deploy_params_has_key registryUsername; then
-            DEPLOY_PARAMS+=(--parameters "registryUsername=$REGISTRY_USERNAME")
-          fi
-          if [ -n "$REGISTRY_PASSWORD" ] && ! deploy_params_has_key registryPassword; then
-            DEPLOY_PARAMS+=(--parameters "registryPassword=$REGISTRY_PASSWORD")
           fi
           # The recorded command string omits the parameters so secret values are
           # not written into the result artifact.

--- a/.github/extension/actions/run-rad-commands/deploy-parameters.sh
+++ b/.github/extension/actions/run-rad-commands/deploy-parameters.sh
@@ -11,6 +11,7 @@ load_declared_app_params() {
     local app_file="$1"
     local bicep_bin="${BICEP_BIN:-${BICEP:-${HOME}/.rad/bin/bicep}}"
     local compiled_template
+    local declared_parameters
 
     if [[ "${DECLARED_APP_PARAMS_LOADED}" == "true" ]]; then
         return 0
@@ -43,9 +44,20 @@ load_declared_app_params() {
         return 1
     fi
 
+    if ! declared_parameters="$(
+        jq -r '(.parameters // {}) | keys[]' "${compiled_template}"
+    )"; then
+        rm -f "${compiled_template}"
+        echo "::error::Failed to read parameters from compiled template." >&2
+        return 1
+    fi
+
+    DECLARED_APP_PARAMS=()
     while IFS= read -r parameter; do
-        DECLARED_APP_PARAMS+=("${parameter}")
-    done < <(jq -r '(.parameters // {}) | keys[]' "${compiled_template}")
+        if [[ -n "${parameter}" ]]; then
+            DECLARED_APP_PARAMS+=("${parameter}")
+        fi
+    done <<<"${declared_parameters}"
     rm -f "${compiled_template}"
     DECLARED_APP_PARAMS_LOADED=true
 }

--- a/.github/extension/actions/run-rad-commands/deploy-parameters.sh
+++ b/.github/extension/actions/run-rad-commands/deploy-parameters.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Discovers the parameters declared by the application template and appends only
+# compatible extension-generated values to a rad deploy argument array.
+
+declare -a DECLARED_APP_PARAMS=()
+DECLARED_APP_PARAMS_LOADED=false
+declare -a GENERATED_APP_PARAMS=()
+
+load_declared_app_params() {
+    local app_file="$1"
+    local bicep_bin="${BICEP_BIN:-${BICEP:-${HOME}/.rad/bin/bicep}}"
+    local compiled_template
+
+    if [[ "${DECLARED_APP_PARAMS_LOADED}" == "true" ]]; then
+        return 0
+    fi
+
+    if [[ -d "${bicep_bin}" ]]; then
+        bicep_bin="${bicep_bin}/bicep"
+    fi
+    if [[ ! -x "${bicep_bin}" ]]; then
+        echo "::error::Bicep compiler not found at ${bicep_bin}." >&2
+        return 1
+    fi
+
+    if ! compiled_template="$(
+        mktemp "${TMPDIR:-/tmp}/radius-app-template.XXXXXX"
+    )"; then
+        echo "::error::Failed to create temporary Bicep output file." >&2
+        return 1
+    fi
+    if ! "${bicep_bin}" build "${app_file}" --outfile "${compiled_template}"; then
+        rm -f "${compiled_template}"
+        echo "::error::Failed to compile ${app_file} before deployment." >&2
+        return 1
+    fi
+
+    if ! jq -e '(.parameters // {}) | type == "object"' \
+        "${compiled_template}" >/dev/null; then
+        rm -f "${compiled_template}"
+        echo "::error::Compiled template parameters are not a JSON object." >&2
+        return 1
+    fi
+
+    while IFS= read -r parameter; do
+        DECLARED_APP_PARAMS+=("${parameter}")
+    done < <(jq -r '(.parameters // {}) | keys[]' "${compiled_template}")
+    rm -f "${compiled_template}"
+    DECLARED_APP_PARAMS_LOADED=true
+}
+
+app_declares_parameter() {
+    local expected="$1"
+    local parameter
+
+    for parameter in "${DECLARED_APP_PARAMS[@]-}"; do
+        if [[ "${parameter}" == "${expected}" ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+append_generated_app_params() {
+    GENERATED_APP_PARAMS=()
+
+    if [[ -n "${APP_IMAGE}" ]] && app_declares_parameter "image"; then
+        GENERATED_APP_PARAMS+=(--parameters "image=${APP_IMAGE}")
+    fi
+    if [[ -n "${REGISTRY_USERNAME}" ]] &&
+        app_declares_parameter "registryUsername" &&
+        ! deploy_params_has_key "registryUsername"; then
+        GENERATED_APP_PARAMS+=(
+            --parameters "registryUsername=${REGISTRY_USERNAME}"
+        )
+    fi
+    if [[ -n "${REGISTRY_PASSWORD}" ]] &&
+        app_declares_parameter "registryPassword" &&
+        ! deploy_params_has_key "registryPassword"; then
+        GENERATED_APP_PARAMS+=(
+            --parameters "registryPassword=${REGISTRY_PASSWORD}"
+        )
+    fi
+}

--- a/.github/extension/actions/run-rad-commands/deploy-parameters_test.sh
+++ b/.github/extension/actions/run-rad-commands/deploy-parameters_test.sh
@@ -13,6 +13,12 @@ fail() {
     exit 1
 }
 
+if ! command -v jq >/dev/null 2>&1; then
+    fail "jq is required; run 'make install-jq'"
+fi
+REAL_JQ="$(command -v jq)"
+readonly REAL_JQ
+
 assert_param_present() {
     local expected="$1"
     local actual
@@ -141,6 +147,33 @@ fi
 unset BICEP_SHOULD_FAIL
 [[ "${DECLARED_APP_PARAMS_LOADED}" == "false" ]] ||
     fail "failed compilation must not populate the parameter cache"
+
+fake_jq_dir="${TEST_ROOT}/fake-jq"
+mkdir "${fake_jq_dir}"
+cat >"${fake_jq_dir}/jq" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+if [[ "$*" == *'(.parameters // {}) | keys[]'* ]]; then
+    echo "synthetic parameter extraction failure" >&2
+    exit 1
+fi
+exec "${REAL_JQ}" "$@"
+EOF
+chmod +x "${fake_jq_dir}/jq"
+export REAL_JQ
+
+reset_discovery
+write_template '{"image":{}}'
+original_path="${PATH}"
+PATH="${fake_jq_dir}:${PATH}"
+if load_declared_app_params "${APP_FILE}"; then
+    PATH="${original_path}"
+    fail "expected parameter extraction failure to stop discovery"
+fi
+PATH="${original_path}"
+[[ "${DECLARED_APP_PARAMS_LOADED}" == "false" ]] ||
+    fail "failed parameter extraction must not populate the parameter cache"
 
 action_file="${SCRIPT_DIR}/action.yml"
 [[ "$(grep -c 'append_generated_app_params' "${action_file}")" == "2" ]] ||

--- a/.github/extension/actions/run-rad-commands/deploy-parameters_test.sh
+++ b/.github/extension/actions/run-rad-commands/deploy-parameters_test.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+TEST_ROOT="$(mktemp -d)"
+readonly TEST_ROOT
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_param_present() {
+    local expected="$1"
+    local actual
+
+    for actual in "${DEPLOY_ARGS[@]-}"; do
+        if [[ "${actual}" == "${expected}" ]]; then
+            return 0
+        fi
+    done
+
+    fail "expected deploy parameters to contain '${expected}'"
+}
+
+assert_param_absent() {
+    local unexpected="$1"
+    local actual
+
+    for actual in "${DEPLOY_ARGS[@]-}"; do
+        if [[ "${actual}" == "${unexpected}" ]]; then
+            fail "did not expect deploy parameters to contain '${unexpected}'"
+        fi
+    done
+}
+
+deploy_params_has_key() {
+    [[ -n "${DEPLOY_PARAMS_JSON}" ]] || return 1
+    printf '%s' "${DEPLOY_PARAMS_JSON}" |
+        jq -e --arg k "$1" \
+            'has($k) and (.[$k] != null) and (.[$k] != "")' \
+            >/dev/null
+}
+
+reset_discovery() {
+    DECLARED_APP_PARAMS=()
+    DECLARED_APP_PARAMS_LOADED=false
+    GENERATED_APP_PARAMS=()
+    DEPLOY_ARGS=()
+    : >"${BICEP_CALLS}"
+}
+
+write_template() {
+    local parameters="$1"
+    jq -n --argjson parameters "${parameters}" \
+        '{parameters:$parameters, resources:[]}' >"${FAKE_ARM_TEMPLATE}"
+}
+
+run_generated_params_case() {
+    local parameters="$1"
+
+    reset_discovery
+    write_template "${parameters}"
+    load_declared_app_params "${APP_FILE}"
+    append_generated_app_params
+    if ((${#GENERATED_APP_PARAMS[@]} > 0)); then
+        DEPLOY_ARGS+=("${GENERATED_APP_PARAMS[@]}")
+    fi
+}
+
+readonly FAKE_ARM_TEMPLATE="${TEST_ROOT}/app.json"
+readonly BICEP_CALLS="${TEST_ROOT}/bicep-calls"
+readonly BICEP_BIN="${TEST_ROOT}/bicep"
+readonly APP_FILE="${TEST_ROOT}/app.bicep"
+
+cat >"${BICEP_BIN}" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${BICEP_CALLS}"
+if [[ "${BICEP_SHOULD_FAIL:-false}" == "true" ]]; then
+    echo "synthetic compile failure" >&2
+    exit 1
+fi
+[[ "$1" == "build" && "$3" == "--outfile" ]]
+cp "${FAKE_ARM_TEMPLATE}" "$4"
+EOF
+chmod +x "${BICEP_BIN}"
+touch "${APP_FILE}" "${BICEP_CALLS}"
+export BICEP_BIN BICEP_CALLS FAKE_ARM_TEMPLATE
+
+# The production helper is sourced by the composite action.
+# shellcheck source=.github/extension/actions/run-rad-commands/deploy-parameters.sh
+source "${SCRIPT_DIR}/deploy-parameters.sh"
+
+APP_IMAGE="ghcr.io/example/app:sha"
+REGISTRY_USERNAME="octocat"
+REGISTRY_PASSWORD="token"
+DEPLOY_PARAMS_JSON=""
+
+run_generated_params_case \
+    '{"environment":{},"registryUsername":{},"registryPassword":{}}'
+assert_param_absent "image=${APP_IMAGE}"
+assert_param_present "registryUsername=${REGISTRY_USERNAME}"
+assert_param_present "registryPassword=${REGISTRY_PASSWORD}"
+
+run_generated_params_case \
+    '{"environment":{},"image":{},"registryUsername":{},"registryPassword":{}}'
+assert_param_present "image=${APP_IMAGE}"
+assert_param_present "registryUsername=${REGISTRY_USERNAME}"
+assert_param_present "registryPassword=${REGISTRY_PASSWORD}"
+
+run_generated_params_case '{"environment":{}}'
+assert_param_absent "image=${APP_IMAGE}"
+assert_param_absent "registryUsername=${REGISTRY_USERNAME}"
+assert_param_absent "registryPassword=${REGISTRY_PASSWORD}"
+
+DEPLOY_PARAMS_JSON='{"registryUsername":"configured-user"}'
+run_generated_params_case \
+    '{"image":{},"registryUsername":{},"registryPassword":{}}'
+assert_param_present "image=${APP_IMAGE}"
+assert_param_absent "registryUsername=${REGISTRY_USERNAME}"
+assert_param_present "registryPassword=${REGISTRY_PASSWORD}"
+DEPLOY_PARAMS_JSON=""
+
+reset_discovery
+write_template '{"image":{}}'
+load_declared_app_params "${APP_FILE}"
+load_declared_app_params "${APP_FILE}"
+[[ "$(wc -l <"${BICEP_CALLS}" | tr -d ' ')" == "1" ]] ||
+    fail "expected the app template to compile once"
+
+reset_discovery
+export BICEP_SHOULD_FAIL=true
+if load_declared_app_params "${APP_FILE}"; then
+    fail "expected a Bicep compilation failure to stop parameter discovery"
+fi
+unset BICEP_SHOULD_FAIL
+[[ "${DECLARED_APP_PARAMS_LOADED}" == "false" ]] ||
+    fail "failed compilation must not populate the parameter cache"
+
+action_file="${SCRIPT_DIR}/action.yml"
+[[ "$(grep -c 'append_generated_app_params' "${action_file}")" == "2" ]] ||
+    fail "expected both deploy paths to use generated parameter filtering"
+
+echo "run-rad-commands deploy parameter tests passed"

--- a/.github/extension/run-rad-commands-aws.yml
+++ b/.github/extension/run-rad-commands-aws.yml
@@ -17,7 +17,7 @@ on:
         type: string
         required: true
       image:
-        description: 'Container image for the application'
+        description: 'Container image passed only when the application template declares the image parameter'
         type: string
         required: false
         default: ''
@@ -251,10 +251,11 @@ jobs:
           # $BUILD_REGISTRY, authenticating with the Kubernetes Secret named
           # $REGISTRY_SECRET_NAME. That Secret is created on the target cluster by
           # the app's Radius.Security/secrets resource during `rad deploy` (fed by
-          # the registryUsername/registryPassword parameters injected by the
-          # run-rad-commands action). Only the secret NAME is wired here via the
-          # recipe pack's registrySecretName. $BUILD_REGISTRY is ghcr.io/<owner>/<repo>
-          # so images land under the repository's package namespace; it must be lowercase.
+          # the registryUsername/registryPassword parameters conditionally injected
+          # by the run-rad-commands action when the app declares them). Only the secret
+          # NAME is wired here via the recipe pack's registrySecretName.
+          # $BUILD_REGISTRY is ghcr.io/<owner>/<repo> so images land under the
+          # repository's package namespace; it must be lowercase.
           BUILD_REGISTRY=$(echo "${{ vars.RADIUS_BUILD_REGISTRY || format('ghcr.io/{0}', github.repository) }}" | tr '[:upper:]' '[:lower:]')
           REGISTRY_SECRET_NAME="radius-ghcr-registry-creds"
 

--- a/.github/extension/run-rad-commands-azure.yml
+++ b/.github/extension/run-rad-commands-azure.yml
@@ -17,7 +17,7 @@ on:
         type: string
         required: true
       image:
-        description: 'Container image for the application'
+        description: 'Container image passed only when the application template declares the image parameter'
         type: string
         required: false
         default: ''
@@ -212,9 +212,10 @@ jobs:
           # $BUILD_REGISTRY, authenticating with the Kubernetes Secret named
           # $REGISTRY_SECRET_NAME. That Secret is created on the target cluster by
           # the app's Radius.Security/secrets resource during `rad deploy` (fed by
-          # the registryUsername/registryPassword parameters injected by the
-          # run-rad-commands action). Only the secret NAME is wired here via the
-          # recipe pack's containerImagesRegistrySecretName. $BUILD_REGISTRY is
+          # the registryUsername/registryPassword parameters conditionally injected
+          # by the run-rad-commands action when the app declares them). Only the secret
+          # NAME is wired here via the recipe pack's
+          # containerImagesRegistrySecretName. $BUILD_REGISTRY is
           # ghcr.io/<owner>/<repo> so images land under the repository's package
           # namespace; it must be lowercase.
           BUILD_REGISTRY=$(echo "${{ vars.RADIUS_BUILD_REGISTRY || format('ghcr.io/{0}', github.repository) }}" | tr '[:upper:]' '[:lower:]')

--- a/.github/extension/run-rad-commands.yml
+++ b/.github/extension/run-rad-commands.yml
@@ -16,7 +16,7 @@ on:
         required: true
         default: '{{ENV}}'
       image:
-        description: 'Container image for the application'
+        description: 'Container image passed only when the application template declares the image parameter'
         required: false
         default: ''
       rad_commands:

--- a/build/test.mk
+++ b/build/test.mk
@@ -53,7 +53,7 @@ GOTEST_OPTS ?=
 GOTEST_TOOL ?= go tool gotestsum $(GOTESTSUM_OPTS) --
 
 .PHONY: test
-test: test-get-envtools test-helm test-manage-radius-installation test-update-tools-pr ## Runs unit tests, excluding kubernetes controller tests
+test: test-get-envtools test-helm test-manage-radius-installation test-update-tools-pr test-run-rad-commands-action ## Runs unit tests, excluding kubernetes controller tests
 	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" CGO_ENABLED=1 $(GOTEST_TOOL) ./pkg/... $(GOTEST_OPTS)
 
 .PHONY: test-manage-radius-installation
@@ -63,6 +63,10 @@ test-manage-radius-installation: ## Tests Radius installation lifecycle reconcil
 .PHONY: test-update-tools-pr
 test-update-tools-pr: ## Tests the automated tool-update pull request workflow
 	@bash ./.github/scripts/update-tools-pr_test.sh
+
+.PHONY: test-run-rad-commands-action
+test-run-rad-commands-action: ## Tests application deploy parameter filtering in the run-rad-commands action
+	@bash ./.github/extension/actions/run-rad-commands/deploy-parameters_test.sh
 
 .PHONY: test-compile
 test-compile: test-get-envtools ## Compiles all tests without running them


### PR DESCRIPTION
<!-- Radius application graph diff unavailable: radius-project/radius has no .radius/app.bicep on main or this branch. -->

## Summary

- compile the target app Bicep once and read its declared ARM parameter keys
- pass extension-generated `image`, `registryUsername`, and `registryPassword` values only when the app declares them
- keep explicitly configured `RADIUS_DEPLOY_PARAMS` strict and unchanged
- cover build-from-source, pre-built-image, credential, caching, and compile-failure behavior in a local action test

## Reproductions fixed

- [`ryanwaite/public-todo-list-app-2` run 30314289207](https://github.com/ryanwaite/public-todo-list-app-2/actions/runs/30314289207)
- [`ryanwaite/public-todo-list-app-3` run 30495908969](https://github.com/ryanwaite/public-todo-list-app-3/actions/runs/30495908969)
- [`radius-project/ai-extensions#174`](https://github.com/radius-project/ai-extensions/issues/174), reported by `nicolejms` from a RefChecker fork
- [`willtsai/aks-store-demo` run 30494088396](https://github.com/willtsai/aks-store-demo/actions/runs/30494088396), reported on [`ai-extensions#174`](https://github.com/radius-project/ai-extensions/issues/174#issuecomment-5123857061)

## Validation

- `make test-run-rad-commands-action`
- ShellCheck for the helper, regression harness, and extracted composite-action Bash
- YAML parsing for the shared action and all three generated workflow templates
- Markdown lint, table formatting, and spelling checks

### Live deployment procedure

The Radius Canvas workflow presync regenerates `.github/workflows/run-rad-commands-azure.yml` from the upstream templates before dispatch. That behavior overwrote the initial test pin back to `@main`; [run 30501935484](https://github.com/ryanwaite/public-todo-list-app-3/actions/runs/30501935484) therefore reproduced the old failure and did **not** exercise this PR.

To test this branch without presync:

1. Temporarily changed only the generated workflow's shared deploy-action reference to:

   ```yaml
   uses: radius-project/radius/.github/extension/actions/run-rad-commands@ryanwaite-fix-deploy-image-param
   ```

2. Committed and pushed that pin to the app branch.
3. Dispatched `.github/workflows/run-rad-commands.yml` directly with `gh workflow run`, rather than deploying through Canvas.
4. Verified the runner downloaded `radius-project/radius@ryanwaite-fix-deploy-image-param` at commit `96a2e15069984368efdc9774c3d5bf2c23e73dcb` before trusting the result.

[Run 30502349286](https://github.com/ryanwaite/public-todo-list-app-3/actions/runs/30502349286) exercised the fixed action against the original build-from-source template. It omitted undeclared `image`, passed ARM template validation, and returned `OK` for `Radius.Compute/containerImages`, `Radius.Security/secrets`, and the application resource. Deployment then failed later for the unrelated globally conflicting MySQL name `mysql`.

After renaming that test resource, [run 30503137712](https://github.com/ryanwaite/public-todo-list-app-3/actions/runs/30503137712) again passed the parameter-validation stage and failed later because the subscription cannot provision Azure MySQL Flexible Server in West US (`ProvisionNotSupportedForRegion`). Both runs confirm that the `InvalidTemplate` failure fixed by this PR is gone.

Closes #12560

Related: radius-project/ai-extensions#174