### PR TITLE
Update containers schema to match resource-types-contrib

### DIFF
--- a/deploy/manifest/built-in-providers/dev/containers.yaml
+++ b/deploy/manifest/built-in-providers/dev/containers.yaml
@@ -48,7 +48,7 @@ types:
       }
       ```
       
-      When a port is included, a Kubernetes Service named demo with the type ClusterIP is created.
+      When a port is included, a Kubernetes Service of type ClusterIP is created for the container. Its name is `<container-resource-name>-<container-name>`, lowercased to satisfy Kubernetes naming rules — for the example above, `mycontainer-demo`. The recipe publishes each port-exposing container's in-cluster Service DNS name in the read-only `hosts` map, keyed by container name. Peer containers can address a specific container by referencing `<peer>.properties.hosts.<containerName>` instead of hardcoding a Service name.
       
       To create an ephemeral emptyDir shared between two containers add a Containers.properties.volumes.
 
@@ -100,6 +100,12 @@ types:
             application:
               type: string
               description: (Required) The Radius Application ID. `myApplication.id` for example.
+            hosts:
+              type: object
+              readOnly: true
+              additionalProperties:
+                type: string
+              description: "(Read Only) Map of container name to the in-cluster DNS host of that container's Kubernetes Service. Populated for every container that exposes a port, so a multi-container resource publishes all of its Service hosts. Peer containers address a specific container by referencing `<peer>.properties.hosts.<containerName>`."
             connections:
               type: object
               description: '(Optional) Map of resources this container is dependent upon. `db: { source: db.id } for example.'

--- a/deploy/manifest/built-in-providers/self-hosted/containers.yaml
+++ b/deploy/manifest/built-in-providers/self-hosted/containers.yaml
@@ -48,7 +48,7 @@ types:
       }
       ```
       
-      When a port is included, a Kubernetes Service named demo with the type ClusterIP is created.
+      When a port is included, a Kubernetes Service of type ClusterIP is created for the container. Its name is `<container-resource-name>-<container-name>`, lowercased to satisfy Kubernetes naming rules — for the example above, `mycontainer-demo`. The recipe publishes each port-exposing container's in-cluster Service DNS name in the read-only `hosts` map, keyed by container name. Peer containers can address a specific container by referencing `<peer>.properties.hosts.<containerName>` instead of hardcoding a Service name.
       
       To create an ephemeral emptyDir shared between two containers add a Containers.properties.volumes.
 
@@ -100,6 +100,12 @@ types:
             application:
               type: string
               description: (Required) The Radius Application ID. `myApplication.id` for example.
+            hosts:
+              type: object
+              readOnly: true
+              additionalProperties:
+                type: string
+              description: "(Read Only) Map of container name to the in-cluster DNS host of that container's Kubernetes Service. Populated for every container that exposes a port, so a multi-container resource publishes all of its Service hosts. Peer containers address a specific container by referencing `<peer>.properties.hosts.<containerName>`."
             connections:
               type: object
               description: '(Optional) Map of resources this container is dependent upon. `db: { source: db.id } for example.'

--- a/deploy/manifest/defaults.yaml
+++ b/deploy/manifest/defaults.yaml
@@ -45,36 +45,36 @@ resourceTypes:
     repo: github.com/radius-project/resource-types-contrib
     # A branch or tag is also accepted by the fetch, but update-resource-types
     # always pins a full commit SHA.
-    ref: 39f65be914c931acce42bc730ebdedff6fcc7af7
+    ref: 65d8ba845c516d76dc31ae88a8f96925dabfe2a7
     tag: ""
   - name: Radius.Data
     repo: github.com/radius-project/resource-types-contrib
-    ref: 39f65be914c931acce42bc730ebdedff6fcc7af7
+    ref: 65d8ba845c516d76dc31ae88a8f96925dabfe2a7
     tag: ""
   - name: Radius.Security
     repo: github.com/radius-project/resource-types-contrib
-    ref: 39f65be914c931acce42bc730ebdedff6fcc7af7
+    ref: 65d8ba845c516d76dc31ae88a8f96925dabfe2a7
     tag: ""
   - name: Radius.Messaging
     repo: github.com/radius-project/resource-types-contrib
-    ref: 39f65be914c931acce42bc730ebdedff6fcc7af7
+    ref: 65d8ba845c516d76dc31ae88a8f96925dabfe2a7
     tag: ""
   - name: Radius.AI
     repo: github.com/radius-project/resource-types-contrib
-    ref: 39f65be914c931acce42bc730ebdedff6fcc7af7
+    ref: 65d8ba845c516d76dc31ae88a8f96925dabfe2a7
     tag: ""
   - name: Radius.Storage
     repo: github.com/radius-project/resource-types-contrib
-    ref: 39f65be914c931acce42bc730ebdedff6fcc7af7
+    ref: 65d8ba845c516d76dc31ae88a8f96925dabfe2a7
     tag: ""
 recipePacks:
   - name: azure
     repo: github.com/radius-project/resource-types-contrib
-    ref: 39f65be914c931acce42bc730ebdedff6fcc7af7
+    ref: 65d8ba845c516d76dc31ae88a8f96925dabfe2a7
     tag: ""
   - name: kubernetes
     repo: github.com/radius-project/resource-types-contrib
-    ref: 39f65be914c931acce42bc730ebdedff6fcc7af7
+    ref: 65d8ba845c516d76dc31ae88a8f96925dabfe2a7
     tag: ""
 defaultRegistration:
   - Radius.Compute/containers


### PR DESCRIPTION
Syncs the `Radius.Compute/containers` manifests (`dev` and `self-hosted`) with the container schema changes from [resource-types-contrib](https://github.com/radius-project/resource-types-contrib) (`Compute/containers/containers.yaml`).

Changes:
- Add read-only `hosts` property — map of container name → in-cluster Service DNS host, populated for each port-exposing container.
- Update the Kubernetes Service description to document the `<container-resource-name>-<container-name>` naming and the `hosts` map.

Manifests are embedded via `deploy/manifest/embed.go`, so no code generation is required.