### PR TITLE
Release-0.60.0-rc3 versions.yaml

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.60'
-    version: 'v0.60.0-rc2'
+    version: 'v0.60.0-rc3'
   - channel: '0.59'
     version: 'v0.59.0'
 deprecated:


### PR DESCRIPTION
## Description

Updated the supported version for channel `0.60` from `v0.60.0-rc2` to `v0.60.0-rc3` in `versions.yaml`.

See the [release process](https://github.com/radius-project/radius/tree/main/docs/contributing/contributing-releases#step-4-update-versionsyaml) for more context.