### PR TITLE
fix rad env update --recipe-packs error hidden beneath warning

### DIFF
--- a/pkg/cli/cmd/env/create/preview/create.go
+++ b/pkg/cli/cmd/env/create/preview/create.go
@@ -322,14 +322,14 @@ func (r *Runner) resolveRecipePacks(ctx context.Context) ([]*string, error) {
 
 	recipePackIDs := make([]*string, 0, len(r.recipePacks))
 	for _, recipePack := range r.recipePacks {
-		recipePackID, err := resolveRecipePackID(recipePack, r.Workspace.Scope)
+		recipePackID, isFullID, err := recipepack.ResolveID(recipePack, r.Workspace.Scope)
 		if err != nil {
 			return nil, err
 		}
 
 		_, err = recipePackClient.Get(ctx, recipePackID.RootScope(), recipePackID.Name(), &corerpv20250801.RecipePacksClientGetOptions{})
 		if clients.Is404Error(err) {
-			return nil, clierrors.Message("Recipe pack %q does not exist. Please provide a valid recipe pack to set on the environment.", recipePack)
+			return nil, recipepack.NotFoundError(recipePack, recipePackID, isFullID)
 		} else if err != nil {
 			return nil, err
 		}
@@ -395,25 +395,6 @@ func (r *Runner) addEnvironmentReferences(ctx context.Context, recipePackIDs []*
 	}
 
 	return nil
-}
-
-// resolveRecipePackID resolves a recipe pack reference to a full resource ID.
-// The reference may be a full resource ID or a bare name, in which case it is
-// scoped to the environment's resource group.
-func resolveRecipePackID(recipePack string, workspaceScope string) (resources.ID, error) {
-	if recipePackID, err := resources.Parse(recipePack); err == nil {
-		return recipePackID, nil
-	}
-
-	scopeID, err := resources.ParseScope(workspaceScope)
-	if err != nil {
-		return resources.ID{}, err
-	}
-
-	return scopeID.Append(resources.TypeSegment{
-		Type: "Radius.Core/recipePacks",
-		Name: recipePack,
-	}), nil
 }
 
 // addEnvReferenceToRecipePack adds the environment ID to a recipe pack's

--- a/pkg/cli/cmd/env/create/preview/create_test.go
+++ b/pkg/cli/cmd/env/create/preview/create_test.go
@@ -702,7 +702,34 @@ func Test_Run(t *testing.T) {
 
 		err = runner.Run(t.Context())
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "Recipe pack \"missing-pack\" does not exist")
+		require.Equal(t,
+			`Recipe pack "missing-pack" does not exist in resource group "test-resource-group". To reference a recipe pack in another resource group, pass its full resource ID, for example: /planes/radius/local/resourceGroups/test-resource-group/providers/Radius.Core/recipePacks/missing-pack`,
+			err.Error())
+	})
+
+	t.Run("returns error without cross-group hint when a full resource ID does not exist", func(t *testing.T) {
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(
+			workspace.Scope,
+			nil,
+			test_client_factory.WithRecipePackServer404OnGet,
+		)
+		require.NoError(t, err)
+
+		packID := "/planes/radius/local/resourceGroups/other-group/providers/Radius.Core/recipePacks/missing-pack"
+		runner := &Runner{
+			RadiusCoreClientFactory: factory,
+			Output:                  &output.MockOutput{},
+			Workspace:               workspace,
+			EnvironmentName:         "testenv",
+			ResourceGroupName:       "test-resource-group",
+			recipePacks:             []string{packID},
+		}
+
+		err = runner.Run(t.Context())
+		require.Error(t, err)
+		require.Equal(t,
+			`Recipe pack "`+packID+`" does not exist. Please provide a valid recipe pack to set on the environment.`,
+			err.Error())
 	})
 
 	t.Run("surfaces non-404 errors when validating a recipe pack", func(t *testing.T) {

--- a/pkg/cli/cmd/env/update/preview/update.go
+++ b/pkg/cli/cmd/env/update/preview/update.go
@@ -297,51 +297,24 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 	}
 
-	newRecipePacks := []*string{}
-
 	// Update recipe packs if specified: replace the environment's recipe pack list,
 	// keeping referencedBy on each recipe pack in sync.
 	if len(r.recipePacks) > 0 {
+		envID := *env.ID
+
+		// Resolve and validate all recipe packs before mutating anything or warning the
+		// user. Validating first keeps a failure from being printed underneath the
+		// replacement warning, where it reads as part of the warning instead of an error.
+		newRecipePacks, err := r.resolveRecipePacks(ctx)
+		if err != nil {
+			return err
+		}
+
 		if len(env.Properties.RecipePacks) > 0 {
 			r.Output.LogInfo("WARNING: The existing recipe pack list will be replaced with the specified packs.")
 		}
 
-		envID := *env.ID
-
-		// Resolve all new recipe packs to full IDs.
-		for _, recipePack := range r.recipePacks {
-			var rClientFactory *corerpv20250801.ClientFactory
-			recipePackID, err := resources.Parse(recipePack)
-			// If the provided recipe pack value is an ID, parse its scope.
-			if err == nil {
-				rClientFactory, err = cmd.InitializeRadiusCoreClientFactory(ctx, r.Workspace)
-				if err != nil {
-					return err
-				}
-			} else {
-				rClientFactory = r.RadiusCoreClientFactory
-				scopeID, err := resources.ParseScope(r.Workspace.Scope)
-				if err != nil {
-					return err
-				}
-
-				recipePackID = scopeID.Append(resources.TypeSegment{
-					Type: "Radius.Core/recipePacks",
-					Name: recipePack,
-				})
-			}
-
-			cfclient := rClientFactory.NewRecipePacksClient()
-
-			_, err = cfclient.Get(ctx, recipePackID.RootScope(), recipePackID.Name(), &corerpv20250801.RecipePacksClientGetOptions{})
-			if err != nil {
-				return clierrors.Message("Recipe pack %q does not exist. Please provide a valid recipe pack to set on the environment.", recipePack)
-			}
-
-			newRecipePacks = append(newRecipePacks, to.Ptr(recipePackID.String()))
-		}
-
-		err := syncRecipePackReferences(ctx, envID, env.Properties.RecipePacks, newRecipePacks, r.Workspace, r.RadiusCoreClientFactory)
+		err = syncRecipePackReferences(ctx, envID, env.Properties.RecipePacks, newRecipePacks, r.Workspace, r.RadiusCoreClientFactory)
 		if err != nil {
 			return err
 		}
@@ -358,6 +331,33 @@ func (r *Runner) Run(ctx context.Context) error {
 	r.Output.LogInfo("Radius.Core/environments/%s updated", r.EnvironmentName)
 
 	return nil
+}
+
+// resolveRecipePacks resolves each value passed to --recipe-packs to a full recipe
+// pack resource ID and verifies that the recipe pack exists. A bare name is scoped
+// to the workspace's resource group; a full resource ID is used as-is, which allows
+// referencing a recipe pack in another resource group.
+func (r *Runner) resolveRecipePacks(ctx context.Context) ([]*string, error) {
+	recipePackClient := r.RadiusCoreClientFactory.NewRecipePacksClient()
+	recipePackIDs := make([]*string, 0, len(r.recipePacks))
+
+	for _, recipePack := range r.recipePacks {
+		recipePackID, isFullID, err := recipepack.ResolveID(recipePack, r.Workspace.Scope)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = recipePackClient.Get(ctx, recipePackID.RootScope(), recipePackID.Name(), &corerpv20250801.RecipePacksClientGetOptions{})
+		if clients.Is404Error(err) {
+			return nil, recipepack.NotFoundError(recipePack, recipePackID, isFullID)
+		} else if err != nil {
+			return nil, clierrors.MessageWithCause(err, "Failed to look up recipe pack %q.", recipePack)
+		}
+
+		recipePackIDs = append(recipePackIDs, to.Ptr(recipePackID.String()))
+	}
+
+	return recipePackIDs, nil
 }
 
 // syncRecipePackReferences updates the referencedBy field on recipe packs to reflect

--- a/pkg/cli/cmd/env/update/preview/update_test.go
+++ b/pkg/cli/cmd/env/update/preview/update_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/radius-project/radius/pkg/cli/clierrors"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
 	"github.com/radius-project/radius/pkg/cli/framework"
 	"github.com/radius-project/radius/pkg/cli/output"
@@ -364,6 +365,157 @@ func Test_Run_RecipePacksReplaced(t *testing.T) {
 		}
 	}
 	require.True(t, foundWarning, "expected replacement warning in output")
+}
+
+// Test_Run_RecipePackNotFound verifies that a missing recipe pack fails the update
+// before the replacement warning is printed, and that the error names the resource
+// group that was searched along with the full resource ID form.
+func Test_Run_RecipePackNotFound(t *testing.T) {
+	workspace := &workspaces.Workspace{
+		Name:  "test-workspace",
+		Scope: "/planes/radius/local/resourceGroups/test-group",
+	}
+
+	existingPackID := "/planes/radius/local/resourceGroups/test-group/providers/Radius.Core/recipePacks/old-pack"
+
+	envServer := func() fake.EnvironmentsServer {
+		return fake.EnvironmentsServer{
+			Get: func(
+				_ context.Context,
+				_ string,
+				environmentName string,
+				_ *v20250801preview.EnvironmentsClientGetOptions,
+			) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
+				result := v20250801preview.EnvironmentsClientGetResponse{
+					EnvironmentResource: v20250801preview.EnvironmentResource{
+						ID:   to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
+						Name: to.Ptr(environmentName),
+						Properties: &v20250801preview.EnvironmentProperties{
+							RecipePacks: []*string{to.Ptr(existingPackID)},
+						},
+					},
+				}
+				resp.SetResponse(http.StatusOK, result, nil)
+				return
+			},
+			CreateOrUpdate: func(
+				_ context.Context,
+				_ string,
+				_ string,
+				_ v20250801preview.EnvironmentResource,
+				_ *v20250801preview.EnvironmentsClientCreateOrUpdateOptions,
+			) (resp azfake.Responder[v20250801preview.EnvironmentsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+				require.Fail(t, "environment should not be updated when a recipe pack does not exist")
+				return
+			},
+		}
+	}
+
+	factory, err := test_client_factory.NewRadiusCoreTestClientFactory(
+		workspace.Scope,
+		envServer,
+		func() corerpfake.RecipePacksServer { return test_client_factory.WithRecipePackServer404OnGet() },
+	)
+	require.NoError(t, err)
+
+	outputSink := &output.MockOutput{}
+	runner := &Runner{
+		ConfigHolder:            &framework.ConfigHolder{},
+		Output:                  outputSink,
+		Workspace:               workspace,
+		EnvironmentName:         "test-env",
+		RadiusCoreClientFactory: factory,
+		recipePacks:             []string{"missing-pack"},
+		providers:               &v20250801preview.Providers{},
+	}
+
+	err = runner.Run(t.Context())
+	require.Error(t, err)
+	require.True(t, clierrors.IsFriendlyError(err))
+	require.Equal(t,
+		`Recipe pack "missing-pack" does not exist in resource group "test-group". To reference a recipe pack in another resource group, pass its full resource ID, for example: /planes/radius/local/resourceGroups/test-group/providers/Radius.Core/recipePacks/missing-pack`,
+		err.Error())
+
+	for _, w := range outputSink.Writes {
+		if logOut, ok := w.(output.LogOutput); ok {
+			require.NotEqual(t, "WARNING: The existing recipe pack list will be replaced with the specified packs.", logOut.Format,
+				"replacement warning should not be printed when validation fails")
+		}
+	}
+}
+
+// Test_Run_RecipePackFullResourceID verifies that a recipe pack referenced by full
+// resource ID is validated and stored as-is rather than being re-scoped.
+func Test_Run_RecipePackFullResourceID(t *testing.T) {
+	workspace := &workspaces.Workspace{
+		Name:  "test-workspace",
+		Scope: "/planes/radius/local/resourceGroups/test-group",
+	}
+
+	var capturedEnv v20250801preview.EnvironmentResource
+
+	packID := workspace.Scope + "/providers/Radius.Core/recipePacks/shared-pack"
+
+	envServer := func() fake.EnvironmentsServer {
+		return fake.EnvironmentsServer{
+			Get: func(
+				_ context.Context,
+				_ string,
+				environmentName string,
+				_ *v20250801preview.EnvironmentsClientGetOptions,
+			) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
+				result := v20250801preview.EnvironmentsClientGetResponse{
+					EnvironmentResource: v20250801preview.EnvironmentResource{
+						ID:         to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
+						Name:       to.Ptr(environmentName),
+						Properties: &v20250801preview.EnvironmentProperties{},
+					},
+				}
+				resp.SetResponse(http.StatusOK, result, nil)
+				return
+			},
+			CreateOrUpdate: func(
+				_ context.Context,
+				_ string,
+				_ string,
+				resource v20250801preview.EnvironmentResource,
+				_ *v20250801preview.EnvironmentsClientCreateOrUpdateOptions,
+			) (resp azfake.Responder[v20250801preview.EnvironmentsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+				capturedEnv = resource
+				result := v20250801preview.EnvironmentsClientCreateOrUpdateResponse{EnvironmentResource: resource}
+				resp.SetResponse(http.StatusOK, result, nil)
+				return
+			},
+		}
+	}
+
+	factory, err := test_client_factory.NewRadiusCoreTestClientFactory(
+		workspace.Scope,
+		envServer,
+		func() corerpfake.RecipePacksServer {
+			return corerpfake.RecipePacksServer{
+				Get:            test_client_factory.WithRecipePackServerNoError().Get,
+				CreateOrUpdate: recipePackCreateOrUpdateNoError(),
+			}
+		},
+	)
+	require.NoError(t, err)
+
+	runner := &Runner{
+		ConfigHolder:            &framework.ConfigHolder{},
+		Output:                  &output.MockOutput{},
+		Workspace:               workspace,
+		EnvironmentName:         "test-env",
+		RadiusCoreClientFactory: factory,
+		recipePacks:             []string{packID},
+		providers:               &v20250801preview.Providers{},
+	}
+
+	err = runner.Run(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, capturedEnv.Properties.RecipePacks, 1)
+	require.Equal(t, packID, *capturedEnv.Properties.RecipePacks[0])
 }
 
 // Test_Run_DefaultsKubernetesNamespace verifies the namespace defaulting that

--- a/pkg/cli/recipepack/recipepack.go
+++ b/pkg/cli/recipepack/recipepack.go
@@ -23,13 +23,57 @@ import (
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/cli/clients"
+	"github.com/radius-project/radius/pkg/cli/clierrors"
 	"github.com/radius-project/radius/pkg/cli/helm"
 	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
 	"github.com/radius-project/radius/pkg/defaults"
 	"github.com/radius-project/radius/pkg/to"
 	ucpv20231001 "github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/ucp/resources"
+	resources_radius "github.com/radius-project/radius/pkg/ucp/resources/radius"
 	"github.com/radius-project/radius/pkg/version"
 )
+
+// ResourceType is the resource type of a recipe pack.
+const ResourceType = "Radius.Core/recipePacks"
+
+// ResolveID resolves a recipe pack reference to a full resource ID. The reference
+// may be a full recipe pack resource ID, in which case it is used as-is and isFullID
+// is true, or a bare name, which is scoped to workspaceScope. A value that parses as
+// a resource ID but is not a Radius.Core/recipePacks resource is rejected, so that a
+// mistyped ID of another type is not silently looked up as a recipe pack name.
+func ResolveID(recipePack string, workspaceScope string) (id resources.ID, isFullID bool, err error) {
+	if recipePackID, parseErr := resources.Parse(recipePack); parseErr == nil {
+		if !recipePackID.IsResource() || !strings.EqualFold(recipePackID.Type(), ResourceType) {
+			return resources.ID{}, false, clierrors.Message("%q is not a recipe pack resource ID. Provide a recipe pack name, or a resource ID of the form /planes/radius/local/resourceGroups/<group>/providers/%s/<name>.", recipePack, ResourceType)
+		}
+
+		return recipePackID, true, nil
+	}
+
+	scopeID, err := resources.ParseScope(workspaceScope)
+	if err != nil {
+		return resources.ID{}, false, err
+	}
+
+	return scopeID.Append(resources.TypeSegment{
+		Type: ResourceType,
+		Name: recipePack,
+	}), false, nil
+}
+
+// NotFoundError builds the error returned when a recipe pack passed to --recipe-packs
+// cannot be found. When the user supplied a bare name, the message names the resource
+// group that was searched and shows how to reference a pack in another resource group.
+func NotFoundError(recipePack string, recipePackID resources.ID, isFullID bool) error {
+	resourceGroup := recipePackID.FindScope(resources_radius.ScopeResourceGroups)
+	if isFullID || resourceGroup == "" {
+		return clierrors.Message("Recipe pack %q does not exist. Please provide a valid recipe pack to set on the environment.", recipePack)
+	}
+
+	return clierrors.Message("Recipe pack %q does not exist in resource group %q. To reference a recipe pack in another resource group, pass its full resource ID, for example: %s",
+		recipePack, resourceGroup, recipePackID.String())
+}
 
 // NormalizeRecipePacks splits comma-separated values, trims whitespace, and
 // removes empty entries and duplicates while preserving the first-seen order.

--- a/pkg/cli/recipepack/recipepack_test.go
+++ b/pkg/cli/recipepack/recipepack_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/radius-project/radius/pkg/cli/clierrors"
 	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
 	"github.com/radius-project/radius/pkg/defaults"
 	"github.com/radius-project/radius/pkg/to"
@@ -232,4 +233,105 @@ func Test_RefExists(t *testing.T) {
 			require.Equal(t, tc.expected, RefExists(tc.refs, tc.id))
 		})
 	}
+}
+
+func Test_ResolveID(t *testing.T) {
+	const scope = "/planes/radius/local/resourceGroups/test-group"
+
+	tests := []struct {
+		name           string
+		recipePack     string
+		expectedID     string
+		expectedFullID bool
+	}{
+		{
+			name:       "bare name is scoped to the workspace resource group",
+			recipePack: "my-pack",
+			expectedID: scope + "/providers/Radius.Core/recipePacks/my-pack",
+		},
+		{
+			name:           "full resource ID is used as-is",
+			recipePack:     "/planes/radius/local/resourceGroups/other-group/providers/Radius.Core/recipePacks/my-pack",
+			expectedID:     "/planes/radius/local/resourceGroups/other-group/providers/Radius.Core/recipePacks/my-pack",
+			expectedFullID: true,
+		},
+		{
+			name:           "trailing slash on a full resource ID is normalized",
+			recipePack:     "/planes/radius/local/resourceGroups/other-group/providers/Radius.Core/recipePacks/my-pack/",
+			expectedID:     "/planes/radius/local/resourceGroups/other-group/providers/Radius.Core/recipePacks/my-pack",
+			expectedFullID: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			id, isFullID, err := ResolveID(tt.recipePack, scope)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedID, id.String())
+			require.Equal(t, tt.expectedFullID, isFullID)
+		})
+	}
+
+	t.Run("returns an error for an invalid workspace scope", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := ResolveID("my-pack", "not-a-scope")
+		require.Error(t, err)
+	})
+
+	rejected := []struct {
+		name       string
+		recipePack string
+	}{
+		{
+			name:       "resource ID of another type",
+			recipePack: "/planes/radius/local/resourceGroups/test-group/providers/Radius.Core/environments/my-env",
+		},
+		{
+			name:       "resource group scope",
+			recipePack: "/planes/radius/local/resourceGroups/test-group",
+		},
+		{
+			name:       "plane scope",
+			recipePack: "/planes/radius/local",
+		},
+	}
+
+	for _, tt := range rejected {
+		t.Run("rejects "+tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := ResolveID(tt.recipePack, scope)
+			require.Error(t, err)
+			require.True(t, clierrors.IsFriendlyError(err))
+			require.Contains(t, err.Error(), "is not a recipe pack resource ID")
+		})
+	}
+}
+
+func Test_NotFoundError(t *testing.T) {
+	t.Run("bare name names the resource group and shows the full ID form", func(t *testing.T) {
+		t.Parallel()
+
+		id, isFullID, err := ResolveID("my-pack", "/planes/radius/local/resourceGroups/test-group")
+		require.NoError(t, err)
+
+		require.Equal(t,
+			`Recipe pack "my-pack" does not exist in resource group "test-group". To reference a recipe pack in another resource group, pass its full resource ID, for example: /planes/radius/local/resourceGroups/test-group/providers/Radius.Core/recipePacks/my-pack`,
+			NotFoundError("my-pack", id, isFullID).Error())
+	})
+
+	t.Run("full resource ID omits the cross-group hint", func(t *testing.T) {
+		t.Parallel()
+
+		packID := "/planes/radius/local/resourceGroups/other-group/providers/Radius.Core/recipePacks/my-pack"
+		id, isFullID, err := ResolveID(packID, "/planes/radius/local/resourceGroups/test-group")
+		require.NoError(t, err)
+
+		require.Equal(t,
+			`Recipe pack "`+packID+`" does not exist. Please provide a valid recipe pack to set on the environment.`,
+			NotFoundError(packID, id, isFullID).Error())
+	})
 }


### PR DESCRIPTION
## Summary

Makes a bad `--recipe-packs` value on `rad env create`/`rad env update` fail clearly instead of printing an error that reads as part of a boilerplate warning.

- `rad env update --preview --recipe-packs` now resolves and validates every recipe pack **before** printing `WARNING: The existing recipe pack list will be replaced with the specified packs.`, so a failure is no longer emitted directly beneath (and visually attached to) that warning.
- When a bare recipe pack name is not found, the error now names the resource group that was searched and shows the full resource ID form used to reference a pack in another resource group.
- Recipe pack ID resolution and the not-found message moved into `pkg/cli/recipepack` and are now shared by `rad env create` and `rad env update`, so the two commands cannot drift.
- `ResolveID` now rejects a value that parses as a resource ID but is not a `Radius.Core/recipePacks` resource. Previously an ID of another type (for example an environment ID) or a scope was accepted and its trailing name segment was looked up as a recipe pack — on a match, the wrong resource ID was written into `environment.properties.recipePacks`.
- Only `404` responses are reported as "does not exist" during update validation; other failures (403, 500, connection errors) surface as a lookup failure instead of being mislabelled as a missing recipe pack.

Before:

```console
$ rad env update default --preview --recipe-packs test-recipes
WARNING: The existing recipe pack list will be replaced with the specified packs.
Recipe pack "test-recipes" does not exist. Please provide a valid recipe pack to set on the environment.
```

After:

```console
$ rad env update default --preview --recipe-packs test-recipes
Recipe pack "test-recipes" does not exist in resource group "test". To reference a recipe pack in another resource group, pass its full resource ID, for example: /planes/radius/local/resourceGroups/test/providers/Radius.Core/recipePacks/test-recipes
```

The command already exited non-zero; it still does.

## Reason for change

The replacement warning was printed before the recipe packs were validated, so the failure appeared on the line immediately after it and read like a continuation of the warning rather than a distinct error. The message also gave no indication of which resource group was searched or how to reference a pack in a different resource group, which is the actual workaround for the reported scenario.

Fixes #12426

Unit tests:

```console
go test ./pkg/cli/recipepack/... ./pkg/cli/cmd/env/...
```

Manual (verified end to end on a local k3d cluster). No Bicep file is needed — `rad env create` auto-creates a `default` recipe pack in the `default` resource group, which is enough to reproduce the cross-resource-group scenario from the issue:

1. Build the CLI and install Radius:

   ```console
   go build -o ./dist/rad ./cmd/rad
   helm repo add bitnami https://charts.bitnami.com/bitnami   # needed for the Contour chart
   ./dist/rad install kubernetes
   ```

2. Create a workspace and an environment in the `default` group. This creates the `default` recipe pack in `default`:

   ```console
   ./dist/rad workspace create kubernetes default --force
   ./dist/rad group create default && ./dist/rad group switch default
   ./dist/rad env create default --preview
   ./dist/rad resource list Radius.Core/recipePacks     # default / Radius.Core/recipePacks / default
   ```

3. Create a second resource group with its own environment, so the recipe pack now lives in a different group:

   ```console
   ./dist/rad group create test && ./dist/rad group switch test
   ./dist/rad env create default --preview
   ```

4. Reference the pack by bare name from the wrong group. The error stands alone (no replacement warning above it), names resource group `test`, suggests the full resource ID, and exits non-zero:

   ```console
   ./dist/rad env update default --preview --recipe-packs default
   Recipe pack "default" does not exist in resource group "test". To reference a recipe pack in another resource group, pass its full resource ID, for example: /planes/radius/local/resourceGroups/test/providers/Radius.Core/recipePacks/default
   ```

   With a released `rad`, the same command prints the replacement warning first and the error underneath it.

5. Confirm the suggested workaround succeeds and the ID is stored verbatim:

   ```console
   ./dist/rad env update default --preview --recipe-packs /planes/radius/local/resourceGroups/default/providers/Radius.Core/recipePacks/default
   ./dist/rad env show default --preview -o json   # recipePacks: [".../resourceGroups/default/providers/Radius.Core/recipePacks/default"]
   ```

6. Confirm a resource ID of another type is rejected instead of being looked up as a recipe pack name:

   ```console
   ./dist/rad env update default --preview --recipe-packs /planes/radius/local/resourceGroups/default/providers/Radius.Core/environments/default
   "/planes/radius/local/resourceGroups/default/providers/Radius.Core/environments/default" is not a recipe pack resource ID. Provide a recipe pack name, or a resource ID of the form /planes/radius/local/resourceGroups/<group>/providers/Radius.Core/recipePacks/<name>.
   ```

7. Repeat steps 4 and 6 with `rad env create <name> --preview --recipe-packs ...` to confirm the same messages on the create path.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `pkg/cli/recipepack/recipepack.go` | Added the shared `ResourceType` constant, `ResolveID` (resolves a bare name or full recipe pack resource ID and reports which form was given, rejecting IDs of another type or scopes), and `NotFoundError` (resource-group-qualified message with the cross-group full-ID hint). |
| `pkg/cli/recipepack/recipepack_test.go` | Added table tests for `ResolveID` (bare name, full ID, trailing slash, invalid workspace scope, wrong resource type, resource group scope, plane scope) and for both `NotFoundError` message forms. |
| `pkg/cli/cmd/env/update/preview/update.go` | Extracted the inline resolution loop into `resolveRecipePacks` and now validate before printing the replacement warning; use the injected client factory for both bare names and full IDs instead of building a new one per pack; classify only 404 as not found and wrap other lookup failures; use the shared `recipepack` helpers. |
| `pkg/cli/cmd/env/update/preview/update_test.go` | Added `Test_Run_RecipePackNotFound` (asserts the exact message, that it is a friendly error, that the warning is not printed, and that the environment is not updated) and `Test_Run_RecipePackFullResourceID` (a full resource ID is validated and stored as-is). |
| `pkg/cli/cmd/env/create/preview/create.go` | Switched to the shared `recipepack.ResolveID`/`NotFoundError` and removed the now-duplicated local `resolveRecipePackID` helper. |
| `pkg/cli/cmd/env/create/preview/create_test.go` | Tightened the not-found assertion to the exact resource-group-qualified message and added a full-resource-ID not-found case. |
