### PR TITLE
Retry Azure login in verify-azure workflow to absorb role-assignment propagation

### DIFF
--- a/.github/extension/verify-azure.yml
+++ b/.github/extension/verify-azure.yml
@@ -76,11 +76,65 @@ jobs:
 
       - name: Azure Login (OIDC)
         id: azure_login
-        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
-        with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+        # Log in as the environment's workload-identity federated credential.
+        #
+        # This replaces the azure/login action with an explicit federated login so
+        # it can RETRY the Azure AD propagation race: when Create Environment has
+        # just granted this service principal its subscription role assignment,
+        # Azure AD can take a few minutes to propagate that grant to the SP's
+        # token, so a verify that runs seconds later fails with
+        # "No subscriptions found" even though the setup is correct. We retry only
+        # that transient race and fail fast on any genuine authentication or
+        # configuration error, so e.g. an AADSTS7002381 enterprise-claim failure
+        # still surfaces immediately for the explainer step below.
+        env:
+          AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          OIDC_AUDIENCE: api://AzureADTokenExchange
+        run: |
+          set -uo pipefail
+
+          attempts=12
+          delay=15
+          err_file="$(mktemp)"
+
+          for i in $(seq 1 "$attempts"); do
+            token="$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${OIDC_AUDIENCE}" | jq -r '.value // empty')"
+            if [[ -z "$token" ]]; then
+              echo "Attempt $i/$attempts: could not obtain a GitHub OIDC token; retrying in ${delay}s..."
+              sleep "$delay"
+              continue
+            fi
+
+            if az login --service-principal \
+                 --username "$AZURE_CLIENT_ID" \
+                 --tenant "$AZURE_TENANT_ID" \
+                 --federated-token "$token" \
+                 --output none 2> "$err_file"; then
+              az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+              echo "Azure OIDC login succeeded on attempt $i."
+              exit 0
+            fi
+
+            # Only the role-assignment propagation race is transient. Any other
+            # failure (wrong client/tenant/subscription id, missing federated
+            # credential, enterprise-claim policy) is permanent -- fail fast so it
+            # is reported immediately instead of after every retry.
+            if ! grep -qi "No subscriptions found" "$err_file"; then
+              echo "Azure Login failed with a non-transient error:" >&2
+              cat "$err_file" >&2
+              exit 1
+            fi
+
+            echo "Attempt $i/$attempts: subscription not visible yet (role assignment still propagating); retrying in ${delay}s..."
+            sleep "$delay"
+          done
+
+          echo "Azure Login failed after $attempts attempts; last error:" >&2
+          cat "$err_file" >&2
+          exit 1
 
       - name: Report possible GitHub enterprise-claim mismatch
         # Fires only when Azure Login failed AND the OIDC token carried an empty


### PR DESCRIPTION
## Problem

During **Create Environment**, the Radius Copilot extension creates an app registration + federated credential, grants the service principal a `Contributor` role assignment on the subscription, and then immediately dispatches `.github/extension/verify-azure.yml`.

Azure AD can take several minutes to propagate a fresh role assignment to the SP's token. When the verify workflow's `Azure Login (OIDC)` step runs seconds later, `az login` reports **`No subscriptions found`** and the step fails — even though the OIDC trust, federated credential, SP, and role assignment are all correct. Re-running ~15 minutes later passes unchanged.

Confirmed timeline in one failure:
- Contributor role created **21:01:40 UTC**
- Workflow `az login` ran **21:02:26 UTC** (~40s later) → failed with `No subscriptions found`

## Fix

Replace the `azure/login` action in the `Azure Login (OIDC)` step with an explicit federated `az login` that:

- **Retries only the propagation race** (~12 attempts × 15s ≈ 3 min): it retries when the error contains `No subscriptions found`.
- **Fails fast on any other error** (wrong client/tenant/subscription id, missing federated credential, enterprise-claim policy such as `AADSTS7002381`), so genuine misconfigurations surface immediately instead of after every retry.

The step keeps `id: azure_login` unchanged, so the existing **Report possible GitHub enterprise-claim mismatch** step (which references `steps.azure_login.outcome == 'failure'`) still fires on failure. No other step is changed and no `{{RADIUS_REF}}` / `{{ENV}}` placeholders are touched.

## Draft

Opening as a **draft** because the reporter wants to test this end-to-end first before it's marked ready for review.