### PR TITLE
Update Radius.Messaging/rabbitMQ default schema to password-via-secret

### DIFF
--- a/deploy/manifest/built-in-providers/dev/rabbitMQ.yaml
+++ b/deploy/manifest/built-in-providers/dev/rabbitMQ.yaml
@@ -1,24 +1,47 @@
 # Portability note: this schema is platform-neutral so the same type works with
-# Azure AVM (Bicep), AWS Amazon MQ via Terraform modules, and Kubernetes RabbitMQ
-# recipes. Only the recipePack source plus parameters/outputs mapping changes per
-# platform; the developer-facing queue knob and readOnly connection surface stay
-# identical.
+# Azure (a Kubernetes RabbitMQ recipe on the AKS cluster), AWS Amazon MQ via
+# Terraform modules, and Kubernetes RabbitMQ recipes. Only the recipePack source
+# plus parameters/outputs mapping changes per platform; the developer-facing queue
+# name and readOnly connection surface stay identical.
 namespace: Radius.Messaging
 types:
   rabbitMQ:
     description: |
-      The Radius.Messaging/rabbitMQ Resource Type deploys a queue-compatible
-      messaging resource. In the Azure verification recipe, the platform engineer
-      maps this type to Azure Service Bus using the Service Bus AMQP endpoint. This
-      provisions the resource and maps its connection outputs; it does not prove
-      RabbitMQ broker API compatibility.
+      The Radius.Messaging/rabbitMQ Resource Type deploys a RabbitMQ message broker
+      that speaks AMQP 0-9-1. It allows developers to create and connect to a queue
+      as part of their Radius applications.
+
+      Provision the broker password by creating a `Radius.Security/secrets` resource
+      (with the value passed to `rad deploy` as a `@secure()` parameter) and pass its
+      resource ID on the `passwordSecret` property. The Recipe references the
+      materialized Kubernetes Secret by name and mounts the password into the broker
+      via `secretKeyRef`, so the plaintext password is never written into the pod spec
+      or onto this resource.
       ```bicep
+      @secure()
+      param password string
+
+      resource rabbitmqSecret 'Radius.Security/secrets@2025-08-01-preview' = {
+        name: 'rabbitmq-credentials'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          data: {
+            password: {
+              value: password
+            }
+          }
+        }
+      }
+
       resource queue 'Radius.Messaging/rabbitMQ@2025-08-01-preview' = {
         name: 'rabbitmq'
         properties: {
           environment: environment
           application: myApplication.id
           queue: 'jobs'
+          username: 'radius'
+          passwordSecret: rabbitmqSecret.id
         }
       }
       ```
@@ -29,11 +52,13 @@ types:
       For a connection named `rabbitmq`, the variables are:
 
       - CONNECTION_RABBITMQ_HOST
+      - CONNECTION_RABBITMQ_PORT
+      - CONNECTION_RABBITMQ_USERNAME
 
-      The `connectionString` secret is NOT injected via the connection — it is
-      materialized into a managed `Radius.Security/secrets` resource. Bind it into
-      a container env var with a `secretKeyRef`, using `rabbitmq.properties.secrets.name`
-      as the `secretName` and key `connectionString` (see the `secrets` property).
+      The password is NOT emitted by this resource. Read it from the same
+      `Radius.Security/secrets` resource you created above by binding it into a
+      container env var with a `secretKeyRef`, using `rabbitmqSecret.name` as the
+      `secretName` and key `password`.
 
     apiVersions:
       '2025-08-01-preview':
@@ -49,26 +74,20 @@ types:
             queue:
               type: string
               default: jobs
-              description: "(Optional) The queue name to create. Defaults to `jobs` if not provided."
+              description: "(Optional) The name of the queue to pre-provision on the broker. The Recipe creates this durable queue on the default virtual host when the broker starts, so it exists before your workload connects. Defaults to `jobs` if not provided."
+            username:
+              type: string
+              default: radius
+              description: "(Optional) The username the broker is provisioned with and that clients authenticate as. Defaults to `radius` if not provided. Avoid `guest`, which RabbitMQ restricts to loopback connections. The username is not sensitive and is exposed as a read-only connection value."
+            passwordSecret:
+              type: string
+              description: "(Required) The resource ID of the `Radius.Security/secrets` resource that holds the broker password under the data key `password`. Set to `<secretResource>.id`. The Kubernetes Recipe references the materialized Kubernetes Secret by name and mounts the password into the broker via `secretKeyRef`, so the plaintext password is never written into the pod spec or onto this resource."
             host:
               type: string
-              description: The host or namespace name used to connect to the queue. Mapped from the recipe module's output.
+              description: (Read Only) The host name used to connect to the broker. Mapped from the recipe's Service DNS name.
               readOnly: true
-            secrets:
-              type: object
-              description: >-
-                (Read-only) Recipe secrets. The reserved `name` sub-property references the managed
-                Radius.Security/secrets resource Radius materializes from the recipe's `outputs.secrets`;
-                the other sub-properties declare secret keys whose values are written only into that
-                managed secret (never onto this resource). Consumers bind a key into a container env var
-                via `secretKeyRef`, using `<resource>.properties.secrets.name` as `secretName`.
-              properties:
-                name:
-                  type: string
-                  readOnly: true
-                  description: (Reserved) Name of the managed Radius.Security/secrets resource. Use as `secretName` in a container `secretKeyRef`.
-                connectionString:
-                  type: string
-                  readOnly: true
-                  description: The primary connection string used to connect to the queue. Mapped from the recipe module's output; delivered via the managed secret.
-          required: [environment]
+            port:
+              type: integer
+              description: (Read Only) The port used to connect to the broker over AMQP 0-9-1 (5672). Mapped from the recipe's output.
+              readOnly: true
+          required: [environment, passwordSecret]

--- a/deploy/manifest/built-in-providers/self-hosted/rabbitMQ.yaml
+++ b/deploy/manifest/built-in-providers/self-hosted/rabbitMQ.yaml
@@ -1,24 +1,47 @@
 # Portability note: this schema is platform-neutral so the same type works with
-# Azure AVM (Bicep), AWS Amazon MQ via Terraform modules, and Kubernetes RabbitMQ
-# recipes. Only the recipePack source plus parameters/outputs mapping changes per
-# platform; the developer-facing queue knob and readOnly connection surface stay
-# identical.
+# Azure (a Kubernetes RabbitMQ recipe on the AKS cluster), AWS Amazon MQ via
+# Terraform modules, and Kubernetes RabbitMQ recipes. Only the recipePack source
+# plus parameters/outputs mapping changes per platform; the developer-facing queue
+# name and readOnly connection surface stay identical.
 namespace: Radius.Messaging
 types:
   rabbitMQ:
     description: |
-      The Radius.Messaging/rabbitMQ Resource Type deploys a queue-compatible
-      messaging resource. In the Azure verification recipe, the platform engineer
-      maps this type to Azure Service Bus using the Service Bus AMQP endpoint. This
-      provisions the resource and maps its connection outputs; it does not prove
-      RabbitMQ broker API compatibility.
+      The Radius.Messaging/rabbitMQ Resource Type deploys a RabbitMQ message broker
+      that speaks AMQP 0-9-1. It allows developers to create and connect to a queue
+      as part of their Radius applications.
+
+      Provision the broker password by creating a `Radius.Security/secrets` resource
+      (with the value passed to `rad deploy` as a `@secure()` parameter) and pass its
+      resource ID on the `passwordSecret` property. The Recipe references the
+      materialized Kubernetes Secret by name and mounts the password into the broker
+      via `secretKeyRef`, so the plaintext password is never written into the pod spec
+      or onto this resource.
       ```bicep
+      @secure()
+      param password string
+
+      resource rabbitmqSecret 'Radius.Security/secrets@2025-08-01-preview' = {
+        name: 'rabbitmq-credentials'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          data: {
+            password: {
+              value: password
+            }
+          }
+        }
+      }
+
       resource queue 'Radius.Messaging/rabbitMQ@2025-08-01-preview' = {
         name: 'rabbitmq'
         properties: {
           environment: environment
           application: myApplication.id
           queue: 'jobs'
+          username: 'radius'
+          passwordSecret: rabbitmqSecret.id
         }
       }
       ```
@@ -29,11 +52,13 @@ types:
       For a connection named `rabbitmq`, the variables are:
 
       - CONNECTION_RABBITMQ_HOST
+      - CONNECTION_RABBITMQ_PORT
+      - CONNECTION_RABBITMQ_USERNAME
 
-      The `connectionString` secret is NOT injected via the connection — it is
-      materialized into a managed `Radius.Security/secrets` resource. Bind it into
-      a container env var with a `secretKeyRef`, using `rabbitmq.properties.secrets.name`
-      as the `secretName` and key `connectionString` (see the `secrets` property).
+      The password is NOT emitted by this resource. Read it from the same
+      `Radius.Security/secrets` resource you created above by binding it into a
+      container env var with a `secretKeyRef`, using `rabbitmqSecret.name` as the
+      `secretName` and key `password`.
 
     apiVersions:
       '2025-08-01-preview':
@@ -49,26 +74,20 @@ types:
             queue:
               type: string
               default: jobs
-              description: "(Optional) The queue name to create. Defaults to `jobs` if not provided."
+              description: "(Optional) The name of the queue to pre-provision on the broker. The Recipe creates this durable queue on the default virtual host when the broker starts, so it exists before your workload connects. Defaults to `jobs` if not provided."
+            username:
+              type: string
+              default: radius
+              description: "(Optional) The username the broker is provisioned with and that clients authenticate as. Defaults to `radius` if not provided. Avoid `guest`, which RabbitMQ restricts to loopback connections. The username is not sensitive and is exposed as a read-only connection value."
+            passwordSecret:
+              type: string
+              description: "(Required) The resource ID of the `Radius.Security/secrets` resource that holds the broker password under the data key `password`. Set to `<secretResource>.id`. The Kubernetes Recipe references the materialized Kubernetes Secret by name and mounts the password into the broker via `secretKeyRef`, so the plaintext password is never written into the pod spec or onto this resource."
             host:
               type: string
-              description: The host or namespace name used to connect to the queue. Mapped from the recipe module's output.
+              description: (Read Only) The host name used to connect to the broker. Mapped from the recipe's Service DNS name.
               readOnly: true
-            secrets:
-              type: object
-              description: >-
-                (Read-only) Recipe secrets. The reserved `name` sub-property references the managed
-                Radius.Security/secrets resource Radius materializes from the recipe's `outputs.secrets`;
-                the other sub-properties declare secret keys whose values are written only into that
-                managed secret (never onto this resource). Consumers bind a key into a container env var
-                via `secretKeyRef`, using `<resource>.properties.secrets.name` as `secretName`.
-              properties:
-                name:
-                  type: string
-                  readOnly: true
-                  description: (Reserved) Name of the managed Radius.Security/secrets resource. Use as `secretName` in a container `secretKeyRef`.
-                connectionString:
-                  type: string
-                  readOnly: true
-                  description: The primary connection string used to connect to the queue. Mapped from the recipe module's output; delivered via the managed secret.
-          required: [environment]
+            port:
+              type: integer
+              description: (Read Only) The port used to connect to the broker over AMQP 0-9-1 (5672). Mapped from the recipe's output.
+              readOnly: true
+          required: [environment, passwordSecret]

--- a/hack/bicep-types-radius/generated/radius/radius.messaging/2025-08-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/radius/radius.messaging/2025-08-01-preview/types.json
@@ -299,30 +299,13 @@
     "$type": "StringType"
   },
   {
-    "$type": "StringType"
+    "$type": "IntegerType"
   },
   {
     "$type": "StringType"
   },
   {
-    "$type": "ObjectType",
-    "name": "secrets",
-    "properties": {
-      "connectionString": {
-        "description": "The primary connection string used to connect to the queue. Mapped from the recipe module's output; delivered via the managed secret.",
-        "flags": 2,
-        "type": {
-          "$ref": "#/28"
-        }
-      },
-      "name": {
-        "description": "(Reserved) Name of the managed Radius.Security/secrets resource. Use as `secretName` in a container `secretKeyRef`.",
-        "flags": 2,
-        "type": {
-          "$ref": "#/29"
-        }
-      }
-    }
+    "$type": "StringType"
   },
   {
     "$type": "ObjectType",
@@ -357,21 +340,35 @@
         }
       },
       "host": {
-        "description": "The host or namespace name used to connect to the queue. Mapped from the recipe module's output.",
+        "description": "(Read Only) The host name used to connect to the broker. Mapped from the recipe's Service DNS name.",
         "flags": 2,
         "type": {
           "$ref": "#/26"
         }
       },
-      "queue": {
-        "description": "(Optional) The queue name to create. Defaults to `jobs` if not provided.",
-        "flags": 0,
+      "passwordSecret": {
+        "description": "(Required) The resource ID of the `Radius.Security/secrets` resource that holds the broker password under the data key `password`. Set to `\u003csecretResource\u003e.id`. The Kubernetes Recipe references the materialized Kubernetes Secret by name and mounts the password into the broker via `secretKeyRef`, so the plaintext password is never written into the pod spec or onto this resource.",
+        "flags": 1,
         "type": {
           "$ref": "#/27"
         }
       },
-      "secrets": {
-        "description": "(Read-only) Recipe secrets. The reserved `name` sub-property references the managed Radius.Security/secrets resource Radius materializes from the recipe's `outputs.secrets`; the other sub-properties declare secret keys whose values are written only into that managed secret (never onto this resource). Consumers bind a key into a container env var via `secretKeyRef`, using `\u003cresource\u003e.properties.secrets.name` as `secretName`.",
+      "port": {
+        "description": "(Read Only) The port used to connect to the broker over AMQP 0-9-1 (5672). Mapped from the recipe's output.",
+        "flags": 2,
+        "type": {
+          "$ref": "#/28"
+        }
+      },
+      "queue": {
+        "description": "(Optional) The name of the queue to pre-provision on the broker. The Recipe creates this durable queue on the default virtual host when the broker starts, so it exists before your workload connects. Defaults to `jobs` if not provided.",
+        "flags": 0,
+        "type": {
+          "$ref": "#/29"
+        }
+      },
+      "username": {
+        "description": "(Optional) The username the broker is provisioned with and that clients authenticate as. Defaults to `radius` if not provided. Avoid `guest`, which RabbitMQ restricts to loopback connections. The username is not sensitive and is exposed as a read-only connection value.",
         "flags": 0,
         "type": {
           "$ref": "#/30"
@@ -436,7 +433,7 @@
         }
       },
       "host": {
-        "description": "The host or namespace name used to connect to the queue. Mapped from the recipe module's output.",
+        "description": "(Read Only) The host name used to connect to the broker. Mapped from the recipe's Service DNS name.",
         "flags": 2,
         "type": {
           "$ref": "#/26"
@@ -463,6 +460,20 @@
           "$ref": "#/32"
         }
       },
+      "passwordSecret": {
+        "description": "(Required) The resource ID of the `Radius.Security/secrets` resource that holds the broker password under the data key `password`. Set to `\u003csecretResource\u003e.id`. The Kubernetes Recipe references the materialized Kubernetes Secret by name and mounts the password into the broker via `secretKeyRef`, so the plaintext password is never written into the pod spec or onto this resource.",
+        "flags": 2,
+        "type": {
+          "$ref": "#/27"
+        }
+      },
+      "port": {
+        "description": "(Read Only) The port used to connect to the broker over AMQP 0-9-1 (5672). Mapped from the recipe's output.",
+        "flags": 2,
+        "type": {
+          "$ref": "#/28"
+        }
+      },
       "properties": {
         "description": "The resource properties.",
         "flags": 1,
@@ -471,17 +482,10 @@
         }
       },
       "queue": {
-        "description": "(Optional) The queue name to create. Defaults to `jobs` if not provided.",
+        "description": "(Optional) The name of the queue to pre-provision on the broker. The Recipe creates this durable queue on the default virtual host when the broker starts, so it exists before your workload connects. Defaults to `jobs` if not provided.",
         "flags": 2,
         "type": {
-          "$ref": "#/27"
-        }
-      },
-      "secrets": {
-        "description": "(Read-only) Recipe secrets. The reserved `name` sub-property references the managed Radius.Security/secrets resource Radius materializes from the recipe's `outputs.secrets`; the other sub-properties declare secret keys whose values are written only into that managed secret (never onto this resource). Consumers bind a key into a container env var via `secretKeyRef`, using `\u003cresource\u003e.properties.secrets.name` as `secretName`.",
-        "flags": 2,
-        "type": {
-          "$ref": "#/30"
+          "$ref": "#/29"
         }
       },
       "type": {
@@ -489,6 +493,13 @@
         "flags": 10,
         "type": {
           "$ref": "#/35"
+        }
+      },
+      "username": {
+        "description": "(Optional) The username the broker is provisioned with and that clients authenticate as. Defaults to `radius` if not provided. Avoid `guest`, which RabbitMQ restricts to loopback connections. The username is not sensitive and is exposed as a read-only connection value.",
+        "flags": 2,
+        "type": {
+          "$ref": "#/30"
         }
       }
     }


### PR DESCRIPTION
## Summary

Vendors the `Radius.Messaging/rabbitMQ` default resource-type schema change from resource-types-contrib PR [radius-project/resource-types-contrib#287](https://github.com/radius-project/resource-types-contrib/pull/287) so the published `radius` Bicep extension carries the new password-via-secret shape.

The vendored copies in this repo were stale (still the old `queue`/`secrets`/`connectionString` shape). Because the published `radius` extension is generated from these manifests, it rejected the new `username`/`passwordSecret` properties with **BCP037**, which blocks #287's CI.

## What changed

Both vendored manifest copies (kept byte-identical to each other and to the upstream contrib manifest) are updated:
- `deploy/manifest/built-in-providers/dev/rabbitMQ.yaml`
- `deploy/manifest/built-in-providers/self-hosted/rabbitMQ.yaml`

Schema changes (matching upstream #287):
- Password is now supplied via a `Radius.Security/secrets` resource, referenced by ID on a new **required** `passwordSecret` property, instead of a plaintext `password` property.
- Adds `username` (optional, defaults to `radius`).
- Removes the `secrets`/`connectionString` block; the type now exposes read-only `host`, `port`, and `username` connection values instead.
- `required: [environment, passwordSecret]`.

## Generated artifacts

Regenerated the derived Bicep extension types for the `Radius.Messaging` namespace so the committed generated files stay in sync:
- `hack/bicep-types-radius/generated/radius/radius.messaging/2025-08-01-preview/types.json`

The per-namespace and top-level `index.json` files are unchanged (resource-type indices are stable), and the generator's `docs/`/`index.md` output is not committed (gitignored).

## Validation

- `go test ./pkg/defaults/... ./deploy/manifest/... ./pkg/graph/edges/... ./pkg/cli/graph/... ./bicep-tools/...` — the manifest/registration/graph and converter tests pass. (Pre-existing, unrelated failures in `bicep-tools/pkg/cli` and `bicep-tools/pkg/manifest` reproduce on a clean `main` and are not affected by this change.)

## Rollout ordering

This PR (and the subsequent republish of the `radius` Bicep extension) must merge **before** resource-types-contrib [#287](https://github.com/radius-project/resource-types-contrib/pull/287)'s CI can pass, since #287's manifest relies on the extension accepting the new `username`/`passwordSecret` properties.