### PR TITLE
Fast-fail rad deploy when app.bicep is missing on the branch

### DIFF
--- a/.github/extension/actions/run-rad-commands/action.yml
+++ b/.github/extension/actions/run-rad-commands/action.yml
@@ -41,10 +41,20 @@ runs:
   steps:
     - name: Verify app namespace on target cluster
       shell: bash
+      env:
+        APP_FILE: ${{ inputs.app-file }}
       run: |
         TARGET_KUBECONFIG="$RADIUS_TARGET_KUBECONFIG"
         if [ -f "$TARGET_KUBECONFIG" ]; then
-          BICEP_APP_NAME=$(grep -oP "name:\s*'\K[^']+" ".radius/app.bicep" 2>/dev/null | head -1)
+          # Tolerate a missing app file or no name match here: `grep` exits
+          # non-zero on both, and with `set -e -o pipefail` (the composite
+          # bash default) that would kill this step with a bare exit code and
+          # no message -- pre-empting the actionable "file not found" error
+          # raised later in Run rad commands. `|| true` keeps this best-effort
+          # namespace pre-creation from masking that gate. It also makes the
+          # BICEP_APP_NAME="app" fallback reachable (pipefail otherwise aborts
+          # before it). Use $APP_FILE rather than a hardcoded path.
+          BICEP_APP_NAME=$(grep -oP "name:\s*'\K[^']+" "$APP_FILE" 2>/dev/null | head -1 || true)
           if [ -z "$BICEP_APP_NAME" ]; then
             BICEP_APP_NAME="app"
           fi

--- a/.github/extension/actions/run-rad-commands/deploy-parameters.sh
+++ b/.github/extension/actions/run-rad-commands/deploy-parameters.sh
@@ -22,7 +22,16 @@ load_declared_app_params() {
     # error below. This commonly happens when a deploy is dispatched before the
     # generated app.bicep has been committed and pushed to the deployed branch.
     if [[ ! -f "${app_file}" ]]; then
-        echo "::error::Application file ${app_file} not found on this branch/commit. Generate it (ask Copilot to \"create app.bicep\") and commit it to the deployed branch before deploying." >&2
+        # Escape workflow-command metacharacters in the interpolated path before
+        # embedding it in the ::error:: annotation: '%' is the escape character
+        # (must be first), and CR/LF would otherwise break or inject the command.
+        # The assignments are intentionally unquoted so the single quotes around
+        # the patterns/replacements are treated as quoting, not literal text.
+        local escaped_app_file="${app_file}"
+        escaped_app_file=${escaped_app_file//'%'/'%25'}
+        escaped_app_file=${escaped_app_file//$'\r'/'%0D'}
+        escaped_app_file=${escaped_app_file//$'\n'/'%0A'}
+        echo "::error::Application file ${escaped_app_file} not found on this branch/commit. Generate it (ask Copilot to \"create app.bicep\") and commit it to the deployed branch before deploying." >&2
         return 1
     fi
 

--- a/.github/extension/actions/run-rad-commands/deploy-parameters.sh
+++ b/.github/extension/actions/run-rad-commands/deploy-parameters.sh
@@ -17,6 +17,15 @@ load_declared_app_params() {
         return 0
     fi
 
+    # Fast-fail with a clear message when the application file is missing on the
+    # deployed branch/commit, rather than surfacing a confusing Bicep compile
+    # error below. This commonly happens when a deploy is dispatched before the
+    # generated app.bicep has been committed and pushed to the deployed branch.
+    if [[ ! -f "${app_file}" ]]; then
+        echo "::error::Application file ${app_file} not found on this branch/commit. Generate it (ask Copilot to \"create app.bicep\") and commit it to the deployed branch before deploying." >&2
+        return 1
+    fi
+
     if [[ -d "${bicep_bin}" ]]; then
         bicep_bin="${bicep_bin}/bicep"
     fi

--- a/.github/extension/actions/run-rad-commands/deploy-parameters_test.sh
+++ b/.github/extension/actions/run-rad-commands/deploy-parameters_test.sh
@@ -148,6 +148,20 @@ unset BICEP_SHOULD_FAIL
 [[ "${DECLARED_APP_PARAMS_LOADED}" == "false" ]] ||
     fail "failed compilation must not populate the parameter cache"
 
+# A missing application file must fast-fail before the Bicep compiler is invoked.
+reset_discovery
+missing_app_file="${TEST_ROOT}/missing-app.bicep"
+rm -f "${missing_app_file}"
+if load_declared_app_params "${missing_app_file}" 2>"${TEST_ROOT}/missing-app.err"; then
+    fail "expected a missing application file to stop parameter discovery"
+fi
+[[ "$(wc -l <"${BICEP_CALLS}" | tr -d ' ')" == "0" ]] ||
+    fail "a missing application file must not invoke the Bicep compiler"
+grep -q "not found on this branch/commit" "${TEST_ROOT}/missing-app.err" ||
+    fail "expected a helpful not-found error for a missing application file"
+[[ "${DECLARED_APP_PARAMS_LOADED}" == "false" ]] ||
+    fail "a missing application file must not populate the parameter cache"
+
 fake_jq_dir="${TEST_ROOT}/fake-jq"
 mkdir "${fake_jq_dir}"
 cat >"${fake_jq_dir}/jq" <<'EOF'

--- a/.github/extension/actions/run-rad-commands/deploy-parameters_test.sh
+++ b/.github/extension/actions/run-rad-commands/deploy-parameters_test.sh
@@ -162,6 +162,19 @@ grep -q "not found on this branch/commit" "${TEST_ROOT}/missing-app.err" ||
 [[ "${DECLARED_APP_PARAMS_LOADED}" == "false" ]] ||
     fail "a missing application file must not populate the parameter cache"
 
+# A missing-file path containing workflow-command metacharacters must be escaped
+# in the ::error:: annotation so it cannot break or inject the workflow command.
+reset_discovery
+injecting_app_file="${TEST_ROOT}/pct%evil.bicep"
+rm -f "${injecting_app_file}"
+if load_declared_app_params "${injecting_app_file}" 2>"${TEST_ROOT}/inject.err"; then
+    fail "expected a missing application file to stop parameter discovery"
+fi
+grep -q 'pct%25evil.bicep' "${TEST_ROOT}/inject.err" ||
+    fail "expected '%' in the app-file path to be escaped as %25 in the error"
+grep -q 'pct%evil.bicep' "${TEST_ROOT}/inject.err" &&
+    fail "expected the raw '%' app-file path to not appear unescaped in the error"
+
 fake_jq_dir="${TEST_ROOT}/fake-jq"
 mkdir "${fake_jq_dir}"
 cat >"${fake_jq_dir}/jq" <<'EOF'
@@ -192,5 +205,11 @@ PATH="${original_path}"
 action_file="${SCRIPT_DIR}/action.yml"
 [[ "$(grep -c 'append_generated_app_params' "${action_file}")" == "2" ]] ||
     fail "expected both deploy paths to use generated parameter filtering"
+
+# The "Verify app namespace" step must tolerate a missing app file so it cannot
+# pre-empt the actionable not-found error raised in Run rad commands. Guard
+# against regression by requiring the grep there to use the `|| true` form.
+grep -qE "grep -oP .*head -1 \|\| true" "${action_file}" ||
+    fail "expected the app-name grep in action.yml to tolerate a missing file via '|| true'"
 
 echo "run-rad-commands deploy parameter tests passed"


### PR DESCRIPTION
## Description

The `run-rad-commands` composite action compiles `app.bicep` with `bicep build` before deploying. When the application file is missing on the deployed branch/commit, this surfaced as a confusing Bicep **compile** error rather than a clear "file not found" signal — which is exactly the failure mode reported for deploys dispatched before the generated `app.bicep` was committed and pushed.

This PR adds an explicit existence check in `load_declared_app_params` that **fast-fails before the Bicep compiler is invoked**, with an actionable message:

> `Application file .radius/app.bicep not found on this branch/commit. Generate it (ask Copilot to "create app.bicep") and commit it to the deployed branch before deploying.`

The gate runs on both the default deploy path and custom commands that target the app file.

This is defense-in-depth on the workflow side. The authoritative fix (never dispatch a deploy against a commit missing `app.bicep`, and disable the Deploy button when it is absent) is tracked in the extension: radius-project/ai-extensions#238. See also radius-project/ai-extensions#113.

## Type of change

- Bug fix (non-breaking change which fixes an issue / improves an error message)

## Testing

- Added a unit test in `deploy-parameters_test.sh` asserting the gate:
  - fast-fails on a missing app file,
  - never invokes the Bicep compiler,
  - emits the "not found on this branch/commit" message,
  - does not populate the parameter cache.
- `bash .github/extension/actions/run-rad-commands/deploy-parameters_test.sh` passes.
- `shellcheck` clean on the modified script.

## Related

- radius-project/ai-extensions#113
- radius-project/ai-extensions#238
