### PR TITLE
Fix samples tutorial functional test for modernized Radius.* demo sample

### DIFF
--- a/test/functional-portable/samples/noncloud/testdata/tutorial-environment.bicep
+++ b/test/functional-portable/samples/noncloud/testdata/tutorial-environment.bicep
@@ -1,22 +1,11 @@
 extension radius
 
-param registry string
-param version string
-
-resource env 'Applications.Core/environments@2023-10-01-preview' = {
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
   name: 'tutorial'
   properties: {
-    compute: {
-      kind: 'kubernetes'
-      resourceId: 'self'
-      namespace: 'tutorial'
-    }
-    recipes: {
-      'Applications.Datastores/redisCaches': {
-        default: {
-          templateKind: 'bicep'
-          templatePath: '${registry}/test/testrecipes/test-bicep-recipes/redis-recipe-value-backed:${version}'
-        }
+    providers: {
+      kubernetes: {
+        namespace: 'tutorial'
       }
     }
   }

--- a/test/functional-portable/samples/noncloud/tutorial_test.go
+++ b/test/functional-portable/samples/noncloud/tutorial_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	clikubernetes "github.com/radius-project/radius/pkg/cli/kubernetes"
 	"github.com/radius-project/radius/pkg/kubernetes"
 	"github.com/radius-project/radius/test/rp"
 	"github.com/radius-project/radius/test/step"
@@ -118,6 +119,16 @@ func Test_FirstApplicationSample(t *testing.T) {
 			},
 		},
 	})
+
+	// Radius.Core/environments rejects a Kubernetes namespace that does not already
+	// exist. RPTest.CreateInitialResources only ensures the namespace named after the
+	// test (demo-tutorial), so the environment's "tutorial" namespace must be created
+	// here before the steps run, mirroring NewPreviewEnvPreSetup.
+	test.PreSetup = func(ctx context.Context, t *testing.T, ct rp.RPTest) {
+		nsClient, err := rp.DeploymentTargetK8sClient(ct.Options)
+		require.NoError(t, err)
+		require.NoError(t, clikubernetes.EnsureNamespace(ctx, nsClient, appNamespace))
+	}
 
 	test.Test(t)
 }

--- a/test/functional-portable/samples/noncloud/tutorial_test.go
+++ b/test/functional-portable/samples/noncloud/tutorial_test.go
@@ -96,6 +96,13 @@ func Test_FirstApplicationSample(t *testing.T) {
 						Type: validation.ComputeContainersResource,
 						App:  appName,
 					},
+					{
+						// The environment-deploy step skips validation and has no RPResources,
+						// so include the fixed-name tutorial environment here to validate it and
+						// ensure the cleanup loop deletes it after the application.
+						Name: "tutorial",
+						Type: validation.CoreEnvironmentsResource,
+					},
 				},
 			},
 			PostStepVerify: func(ctx context.Context, t *testing.T, ct rp.RPTest) {

--- a/test/functional-portable/samples/noncloud/tutorial_test.go
+++ b/test/functional-portable/samples/noncloud/tutorial_test.go
@@ -61,31 +61,33 @@ func Test_FirstApplicationSample(t *testing.T) {
 	relPathSamplesRepo, err := filepath.Rel(cwd, samplesRepoAbsPath)
 	require.NoError(t, err)
 	template := filepath.Join(relPathSamplesRepo, "samples/demo/app.bicep")
-	appName := "demo"
-	appNamespace := "tutorial-demo"
+	// The modernized sample (radius-project/samples#2645) names both the application
+	// and the container demo-${environmentName}, which resolves to demo-tutorial for the
+	// "tutorial" environment. The recipe-driven Radius.Compute/containers pod lands in the
+	// environment's Kubernetes namespace ("tutorial").
+	appName := "demo-tutorial"
+	appNamespace := "tutorial"
 
 	test := rp.NewRPTest(t, appName, []rp.TestStep{
 		{
-			Executor:                               step.NewDeployExecutor("testdata/tutorial-environment.bicep", testutil.GetBicepRecipeRegistry(), testutil.GetBicepRecipeVersion()),
+			Executor:                               step.NewDeployExecutor("testdata/tutorial-environment.bicep"),
 			SkipKubernetesOutputResourceValidation: true,
 			SkipObjectValidation:                   true,
 		},
 		{
-
-			Executor: step.NewDeployExecutor(template).WithEnvironment("tutorial").WithApplication(appName),
+			// The modernized sample has no "application" parameter; it derives the app name
+			// from the environment, so only --environment is passed.
+			Executor: step.NewDeployExecutor(template).WithEnvironment("tutorial"),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: appName,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
-						Name: "demo",
-						Type: validation.ContainersResource,
-					},
-					{
-						Name: "db",
-						Type: validation.RedisCachesResource,
+						Name: appName,
+						Type: validation.ComputeContainersResource,
+						App:  appName,
 					},
 				},
 			},
@@ -93,7 +95,7 @@ func Test_FirstApplicationSample(t *testing.T) {
 				// Set up pod port-forwarding for the pod
 				for i := 1; i <= retries; i++ {
 					t.Logf("Setting up portforward (attempt %d/%d)", i, retries)
-					selector := fmt.Sprintf("%s=%s", kubernetes.LabelRadiusResource, "demo")
+					selector := fmt.Sprintf("%s=%s", kubernetes.LabelRadiusResource, appName)
 					err := testWithPortForward(t, ctx, ct, appNamespace, selector, remotePort)
 					if err != nil {
 						t.Logf("Failed to test pod via portforward with error: %s", err)
@@ -110,7 +112,7 @@ func Test_FirstApplicationSample(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(appName, "demo"),
+						validation.NewK8sPodForResource(appName, appName),
 					},
 				},
 			},

--- a/test/functional-portable/samples/noncloud/tutorial_test.go
+++ b/test/functional-portable/samples/noncloud/tutorial_test.go
@@ -45,6 +45,12 @@ const (
 	retries      = 3
 	retryTimeout = 1 * time.Minute
 	retryBackoff = 1 * time.Second
+
+	// noDatabaseMessage is returned by the demo app's list endpoint when it runs
+	// without a configured database. The modernized sample (radius-project/samples#2645)
+	// removed the inline redis resource from app.bicep, so the app stores todo items in
+	// memory and surfaces this message in every list response.
+	noDatabaseMessage = "No database is configured, items will be stored in memory."
 )
 
 var samplesRepoAbsPath, samplesRepoEnvVarSet = os.LookupEnv("RADIUS_SAMPLES_REPO_ROOT")
@@ -180,7 +186,7 @@ func testWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest, namesp
 
 		expectedListResponseBody := map[string]any{
 			"items":   []any{},
-			"message": nil,
+			"message": noDatabaseMessage,
 		}
 		require.Equal(t, expectedListResponseBody, actualListResponseBody)
 
@@ -236,7 +242,7 @@ func testWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest, namesp
 			"items": []any{
 				createdItem,
 			},
-			"message": nil,
+			"message": noDatabaseMessage,
 		}
 		require.Equal(t, expectedListResponseBody, actualListResponseBody)
 
@@ -303,7 +309,7 @@ func testWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest, namesp
 
 		expectedListResponseBody = map[string]any{
 			"items":   []any{},
-			"message": nil,
+			"message": noDatabaseMessage,
 		}
 		require.Equal(t, expectedListResponseBody, actualListResponseBody)
 


### PR DESCRIPTION
## Root cause

The repo-wide `Functional Tests - samples-noncloud` job is failing on `main` since the samples repo was updated [radius-project/samples#2645](https://github.com/radius-project/samples/pull/2645) ("Modernize demo sample to Radius.* resource types").

radius CI checks out the samples repo at `refs/heads/edge` (`.github/workflows/functional-test-noncloud.yaml`). That samples PR merged into `edge`, so CI now pulls a modernized `samples/demo/app.bicep` that:

- uses `Radius.Core/applications` + `Radius.Compute/containers` at `2025-08-01-preview` (was `Applications.Core`),
- has **no** `application` parameter (only `environment`),
- names the app/container `demo-${environmentName}` → `demo-tutorial` for the `tutorial` environment,
- removes the inline `Applications.Datastores/redisCaches` resource (redis now lives in a separate `app-redis.bicep` this test does not deploy).

The consuming `Test_FirstApplicationSample` still used the legacy `Applications.Core` types and app name `demo`, and passed `--application`, producing a deploy 404 (container created under `Radius.Compute/containers/demo-tutorial`, app looked up under `Applications.Core/applications/demo-tutorial`).

## Changes

**`testdata/tutorial-environment.bicep`**
- Modernized to `Radius.Core/environments@2025-08-01-preview` named `tutorial` with `properties.providers.kubernetes.namespace: 'tutorial'`.
- Removed the redis recipe registration and the now-unused `registry`/`version` params. `rad deploy` injects the default recipe pack, which supplies the `Radius.Compute/containers` recipe, so no explicit pack is needed.

**`tutorial_test.go` (`Test_FirstApplicationSample`)**
- Env-deploy executor no longer passes `registry`/`version` bicep params.
- App-deploy step drops `.WithApplication(...)`; keeps `.WithEnvironment("tutorial")`.
- Expected `RPResources` updated: application `demo-tutorial` (`radius.core/applications`) and container `demo-tutorial` (`radius.compute/containers`); removed the redis `db` expectation.
- Pod port-forward + K8s validation now target the `demo-tutorial` resource selector in the environment namespace `tutorial` (recipe-driven `Radius.Compute/containers` pods land in the env's Kubernetes namespace, matching existing modern container tests).

This unblocks the repo-wide `samples-noncloud` functional test failure.

## Validation

- `go build ./test/...` passes.
- `go vet ./test/functional-portable/samples/...` passes.
- End-to-end run requires a kind cluster with Radius installed and `RADIUS_SAMPLES_REPO_ROOT` pointing at a samples `edge` checkout; the logic mirrors the modernized sample and existing modern `Radius.Compute/containers` functional tests.