### PR TITLE
Release 0.60 RC3

### DIFF
--- a/.cspellignore
+++ b/.cspellignore
@@ -312,10 +312,12 @@ RDBMS
 RDBMS's
 READMD
 READMEs
+RLENGTH
 RP's
 RPs
 RRT
 RRTs
+RSTART
 RabbitMQListSecretsResult
 RabbitMQQueue
 RabbitMQQueueProperties
@@ -852,6 +854,7 @@ managedStore
 manualScaling
 mapstructure
 materializer
+mawk
 maxLogRequests
 maxOperationConcurrency
 maxOperationRetryCount

--- a/.github/extension/run-rad-commands-azure.yml
+++ b/.github/extension/run-rad-commands-azure.yml
@@ -259,13 +259,48 @@ jobs:
               exit 1
             fi
           }
-          pin_kube_recipe Radius.Compute/containers containers
-          pin_kube_recipe Radius.Compute/containerImages containerimages
-          pin_kube_recipe Radius.Compute/persistentVolumes persistentvolumes
-          pin_kube_recipe Radius.Compute/routes routes
-          pin_kube_recipe Radius.Security/secrets secrets
-          if grep -Eq 'ghcr\.io/radius-project/kube-recipes/[^'"'"']+:latest' "$ENV_BICEP"; then
-            echo "ERROR: the Azure recipe pack still contains a mutable kube recipe tag." >&2
+          # Derive the Kubernetes recipes to pin directly from the pack instead of
+          # maintaining a hardcoded list. Each recipe entry is keyed by its Radius
+          # resource type, e.g.
+          #   'Radius.Messaging/rabbitMQ': { kind: 'bicep' source: '...rabbitmq:latest' }
+          # so both the resource type (which selects the namespace commit in
+          # defaults.yaml) and the kube-recipe artifact come from the pack itself.
+          # Whatever kube recipes the Azure pack ships, present or future, are pinned
+          # automatically. awk remembers the most recent resource-type key and emits
+          # it alongside each kube-recipes '*:latest' source it then encounters. The
+          # quote is passed via -v to keep the program single-quote free, and only
+          # 2-arg match/RSTART/RLENGTH are used so it runs under mawk on the runner.
+          while read -r resource_type artifact; do
+            [ -n "$resource_type" ] || continue
+            pin_kube_recipe "$resource_type" "$artifact"
+          done < <(awk -v q="'" '
+            {
+              if (match($0, q "Radius\\.[^" q "]*" q)) {
+                rt = substr($0, RSTART + 1, RLENGTH - 2)
+              }
+              else if (match($0, /kube-recipes\/[a-z0-9._-]+:latest/)) {
+                s = substr($0, RSTART, RLENGTH)
+                sub(/^kube-recipes\//, "", s)
+                sub(/:latest$/, "", s)
+                if (rt != "") { print rt, s }
+              }
+            }
+          ' "$ENV_BICEP")
+          # grep exits 1 when there are no matches, which is the success case here.
+          # Tolerate that under `set -eo pipefail` while still failing on a real
+          # grep error (exit status greater than 1).
+          offenders=$(grep -oE 'ghcr\.io/radius-project/kube-recipes/[a-z0-9._-]+:latest' "$ENV_BICEP") || {
+            grep_status=$?
+            if [ "$grep_status" -gt 1 ]; then
+              echo "ERROR: failed to scan ${ENV_BICEP} for unpinned kube recipes." >&2
+              exit "$grep_status"
+            fi
+          }
+          offenders=$(printf '%s' "$offenders" | sort -u)
+          if [ -n "$offenders" ]; then
+            echo "ERROR: unpinned kube recipes remain in the Azure recipe pack:" >&2
+            echo "$offenders" >&2
+            echo "Each must be keyed by its 'Radius.<namespace>/<type>' resource type in the pack, with that namespace pinned in deploy/manifest/defaults.yaml, so its commit can be resolved." >&2
             exit 1
           fi
 

--- a/build/scripts/test-sync-resource-types.sh
+++ b/build/scripts/test-sync-resource-types.sh
@@ -69,8 +69,91 @@ test_azure_recipe_pack_pinning() {
     rm -rf "${fixture}"
 }
 
-# Stub the one git operation exercised by the selection helpers. The fixtures
-# deliberately include a newer prerelease and numerically ambiguous versions.
+# Regression guard for the drift that broke Azure deploys (#12688): the Azure
+# pack shipped a sixth Kubernetes recipe (RabbitMQ) that the hardcoded pin list
+# never covered, so it survived to the mutable-tag guard and failed the step.
+# The workflow now derives the pin set from the pack, so this asserts that
+# derivation pins every kube recipe a pack ships and leaves the guard nothing to
+# reject, and that the guard still fires for a recipe that cannot be mapped.
+test_azure_recipe_pack_pin_coverage() {
+    local workflow run_block region fixture
+    local sha="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    workflow="${REPO_ROOT}/.github/extension/run-rad-commands-azure.yml"
+    run_block="$(
+        yq -r '
+            .jobs.deploy.steps[] |
+            select(.name == "Create Radius environment and recipe pack") |
+            .run
+        ' "${workflow}"
+    )"
+    # The self-contained pinning region under test: the pin_kube_recipe helper,
+    # the loop that derives recipes from the pack, and the mutable-tag guard.
+    region="$(
+        printf '%s\n' "${run_block}" |
+            awk '/^pin_kube_recipe\(\) \{$/ { c = 1 } c { print } c && /^fi$/ { exit }'
+    )"
+    [[ -n "${region}" ]] ||
+        fail "kube-recipe pinning region not found in ${workflow}."
+
+    fixture="$(mktemp -d)"
+
+    # A pack shipping two Kubernetes recipes (one of them RabbitMQ, the recipe the
+    # old hardcoded list omitted) plus a managed AVM recipe that must be left
+    # untouched. Derivation must pin both kube recipes and the guard must pass.
+    cat >"${fixture}/pack.bicep" <<'PACK'
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/containers:latest'
+      }
+      'Radius.Data/redisCaches': {
+        kind: 'bicep'
+        source: 'mcr.microsoft.com/bicep/avm/res/cache/redis-enterprise:0.5.1'
+      }
+      'Radius.Messaging/rabbitMQ': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/rabbitmq:latest'
+      }
+PACK
+    (
+        # shellcheck disable=SC2329 # Invoked by the sourced workflow region.
+        radius_contrib_kube_recipe_source() {
+            printf 'ghcr.io/radius-project/kube-recipes/%s:%s' "$2" "${sha}"
+        }
+        ENV_BICEP="${fixture}/pack.bicep"
+        # shellcheck disable=SC1090 # Generated from the workflow under test.
+        eval "${region}"
+    ) || fail "derivation rejected a pack whose kube recipes are all mappable."
+    ! grep -Eq 'kube-recipes/[a-z0-9._-]+:latest' "${fixture}/pack.bicep" ||
+        fail "a pack kube recipe was left unpinned by the derivation."
+    grep -Fq "kube-recipes/rabbitmq:${sha}" "${fixture}/pack.bicep" ||
+        fail "the RabbitMQ recipe was not pinned by the derivation."
+    grep -Fq "kube-recipes/containers:${sha}" "${fixture}/pack.bicep" ||
+        fail "the containers recipe was not pinned by the derivation."
+    grep -Fq 'redis-enterprise:0.5.1' "${fixture}/pack.bicep" ||
+        fail "the managed AVM recipe was altered by the derivation."
+
+    # A kube recipe not keyed by a Radius resource type cannot be mapped to a
+    # namespace ref, so the guard must catch the leftover mutable tag.
+    cat >"${fixture}/drift.bicep" <<'PACK'
+      'somethingElse': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/mysteryservice:latest'
+      }
+PACK
+    if (
+        # shellcheck disable=SC2329 # Invoked by the sourced workflow region.
+        radius_contrib_kube_recipe_source() {
+            printf 'ghcr.io/radius-project/kube-recipes/%s:%s' "$2" "${sha}"
+        }
+        ENV_BICEP="${fixture}/drift.bicep"
+        # shellcheck disable=SC1090 # Generated from the workflow under test.
+        eval "${region}"
+    ) 2>/dev/null; then
+        fail "the guard accepted a pack with an unmappable mutable kube recipe."
+    fi
+
+    rm -rf "${fixture}"
+}
 git() {
     [[ "$1" == "ls-remote" ]] || return 2
     if [[ "$2" == "--tags" && "$3" == "--refs" ]]; then
@@ -270,7 +353,7 @@ main() {
     done
 
     test_azure_recipe_pack_pinning
-
+    test_azure_recipe_pack_pin_coverage
     invariant_fixture="$(mktemp -d)"
     cat >"${invariant_fixture}/bad.yml" <<'EOF'
 ---

--- a/build/scripts/verify-contrib-consumers.sh
+++ b/build/scripts/verify-contrib-consumers.sh
@@ -78,6 +78,14 @@ extract_run_blocks() {
     done < <(extension_yaml_files)
 }
 
+# Emit the "<pack> <file>" recipe packs consumed across the extension workflows,
+# resolved from defaults.yaml via radius_contrib_recipe_pack_url call sites.
+recipe_pack_consumers() {
+    printf '%s\n' "${RUN_BLOCKS}" |
+        sed -nE 's/.*radius_contrib_recipe_pack_url ([A-Za-z0-9._-]+) ([A-Za-z0-9._\/-]+).*/\1 \2/p' |
+        sort -u
+}
+
 verify_recipe_packs() {
     local pack file url count=0
     while read -r pack file; do
@@ -86,12 +94,50 @@ verify_recipe_packs() {
         curl -fsSL "${url}" -o /dev/null
         echo "  Verified recipe pack file ${pack}/${file}"
         ((count += 1))
-    done < <(
-        printf '%s\n' "${RUN_BLOCKS}" |
-            sed -nE 's/.*radius_contrib_recipe_pack_url ([A-Za-z0-9._-]+) ([A-Za-z0-9._\/-]+).*/\1 \2/p' |
-            sort -u
-    )
+    done < <(recipe_pack_consumers)
     ((count > 0)) || fail "no recipe pack catalog consumers found."
+}
+
+# Emit "<ResourceType> <artifact>" for each Kubernetes recipe a pack ships. Each
+# recipe entry is keyed by its Radius resource type, e.g.
+#   'Radius.Messaging/rabbitMQ': { kind: 'bicep' source: '...rabbitmq:latest' }
+# so both the resource type (which selects the namespace commit in defaults.yaml)
+# and the kube-recipe artifact come from the pack itself. This mirrors how
+# run-rad-commands-azure.yml derives its pins, so the verifier checks exactly the
+# recipes a deploy would pin without maintaining a parallel hardcoded list. Only
+# 2-arg match/RSTART/RLENGTH are used so it runs under mawk on the runner, and the
+# quote is passed via -v to keep the program single-quote free.
+parse_pack_kube_recipes() {
+    awk -v q="'" '
+        {
+            if (match($0, q "Radius\\.[^" q "]*" q)) {
+                rt = substr($0, RSTART + 1, RLENGTH - 2)
+            }
+            else if (match($0, /kube-recipes\/[a-z0-9._-]+:latest/)) {
+                s = substr($0, RSTART, RLENGTH)
+                sub(/^kube-recipes\//, "", s)
+                sub(/:latest$/, "", s)
+                if (rt != "") { print rt, s }
+            }
+        }
+    ' "$1"
+}
+
+# Collect every "<ResourceType> <artifact>" kube-recipe pair the workflows pin,
+# from two sources: workflows that name a recipe directly via
+# radius_contrib_kube_recipe_source, and recipe packs that ship Kubernetes
+# recipes (downloaded and parsed here so pack-derived pins are verified too).
+kube_recipe_consumers() {
+    local pack file url pack_file
+    printf '%s\n' "${RUN_BLOCKS}" |
+        sed -nE 's/.*radius_contrib_kube_recipe_source (Radius\.[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+) ([a-z0-9._-]+).*/\1 \2/p'
+    while read -r pack file; do
+        [[ -n "${pack}" ]] || continue
+        url="$(radius_contrib_recipe_pack_url "${pack}" "${file}")"
+        pack_file="${TMP_ROOT}/pack_${pack}_$(basename "${file}")"
+        curl -fsSL "${url}" -o "${pack_file}"
+        parse_pack_kube_recipes "${pack_file}"
+    done < <(recipe_pack_consumers)
 }
 
 verify_kube_recipes() {
@@ -102,13 +148,7 @@ verify_kube_recipes() {
         docker manifest inspect "${source}" >/dev/null
         echo "  Verified OCI recipe ${source}"
         ((count += 1))
-    done < <(
-        printf '%s\n' "${RUN_BLOCKS}" |
-            sed -nE \
-                -e 's/.*radius_contrib_kube_recipe_source (Radius\.[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+) ([a-z0-9._-]+).*/\1 \2/p' \
-                -e 's/^[[:space:]]*pin_kube_recipe (Radius\.[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+) ([a-z0-9._-]+).*/\1 \2/p' |
-            sort -u
-    )
+    done < <(kube_recipe_consumers | sort -u)
     ((count > 0)) || fail "no OCI recipe catalog consumers found."
 }
 

--- a/test/functional-portable/samples/noncloud/testdata/tutorial-environment.bicep
+++ b/test/functional-portable/samples/noncloud/testdata/tutorial-environment.bicep
@@ -1,22 +1,11 @@
 extension radius
 
-param registry string
-param version string
-
-resource env 'Applications.Core/environments@2023-10-01-preview' = {
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
   name: 'tutorial'
   properties: {
-    compute: {
-      kind: 'kubernetes'
-      resourceId: 'self'
-      namespace: 'tutorial'
-    }
-    recipes: {
-      'Applications.Datastores/redisCaches': {
-        default: {
-          templateKind: 'bicep'
-          templatePath: '${registry}/test/testrecipes/test-bicep-recipes/redis-recipe-value-backed:${version}'
-        }
+    providers: {
+      kubernetes: {
+        namespace: 'tutorial'
       }
     }
   }

--- a/test/functional-portable/samples/noncloud/tutorial_test.go
+++ b/test/functional-portable/samples/noncloud/tutorial_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	clikubernetes "github.com/radius-project/radius/pkg/cli/kubernetes"
 	"github.com/radius-project/radius/pkg/kubernetes"
 	"github.com/radius-project/radius/test/rp"
 	"github.com/radius-project/radius/test/step"
@@ -44,6 +45,12 @@ const (
 	retries      = 3
 	retryTimeout = 1 * time.Minute
 	retryBackoff = 1 * time.Second
+
+	// noDatabaseMessage is returned by the demo app's list endpoint when it runs
+	// without a configured database. The modernized sample (radius-project/samples#2645)
+	// removed the inline redis resource from app.bicep, so the app stores todo items in
+	// memory and surfaces this message in every list response.
+	noDatabaseMessage = "No database is configured, items will be stored in memory."
 )
 
 var samplesRepoAbsPath, samplesRepoEnvVarSet = os.LookupEnv("RADIUS_SAMPLES_REPO_ROOT")
@@ -61,31 +68,40 @@ func Test_FirstApplicationSample(t *testing.T) {
 	relPathSamplesRepo, err := filepath.Rel(cwd, samplesRepoAbsPath)
 	require.NoError(t, err)
 	template := filepath.Join(relPathSamplesRepo, "samples/demo/app.bicep")
-	appName := "demo"
-	appNamespace := "tutorial-demo"
+	// The modernized sample (radius-project/samples#2645) names both the application
+	// and the container demo-${environmentName}, which resolves to demo-tutorial for the
+	// "tutorial" environment. The recipe-driven Radius.Compute/containers pod lands in the
+	// environment's Kubernetes namespace ("tutorial").
+	appName := "demo-tutorial"
+	appNamespace := "tutorial"
 
 	test := rp.NewRPTest(t, appName, []rp.TestStep{
 		{
-			Executor:                               step.NewDeployExecutor("testdata/tutorial-environment.bicep", testutil.GetBicepRecipeRegistry(), testutil.GetBicepRecipeVersion()),
+			Executor:                               step.NewDeployExecutor("testdata/tutorial-environment.bicep"),
 			SkipKubernetesOutputResourceValidation: true,
 			SkipObjectValidation:                   true,
 		},
 		{
-
-			Executor: step.NewDeployExecutor(template).WithEnvironment("tutorial").WithApplication(appName),
+			// The modernized sample has no "application" parameter; it derives the app name
+			// from the environment, so only --environment is passed.
+			Executor: step.NewDeployExecutor(template).WithEnvironment("tutorial"),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
 						Name: appName,
-						Type: validation.ApplicationsResource,
+						Type: validation.CoreApplicationsResource,
 					},
 					{
-						Name: "demo",
-						Type: validation.ContainersResource,
+						Name: appName,
+						Type: validation.ComputeContainersResource,
+						App:  appName,
 					},
 					{
-						Name: "db",
-						Type: validation.RedisCachesResource,
+						// The environment-deploy step skips validation and has no RPResources,
+						// so include the fixed-name tutorial environment here to validate it and
+						// ensure the cleanup loop deletes it after the application.
+						Name: "tutorial",
+						Type: validation.CoreEnvironmentsResource,
 					},
 				},
 			},
@@ -93,7 +109,7 @@ func Test_FirstApplicationSample(t *testing.T) {
 				// Set up pod port-forwarding for the pod
 				for i := 1; i <= retries; i++ {
 					t.Logf("Setting up portforward (attempt %d/%d)", i, retries)
-					selector := fmt.Sprintf("%s=%s", kubernetes.LabelRadiusResource, "demo")
+					selector := fmt.Sprintf("%s=%s", kubernetes.LabelRadiusResource, appName)
 					err := testWithPortForward(t, ctx, ct, appNamespace, selector, remotePort)
 					if err != nil {
 						t.Logf("Failed to test pod via portforward with error: %s", err)
@@ -110,12 +126,22 @@ func Test_FirstApplicationSample(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(appName, "demo"),
+						validation.NewK8sPodForResource(appName, appName),
 					},
 				},
 			},
 		},
 	})
+
+	// Radius.Core/environments rejects a Kubernetes namespace that does not already
+	// exist. RPTest.CreateInitialResources only ensures the namespace named after the
+	// test (demo-tutorial), so the environment's "tutorial" namespace must be created
+	// here before the steps run, mirroring NewPreviewEnvPreSetup.
+	test.PreSetup = func(ctx context.Context, t *testing.T, ct rp.RPTest) {
+		nsClient, err := rp.DeploymentTargetK8sClient(ct.Options)
+		require.NoError(t, err)
+		require.NoError(t, clikubernetes.EnsureNamespace(ctx, nsClient, appNamespace))
+	}
 
 	test.Test(t)
 }
@@ -167,7 +193,7 @@ func testWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest, namesp
 
 		expectedListResponseBody := map[string]any{
 			"items":   []any{},
-			"message": nil,
+			"message": noDatabaseMessage,
 		}
 		require.Equal(t, expectedListResponseBody, actualListResponseBody)
 
@@ -223,7 +249,7 @@ func testWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest, namesp
 			"items": []any{
 				createdItem,
 			},
-			"message": nil,
+			"message": noDatabaseMessage,
 		}
 		require.Equal(t, expectedListResponseBody, actualListResponseBody)
 
@@ -290,7 +316,7 @@ func testWithPortForward(t *testing.T, ctx context.Context, at rp.RPTest, namesp
 
 		expectedListResponseBody = map[string]any{
 			"items":   []any{},
-			"message": nil,
+			"message": noDatabaseMessage,
 		}
 		require.Equal(t, expectedListResponseBody, actualListResponseBody)
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.60'
-    version: 'v0.60.0-rc2'
+    version: 'v0.60.0-rc3'
   - channel: '0.59'
     version: 'v0.59.0'
 deprecated:


### PR DESCRIPTION
## Description
Cherry-picking the following commits to the release branch for release 0.60 RC3.

- [Release-0.60.0-rc3 versions.yaml](https://github.com/radius-project/radius/commit/415ea7c1e2eefaf4221cf643d746f7bc54337d76)
- [fix: derive Azure kube-recipe pins from the recipe pack](https://github.com/radius-project/radius/commit/e208937d930730589f22fb3ae0f173b02aaa3266)
- [Fix samples tutorial functional test for modernized Radius.* demo sample](https://github.com/radius-project/radius/commit/5ba29da7991eb7bd6d28aeeb430ef5102fa137f4)