### PR TITLE
fix: derive Azure kube-recipe pins from the recipe pack (#12688)

### DIFF
--- a/.cspellignore
+++ b/.cspellignore
@@ -312,10 +312,12 @@ RDBMS
 RDBMS's
 READMD
 READMEs
+RLENGTH
 RP's
 RPs
 RRT
 RRTs
+RSTART
 RabbitMQListSecretsResult
 RabbitMQQueue
 RabbitMQQueueProperties
@@ -852,6 +854,7 @@ managedStore
 manualScaling
 mapstructure
 materializer
+mawk
 maxLogRequests
 maxOperationConcurrency
 maxOperationRetryCount

--- a/.github/extension/run-rad-commands-azure.yml
+++ b/.github/extension/run-rad-commands-azure.yml
@@ -265,7 +265,17 @@ jobs:
           pin_kube_recipe Radius.Compute/routes routes
           pin_kube_recipe Radius.Security/secrets secrets
           pin_kube_recipe Radius.Messaging/rabbitMQ rabbitmq
-          offenders=$(grep -oE 'ghcr\.io/radius-project/kube-recipes/[a-z0-9._-]+:latest' "$ENV_BICEP" | sort -u)
+          # grep exits 1 when there are no matches, which is the success case here.
+          # Tolerate that under `set -eo pipefail` while still failing on a real
+          # grep error (exit status greater than 1).
+          offenders=$(grep -oE 'ghcr\.io/radius-project/kube-recipes/[a-z0-9._-]+:latest' "$ENV_BICEP") || {
+            grep_status=$?
+            if [ "$grep_status" -gt 1 ]; then
+              echo "ERROR: failed to scan ${ENV_BICEP} for unpinned kube recipes." >&2
+              exit "$grep_status"
+            fi
+          }
+          offenders=$(printf '%s' "$offenders" | sort -u)
           if [ -n "$offenders" ]; then
             echo "ERROR: unpinned kube recipes remain in the Azure recipe pack:" >&2
             echo "$offenders" >&2

--- a/.github/extension/run-rad-commands-azure.yml
+++ b/.github/extension/run-rad-commands-azure.yml
@@ -259,12 +259,33 @@ jobs:
               exit 1
             fi
           }
-          pin_kube_recipe Radius.Compute/containers containers
-          pin_kube_recipe Radius.Compute/containerImages containerimages
-          pin_kube_recipe Radius.Compute/persistentVolumes persistentvolumes
-          pin_kube_recipe Radius.Compute/routes routes
-          pin_kube_recipe Radius.Security/secrets secrets
-          pin_kube_recipe Radius.Messaging/rabbitMQ rabbitmq
+          # Derive the Kubernetes recipes to pin directly from the pack instead of
+          # maintaining a hardcoded list. Each recipe entry is keyed by its Radius
+          # resource type, e.g.
+          #   'Radius.Messaging/rabbitMQ': { kind: 'bicep' source: '...rabbitmq:latest' }
+          # so both the resource type (which selects the namespace commit in
+          # defaults.yaml) and the kube-recipe artifact come from the pack itself.
+          # Whatever kube recipes the Azure pack ships, present or future, are pinned
+          # automatically. awk remembers the most recent resource-type key and emits
+          # it alongside each kube-recipes '*:latest' source it then encounters. The
+          # quote is passed via -v to keep the program single-quote free, and only
+          # 2-arg match/RSTART/RLENGTH are used so it runs under mawk on the runner.
+          while read -r resource_type artifact; do
+            [ -n "$resource_type" ] || continue
+            pin_kube_recipe "$resource_type" "$artifact"
+          done < <(awk -v q="'" '
+            {
+              if (match($0, q "Radius\\.[^" q "]*" q)) {
+                rt = substr($0, RSTART + 1, RLENGTH - 2)
+              }
+              else if (match($0, /kube-recipes\/[a-z0-9._-]+:latest/)) {
+                s = substr($0, RSTART, RLENGTH)
+                sub(/^kube-recipes\//, "", s)
+                sub(/:latest$/, "", s)
+                if (rt != "") { print rt, s }
+              }
+            }
+          ' "$ENV_BICEP")
           # grep exits 1 when there are no matches, which is the success case here.
           # Tolerate that under `set -eo pipefail` while still failing on a real
           # grep error (exit status greater than 1).
@@ -279,7 +300,7 @@ jobs:
           if [ -n "$offenders" ]; then
             echo "ERROR: unpinned kube recipes remain in the Azure recipe pack:" >&2
             echo "$offenders" >&2
-            echo "Add a matching 'pin_kube_recipe <resourceType> <artifact>' for each." >&2
+            echo "Each must be keyed by its 'Radius.<namespace>/<type>' resource type in the pack, with that namespace pinned in deploy/manifest/defaults.yaml, so its commit can be resolved." >&2
             exit 1
           fi
 

--- a/.github/extension/run-rad-commands-azure.yml
+++ b/.github/extension/run-rad-commands-azure.yml
@@ -264,8 +264,12 @@ jobs:
           pin_kube_recipe Radius.Compute/persistentVolumes persistentvolumes
           pin_kube_recipe Radius.Compute/routes routes
           pin_kube_recipe Radius.Security/secrets secrets
-          if grep -Eq 'ghcr\.io/radius-project/kube-recipes/[^'"'"']+:latest' "$ENV_BICEP"; then
-            echo "ERROR: the Azure recipe pack still contains a mutable kube recipe tag." >&2
+          pin_kube_recipe Radius.Messaging/rabbitMQ rabbitmq
+          offenders=$(grep -oE 'ghcr\.io/radius-project/kube-recipes/[a-z0-9._-]+:latest' "$ENV_BICEP" | sort -u)
+          if [ -n "$offenders" ]; then
+            echo "ERROR: unpinned kube recipes remain in the Azure recipe pack:" >&2
+            echo "$offenders" >&2
+            echo "Add a matching 'pin_kube_recipe <resourceType> <artifact>' for each." >&2
             exit 1
           fi
 

--- a/build/scripts/test-sync-resource-types.sh
+++ b/build/scripts/test-sync-resource-types.sh
@@ -69,8 +69,91 @@ test_azure_recipe_pack_pinning() {
     rm -rf "${fixture}"
 }
 
-# Stub the one git operation exercised by the selection helpers. The fixtures
-# deliberately include a newer prerelease and numerically ambiguous versions.
+# Regression guard for the drift that broke Azure deploys (#12688): the Azure
+# pack shipped a sixth Kubernetes recipe (RabbitMQ) that the hardcoded pin list
+# never covered, so it survived to the mutable-tag guard and failed the step.
+# The workflow now derives the pin set from the pack, so this asserts that
+# derivation pins every kube recipe a pack ships and leaves the guard nothing to
+# reject, and that the guard still fires for a recipe that cannot be mapped.
+test_azure_recipe_pack_pin_coverage() {
+    local workflow run_block region fixture
+    local sha="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    workflow="${REPO_ROOT}/.github/extension/run-rad-commands-azure.yml"
+    run_block="$(
+        yq -r '
+            .jobs.deploy.steps[] |
+            select(.name == "Create Radius environment and recipe pack") |
+            .run
+        ' "${workflow}"
+    )"
+    # The self-contained pinning region under test: the pin_kube_recipe helper,
+    # the loop that derives recipes from the pack, and the mutable-tag guard.
+    region="$(
+        printf '%s\n' "${run_block}" |
+            awk '/^pin_kube_recipe\(\) \{$/ { c = 1 } c { print } c && /^fi$/ { exit }'
+    )"
+    [[ -n "${region}" ]] ||
+        fail "kube-recipe pinning region not found in ${workflow}."
+
+    fixture="$(mktemp -d)"
+
+    # A pack shipping two Kubernetes recipes (one of them RabbitMQ, the recipe the
+    # old hardcoded list omitted) plus a managed AVM recipe that must be left
+    # untouched. Derivation must pin both kube recipes and the guard must pass.
+    cat >"${fixture}/pack.bicep" <<'PACK'
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/containers:latest'
+      }
+      'Radius.Data/redisCaches': {
+        kind: 'bicep'
+        source: 'mcr.microsoft.com/bicep/avm/res/cache/redis-enterprise:0.5.1'
+      }
+      'Radius.Messaging/rabbitMQ': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/rabbitmq:latest'
+      }
+PACK
+    (
+        # shellcheck disable=SC2329 # Invoked by the sourced workflow region.
+        radius_contrib_kube_recipe_source() {
+            printf 'ghcr.io/radius-project/kube-recipes/%s:%s' "$2" "${sha}"
+        }
+        ENV_BICEP="${fixture}/pack.bicep"
+        # shellcheck disable=SC1090 # Generated from the workflow under test.
+        eval "${region}"
+    ) || fail "derivation rejected a pack whose kube recipes are all mappable."
+    ! grep -Eq 'kube-recipes/[a-z0-9._-]+:latest' "${fixture}/pack.bicep" ||
+        fail "a pack kube recipe was left unpinned by the derivation."
+    grep -Fq "kube-recipes/rabbitmq:${sha}" "${fixture}/pack.bicep" ||
+        fail "the RabbitMQ recipe was not pinned by the derivation."
+    grep -Fq "kube-recipes/containers:${sha}" "${fixture}/pack.bicep" ||
+        fail "the containers recipe was not pinned by the derivation."
+    grep -Fq 'redis-enterprise:0.5.1' "${fixture}/pack.bicep" ||
+        fail "the managed AVM recipe was altered by the derivation."
+
+    # A kube recipe not keyed by a Radius resource type cannot be mapped to a
+    # namespace ref, so the guard must catch the leftover mutable tag.
+    cat >"${fixture}/drift.bicep" <<'PACK'
+      'somethingElse': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/mysteryservice:latest'
+      }
+PACK
+    if (
+        # shellcheck disable=SC2329 # Invoked by the sourced workflow region.
+        radius_contrib_kube_recipe_source() {
+            printf 'ghcr.io/radius-project/kube-recipes/%s:%s' "$2" "${sha}"
+        }
+        ENV_BICEP="${fixture}/drift.bicep"
+        # shellcheck disable=SC1090 # Generated from the workflow under test.
+        eval "${region}"
+    ) 2>/dev/null; then
+        fail "the guard accepted a pack with an unmappable mutable kube recipe."
+    fi
+
+    rm -rf "${fixture}"
+}
 git() {
     [[ "$1" == "ls-remote" ]] || return 2
     if [[ "$2" == "--tags" && "$3" == "--refs" ]]; then
@@ -270,7 +353,7 @@ main() {
     done
 
     test_azure_recipe_pack_pinning
-
+    test_azure_recipe_pack_pin_coverage
     invariant_fixture="$(mktemp -d)"
     cat >"${invariant_fixture}/bad.yml" <<'EOF'
 ---

--- a/build/scripts/verify-contrib-consumers.sh
+++ b/build/scripts/verify-contrib-consumers.sh
@@ -78,6 +78,14 @@ extract_run_blocks() {
     done < <(extension_yaml_files)
 }
 
+# Emit the "<pack> <file>" recipe packs consumed across the extension workflows,
+# resolved from defaults.yaml via radius_contrib_recipe_pack_url call sites.
+recipe_pack_consumers() {
+    printf '%s\n' "${RUN_BLOCKS}" |
+        sed -nE 's/.*radius_contrib_recipe_pack_url ([A-Za-z0-9._-]+) ([A-Za-z0-9._\/-]+).*/\1 \2/p' |
+        sort -u
+}
+
 verify_recipe_packs() {
     local pack file url count=0
     while read -r pack file; do
@@ -86,12 +94,50 @@ verify_recipe_packs() {
         curl -fsSL "${url}" -o /dev/null
         echo "  Verified recipe pack file ${pack}/${file}"
         ((count += 1))
-    done < <(
-        printf '%s\n' "${RUN_BLOCKS}" |
-            sed -nE 's/.*radius_contrib_recipe_pack_url ([A-Za-z0-9._-]+) ([A-Za-z0-9._\/-]+).*/\1 \2/p' |
-            sort -u
-    )
+    done < <(recipe_pack_consumers)
     ((count > 0)) || fail "no recipe pack catalog consumers found."
+}
+
+# Emit "<ResourceType> <artifact>" for each Kubernetes recipe a pack ships. Each
+# recipe entry is keyed by its Radius resource type, e.g.
+#   'Radius.Messaging/rabbitMQ': { kind: 'bicep' source: '...rabbitmq:latest' }
+# so both the resource type (which selects the namespace commit in defaults.yaml)
+# and the kube-recipe artifact come from the pack itself. This mirrors how
+# run-rad-commands-azure.yml derives its pins, so the verifier checks exactly the
+# recipes a deploy would pin without maintaining a parallel hardcoded list. Only
+# 2-arg match/RSTART/RLENGTH are used so it runs under mawk on the runner, and the
+# quote is passed via -v to keep the program single-quote free.
+parse_pack_kube_recipes() {
+    awk -v q="'" '
+        {
+            if (match($0, q "Radius\\.[^" q "]*" q)) {
+                rt = substr($0, RSTART + 1, RLENGTH - 2)
+            }
+            else if (match($0, /kube-recipes\/[a-z0-9._-]+:latest/)) {
+                s = substr($0, RSTART, RLENGTH)
+                sub(/^kube-recipes\//, "", s)
+                sub(/:latest$/, "", s)
+                if (rt != "") { print rt, s }
+            }
+        }
+    ' "$1"
+}
+
+# Collect every "<ResourceType> <artifact>" kube-recipe pair the workflows pin,
+# from two sources: workflows that name a recipe directly via
+# radius_contrib_kube_recipe_source, and recipe packs that ship Kubernetes
+# recipes (downloaded and parsed here so pack-derived pins are verified too).
+kube_recipe_consumers() {
+    local pack file url pack_file
+    printf '%s\n' "${RUN_BLOCKS}" |
+        sed -nE 's/.*radius_contrib_kube_recipe_source (Radius\.[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+) ([a-z0-9._-]+).*/\1 \2/p'
+    while read -r pack file; do
+        [[ -n "${pack}" ]] || continue
+        url="$(radius_contrib_recipe_pack_url "${pack}" "${file}")"
+        pack_file="${TMP_ROOT}/pack_${pack}_$(basename "${file}")"
+        curl -fsSL "${url}" -o "${pack_file}"
+        parse_pack_kube_recipes "${pack_file}"
+    done < <(recipe_pack_consumers)
 }
 
 verify_kube_recipes() {
@@ -102,13 +148,7 @@ verify_kube_recipes() {
         docker manifest inspect "${source}" >/dev/null
         echo "  Verified OCI recipe ${source}"
         ((count += 1))
-    done < <(
-        printf '%s\n' "${RUN_BLOCKS}" |
-            sed -nE \
-                -e 's/.*radius_contrib_kube_recipe_source (Radius\.[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+) ([a-z0-9._-]+).*/\1 \2/p' \
-                -e 's/^[[:space:]]*pin_kube_recipe (Radius\.[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+) ([a-z0-9._-]+).*/\1 \2/p' |
-            sort -u
-    )
+    done < <(kube_recipe_consumers | sort -u)
     ((count > 0)) || fail "no OCI recipe catalog consumers found."
 }
 


### PR DESCRIPTION
## What

Fixes #12688.

Every Azure deploy driven by the generated `run-rad-commands-azure.yml` was failing in the **Create Radius environment and recipe pack** step, before `rad deploy` ever read the application model:

```
ERROR: the Azure recipe pack still contains a mutable kube recipe tag.
```

## Why

The step downloads the upstream Azure recipe pack and rewrites each mutable `ghcr.io/radius-project/kube-recipes/*:latest` source to a commit-pinned source, then asserts none remain. The pin list was **hardcoded** to five recipes, but the pack now ships a **sixth** — `kube-recipes/rabbitmq:latest` — pulled in when the pack ref was bumped. Nothing pinned it, so the mutable `:latest` survived the rewrite, the guard's `grep` matched it, and the job exited 1 for **every** repo, independent of app content.

This is drift between two independently versioned things. Rather than re-sync the hardcoded list, this takes the issue's **recommended durable fix**: stop hardcoding and derive the pin set from the pack.

## Change

**`.github/extension/run-rad-commands-azure.yml`** — derive the pins from the downloaded pack instead of a fixed list. Each recipe entry is keyed by its Radius resource type, e.g.

```
'Radius.Messaging/rabbitMQ': { kind: 'bicep' source: 'ghcr.io/radius-project/kube-recipes/rabbitmq:latest' }
```

so both the resource type (which selects the namespace commit in `deploy/manifest/defaults.yaml`) and the kube-recipe artifact come from the pack itself. `awk` walks the pack, pairs each `kube-recipes/*:latest` source with its owning resource type, and each pair is pinned via the existing `pin_kube_recipe`/`radius_contrib_kube_recipe_source` path. Whatever Kubernetes recipes the pack ships — `rabbitmq` today, anything new tomorrow — are pinned automatically, so this class of drift can't reblock deploys.

The mutable-tag guard stays as a safety net. It now **names the offending sources** (fixing the "deploy failed with no error text" symptom), tolerates `grep`'s no-match exit under `set -eo pipefail` instead of failing the success path, and explains what an operator must fix.

**`build/scripts/verify-contrib-consumers.sh`** — CI's `verify-contrib-consumers` used to enumerate recipes by scraping the (now-removed) static `pin_kube_recipe` lines. It now downloads each consumed recipe pack, derives the same `<resourceType, artifact>` pairs, and `docker manifest inspect`s every pinned source — so CI still proves each ref exists upstream at build time, without a parallel hardcoded list.

**`build/scripts/test-sync-resource-types.sh`** — new `test_azure_recipe_pack_pin_coverage` runs the workflow's own derivation against a fixture pack (including `rabbitMQ`, the recipe the old list omitted, plus a managed AVM recipe that must be left untouched) and asserts every kube recipe is pinned with nothing left for the guard, and that the guard still fires for a recipe that can't be mapped.

## Mapping to the issue's criteria

- **Durable fix (recommended)** — pin set computed from `$ENV_BICEP`; any `kube-recipes/<artifact>:latest` is pinned automatically via its owning resource type's namespace ref. ✅
- **Improve failure reporting** — guard names offenders and gives actionable remediation. ✅ (plus a `pipefail` correctness fix)
- **Regression test catching this drift at build time** — the new coverage test and the pack-deriving CI verifier. ✅

## Validation

- `test_azure_recipe_pack_pin_coverage` passes: `containers` + `rabbitmq` derived and pinned, AVM source untouched, zero offenders; unmappable recipe trips the guard.
- Full `verify-contrib-consumers.sh` passes, verifying all six Azure-pack kube recipes (including `rabbitmq` at the `Radius.Messaging` ref) plus AWS's direct recipe and the git recipes; `--source-of-truth-only` passes.
- `test_azure_recipe_pack_pinning` (the `pin_kube_recipe` unit test) and the rest of the sync test suite still pass.
- YAML still parses.

_Note: no `resource-types-contrib` change is needed — the read-only `secrets` schema block on `Radius.Messaging/rabbitMQ` follows the existing repo convention and is kept._