### PR TITLE
fix(test): retry rad deploy through kube-apiserver restarts

### DIFF
--- a/test/step/deployexecutor.go
+++ b/test/step/deployexecutor.go
@@ -50,7 +50,8 @@ type DeployExecutor struct {
 	// Zero means no retries (default behavior).
 	MaxRetries int
 
-	// RetryDelay is the duration to wait between retry attempts.
+	// RetryDelay is the base duration to wait between retry attempts. The wait
+	// doubles after each attempt, up to maxTransientRetryDelay.
 	RetryDelay time.Duration
 
 	// ShouldRetry is a predicate that determines whether a failed deployment should be retried.
@@ -65,9 +66,16 @@ type DeployExecutor struct {
 // network blips, and UCP connection resets/EOFs when the kind control-plane
 // restarts under runner resource pressure and drops the port-forward tunnel.
 // Callers can override these defaults with WithRetry.
+//
+// The delay doubles per attempt, so the defaults give a recovery window of
+// 30s + 60s + 120s = 3m30s. A fixed 30s delay left the budget exhausted while a
+// restarted kube-apiserver was still initializing (see
+// transientAPIServerRestartErrorMarkers), and only transient-classified failures
+// wait at all - a genuine deployment failure still fails on the first attempt.
 const (
-	defaultTransientMaxRetries = 2
+	defaultTransientMaxRetries = 3
 	defaultTransientRetryDelay = 30 * time.Second
+	maxTransientRetryDelay     = 2 * time.Minute
 )
 
 // transientImagePullErrorMarkers are substrings that indicate a container image
@@ -141,13 +149,61 @@ func IsTransientConnectionError(err error) bool {
 	return ErrorContainsAny(err, transientConnectionErrorMarkers...)
 }
 
+// transientAPIServerRestartErrorMarkers are substrings that indicate the
+// kube-apiserver answered rad while it was still restarting, rather than that
+// the deployment itself failed.
+//
+// A kind control-plane restart reaches rad in two phases. First the in-flight
+// connections are torn down, producing the transport errors matched by
+// transientConnectionErrorMarkers. Then the apiserver process is back and
+// accepting connections, but has not finished initializing, so it answers with
+// structured HTTP errors instead. Classifying only the first phase as retryable
+// exhausts the retry budget while the cluster is still recovering, which is what
+// makes a control-plane restart fail every parallel test in the job at once.
+var transientAPIServerRestartErrorMarkers = []string{
+	// 503 ServiceUnavailable returned by the kube-apiserver mux until every
+	// handler - including the aggregation layer that fronts UCP - is registered:
+	// `{"message":"the request has been made before all known HTTP paths have
+	// been installed, please try again","reason":"ServiceUnavailable"}`.
+	"before all known HTTP paths have been installed",
+}
+
+// IsTransientAPIServerRestartError reports whether err was caused by the kind
+// kube-apiserver still recovering from a restart. See
+// transientAPIServerRestartErrorMarkers for the environmental root cause.
+//
+// These errors originate in rad's connection health check, which returns a plain
+// error rather than an ARM error response, so - as in IsTransientConnectionError
+// - a *radcli.CLIError is never a match.
+func IsTransientAPIServerRestartError(err error) bool {
+	if _, ok := errors.AsType[*radcli.CLIError](err); ok {
+		return false
+	}
+
+	if ErrorContainsAny(err, transientAPIServerRestartErrorMarkers...) {
+		return true
+	}
+
+	// A 403 on the aggregated Radius API path is also a restart signal: until the
+	// RBAC authorizer finishes reconciling the bootstrap policy, even the
+	// cluster-admin user is denied, e.g. `forbidden: User "kubernetes-admin"
+	// cannot get path "/apis/api.ucp.dev/v1alpha3"`. That denial is impossible
+	// once the authorizer chain is wired up. Both markers are required so a real
+	// authorization failure elsewhere is not swept up; if RBAC is genuinely
+	// misconfigured the deployment still fails once the retries are exhausted.
+	return ErrorContainsAny(err, "cannot get path") && ErrorContainsAny(err, "/apis/api.ucp.dev")
+}
+
 // IsTransientDeployError reports whether err was caused by any transient failure
-// that a deployment is likely to recover from on retry - either a container
-// image pull blip (IsTransientImagePullError) or a UCP connection reset/EOF
-// (IsTransientConnectionError). It is the default ShouldRetry predicate for
+// that a deployment is likely to recover from on retry - a container image pull
+// blip (IsTransientImagePullError), a UCP connection reset/EOF
+// (IsTransientConnectionError), or a kube-apiserver restart
+// (IsTransientAPIServerRestartError). It is the default ShouldRetry predicate for
 // DeployExecutor (see NewDeployExecutor).
 func IsTransientDeployError(err error) bool {
-	return IsTransientImagePullError(err) || IsTransientConnectionError(err)
+	return IsTransientImagePullError(err) ||
+		IsTransientConnectionError(err) ||
+		IsTransientAPIServerRestartError(err)
 }
 
 // NewDeployExecutor creates a new DeployExecutor instance with the given template and parameters.
@@ -182,8 +238,9 @@ func (d *DeployExecutor) WithEnvironment(environment string) *DeployExecutor {
 // WithRetry configures retry behavior for transient deployment failures,
 // replacing the default transient image pull retry set by NewDeployExecutor.
 // maxRetries is the number of additional attempts after the first failure.
-// delay is the wait time between attempts. shouldRetry determines whether
-// a given error is eligible for retry.
+// delay is the base wait time between attempts, doubling per attempt up to
+// maxTransientRetryDelay. shouldRetry determines whether a given error is
+// eligible for retry.
 func (d *DeployExecutor) WithRetry(maxRetries int, delay time.Duration, shouldRetry func(error) bool) *DeployExecutor {
 	d.MaxRetries = maxRetries
 	d.RetryDelay = delay
@@ -224,8 +281,9 @@ func (d *DeployExecutor) executeWithRetry(ctx context.Context, t *testing.T, dep
 	var lastErr error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		if attempt > 1 {
-			t.Logf("waiting %s before retry attempt %d/%d", d.RetryDelay, attempt, maxAttempts)
-			timer := time.NewTimer(d.RetryDelay)
+			delay := d.retryDelayForAttempt(attempt)
+			t.Logf("waiting %s before retry attempt %d/%d", delay, attempt, maxAttempts)
+			timer := time.NewTimer(delay)
 			select {
 			case <-timer.C:
 			case <-ctx.Done():
@@ -250,4 +308,17 @@ func (d *DeployExecutor) executeWithRetry(ctx context.Context, t *testing.T, dep
 	}
 
 	return lastErr
+}
+
+// retryDelayForAttempt returns how long to wait before the given attempt, which
+// is always 2 or greater. The wait starts at RetryDelay and doubles per attempt
+// so the retry budget spans a control-plane restart, and stops growing once it
+// reaches maxTransientRetryDelay. A caller-supplied delay is never shortened.
+func (d *DeployExecutor) retryDelayForAttempt(attempt int) time.Duration {
+	delay := d.RetryDelay
+	for i := 2; i < attempt && delay < maxTransientRetryDelay; i++ {
+		delay *= 2
+	}
+
+	return delay
 }

--- a/test/step/deployexecutor.go
+++ b/test/step/deployexecutor.go
@@ -312,13 +312,16 @@ func (d *DeployExecutor) executeWithRetry(ctx context.Context, t *testing.T, dep
 
 // retryDelayForAttempt returns how long to wait before the given attempt, which
 // is always 2 or greater. The wait starts at RetryDelay and doubles per attempt
-// so the retry budget spans a control-plane restart, and stops growing once it
-// reaches maxTransientRetryDelay. A caller-supplied delay is never shortened.
+// so the retry budget spans a control-plane restart, clamped to
+// maxTransientRetryDelay. A caller-supplied delay is never shortened.
 func (d *DeployExecutor) retryDelayForAttempt(attempt int) time.Duration {
+	// Taking the max keeps a caller-supplied delay that already exceeds the cap.
+	limit := max(d.RetryDelay, maxTransientRetryDelay)
+
 	delay := d.RetryDelay
-	for i := 2; i < attempt && delay < maxTransientRetryDelay; i++ {
+	for i := 2; i < attempt && delay < limit; i++ {
 		delay *= 2
 	}
 
-	return delay
+	return min(delay, limit)
 }

--- a/test/step/deployexecutor_test.go
+++ b/test/step/deployexecutor_test.go
@@ -228,6 +228,10 @@ func Test_RetryDelayForAttempt(t *testing.T) {
 		{name: "delay doubles per attempt", base: 30 * time.Second, attempt: 3, expected: 60 * time.Second},
 		{name: "delay reaches the cap", base: 30 * time.Second, attempt: 4, expected: maxTransientRetryDelay},
 		{name: "delay stops growing at the cap", base: 30 * time.Second, attempt: 9, expected: maxTransientRetryDelay},
+		// A base above half the cap makes the next doubling overshoot it, so the
+		// result has to be clamped rather than just left ungrown.
+		{name: "doubling overshoots the cap", base: 90 * time.Second, attempt: 3, expected: maxTransientRetryDelay},
+		{name: "overshooting base stays at the cap", base: 90 * time.Second, attempt: 9, expected: maxTransientRetryDelay},
 		// A caller that asks for a longer delay than the cap keeps it: the cap only
 		// bounds the doubling, it never shortens a caller-supplied delay.
 		{name: "caller delay above the cap is preserved", base: 5 * time.Minute, attempt: 3, expected: 5 * time.Minute},

--- a/test/step/deployexecutor_test.go
+++ b/test/step/deployexecutor_test.go
@@ -153,6 +153,32 @@ Error: Get "https://127.0.0.1:37481/apis/api.ucp.dev/v1alpha3/.../operationStatu
 	assert.Equal(t, int32(2), calls.Load()) // failed once, succeeded on retry
 }
 
+func Test_ExecuteWithRetry_DefaultRetriesAPIServerRestartError(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	// NewDeployExecutor retries a kube-apiserver that is still restarting by
+	// default. This is the second phase of a control-plane restart: the socket is
+	// accepted again, but the apiserver answers 503 until its handlers are
+	// installed.
+	d := NewDeployExecutor("test.bicep")
+	d.RetryDelay = 10 * time.Millisecond // shorten the delay for the test
+
+	err := d.executeWithRetry(t.Context(), t, func() error {
+		n := calls.Add(1)
+		if n < 2 {
+			return errors.New(`command 'rad deploy' had non-zero exit code: exit status 1
+Error: An unknown error was returned while testing Radius API status:
+Status Code: 503
+Response Body:
+{"kind":"Status","message":"the request has been made before all known HTTP paths have been installed, please try again","reason":"ServiceUnavailable","code":503}`)
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), calls.Load()) // failed once, succeeded on retry
+}
+
 func Test_ExecuteWithRetry_ContextCancelledDuringDelay(t *testing.T) {
 	t.Parallel()
 	var calls atomic.Int32
@@ -188,6 +214,35 @@ func Test_ExecuteWithRetry_NilShouldRetryDisablesRetries(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Equal(t, int32(1), calls.Load())
+}
+
+func Test_RetryDelayForAttempt(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		base     time.Duration
+		attempt  int
+		expected time.Duration
+	}{
+		{name: "first retry uses the base delay", base: 30 * time.Second, attempt: 2, expected: 30 * time.Second},
+		{name: "delay doubles per attempt", base: 30 * time.Second, attempt: 3, expected: 60 * time.Second},
+		{name: "delay reaches the cap", base: 30 * time.Second, attempt: 4, expected: maxTransientRetryDelay},
+		{name: "delay stops growing at the cap", base: 30 * time.Second, attempt: 9, expected: maxTransientRetryDelay},
+		// A caller that asks for a longer delay than the cap keeps it: the cap only
+		// bounds the doubling, it never shortens a caller-supplied delay.
+		{name: "caller delay above the cap is preserved", base: 5 * time.Minute, attempt: 3, expected: 5 * time.Minute},
+		{name: "zero delay stays zero", base: 0, attempt: 5, expected: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := NewDeployExecutor("test.bicep")
+			d.RetryDelay = tc.base
+
+			require.Equal(t, tc.expected, d.retryDelayForAttempt(tc.attempt))
+		})
+	}
 }
 
 func Test_IsTransientImagePullError(t *testing.T) {
@@ -305,6 +360,51 @@ func Test_IsTransientConnectionError(t *testing.T) {
 	}
 }
 
+func Test_IsTransientAPIServerRestartError(t *testing.T) {
+	// restartMarkerBearingStructuredError mirrors a genuine structured ARM
+	// deployment failure whose flattened message happens to contain a restart
+	// marker. The concrete-type guard must keep it from being retried.
+	restartMarkerBearingStructuredError := &radcli.CLIError{
+		ErrorResponse: apiv1.ErrorResponse{
+			Error: &apiv1.ErrorDetails{
+				Code:    "DeploymentFailed",
+				Message: `recipe validation failed: cannot get path "/apis/api.ucp.dev/v1alpha3"`,
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{name: "nil error", err: nil, expected: false},
+		{
+			name:     "503 while HTTP paths are still installing",
+			err:      errors.New(`{"message":"the request has been made before all known HTTP paths have been installed, please try again","reason":"ServiceUnavailable","code":503}`),
+			expected: true,
+		},
+		{
+			name:     "403 before RBAC bootstrap finishes",
+			err:      errors.New(`{"message":"forbidden: User \"kubernetes-admin\" cannot get path \"/apis/api.ucp.dev/v1alpha3\"","reason":"Forbidden","code":403}`),
+			expected: true,
+		},
+		{
+			name:     "403 on an unrelated non-resource path",
+			err:      errors.New(`{"message":"forbidden: User \"tester\" cannot get path \"/metrics\"","reason":"Forbidden","code":403}`),
+			expected: false,
+		},
+		{name: "structured failure containing a marker", err: restartMarkerBearingStructuredError, expected: false},
+		{name: "unrelated error", err: errors.New("the resource type is not supported"), expected: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, IsTransientAPIServerRestartError(tc.err))
+		})
+	}
+}
+
 func Test_IsTransientDeployError(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -314,6 +414,8 @@ func Test_IsTransientDeployError(t *testing.T) {
 		{name: "nil error", err: nil, expected: false},
 		{name: "transient image pull", err: errors.New("pod is stuck in ImagePullBackOff"), expected: true},
 		{name: "transient connection reset", err: errors.New("read: connection reset by peer"), expected: true},
+		{name: "apiserver still installing HTTP paths", err: errors.New("the request has been made before all known HTTP paths have been installed, please try again"), expected: true},
+		{name: "apiserver RBAC not yet bootstrapped", err: errors.New(`forbidden: User \"kubernetes-admin\" cannot get path \"/apis/api.ucp.dev/v1alpha3\"`), expected: true},
 		{name: "non-transient failure", err: errors.New("the resource type is not supported"), expected: false},
 	}
 


### PR DESCRIPTION
## Summary

Functional tests now treat a restarting kind `kube-apiserver` as a transient failure and retry through it, instead of exhausting the retry budget while the control plane is still coming back.

Two changes in `test/step`:

1. A new `IsTransientAPIServerRestartError` predicate that recognizes the HTTP responses a restarting apiserver returns, wired into the default `IsTransientDeployError`.
2. Exponential backoff for transient retries, widening the recovery window from 60s to 3m30s.

## Reason for change

[Run 31035730083](https://github.com/radius-project/radius/actions/runs/31035730083/job/92409525035) failed four `corerp-cloud` tests — `Test_AzureConnections`, `Test_Extender_RecipeAWS_LogGroup`, `Test_AWS_LogsLogGroup_Existing`, and `Test_TerraformPrivateGitModule_KubernetesRedis` — at the same wall-clock second (19:03:46). That rules out anything test-specific.

`rad` reaches UCP through the kube-apiserver aggregation layer (`https://127.0.0.1:<port>/apis/api.ucp.dev/v1alpha3`), so when the kind control plane restarts under runner resource pressure every parallel test is hit at once. The restart surfaces to `rad` in two phases:

| Phase | What `rad` sees | Retried before this PR? |
| ----- | --------------- | ----------------------- |
| Apiserver going down | `EOF`, `read: connection reset by peer` | Yes |
| Apiserver restarting | `503` — `the request has been made before all known HTTP paths have been installed` | **No** |
| RBAC not yet reconciled | `403` — `forbidden: User "kubernetes-admin" cannot get path "/apis/api.ucp.dev/v1alpha3"` | **No** |

`IsTransientDeployError` matched only the first phase. Each test spent all three attempts on transport errors, then hit the second phase on its final attempt and failed — seconds before the cluster became healthy. The fixed 30s delay compounded this: the entire retry budget spanned only ~66s.

A `403` for `kubernetes-admin` (a `system:masters` member) is impossible once the authorizer chain is wired up, so it is a reliable restart signal rather than a real permissions problem. Both the `cannot get path` and `/apis/api.ucp.dev` markers must be present so an unrelated authorization failure is not swept up, and a genuine RBAC misconfiguration still fails once retries are exhausted.

Backoff also applies to the two existing `WithRetry(2, 60*time.Second, isTransientAzureError)` callers, whose second wait grows from 60s to 120s. A caller-supplied delay is never shortened by the cap.

### Not addressed here

`rad`'s health check in `pkg/sdk/health.go` ignores the `Retry-After: 5` header the apiserver sends with that `503`. Honoring it would fix this closer to the source, but that is a product behavior change with a wider blast radius than this flake warrants.

## How to test

```console
go test ./test/step/... -count=1
```

New coverage:

- `Test_IsTransientAPIServerRestartError` — uses the verbatim JSON bodies from the failing run, plus negative cases for a `403` on an unrelated path and for a structured ARM error that happens to contain a marker.
- `Test_IsTransientDeployError` — new apiserver-restart cases.
- `Test_RetryDelayForAttempt` — doubling, the cap, and that a caller-supplied delay is never shortened.
- `Test_ExecuteWithRetry_DefaultRetriesAPIServerRestartError` — end-to-end through the retry loop.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `test/step/deployexecutor.go` | Added `transientAPIServerRestartErrorMarkers` and `IsTransientAPIServerRestartError`, wired into `IsTransientDeployError`. Raised `defaultTransientMaxRetries` 2 → 3 and added `retryDelayForAttempt` exponential backoff capped at `maxTransientRetryDelay` (2m). |
| `test/step/deployexecutor_test.go` | Added `Test_IsTransientAPIServerRestartError`, `Test_RetryDelayForAttempt`, and `Test_ExecuteWithRetry_DefaultRetriesAPIServerRestartError`; extended `Test_IsTransientDeployError` with restart cases. |
