### PR TITLE
chore(resource-types): migrate PR automation to create-pull-request

### DIFF
--- a/.github/ghalint.yaml
+++ b/.github/ghalint.yaml
@@ -12,13 +12,6 @@ excludes:
     workflow_file_path: .github/workflows/release.yaml
     job_name: release
 
-  # update-resource-types.yaml force-pushes the bot PR branch using a
-  # scoped GitHub App token (contents/pull-requests write on radius only), so
-  # the checkout must persist those credentials to run `git push`.
-  - policy_name: checkout_persist_credentials_should_be_false
-    workflow_file_path: .github/workflows/update-resource-types.yaml
-    job_name: open-update-pr
-
   # The actions below are first-party reusable workflows synced from
   # radius-project/.github and pinned to @main by that sync automation. The
   # calling workflow files are marked "DO NOT EDIT MANUALLY"; the ref is

--- a/.github/workflows/update-resource-types.yaml
+++ b/.github/workflows/update-resource-types.yaml
@@ -205,7 +205,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -218,15 +218,6 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
-
-      - name: Set up Git identity
-        # Configure git author for the automated commit on the PR branch.
-        run: |
-          git config user.name "${GIT_USER_NAME}"
-          git config user.email "${GIT_USER_EMAIL}"
-        env:
-          GIT_USER_NAME: ${{ steps.bot-details.outputs.name }}
-          GIT_USER_EMAIL: ${{ steps.bot-details.outputs.email }}
 
       - name: Install yq
         # Required by the resource type sync targets to parse defaults.yaml, and
@@ -283,7 +274,10 @@ jobs:
             fi
           fi
 
-          git checkout -B "${PR_BRANCH}" origin/main
+          # create-pull-request owns the bot branch. Keep the generated changes
+          # on main so the action can rebuild the stable PR branch from the
+          # latest base while preserving the pending pins read above.
+          git checkout -B main origin/main
           base="$(yq -o=json -I=0 '.' "${defaults}")"
 
           # carried <section> <legacy_section> <payload_json> echoes the branch
@@ -340,7 +334,6 @@ jobs:
             echo "pack_pins<<PACK_PINS_EOF"
             printf '%s\n' "${pack_pins}"
             echo "PACK_PINS_EOF"
-            echo "head_sha=${head_sha}"
             echo "carried=${carried_names}"
           } >> "${GITHUB_OUTPUT}"
           echo "Carried forward: [${carried_names}]"
@@ -359,97 +352,30 @@ jobs:
       - name: Generate derived artifacts
         run: make generate
 
-      - name: Detect changes
-        # Uses git status --porcelain (not git diff --quiet) because
-        # the update and generation targets may create new untracked files.
-        # git diff only detects modifications to already-tracked files.
-        id: changes
-        run: |
-          set -euo pipefail
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "changed=false" >> "${GITHUB_OUTPUT}"
-            echo "No resource type or generated changes; nothing to do."
-          else
-            echo "changed=true" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Create or update PR branch
-        if: steps.changes.outputs.changed == 'true'
-        env:
-          CHANNEL: ${{ steps.contrib.outputs.channel }}
-          AFFECTED: ${{ steps.contrib.outputs.affected }}
-          CARRIED: ${{ steps.branch.outputs.carried }}
-          HEAD_SHA: ${{ steps.branch.outputs.head_sha }}
-        run: |
-          set -euo pipefail
-          git add -A
-          message="chore(resource-types): update from ${CONTRIB_REPO}"
-          message+=" (${CHANNEL}: ${AFFECTED:-all})"
-          if [ -n "${CARRIED}" ]; then
-            message+=$'\n\n'"Carried forward: ${CARRIED}"
-          fi
-          git commit -s -m "${message}"
-          git push --force-with-lease="refs/heads/${PR_BRANCH}:${HEAD_SHA}" \
-            origin "HEAD:${PR_BRANCH}"
-
-      - name: Open or update pull request
-        # Creates a new PR if none exists for the bot branch, or updates the
-        # existing one's title and body. Uses github-script because we need
-        # conditional create-or-update logic that gh pr create doesn't support.
-        if: steps.changes.outputs.changed == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          CHANNEL: ${{ steps.contrib.outputs.channel }}
-          AFFECTED: ${{ steps.contrib.outputs.affected }}
-          CARRIED: ${{ steps.branch.outputs.carried }}
-          CONTRIB_REF: ${{ steps.contrib.outputs.ref }}
+      - name: Create or update pull request
+        id: create-pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const branch = process.env.PR_BRANCH;
-            const channel = process.env.CHANNEL || "edge";
-            const affected = process.env.AFFECTED || "";
-            const carried = process.env.CARRIED || "";
-            const contribRef = process.env.CONTRIB_REF || "";
-            const title = "chore: refresh resource type manifests from resource-types-contrib";
-            const body = [
-              "Automated refresh of resource type manifests under `deploy/manifest/built-in-providers/`.",
-              "",
-              `Triggered by [\`${process.env.CONTRIB_REPO}\`](https://github.com/${process.env.CONTRIB_REPO}) on the \`${channel}\` channel at ref \`${contribRef}\`.`,
-              affected ? `Affected: ${affected}.` : "",
-              carried ? `Carried forward from the previous pending update: ${carried}.` : "",
-              "",
-              "Each affected entry is pinned to an immutable commit SHA in `deploy/manifest/defaults.yaml` (`resourceTypes[]` / `recipePacks[]`).",
-              "",
-              "Merging this PR will republish `br:biceptypes.azurecr.io/radius:latest` via the existing `build-and-push-bicep-types` job in `build.yaml`.",
-            ].filter(Boolean).join("\n");
+          token: ${{ steps.app-token.outputs.token }}
+          branch: ${{ env.PR_BRANCH }}
+          base: main
+          commit-message: |
+            chore(resource-types): update from ${{ env.CONTRIB_REPO }} (${{ steps.contrib.outputs.channel }}: ${{ steps.contrib.outputs.affected }})
 
-            const { owner, repo } = context.repo;
-            const { data: existing } = await github.rest.pulls.list({
-              owner,
-              repo,
-              head: `${owner}:${branch}`,
-              state: "open",
-            });
+            ${{ steps.branch.outputs.carried != '' && format('Carried forward: {0}', steps.branch.outputs.carried) || '' }}
+          # Used for the local DCO trailer. The API-created commit itself is
+          # authored and signed by the App because sign-commits is enabled.
+          committer: ${{ steps.bot-details.outputs.name-email }}
+          signoff: true
+          sign-commits: true
+          title: "chore(resource-types-contrib): updates"
+          body: |
+            Automated refresh of resource type manifests under `deploy/manifest/built-in-providers/`.
 
-            if (existing.length === 0) {
-              const { data: pr } = await github.rest.pulls.create({
-                owner,
-                repo,
-                title,
-                head: branch,
-                base: "main",
-                body,
-              });
-              core.notice(`Opened PR #${pr.number}: ${pr.html_url}`);
-            } else {
-              const pr = existing[0];
-              await github.rest.pulls.update({
-                owner,
-                repo,
-                pull_number: pr.number,
-                title,
-                body,
-              });
-              core.notice(`Refreshed existing PR #${pr.number}: ${pr.html_url}`);
-            }
+            Triggered by [`${{ env.CONTRIB_REPO }}`](https://github.com/${{ env.CONTRIB_REPO }}) on the `${{ steps.contrib.outputs.channel }}` channel at ref `${{ steps.contrib.outputs.ref }}`.
+            Affected: ${{ steps.contrib.outputs.affected }}.
+            ${{ steps.branch.outputs.carried != '' && format('Carried forward from the previous pending update: {0}.', steps.branch.outputs.carried) || '' }}
+
+            Each affected entry is pinned to an immutable commit SHA in `deploy/manifest/defaults.yaml` (`resourceTypes[]` / `recipePacks[]`).
+
+            Merging this PR will republish `br:biceptypes.azurecr.io/radius:latest` via the existing `build-and-push-bicep-types` job in `build.yaml`.


### PR DESCRIPTION
## Summary

Migrate automated resource-type branch updates and pull request management to `peter-evans/create-pull-request`.

## Reason for change

The workflow previously maintained custom change detection, commit, force-push, and pull request create-or-update logic. The dedicated action now owns that generic lifecycle while preserving the Radius-specific cumulative pin merge. It uses the `radius-resource-types` GitHub App token, DCO signoff, and GitHub-verified commit signing, and no longer needs persisted checkout credentials.

## How to test

- `actionlint -ignore queue .github/workflows/update-resource-types.yaml`
- Run `ghalint` against `.github/workflows/update-resource-types.yaml`.
- Trigger `resource-types-contrib-updated` and verify the stable bot PR is created or refreshed with a signed-off, verified App commit.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `.github/workflows/update-resource-types.yaml` | Delegate change detection, signed commit creation, branch updates, and PR management to `peter-evans/create-pull-request`. |
| `.github/ghalint.yaml` | Remove the obsolete persisted-checkout-credentials exception. |