### PR TITLE
Enforce K8s namespace uniqueness for Radius.Core/environments

### DIFF
--- a/pkg/armrpc/api/v1/errorcodes.go
+++ b/pkg/armrpc/api/v1/errorcodes.go
@@ -35,6 +35,16 @@ const (
 	// Used for CodeConflict error.
 	CodeConflict = "Conflict"
 
+	// Used when the Kubernetes namespace requested by an environment is already claimed by
+	// another environment. This is distinct from CodeConflict so that clients can recognize
+	// the namespace collision specifically rather than treating every 409 the same way.
+	CodeNamespaceAlreadyInUse = "NamespaceAlreadyInUse"
+
+	// Used when a request attempts to change or clear the Kubernetes namespace of an environment
+	// that already has one. The namespace is immutable once established, because changing it
+	// would orphan resources already deployed into the previous namespace.
+	CodeNamespaceImmutable = "NamespaceImmutable"
+
 	// Used for CodeInvalidResourceType.
 	CodeInvalidResourceType = "InvalidResourceType"
 

--- a/pkg/armrpc/rest/results.go
+++ b/pkg/armrpc/rest/results.go
@@ -431,13 +431,14 @@ func NewBadRequestResponse(message string) Response {
 	}
 }
 
-// NewBadRequestResponseWithCode creates a BadRequestResponse with a specific error code, so that
-// clients can distinguish this failure from a generic validation error.
-func NewBadRequestResponseWithCode(code string, message string) Response {
+// NewBadRequestResponseWithCode creates a BadRequestResponse with a specific ARM error code in the
+// response body. The HTTP status is always 400; errorCode only sets the machine-readable code that
+// lets clients distinguish this failure from a generic validation error (v1.CodeInvalid).
+func NewBadRequestResponseWithCode(errorCode string, message string) Response {
 	return &BadRequestResponse{
 		Body: v1.ErrorResponse{
 			Error: &v1.ErrorDetails{
-				Code:    code,
+				Code:    errorCode,
 				Message: message,
 			},
 		},
@@ -614,14 +615,15 @@ func NewConflictResponse(message string) Response {
 	}
 }
 
-// NewConflictResponseWithCode creates a ConflictResponse with a specific ARM error code. Use this
-// when clients need to distinguish one kind of conflict from another, since callers otherwise
-// cannot tell a namespace collision apart from, for example, an in-flight provisioning conflict.
-func NewConflictResponseWithCode(code string, message string) Response {
+// NewConflictResponseWithCode creates a ConflictResponse with a specific ARM error code in the
+// response body. The HTTP status is always 409; errorCode only sets the machine-readable code that
+// lets clients tell one kind of conflict from another — for example a namespace collision
+// (v1.CodeNamespaceAlreadyInUse) versus an in-flight provisioning conflict, both of which are 409.
+func NewConflictResponseWithCode(errorCode string, message string) Response {
 	return &ConflictResponse{
 		Body: v1.ErrorResponse{
 			Error: &v1.ErrorDetails{
-				Code:    code,
+				Code:    errorCode,
 				Message: message,
 			},
 		},

--- a/pkg/armrpc/rest/results.go
+++ b/pkg/armrpc/rest/results.go
@@ -431,6 +431,19 @@ func NewBadRequestResponse(message string) Response {
 	}
 }
 
+// NewBadRequestResponseWithCode creates a BadRequestResponse with a specific error code, so that
+// clients can distinguish this failure from a generic validation error.
+func NewBadRequestResponseWithCode(code string, message string) Response {
+	return &BadRequestResponse{
+		Body: v1.ErrorResponse{
+			Error: &v1.ErrorDetails{
+				Code:    code,
+				Message: message,
+			},
+		},
+	}
+}
+
 // NewBadRequestARMResponse creates a BadRequestResponse with error message.
 func NewBadRequestARMResponse(body v1.ErrorResponse) Response {
 	return &BadRequestResponse{
@@ -595,6 +608,20 @@ func NewConflictResponse(message string) Response {
 		Body: v1.ErrorResponse{
 			Error: &v1.ErrorDetails{
 				Code:    v1.CodeConflict,
+				Message: message,
+			},
+		},
+	}
+}
+
+// NewConflictResponseWithCode creates a ConflictResponse with a specific ARM error code. Use this
+// when clients need to distinguish one kind of conflict from another, since callers otherwise
+// cannot tell a namespace collision apart from, for example, an in-flight provisioning conflict.
+func NewConflictResponseWithCode(code string, message string) Response {
+	return &ConflictResponse{
+		Body: v1.ErrorResponse{
+			Error: &v1.ErrorDetails{
+				Code:    code,
 				Message: message,
 			},
 		},

--- a/pkg/cli/clients/errors.go
+++ b/pkg/cli/clients/errors.go
@@ -78,3 +78,33 @@ func Is404Error(err error) bool {
 
 	return false
 }
+
+// IsNamespaceAlreadyInUseError reports whether err is the server's "the requested Kubernetes
+// namespace is already claimed by another environment" response.
+//
+// It matches on the specific error code rather than on the 409 status, because the server returns
+// Conflict for unrelated reasons too (for example, a resource that is still provisioning), and
+// reporting those as a namespace collision would misdiagnose them.
+func IsNamespaceAlreadyInUseError(err error) bool {
+	return hasErrorCode(err, v1.CodeNamespaceAlreadyInUse)
+}
+
+// hasErrorCode reports whether err carries the given ARM error code, whether it arrives as a typed
+// azcore.ResponseError or as a raw JSON error envelope.
+func hasErrorCode(err error, code string) bool {
+	if err == nil {
+		return false
+	}
+
+	responseError := &azcore.ResponseError{}
+	if errors.As(err, &responseError) {
+		return responseError.ErrorCode == code
+	}
+
+	errorResponse := errorResponse{}
+	if marshallErr := json.Unmarshal([]byte(err.Error()), &errorResponse); marshallErr != nil {
+		return false
+	}
+
+	return errorResponse.Error != nil && errorResponse.Error.Code != nil && *errorResponse.Error.Code == code
+}

--- a/pkg/cli/clients/errors.go
+++ b/pkg/cli/clients/errors.go
@@ -37,7 +37,8 @@ type errorResponse struct {
 }
 
 type errorDetail struct {
-	Code *string `json:"code,omitempty"`
+	Code    *string `json:"code,omitempty"`
+	Message *string `json:"message,omitempty"`
 }
 
 // Is404Error returns true if the error is a 404 payload from an autorest operation.
@@ -89,6 +90,22 @@ func IsNamespaceAlreadyInUseError(err error) bool {
 	return hasErrorCode(err, v1.CodeNamespaceAlreadyInUse)
 }
 
+// NamespaceAlreadyInUseMessage returns the server's message for a namespace conflict, or an empty
+// string when err is not a namespace conflict or the message cannot be recovered. The server names
+// the environment that currently owns the namespace, which the CLI cannot determine on its own.
+func NamespaceAlreadyInUseMessage(err error) string {
+	if !IsNamespaceAlreadyInUseError(err) {
+		return ""
+	}
+
+	detail := decodeErrorDetail(err)
+	if detail == nil || detail.Message == nil {
+		return ""
+	}
+
+	return *detail.Message
+}
+
 // hasErrorCode reports whether err carries the given ARM error code, whether it arrives as a typed
 // azcore.ResponseError or as a raw JSON error envelope.
 func hasErrorCode(err error, code string) bool {
@@ -101,10 +118,30 @@ func hasErrorCode(err error, code string) bool {
 		return responseError.ErrorCode == code
 	}
 
-	errorResponse := errorResponse{}
-	if marshallErr := json.Unmarshal([]byte(err.Error()), &errorResponse); marshallErr != nil {
-		return false
+	detail := decodeErrorDetail(err)
+
+	return detail != nil && detail.Code != nil && *detail.Code == code
+}
+
+// decodeErrorDetail recovers the ARM error envelope from err, returning nil when it cannot be
+// found. A raw envelope error is JSON in its entirety, while an azcore.ResponseError renders the
+// response body embedded in surrounding diagnostic text, so decoding starts at the first brace and
+// ignores whatever follows the first complete JSON value.
+func decodeErrorDetail(err error) *errorDetail {
+	if err == nil {
+		return nil
 	}
 
-	return errorResponse.Error != nil && errorResponse.Error.Code != nil && *errorResponse.Error.Code == code
+	text := err.Error()
+	start := strings.Index(text, "{")
+	if start < 0 {
+		return nil
+	}
+
+	response := errorResponse{}
+	if decodeErr := json.NewDecoder(strings.NewReader(text[start:])).Decode(&response); decodeErr != nil {
+		return nil
+	}
+
+	return response.Error
 }

--- a/pkg/cli/clients/errors_test.go
+++ b/pkg/cli/clients/errors_test.go
@@ -69,3 +69,54 @@ func TestIs404Error(t *testing.T) {
 		t.Errorf("Expected Is404Error to return true for fake server not found response, but it returned false")
 	}
 }
+
+func TestIsNamespaceAlreadyInUseError(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		err      error
+		expected bool
+	}{
+		{
+			desc:     "typed response error with the namespace code",
+			err:      &azcore.ResponseError{ErrorCode: v1.CodeNamespaceAlreadyInUse, StatusCode: http.StatusConflict},
+			expected: true,
+		},
+		{
+			desc:     "raw JSON envelope with the namespace code",
+			err:      errors.New(`{"error": {"code": "NamespaceAlreadyInUse", "message": "namespace in use"}}`),
+			expected: true,
+		},
+		{
+			// A generic conflict must not be reported as a namespace collision: the server also
+			// returns 409 when a resource is still provisioning.
+			desc:     "generic conflict",
+			err:      &azcore.ResponseError{ErrorCode: v1.CodeConflict, StatusCode: http.StatusConflict},
+			expected: false,
+		},
+		{
+			desc:     "raw JSON envelope with a different code",
+			err:      errors.New(`{"error": {"code": "Conflict"}}`),
+			expected: false,
+		},
+		{
+			desc:     "unrelated error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+		{
+			desc:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if actual := IsNamespaceAlreadyInUseError(tc.err); actual != tc.expected {
+				t.Errorf("IsNamespaceAlreadyInUseError(%v) = %v, want %v", tc.err, actual, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/cli/clients/errors_test.go
+++ b/pkg/cli/clients/errors_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIs404Error(t *testing.T) {
@@ -117,6 +118,58 @@ func TestIsNamespaceAlreadyInUseError(t *testing.T) {
 			if actual := IsNamespaceAlreadyInUseError(tc.err); actual != tc.expected {
 				t.Errorf("IsNamespaceAlreadyInUseError(%v) = %v, want %v", tc.err, actual, tc.expected)
 			}
+		})
+	}
+}
+
+func TestNamespaceAlreadyInUseMessage(t *testing.T) {
+	const conflict = "The Kubernetes namespace specified (default) is already used by another Radius Environment (/planes/radius/local/resourceGroups/g1/providers/Radius.Core/environments/env1). Each environment must use a unique Kubernetes namespace."
+
+	testCases := []struct {
+		desc     string
+		err      error
+		expected string
+	}{
+		{
+			desc:     "raw JSON envelope keeps the conflicting environment ID",
+			err:      errors.New(`{"error": {"code": "NamespaceAlreadyInUse", "message": "` + conflict + `"}}`),
+			expected: conflict,
+		},
+		{
+			// azcore renders the response body inside surrounding diagnostic text, so the
+			// envelope has to be located rather than unmarshalled whole.
+			desc: "azcore-style error with the body embedded in diagnostic text",
+			err: errors.New("PUT https://example.com/env\n" +
+				"--------------------------------------------------------------------------------\n" +
+				"RESPONSE 409: 409 Conflict\n" +
+				"ERROR CODE: NamespaceAlreadyInUse\n" +
+				"--------------------------------------------------------------------------------\n" +
+				`{"error": {"code": "NamespaceAlreadyInUse", "message": "` + conflict + `"}}` + "\n" +
+				"--------------------------------------------------------------------------------\n"),
+			expected: conflict,
+		},
+		{
+			desc:     "envelope without a message falls back to the caller's wording",
+			err:      errors.New(`{"error": {"code": "NamespaceAlreadyInUse"}}`),
+			expected: "",
+		},
+		{
+			desc:     "different error code",
+			err:      errors.New(`{"error": {"code": "Conflict", "message": "something else"}}`),
+			expected: "",
+		},
+		{
+			desc:     "nil error",
+			err:      nil,
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.expected, NamespaceAlreadyInUseMessage(tc.err))
 		})
 	}
 }

--- a/pkg/cli/cmd/env/create/create.go
+++ b/pkg/cli/cmd/env/create/create.go
@@ -253,7 +253,13 @@ func (r *Runner) Run(ctx context.Context) error {
 	err = client.CreateOrUpdateEnvironment(ctx, r.EnvironmentName, resource)
 	if err != nil {
 		if clients.IsNamespaceAlreadyInUseError(err) {
-			return clierrors.Message("The Kubernetes namespace specified (%s) is already used by another Radius Environment. Specify a unique Kubernetes namespace using the --kubernetes-namespace flag.", r.Namespace)
+			// Prefer the server's message: it names the environment that already owns the
+			// namespace, which the CLI cannot determine on its own.
+			if detail := clients.NamespaceAlreadyInUseMessage(err); detail != "" {
+				return clierrors.Message("%s Specify a different namespace using the --kubernetes-namespace flag.", detail)
+			}
+
+			return clierrors.Message("The Kubernetes namespace specified (%s) is already used by another Radius Environment. Specify a different namespace using the --kubernetes-namespace flag.", r.Namespace)
 		}
 
 		return err

--- a/pkg/cli/cmd/env/create/create.go
+++ b/pkg/cli/cmd/env/create/create.go
@@ -252,6 +252,10 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	err = client.CreateOrUpdateEnvironment(ctx, r.EnvironmentName, resource)
 	if err != nil {
+		if clients.IsNamespaceAlreadyInUseError(err) {
+			return clierrors.Message("The Kubernetes namespace specified (%s) is already used by another Radius Environment. Specify a unique Kubernetes namespace using the --kubernetes-namespace flag.", r.Namespace)
+		}
+
 		return err
 	}
 	r.Output.LogInfo("Applications.Core/environments/%s created", r.EnvironmentName)

--- a/pkg/cli/cmd/env/create/preview/create.go
+++ b/pkg/cli/cmd/env/create/preview/create.go
@@ -118,6 +118,16 @@ type Runner struct {
 	providers       *corerpv20250801.Providers
 }
 
+// kubernetesNamespace returns the Kubernetes namespace the environment will use, or an empty
+// string when the environment does not configure a Kubernetes provider.
+func (r *Runner) kubernetesNamespace() string {
+	if r.providers == nil || r.providers.Kubernetes == nil || r.providers.Kubernetes.Namespace == nil {
+		return ""
+	}
+
+	return *r.providers.Kubernetes.Namespace
+}
+
 // NewRunner creates a new instance of the `rad env create` runner.
 func NewRunner(factory framework.Factory) *Runner {
 	return &Runner{
@@ -314,6 +324,10 @@ func (r *Runner) Run(ctx context.Context) error {
 	envClient := r.RadiusCoreClientFactory.NewEnvironmentsClient()
 	_, err = envClient.CreateOrUpdate(ctx, r.Workspace.Scope, r.EnvironmentName, *resource, nil)
 	if err != nil {
+		if clients.IsNamespaceAlreadyInUseError(err) {
+			return clierrors.Message("The Kubernetes namespace specified (%s) is already used by another Radius Environment. Specify a unique Kubernetes namespace using the --kubernetes-namespace flag.", r.kubernetesNamespace())
+		}
+
 		return err
 	}
 

--- a/pkg/cli/cmd/env/create/preview/create.go
+++ b/pkg/cli/cmd/env/create/preview/create.go
@@ -325,7 +325,13 @@ func (r *Runner) Run(ctx context.Context) error {
 	_, err = envClient.CreateOrUpdate(ctx, r.Workspace.Scope, r.EnvironmentName, *resource, nil)
 	if err != nil {
 		if clients.IsNamespaceAlreadyInUseError(err) {
-			return clierrors.Message("The Kubernetes namespace specified (%s) is already used by another Radius Environment. Specify a unique Kubernetes namespace using the --kubernetes-namespace flag.", r.kubernetesNamespace())
+			// Prefer the server's message: it names the environment that already owns the
+			// namespace, which the CLI cannot determine on its own.
+			if detail := clients.NamespaceAlreadyInUseMessage(err); detail != "" {
+				return clierrors.Message("%s Specify a different namespace using the --kubernetes-namespace flag.", detail)
+			}
+
+			return clierrors.Message("The Kubernetes namespace specified (%s) is already used by another Radius Environment. Specify a different namespace using the --kubernetes-namespace flag.", r.kubernetesNamespace())
 		}
 
 		return err

--- a/pkg/cli/cmd/env/update/preview/update.go
+++ b/pkg/cli/cmd/env/update/preview/update.go
@@ -19,6 +19,7 @@ package preview
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -81,10 +82,9 @@ rad env update myenv --clear-azure
 rad env update myenv --clear-aws
 
 ## Add Kubernetes cloud provider (preview)
+## The namespace can only be set on an environment that does not already have one; it is
+## immutable afterwards.
 rad env update myenv --kubernetes-namespace mynamespace
-
-## Remove Kubernetes cloud provider (preview)
-rad env update myenv --clear-kubernetes
 
 ## Set recipe packs to environment (--preview)
 rad env update myenv --recipe-packs pack1,pack2
@@ -100,6 +100,13 @@ rad env update myenv --recipe-packs pack1 --recipe-pack-group other-group
 	cmd.Flags().Bool(commonflags.ClearEnvAzureFlag, false, "Specify if azure provider needs to be cleared on env")
 	cmd.Flags().Bool(commonflags.ClearEnvAWSFlag, false, "Specify if aws provider needs to be cleared on env")
 	cmd.Flags().Bool(commonflags.ClearEnvKubernetesFlag, false, "Specify if kubernetes provider needs to be cleared on env (--preview)")
+
+	// The Kubernetes namespace is immutable once set, so this flag can no longer do anything: it is
+	// rejected on any environment that has a namespace and is a no-op on one that does not. It is
+	// kept, hidden and deprecated, so that users who scripted it get an explanation rather than a
+	// bare "unknown flag" from Cobra. Remove it once Radius.Core leaves preview.
+	_ = cmd.Flags().MarkDeprecated(commonflags.ClearEnvKubernetesFlag, "the Kubernetes namespace of an environment cannot be removed; create a new environment instead")
+
 	cmd.Flags().StringSliceP("recipe-packs", "", []string{}, "Specify recipe packs to replace the environment's recipe pack list (--preview). Accepts comma-separated values.")
 	cmd.Flags().StringP("recipe-pack-group", "", "", "Specify the resource group containing the recipe packs named in --recipe-packs, if different from the environment's resource group (--preview).")
 	commonflags.AddAzureScopeFlags(cmd)
@@ -275,6 +282,25 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	// SystemData is owned by the service; do not send it back on update.
 	env.SystemData = nil
+
+	// The Kubernetes namespace is immutable once an environment has one: changing it would leave
+	// everything already deployed into the old namespace orphaned, and clearing it would release a
+	// claim that other environments were validated against. The server enforces this too, but
+	// failing here gives a better message and avoids a pointless round trip.
+	currentNamespace := ""
+	if env.Properties != nil && env.Properties.Providers != nil && env.Properties.Providers.Kubernetes != nil && env.Properties.Providers.Kubernetes.Namespace != nil {
+		currentNamespace = *env.Properties.Providers.Kubernetes.Namespace
+	}
+
+	if currentNamespace != "" {
+		if r.clearEnvKubernetes {
+			return clierrors.Message("Cannot clear the Kubernetes provider on environment %q: its namespace (%s) cannot be removed because resources already deployed into it would be orphaned. Create a new environment instead.", r.EnvironmentName, currentNamespace)
+		}
+
+		if r.providers.Kubernetes != nil && r.providers.Kubernetes.Namespace != nil && !strings.EqualFold(*r.providers.Kubernetes.Namespace, currentNamespace) {
+			return clierrors.Message("Cannot change the Kubernetes namespace of environment %q from %q to %q: resources already deployed into %s would be orphaned. Create a new environment instead.", r.EnvironmentName, currentNamespace, *r.providers.Kubernetes.Namespace, currentNamespace)
+		}
+	}
 
 	// only update azure provider info if user requires it.
 	if r.clearEnvAzure && env.Properties.Providers != nil {

--- a/pkg/cli/cmd/env/update/preview/update.go
+++ b/pkg/cli/cmd/env/update/preview/update.go
@@ -103,8 +103,9 @@ rad env update myenv --recipe-packs pack1 --recipe-pack-group other-group
 
 	// The Kubernetes namespace is immutable once set, so this flag can no longer do anything: it is
 	// rejected on any environment that has a namespace and is a no-op on one that does not. It is
-	// kept, hidden and deprecated, so that users who scripted it get an explanation rather than a
-	// bare "unknown flag" from Cobra. Remove it once Radius.Core leaves preview.
+	// kept so that users who scripted it get an explanation rather than a bare "unknown flag" from
+	// Cobra. MarkDeprecated also sets Hidden, so it no longer appears in help output. Remove it
+	// once Radius.Core leaves preview.
 	_ = cmd.Flags().MarkDeprecated(commonflags.ClearEnvKubernetesFlag, "the Kubernetes namespace of an environment cannot be removed; create a new environment instead")
 
 	cmd.Flags().StringSliceP("recipe-packs", "", []string{}, "Specify recipe packs to replace the environment's recipe pack list (--preview). Accepts comma-separated values.")

--- a/pkg/cli/cmd/env/update/preview/update_test.go
+++ b/pkg/cli/cmd/env/update/preview/update_test.go
@@ -787,7 +787,7 @@ func Test_Run_DefaultsKubernetesNamespace(t *testing.T) {
 		require.Equal(t, "user-ns", *captured.Properties.Providers.Kubernetes.Namespace)
 	})
 
-	t.Run("--clear-kubernetes is respected and default is not applied", func(t *testing.T) {
+	t.Run("--clear-kubernetes is rejected once a namespace is established", func(t *testing.T) {
 		var captured v20250801preview.EnvironmentResource
 		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(
 			workspace.Scope,
@@ -807,10 +807,69 @@ func Test_Run_DefaultsKubernetesNamespace(t *testing.T) {
 		}
 
 		err = runner.Run(t.Context())
+
+		// Clearing the provider would release a namespace claim that other environments were
+		// validated against, and orphan anything already deployed into it.
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "existing-ns")
+		require.Nil(t, captured.Properties, "the environment must not be updated")
+	})
+
+	t.Run("changing an established namespace is rejected", func(t *testing.T) {
+		var captured v20250801preview.EnvironmentResource
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(
+			workspace.Scope,
+			makeServer(kubernetesOnly("existing-ns"), &captured),
+			nil,
+		)
 		require.NoError(t, err)
 
-		require.NotNil(t, captured.Properties.Providers)
-		require.Nil(t, captured.Properties.Providers.Kubernetes, "clear-kubernetes must not be overridden by the default")
+		runner := &Runner{
+			ConfigHolder:            &framework.ConfigHolder{},
+			Output:                  &output.MockOutput{},
+			Workspace:               workspace,
+			EnvironmentName:         "test-env",
+			RadiusCoreClientFactory: factory,
+			providers: &v20250801preview.Providers{
+				Kubernetes: &v20250801preview.ProvidersKubernetes{
+					Namespace: to.Ptr("new-ns"),
+				},
+			},
+		}
+
+		err = runner.Run(t.Context())
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "existing-ns")
+		require.Contains(t, err.Error(), "new-ns")
+		require.Nil(t, captured.Properties, "the environment must not be updated")
+	})
+
+	t.Run("re-specifying the same namespace is allowed", func(t *testing.T) {
+		var captured v20250801preview.EnvironmentResource
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(
+			workspace.Scope,
+			makeServer(kubernetesOnly("existing-ns"), &captured),
+			nil,
+		)
+		require.NoError(t, err)
+
+		runner := &Runner{
+			ConfigHolder:            &framework.ConfigHolder{},
+			Output:                  &output.MockOutput{},
+			Workspace:               workspace,
+			EnvironmentName:         "test-env",
+			RadiusCoreClientFactory: factory,
+			providers: &v20250801preview.Providers{
+				Kubernetes: &v20250801preview.ProvidersKubernetes{
+					Namespace: to.Ptr("existing-ns"),
+				},
+			},
+		}
+
+		err = runner.Run(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, "existing-ns", *captured.Properties.Providers.Kubernetes.Namespace)
 	})
 
 	t.Run("env with Azure provider does not get default namespace", func(t *testing.T) {

--- a/pkg/cli/cmd/radinit/preview/environment.go
+++ b/pkg/cli/cmd/radinit/preview/environment.go
@@ -288,6 +288,7 @@ func (r *Runner) enterEnvironmentName() (string, error) {
 	return name, nil
 }
 
+// enterEnvironmentNamespace prompts for the Kubernetes namespace the new environment deploys into.
 func (r *Runner) enterEnvironmentNamespace() (string, error) {
 	if !r.Full {
 		return defaultEnvironmentNamespace, nil
@@ -296,7 +297,7 @@ func (r *Runner) enterEnvironmentNamespace() (string, error) {
 	namespace, err := r.Prompter.GetTextInput(enterNamespacePrompt, prompt.TextInputOptions{
 		Default:     defaultEnvironmentNamespace,
 		Placeholder: defaultEnvironmentNamespace,
-		Validate:    prompt.ValidateResourceNameOrDefault,
+		Validate:    prompt.ValidateKubernetesNamespaceOrDefault,
 	})
 	if err != nil {
 		return "", err

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
@@ -81,6 +81,12 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, w http.ResponseWrit
 	}
 
 	// Create Query filter to query kubernetes namespace used by the other environment resources.
+	//
+	// This check is deliberately scoped to the current resource group and to this resource type
+	// only. Applications.Core/environments is on a deprecation path, so its enforcement behavior
+	// is frozen: widening it would start failing writes (rad recipe register, rad env update) for
+	// existing installs that already have duplicate namespaces across resource groups. Plane-wide
+	// uniqueness is enforced on Radius.Core/environments instead, which is where users migrate to.
 	namespace := newResource.Properties.Compute.KubernetesCompute.Namespace
 	result, err := util.FindResources(ctx, serviceCtx.ResourceID.RootScope(), serviceCtx.ResourceID.Type(), "properties.compute.kubernetes.namespace", namespace, e.DatabaseClient())
 	if err != nil {
@@ -96,7 +102,7 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, w http.ResponseWrit
 		// If a different resource has the same namespace, return a conflict
 		// Otherwise, continue and update the resource
 		if (old == nil || env.ID != old.ID) && env.Properties.Compute.Kind != rpv1.ACIComputeKind {
-			return rest.NewConflictResponse(fmt.Sprintf("Environment %s with the same namespace (%s) already exists", env.ID, namespace)), nil
+			return rest.NewConflictResponseWithCode(v1.CodeNamespaceAlreadyInUse, util.NamespaceConflictMessage(namespace, env.ID)), nil
 		}
 	}
 

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
@@ -22,12 +22,16 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	ctrl "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
 	"github.com/radius-project/radius/pkg/armrpc/rpctest"
 	"github.com/radius-project/radius/pkg/components/database"
 	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	"github.com/radius-project/radius/test/k8sutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -424,4 +428,69 @@ func TestCreateOrUpdateEnvironmentRun_20231001Preview(t *testing.T) {
 			require.Equal(t, tt.expectedStatusCode, w.Result().StatusCode)
 		})
 	}
+}
+
+// TestCreateOrUpdateEnvironment_NamespaceConflictError verifies the namespace conflict response for
+// Applications.Core/environments. Enforcement here is deliberately unchanged -- it stays scoped to
+// the current resource group and resource type, because this type is deprecated and widening it
+// would break writes on existing installs. Only the error surface improved: a distinct code the
+// CLI can recognize, and a message that names the conflicting environment.
+func TestCreateOrUpdateEnvironment_NamespaceConflictError(t *testing.T) {
+	mctrl := gomock.NewController(t)
+	defer mctrl.Finish()
+
+	databaseClient := database.NewMockClient(mctrl)
+	ctx := t.Context()
+
+	const conflictingEnvID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/existing-env"
+
+	envInput, _, _ := getTestModels20231001preview()
+	w := httptest.NewRecorder()
+	req, err := rpctest.NewHTTPRequestFromJSON(ctx, http.MethodPut, testHeaderfile, envInput)
+	require.NoError(t, err)
+	ctx = rpctest.NewARMRequestContext(req)
+
+	databaseClient.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
+			return nil, &database.ErrNotFound{ID: id}
+		})
+
+	// A different environment in the same resource group already holds the namespace.
+	conflicting := &datamodel.Environment{}
+	conflicting.ID = conflictingEnvID
+	conflicting.Properties.Compute = rpv1.EnvironmentCompute{
+		Kind:              rpv1.KubernetesComputeKind,
+		KubernetesCompute: rpv1.KubernetesComputeProperties{Namespace: "default"},
+	}
+
+	databaseClient.EXPECT().
+		Query(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, query database.Query, options ...database.QueryOptions) (*database.ObjectQueryResult, error) {
+			// Enforcement must remain scoped to this resource group and resource type.
+			require.False(t, query.ScopeRecursive, "Applications.Core enforcement must not search the whole plane")
+			require.Equal(t, "applications.core/environments", strings.ToLower(query.ResourceType))
+
+			return &database.ObjectQueryResult{
+				Items: []database.Object{{Metadata: database.Metadata{ID: conflictingEnvID}, Data: conflicting}},
+			}, nil
+		})
+
+	opts := ctrl.Options{
+		DatabaseClient: databaseClient,
+		KubeClient:     k8sutil.NewFakeKubeClient(nil),
+	}
+
+	ctl, err := NewCreateOrUpdateEnvironment(opts)
+	require.NoError(t, err)
+
+	resp, err := ctl.Run(ctx, w, req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Apply(ctx, w, req))
+	require.Equal(t, 409, w.Result().StatusCode)
+
+	errorResponse := &v1.ErrorResponse{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), errorResponse))
+	require.Equal(t, v1.CodeNamespaceAlreadyInUse, errorResponse.Error.Code)
+	require.Contains(t, errorResponse.Error.Message, conflictingEnvID)
 }

--- a/pkg/corerp/frontend/controller/environments/v20250801preview/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/v20250801preview/createorupdateenvironment.go
@@ -86,22 +86,8 @@ func (e *CreateOrUpdateEnvironmentv20250801preview) Run(ctx context.Context, w h
 			newResource.Properties.Providers.Kubernetes.Namespace = namespace
 		}
 
-		result, err := util.FindResources(ctx, serviceCtx.ResourceID.RootScope(), serviceCtx.ResourceID.Type(), "properties.providers.kubernetes.namespace", namespace, e.DatabaseClient())
-		if err != nil {
-			return nil, err
-		}
-
-		if len(result.Items) > 0 {
-			env := &datamodel.Environment_v20250801preview{}
-			if err := result.Items[0].As(env); err != nil {
-				return nil, err
-			}
-
-			// If a different resource has the same namespace, return a conflict
-			// Otherwise, continue and update the resource
-			if old == nil || env.ID != old.ID {
-				return rest.NewConflictResponse(fmt.Sprintf("Environment %s with the same namespace (%s) already exists", env.ID, namespace)), nil
-			}
+		if resp, err := e.validateNamespace(ctx, serviceCtx, namespace, old); resp != nil || err != nil {
+			return resp, err
 		}
 
 		// Validate the namespace exists on the cluster the application's resources
@@ -120,6 +106,12 @@ func (e *CreateOrUpdateEnvironmentv20250801preview) Run(ctx context.Context, w h
 				return rest.NewBadRequestResponse(fmt.Sprintf("Namespace '%s' does not exist in the Kubernetes cluster. Please create it before proceeding.", namespace)), nil
 			}
 			return nil, err
+		}
+	} else if old != nil {
+		// The environment is dropping its Kubernetes provider entirely. That releases a namespace
+		// claim, which is not permitted once one has been established -- see validateNamespace.
+		if existing := existingNamespace(old); existing != "" {
+			return rest.NewBadRequestResponseWithCode(v1.CodeNamespaceImmutable, util.NamespaceImmutableMessage(existing, "")), nil
 		}
 	}
 
@@ -279,4 +271,59 @@ func validateConfigRef(
 		return rest.NewBadRequestResponse(fmt.Sprintf("Referenced %s resource %q does not exist.", propertyName, resourceID))
 	}
 	return nil
+}
+
+// existingNamespace returns the Kubernetes namespace recorded on a stored environment, or the
+// empty string when the environment has no Kubernetes provider.
+func existingNamespace(old *datamodel.Environment_v20250801preview) string {
+	if old == nil || old.Properties.Providers == nil || old.Properties.Providers.Kubernetes == nil {
+		return ""
+	}
+
+	return old.Properties.Providers.Kubernetes.Namespace
+}
+
+// validateNamespace enforces the namespace rules for Radius.Core/environments. It returns a
+// non-nil response when the request must be rejected.
+//
+// The rules differ between create and update, which is what keeps the constraint from disrupting
+// unrelated writes:
+//
+//   - Create, or an update that claims a namespace for the first time: the namespace must not
+//     already be claimed by another environment anywhere in the plane.
+//   - Update where a namespace is already established: the namespace is immutable. Changing it
+//     would orphan everything already deployed into the old namespace, and clearing it would
+//     release a claim that other environments were validated against.
+//
+// Because the namespace cannot change once set, an update that leaves it alone cannot introduce a
+// conflict and therefore skips the uniqueness query entirely. That is deliberate: writes that
+// merely touch other properties -- registering a recipe, syncing recipe pack references -- must not
+// fail because of a namespace the caller never intended to modify.
+func (e *CreateOrUpdateEnvironmentv20250801preview) validateNamespace(
+	ctx context.Context,
+	serviceCtx *v1.ARMRequestContext,
+	namespace string,
+	old *datamodel.Environment_v20250801preview,
+) (rest.Response, error) {
+	if existing := existingNamespace(old); existing != "" {
+		if !strings.EqualFold(existing, namespace) {
+			return rest.NewBadRequestResponseWithCode(v1.CodeNamespaceImmutable, util.NamespaceImmutableMessage(existing, namespace)), nil
+		}
+
+		return nil, nil
+	}
+
+	// A namespace is cluster-scoped, so two environments sharing one would deploy into the same
+	// place and their recipe-created resources could collide. The search spans every resource
+	// group in the plane and both environment resource types.
+	conflictingID, err := util.FindEnvironmentNamespaceConflict(ctx, e.DatabaseClient(), serviceCtx.ResourceID.PlaneScope(), namespace, serviceCtx.ResourceID.String())
+	if err != nil {
+		return nil, err
+	}
+
+	if conflictingID != "" {
+		return rest.NewConflictResponseWithCode(v1.CodeNamespaceAlreadyInUse, util.NamespaceConflictMessage(namespace, conflictingID)), nil
+	}
+
+	return nil, nil
 }

--- a/pkg/corerp/frontend/controller/environments/v20250801preview/createorupdateenvironment_test.go
+++ b/pkg/corerp/frontend/controller/environments/v20250801preview/createorupdateenvironment_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	ctrl "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
 	"github.com/radius-project/radius/pkg/armrpc/rpctest"
 	"github.com/radius-project/radius/pkg/components/database"
@@ -112,7 +113,7 @@ func TestCreateOrUpdateEnvironmentRun_20250801Preview(t *testing.T) {
 						return &database.ObjectQueryResult{
 							Items: []database.Object{},
 						}, nil
-					})
+					}).Times(2)
 			}
 
 			expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
@@ -190,16 +191,8 @@ func TestCreateOrUpdateEnvironmentRun_20250801Preview(t *testing.T) {
 					}, nil
 				})
 
-			if !tt.shouldFail {
-				databaseClient.
-					EXPECT().
-					Query(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, query database.Query, options ...database.QueryOptions) (*database.ObjectQueryResult, error) {
-						return &database.ObjectQueryResult{
-							Items: []database.Object{},
-						}, nil
-					})
-			}
+			// No namespace uniqueness query is expected: the environment already has a
+			// namespace and this update does not change it, so the check is skipped.
 
 			if !tt.shouldFail {
 				databaseClient.
@@ -278,7 +271,7 @@ func TestCreateOrUpdateEnvironmentRun_20250801Preview(t *testing.T) {
 						return &database.ObjectQueryResult{
 							Items: []database.Object{},
 						}, nil
-					})
+					}).Times(2)
 			}
 
 			defaultNamespace := &corev1.Namespace{
@@ -333,16 +326,8 @@ func TestCreateOrUpdateEnvironmentRun_20250801Preview(t *testing.T) {
 					}, nil
 				})
 
-			if !tt.shouldFail {
-				databaseClient.
-					EXPECT().
-					Query(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, query database.Query, options ...database.QueryOptions) (*database.ObjectQueryResult, error) {
-						return &database.ObjectQueryResult{
-							Items: []database.Object{},
-						}, nil
-					})
-			}
+			// No namespace uniqueness query is expected: the environment already has a
+			// namespace and this patch does not change it, so the check is skipped.
 
 			if !tt.shouldFail {
 				databaseClient.
@@ -379,6 +364,137 @@ func TestCreateOrUpdateEnvironmentRun_20250801Preview(t *testing.T) {
 				_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
 				require.Equal(t, expectedOutput, actualOutput)
 			}
+		})
+	}
+}
+
+// TestCreateOrUpdateEnvironment_NamespaceUniqueness covers the constraint that a Kubernetes
+// namespace may be claimed by only one environment across the entire plane. The check used to be
+// scoped to a single resource group, which meant creating a second resource group silently
+// bypassed it (issue #12420).
+func TestCreateOrUpdateEnvironment_NamespaceUniqueness(t *testing.T) {
+	ctx := t.Context()
+
+	const (
+		// The environment under test, as declared by the request fixture.
+		requestEnvID = "/planes/radius/local/resourceGroups/testGroup/providers/Radius.Core/environments/my-k8s-env"
+
+		// An environment in a *different* resource group holding the same namespace.
+		otherGroupEnvID = "/planes/radius/local/resourceGroups/otherGroup/providers/Radius.Core/environments/other-env"
+	)
+
+	// conflictingEnvironment returns a stored Radius.Core environment using the "default" namespace.
+	conflictingEnvironment := func(id string) database.Object {
+		env := &datamodel.Environment_v20250801preview{
+			BaseResource: v1.BaseResource{TrackedResource: v1.TrackedResource{ID: id}},
+		}
+		env.Properties.Providers = &datamodel.Providers_v20250801preview{
+			Kubernetes: &datamodel.ProvidersKubernetes_v20250801preview{Namespace: "default"},
+		}
+
+		return database.Object{Metadata: database.Metadata{ID: id}, Data: env}
+	}
+
+	testCases := []struct {
+		desc               string
+		queryResults       []database.Object
+		expectedStatusCode int
+		expectSaved        bool
+	}{
+		{
+			desc:               "conflicts with an environment in another resource group",
+			queryResults:       []database.Object{conflictingEnvironment(otherGroupEnvID)},
+			expectedStatusCode: 409,
+		},
+		{
+			desc: "ignores the environment being updated but still finds a later conflict",
+			queryResults: []database.Object{
+				conflictingEnvironment(requestEnvID),
+				conflictingEnvironment(otherGroupEnvID),
+			},
+			expectedStatusCode: 409,
+		},
+		{
+			desc:               "allows re-applying the same environment",
+			queryResults:       []database.Object{conflictingEnvironment(requestEnvID)},
+			expectedStatusCode: 200,
+			expectSaved:        true,
+		},
+		{
+			desc:               "allows a free namespace",
+			queryResults:       nil,
+			expectedStatusCode: 200,
+			expectSaved:        true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			mctrl := gomock.NewController(t)
+			databaseClient := database.NewMockClient(mctrl)
+
+			envInput, envDataModel, _ := getTestModelsv20250801preview()
+			w := httptest.NewRecorder()
+			req, err := rpctest.NewHTTPRequestFromJSON(ctx, http.MethodPut, testHeaderfilev20250801preview, envInput)
+			require.NoError(t, err)
+			ctx := rpctest.NewARMRequestContext(req)
+
+			databaseClient.EXPECT().
+				Get(gomock.Any(), testRecipePackID).
+				Return(testRecipePackObject(), nil).
+				AnyTimes()
+
+			databaseClient.EXPECT().
+				Get(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
+					return nil, &database.ErrNotFound{ID: id}
+				}).AnyTimes()
+
+			databaseClient.EXPECT().
+				Query(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, query database.Query, options ...database.QueryOptions) (*database.ObjectQueryResult, error) {
+					// The environments in this test are all Radius.Core; the legacy type is empty.
+					if !strings.EqualFold(query.ResourceType, datamodel.EnvironmentResourceType_v20250801preview) {
+						return &database.ObjectQueryResult{}, nil
+					}
+
+					return &database.ObjectQueryResult{Items: tt.queryResults}, nil
+				}).AnyTimes()
+
+			if tt.expectSaved {
+				databaseClient.EXPECT().
+					Save(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, obj *database.Object, opts ...database.SaveOptions) error {
+						obj.ETag = "new-resource-etag"
+						obj.Data = envDataModel
+						return nil
+					}).Times(1)
+			}
+
+			opts := ctrl.Options{
+				DatabaseClient: databaseClient,
+				KubeClient:     k8sutil.NewFakeKubeClient(nil, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}),
+			}
+
+			ctl, err := NewCreateOrUpdateEnvironmentv20250801preview(opts)
+			require.NoError(t, err)
+
+			resp, err := ctl.Run(ctx, w, req)
+			require.NoError(t, err)
+			require.NoError(t, resp.Apply(ctx, w, req))
+			require.Equal(t, tt.expectedStatusCode, w.Result().StatusCode)
+
+			if tt.expectedStatusCode != 409 {
+				return
+			}
+
+			// The response must carry a code the CLI can key on, and name the conflicting
+			// environment so an operator can find it.
+			errorResponse := &v1.ErrorResponse{}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), errorResponse))
+			require.Equal(t, v1.CodeNamespaceAlreadyInUse, errorResponse.Error.Code)
+			require.Contains(t, errorResponse.Error.Message, "The Kubernetes namespace specified (default) is already used by another Radius Environment")
+			require.Contains(t, errorResponse.Error.Message, otherGroupEnvID)
 		})
 	}
 }
@@ -715,7 +831,7 @@ func TestCreateOrUpdateEnvironment_RecipePackValidation(t *testing.T) {
 			// Mock kubernetes namespace query - this happens before recipe pack validation
 			databaseClient.EXPECT().
 				Query(gomock.Any(), gomock.Any()).
-				Return(&database.ObjectQueryResult{Items: []database.Object{}}, nil).MaxTimes(1)
+				Return(&database.ObjectQueryResult{Items: []database.Object{}}, nil).MaxTimes(2)
 
 			// Mock Save only for successful cases
 			if tt.expectedStatusCode == 200 {
@@ -828,7 +944,7 @@ func TestCreateOrUpdateEnvironment_RecipePackNormalization(t *testing.T) {
 
 	databaseClient.EXPECT().
 		Query(gomock.Any(), gomock.Any()).
-		Return(&database.ObjectQueryResult{Items: []database.Object{}}, nil).MaxTimes(1)
+		Return(&database.ObjectQueryResult{Items: []database.Object{}}, nil).MaxTimes(2)
 
 	var savedRecipePacks []string
 	databaseClient.EXPECT().
@@ -856,4 +972,134 @@ func TestCreateOrUpdateEnvironment_RecipePackNormalization(t *testing.T) {
 
 	require.Equal(t, 200, w.Result().StatusCode)
 	require.Equal(t, []string{resolvedByName, fullID}, savedRecipePacks)
+}
+
+// TestCreateOrUpdateEnvironment_NamespaceImmutability covers the update-side rules for the
+// namespace. Once an environment has a namespace it cannot be changed or removed, and because it
+// cannot change, an update that leaves it alone skips the uniqueness query entirely. That last
+// part is what keeps unrelated writes -- registering a recipe, syncing recipe pack references --
+// from failing on installs that predate the constraint.
+func TestCreateOrUpdateEnvironment_NamespaceImmutability(t *testing.T) {
+	ctx := t.Context()
+
+	testCases := []struct {
+		desc               string
+		storedNamespace    string
+		clearKubernetes    bool
+		expectedStatusCode int
+		expectedErrorCode  string
+		expectQueries      bool
+		expectSaved        bool
+	}{
+		{
+			desc:               "unchanged namespace is saved without a uniqueness query",
+			storedNamespace:    "default",
+			expectedStatusCode: 200,
+			expectSaved:        true,
+		},
+		{
+			desc:               "changing the namespace is rejected",
+			storedNamespace:    "previous-namespace",
+			expectedStatusCode: 400,
+			expectedErrorCode:  v1.CodeNamespaceImmutable,
+		},
+		{
+			desc:               "removing the kubernetes provider is rejected",
+			storedNamespace:    "default",
+			clearKubernetes:    true,
+			expectedStatusCode: 400,
+			expectedErrorCode:  v1.CodeNamespaceImmutable,
+		},
+		{
+			desc:               "claiming a namespace for the first time is validated",
+			storedNamespace:    "",
+			expectedStatusCode: 200,
+			expectQueries:      true,
+			expectSaved:        true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			mctrl := gomock.NewController(t)
+			databaseClient := database.NewMockClient(mctrl)
+
+			envInput, envDataModel, _ := getTestModelsv20250801preview()
+
+			// The stored environment is what the request is compared against.
+			stored := *envDataModel
+			if tt.storedNamespace == "" {
+				stored.Properties.Providers = nil
+			} else {
+				stored.Properties.Providers = &datamodel.Providers_v20250801preview{
+					Kubernetes: &datamodel.ProvidersKubernetes_v20250801preview{Namespace: tt.storedNamespace},
+				}
+			}
+
+			if tt.clearKubernetes {
+				envInput.Properties.Providers = nil
+			}
+
+			w := httptest.NewRecorder()
+			req, err := rpctest.NewHTTPRequestFromJSON(ctx, http.MethodPut, testHeaderfilev20250801preview, envInput)
+			require.NoError(t, err)
+			ctx := rpctest.NewARMRequestContext(req)
+
+			databaseClient.EXPECT().
+				Get(gomock.Any(), testRecipePackID).
+				Return(testRecipePackObject(), nil).
+				AnyTimes()
+
+			databaseClient.EXPECT().
+				Get(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
+					return &database.Object{
+						Metadata: database.Metadata{ID: id, ETag: "resource-etag"},
+						Data:     &stored,
+					}, nil
+				}).AnyTimes()
+
+			queryCall := databaseClient.EXPECT().
+				Query(gomock.Any(), gomock.Any()).
+				Return(&database.ObjectQueryResult{}, nil)
+			if tt.expectQueries {
+				// Both environment resource types are searched.
+				queryCall.Times(2)
+			} else {
+				queryCall.Times(0)
+			}
+
+			if tt.expectSaved {
+				databaseClient.EXPECT().
+					Save(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, obj *database.Object, opts ...database.SaveOptions) error {
+						obj.ETag = "new-resource-etag"
+						obj.Data = envDataModel
+						return nil
+					}).Times(1)
+			}
+
+			opts := ctrl.Options{
+				DatabaseClient: databaseClient,
+				KubeClient:     k8sutil.NewFakeKubeClient(nil, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}),
+			}
+
+			ctl, err := NewCreateOrUpdateEnvironmentv20250801preview(opts)
+			require.NoError(t, err)
+
+			resp, err := ctl.Run(ctx, w, req)
+			require.NoError(t, err)
+			require.NoError(t, resp.Apply(ctx, w, req))
+			require.Equal(t, tt.expectedStatusCode, w.Result().StatusCode)
+
+			if tt.expectedErrorCode == "" {
+				return
+			}
+
+			errorResponse := &v1.ErrorResponse{}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), errorResponse))
+			require.Equal(t, tt.expectedErrorCode, errorResponse.Error.Code)
+			require.Contains(t, errorResponse.Error.Message, tt.storedNamespace)
+		})
+	}
 }

--- a/pkg/corerp/frontend/controller/util/namespace.go
+++ b/pkg/corerp/frontend/controller/util/namespace.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/radius-project/radius/pkg/components/database"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
+)
+
+const (
+	// legacyEnvironmentNamespaceField is where Applications.Core/environments stores its namespace.
+	legacyEnvironmentNamespaceField = "properties.compute.kubernetes.namespace"
+
+	// environmentNamespaceField is where Radius.Core/environments stores its namespace.
+	environmentNamespaceField = "properties.providers.kubernetes.namespace"
+)
+
+// FindEnvironmentNamespaceConflict reports whether any other environment in the plane already
+// claims the given Kubernetes namespace, returning the conflicting environment's resource ID or
+// an empty string when the namespace is free.
+//
+// The search is plane-wide (recursive across every resource group) and covers both
+// Applications.Core/environments and Radius.Core/environments, because a namespace is a
+// cluster-scoped resource: two environments that share one would deploy into the same place
+// regardless of which resource group or API version declared them. Scoping the search to a single
+// resource group, as this check historically did, let callers bypass the constraint just by
+// creating a second resource group.
+//
+// excludeID is the resource ID of the environment being created or updated. It is skipped so that
+// re-applying an unchanged environment does not conflict with its own stored record.
+//
+// This check is best-effort with respect to concurrency: it reads the current state and the caller
+// then writes, so two simultaneous creates naming the same namespace can both pass. The database
+// enforces uniqueness on resource ID only and cannot express a cross-resource invariant, so
+// closing that window would require a separate namespace-claim resource. The window is small (the
+// environment PUT is synchronous) and the failure mode is the pre-existing one: a duplicate slips
+// through and is caught the next time either environment is written.
+func FindEnvironmentNamespaceConflict(ctx context.Context, databaseClient database.Client, planeScope string, namespace string, excludeID string) (string, error) {
+	// An environment without a namespace claims nothing. Querying for the empty string would also
+	// be meaningless, since MatchesFilters treats a missing field as a non-match.
+	if namespace == "" {
+		return "", nil
+	}
+
+	legacyResult, err := findResourcesRecursive(ctx, planeScope, datamodel.EnvironmentResourceType, legacyEnvironmentNamespaceField, namespace, databaseClient)
+	if err != nil {
+		return "", err
+	}
+
+	for _, item := range legacyResult.Items {
+		env := &datamodel.Environment{}
+		if err := item.As(env); err != nil {
+			return "", err
+		}
+
+		if strings.EqualFold(env.ID, excludeID) {
+			continue
+		}
+
+		// ACI environments run on Azure Container Instances and never occupy a Kubernetes
+		// namespace, so they do not conflict.
+		if env.Properties.Compute.Kind == rpv1.ACIComputeKind {
+			continue
+		}
+
+		return env.ID, nil
+	}
+
+	result, err := findResourcesRecursive(ctx, planeScope, datamodel.EnvironmentResourceType_v20250801preview, environmentNamespaceField, namespace, databaseClient)
+	if err != nil {
+		return "", err
+	}
+
+	for _, item := range result.Items {
+		env := &datamodel.Environment_v20250801preview{}
+		if err := item.As(env); err != nil {
+			return "", err
+		}
+
+		if strings.EqualFold(env.ID, excludeID) {
+			continue
+		}
+
+		return env.ID, nil
+	}
+
+	return "", nil
+}
+
+// NamespaceConflictMessage builds the error message returned when a Kubernetes namespace is
+// already claimed by another environment. The conflicting environment's ID is included so an
+// operator can find and resolve the collision.
+func NamespaceConflictMessage(namespace string, conflictingEnvironmentID string) string {
+	return fmt.Sprintf("The Kubernetes namespace specified (%s) is already used by another Radius Environment (%s). Specify a unique Kubernetes namespace.", namespace, conflictingEnvironmentID)
+}
+
+// NamespaceImmutableMessage builds the error message returned when a request tries to change or
+// clear the Kubernetes namespace of an environment that already has one. requestedNamespace is
+// empty when the request drops the Kubernetes provider altogether.
+func NamespaceImmutableMessage(currentNamespace string, requestedNamespace string) string {
+	if requestedNamespace == "" {
+		return fmt.Sprintf("The Kubernetes namespace of an existing environment cannot be removed (current namespace: %s). Resources already deployed into that namespace would be orphaned. Create a new environment instead.", currentNamespace)
+	}
+
+	return fmt.Sprintf("The Kubernetes namespace of an existing environment cannot be changed (current namespace: %s, requested: %s). Resources already deployed into %s would be orphaned. Create a new environment instead.", currentNamespace, requestedNamespace, currentNamespace)
+}

--- a/pkg/corerp/frontend/controller/util/namespace.go
+++ b/pkg/corerp/frontend/controller/util/namespace.go
@@ -110,7 +110,7 @@ func FindEnvironmentNamespaceConflict(ctx context.Context, databaseClient databa
 // already claimed by another environment. The conflicting environment's ID is included so an
 // operator can find and resolve the collision.
 func NamespaceConflictMessage(namespace string, conflictingEnvironmentID string) string {
-	return fmt.Sprintf("The Kubernetes namespace specified (%s) is already used by another Radius Environment (%s). Specify a unique Kubernetes namespace.", namespace, conflictingEnvironmentID)
+	return fmt.Sprintf("The Kubernetes namespace specified (%s) is already used by another Radius Environment (%s). Each environment must use a unique Kubernetes namespace.", namespace, conflictingEnvironmentID)
 }
 
 // NamespaceImmutableMessage builds the error message returned when a request tries to change or

--- a/pkg/corerp/frontend/controller/util/namespace_test.go
+++ b/pkg/corerp/frontend/controller/util/namespace_test.go
@@ -195,5 +195,5 @@ func Test_FindEnvironmentNamespaceConflict(t *testing.T) {
 
 func Test_NamespaceConflictMessage(t *testing.T) {
 	message := NamespaceConflictMessage("default", envInDefaultGroup)
-	require.Equal(t, "The Kubernetes namespace specified (default) is already used by another Radius Environment ("+envInDefaultGroup+"). Specify a unique Kubernetes namespace.", message)
+	require.Equal(t, "The Kubernetes namespace specified (default) is already used by another Radius Environment ("+envInDefaultGroup+"). Each environment must use a unique Kubernetes namespace.", message)
 }

--- a/pkg/corerp/frontend/controller/util/namespace_test.go
+++ b/pkg/corerp/frontend/controller/util/namespace_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	"github.com/radius-project/radius/pkg/components/database"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+const (
+	testPlaneScope = "/planes/radius/local"
+
+	envInDefaultGroup = "/planes/radius/local/resourcegroups/default/providers/Radius.Core/environments/default"
+	envInOtherGroup   = "/planes/radius/local/resourcegroups/other/providers/Radius.Core/environments/other"
+	legacyEnvID       = "/planes/radius/local/resourcegroups/default/providers/Applications.Core/environments/legacy"
+)
+
+// legacyEnvironment builds a stored Applications.Core/environments record.
+func legacyEnvironment(id string, namespace string, kind rpv1.EnvironmentComputeKind) database.Object {
+	env := &datamodel.Environment{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{ID: id},
+		},
+	}
+	env.Properties.Compute.Kind = kind
+	env.Properties.Compute.KubernetesCompute.Namespace = namespace
+
+	return database.Object{Metadata: database.Metadata{ID: id}, Data: env}
+}
+
+// previewEnvironment builds a stored Radius.Core/environments record.
+func previewEnvironment(id string, namespace string) database.Object {
+	env := &datamodel.Environment_v20250801preview{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{ID: id},
+		},
+	}
+	env.Properties.Providers = &datamodel.Providers_v20250801preview{
+		Kubernetes: &datamodel.ProvidersKubernetes_v20250801preview{Namespace: namespace},
+	}
+
+	return database.Object{Metadata: database.Metadata{ID: id}, Data: env}
+}
+
+// expectQueries stubs the two namespace queries, returning legacyItems for the
+// Applications.Core query and previewItems for the Radius.Core query.
+func expectQueries(client *database.MockClient, legacyItems, previewItems []database.Object) {
+	client.EXPECT().
+		Query(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, query database.Query, options ...database.QueryOptions) (*database.ObjectQueryResult, error) {
+			if strings.EqualFold(query.ResourceType, datamodel.EnvironmentResourceType) {
+				return &database.ObjectQueryResult{Items: legacyItems}, nil
+			}
+
+			return &database.ObjectQueryResult{Items: previewItems}, nil
+		}).AnyTimes()
+}
+
+func Test_FindEnvironmentNamespaceConflict(t *testing.T) {
+	t.Run("reports a conflict from a different resource group", func(t *testing.T) {
+		// The regression this guards: the check used to be scoped to a single resource group,
+		// so creating an environment in a second group silently reused the namespace.
+		client := database.NewMockClient(gomock.NewController(t))
+		expectQueries(client, nil, []database.Object{previewEnvironment(envInDefaultGroup, "default")})
+
+		conflict, err := FindEnvironmentNamespaceConflict(t.Context(), client, testPlaneScope, "default", envInOtherGroup)
+		require.NoError(t, err)
+		require.Equal(t, envInDefaultGroup, conflict)
+	})
+
+	t.Run("reports a conflict across environment resource types", func(t *testing.T) {
+		client := database.NewMockClient(gomock.NewController(t))
+		expectQueries(client, []database.Object{legacyEnvironment(legacyEnvID, "shared", rpv1.KubernetesComputeKind)}, nil)
+
+		conflict, err := FindEnvironmentNamespaceConflict(t.Context(), client, testPlaneScope, "shared", envInOtherGroup)
+		require.NoError(t, err)
+		require.Equal(t, legacyEnvID, conflict)
+	})
+
+	t.Run("ignores the environment being updated", func(t *testing.T) {
+		client := database.NewMockClient(gomock.NewController(t))
+		expectQueries(client, nil, []database.Object{previewEnvironment(envInDefaultGroup, "default")})
+
+		conflict, err := FindEnvironmentNamespaceConflict(t.Context(), client, testPlaneScope, "default", envInDefaultGroup)
+		require.NoError(t, err)
+		require.Empty(t, conflict)
+	})
+
+	t.Run("ignores the environment being updated regardless of ID casing", func(t *testing.T) {
+		client := database.NewMockClient(gomock.NewController(t))
+		expectQueries(client, nil, []database.Object{previewEnvironment(envInDefaultGroup, "default")})
+
+		conflict, err := FindEnvironmentNamespaceConflict(t.Context(), client, testPlaneScope, "default", strings.ToUpper(envInDefaultGroup))
+		require.NoError(t, err)
+		require.Empty(t, conflict)
+	})
+
+	t.Run("inspects every match rather than only the first", func(t *testing.T) {
+		// A plane-wide query can return several environments. The environment being updated may
+		// come back first, which must not mask a genuine conflict later in the list.
+		client := database.NewMockClient(gomock.NewController(t))
+		expectQueries(client, nil, []database.Object{
+			previewEnvironment(envInDefaultGroup, "default"),
+			previewEnvironment(envInOtherGroup, "default"),
+		})
+
+		conflict, err := FindEnvironmentNamespaceConflict(t.Context(), client, testPlaneScope, "default", envInDefaultGroup)
+		require.NoError(t, err)
+		require.Equal(t, envInOtherGroup, conflict)
+	})
+
+	t.Run("ignores ACI environments", func(t *testing.T) {
+		// ACI environments run on Azure Container Instances and occupy no Kubernetes namespace.
+		client := database.NewMockClient(gomock.NewController(t))
+		expectQueries(client, []database.Object{legacyEnvironment(legacyEnvID, "shared", rpv1.ACIComputeKind)}, nil)
+
+		conflict, err := FindEnvironmentNamespaceConflict(t.Context(), client, testPlaneScope, "shared", envInOtherGroup)
+		require.NoError(t, err)
+		require.Empty(t, conflict)
+	})
+
+	t.Run("returns no conflict when the namespace is free", func(t *testing.T) {
+		client := database.NewMockClient(gomock.NewController(t))
+		expectQueries(client, nil, nil)
+
+		conflict, err := FindEnvironmentNamespaceConflict(t.Context(), client, testPlaneScope, "free", envInOtherGroup)
+		require.NoError(t, err)
+		require.Empty(t, conflict)
+	})
+
+	t.Run("skips the lookup entirely for an empty namespace", func(t *testing.T) {
+		client := database.NewMockClient(gomock.NewController(t))
+		client.EXPECT().Query(gomock.Any(), gomock.Any()).Times(0)
+
+		conflict, err := FindEnvironmentNamespaceConflict(t.Context(), client, testPlaneScope, "", envInOtherGroup)
+		require.NoError(t, err)
+		require.Empty(t, conflict)
+	})
+
+	t.Run("queries the whole plane recursively for both types", func(t *testing.T) {
+		client := database.NewMockClient(gomock.NewController(t))
+
+		queriedTypes := []string{}
+		client.EXPECT().
+			Query(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, query database.Query, options ...database.QueryOptions) (*database.ObjectQueryResult, error) {
+				require.Equal(t, testPlaneScope, query.RootScope)
+				require.True(t, query.ScopeRecursive, "the namespace check must span every resource group in the plane")
+				require.Len(t, query.Filters, 1)
+				require.Equal(t, "default", query.Filters[0].Value)
+
+				queriedTypes = append(queriedTypes, query.ResourceType)
+				return &database.ObjectQueryResult{}, nil
+			}).Times(2)
+
+		_, err := FindEnvironmentNamespaceConflict(t.Context(), client, testPlaneScope, "default", envInOtherGroup)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{datamodel.EnvironmentResourceType, datamodel.EnvironmentResourceType_v20250801preview}, queriedTypes)
+	})
+
+	t.Run("propagates query errors", func(t *testing.T) {
+		client := database.NewMockClient(gomock.NewController(t))
+		client.EXPECT().
+			Query(gomock.Any(), gomock.Any()).
+			Return(nil, errors.New("database unavailable")).
+			Times(1)
+
+		_, err := FindEnvironmentNamespaceConflict(t.Context(), client, testPlaneScope, "default", envInOtherGroup)
+		require.ErrorContains(t, err, "database unavailable")
+	})
+}
+
+func Test_NamespaceConflictMessage(t *testing.T) {
+	message := NamespaceConflictMessage("default", envInDefaultGroup)
+	require.Equal(t, "The Kubernetes namespace specified (default) is already used by another Radius Environment ("+envInDefaultGroup+"). Specify a unique Kubernetes namespace.", message)
+}

--- a/pkg/corerp/frontend/controller/util/query.go
+++ b/pkg/corerp/frontend/controller/util/query.go
@@ -40,9 +40,8 @@ func FindResources(ctx context.Context, rootScope, resourceType, filterKey, filt
 // findResourcesRecursive behaves like FindResources but applies rootScope recursively, so a plane
 // scope such as "/planes/radius/local" matches resources in every resource group beneath it.
 //
-// No QueryOptions are passed, which leaves MaxQueryItemCount unset and the underlying SQL LIMIT
-// null. That matters: the Postgres client applies Filters in Go *after* the query returns, so a
-// limit would silently reduce this to "check only the first page of resources".
+// No max item count is set, because this uniqueness check has to see every match: a limited query
+// returns only the first batch of resources, so a conflict beyond it would go unnoticed.
 func findResourcesRecursive(ctx context.Context, rootScope, resourceType, filterKey, filterValue string, databaseClient database.Client) (*database.ObjectQueryResult, error) {
 	query := database.Query{
 		RootScope:      rootScope,

--- a/pkg/corerp/frontend/controller/util/query.go
+++ b/pkg/corerp/frontend/controller/util/query.go
@@ -36,3 +36,24 @@ func FindResources(ctx context.Context, rootScope, resourceType, filterKey, filt
 	}
 	return databaseClient.Query(ctx, query)
 }
+
+// findResourcesRecursive behaves like FindResources but applies rootScope recursively, so a plane
+// scope such as "/planes/radius/local" matches resources in every resource group beneath it.
+//
+// No QueryOptions are passed, which leaves MaxQueryItemCount unset and the underlying SQL LIMIT
+// null. That matters: the Postgres client applies Filters in Go *after* the query returns, so a
+// limit would silently reduce this to "check only the first page of resources".
+func findResourcesRecursive(ctx context.Context, rootScope, resourceType, filterKey, filterValue string, databaseClient database.Client) (*database.ObjectQueryResult, error) {
+	query := database.Query{
+		RootScope:      rootScope,
+		ScopeRecursive: true,
+		ResourceType:   resourceType,
+		Filters: []database.QueryFilter{
+			{
+				Field: filterKey,
+				Value: filterValue,
+			},
+		},
+	}
+	return databaseClient.Query(ctx, query)
+}

--- a/test/functional-portable/cli/noncloud/cli_test.go
+++ b/test/functional-portable/cli/noncloud/cli_test.go
@@ -897,7 +897,19 @@ func Test_RadiusCoreEnv(t *testing.T) {
 		err = cli.GroupCreate(ctx, "test-group")
 		require.NoError(t, err)
 
-		_, err = cli.EnvironmentCreatePreview(ctx, "env-test-update", "test-group", "env-test-update")
+		// The environment needs its own namespace: namespaces are unique across the plane, and
+		// the default namespace is already claimed by the install-time environment. Radius
+		// requires the namespace to exist on the cluster before the environment can claim it.
+		envNamespace := "env-test-update"
+		createKubernetesNamespace(ctx, t, options, envNamespace)
+
+		// ctx is derived from the parent test's context, which outlives this subtest's cleanup.
+		// t.Context() would be wrong here: it is canceled just before cleanup functions run.
+		t.Cleanup(func() {
+			deleteKubernetesNamespace(ctx, t, options, envNamespace)
+		})
+
+		_, err = cli.EnvironmentCreatePreview(ctx, "env-test-update", "test-group", envNamespace)
 		require.NoError(t, err)
 
 		output, err := cli.EnvironmentListPreview(ctx, "test-group")

--- a/test/functional-portable/cli/noncloud/cli_test.go
+++ b/test/functional-portable/cli/noncloud/cli_test.go
@@ -897,7 +897,7 @@ func Test_RadiusCoreEnv(t *testing.T) {
 		err = cli.GroupCreate(ctx, "test-group")
 		require.NoError(t, err)
 
-		_, err = cli.EnvironmentCreatePreview(ctx, "env-test-update", "test-group", "")
+		_, err = cli.EnvironmentCreatePreview(ctx, "env-test-update", "test-group", "env-test-update")
 		require.NoError(t, err)
 
 		output, err := cli.EnvironmentListPreview(ctx, "test-group")

--- a/test/functional-portable/dynamicrp/noncloud/resources/dynamicrp_test.go
+++ b/test/functional-portable/dynamicrp/noncloud/resources/dynamicrp_test.go
@@ -515,7 +515,7 @@ func Test_UDT_ConnectionTo_UDTTF(t *testing.T) {
 	existingTemplate := "testdata/udt2udt-connection-tf.bicep"
 	name := "dynamicrp-udt2udt-tf"
 	appNamespace := "dynamicrp-udt2udt-tf"
-	appName := "udttoudtapp"
+	appName := "udttoudtapptf"
 	expectedEnvName := "CONN_INJECTED"
 	childResourceTypeName := "Test.Resources/externalResource"
 	childResourceTypeParam := strings.Split(childResourceTypeName, "/")[1]
@@ -567,12 +567,12 @@ func Test_UDT_ConnectionTo_UDTTF(t *testing.T) {
 						Type: validation.CoreApplicationsResource,
 					},
 					{
-						Name: "udttoudtparent",
+						Name: "udttoudtparenttf",
 						Type: "test.resources/usertypealpha",
 						App:  appName,
 					},
 					{
-						Name: "udttoudtchild",
+						Name: "udttoudtchildtf",
 						Type: "test.resources/externalresource",
 					},
 					{

--- a/test/functional-portable/dynamicrp/noncloud/resources/dynamicrp_test.go
+++ b/test/functional-portable/dynamicrp/noncloud/resources/dynamicrp_test.go
@@ -576,7 +576,7 @@ func Test_UDT_ConnectionTo_UDTTF(t *testing.T) {
 						Type: "test.resources/externalresource",
 					},
 					{
-						Name: "udttoudtenv",
+						Name: "udttoudtenvtf",
 						Type: validation.CoreEnvironmentsResource,
 					},
 					{

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/udt2udt-connection-tf.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/udt2udt-connection-tf.bicep
@@ -38,33 +38,33 @@ resource udttoudtenvtf 'Radius.Core/environments@2025-08-01-preview' = {
   }
 }
 
-resource udttoudtapp 'Radius.Core/applications@2025-08-01-preview' = {
-  name: 'udttoudtapp'
+resource udttoudtapptf 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'udttoudtapptf'
   location: 'global'
   properties: {
     environment: udttoudtenvtf.id
   }
 }
 
-resource udttoudtparent 'Test.Resources/userTypeAlpha@2023-10-01-preview' = {
-  name: 'udttoudtparent'
+resource udttoudtparenttf 'Test.Resources/userTypeAlpha@2023-10-01-preview' = {
+  name: 'udttoudtparenttf'
   properties: {
     environment: udttoudtenvtf.id
-    application: udttoudtapp.id
+    application: udttoudtapptf.id
     connections: {
       externalresource: {
-        source: udttoudtchild.id
+        source: udttoudtchildtf.id
       }
     }
   }
 }
 
-resource udttoudtchild 'Test.Resources/externalResource@2023-10-01-preview' = {
-  name: 'udttoudtchild'
+resource udttoudtchildtf 'Test.Resources/externalResource@2023-10-01-preview' = {
+  name: 'udttoudtchildtf'
   location: 'global'
   properties: {
     environment: udttoudtenvtf.id
-    application: udttoudtapp.id
+    application: udttoudtapptf.id
     configMap: '{"app1.sample.properties":"property1=value1\\nproperty2=value2","app2.sample.properties":"property3=value3\\nproperty4=value4"}'
   }
 }

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/udt2udt-connection-tf.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/udt2udt-connection-tf.bicep
@@ -23,8 +23,8 @@ resource recipepack 'Radius.Core/recipePacks@2025-08-01-preview' = {
   }
 }
 
-resource udttoudtenv 'Radius.Core/environments@2025-08-01-preview' = {
-  name: 'udttoudtenv'
+resource udttoudtenvtf 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'udttoudtenvtf'
   location: 'global'
   properties: {
     recipePacks: [
@@ -42,14 +42,14 @@ resource udttoudtapp 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'udttoudtapp'
   location: 'global'
   properties: {
-    environment: udttoudtenv.id
+    environment: udttoudtenvtf.id
   }
 }
 
 resource udttoudtparent 'Test.Resources/userTypeAlpha@2023-10-01-preview' = {
   name: 'udttoudtparent'
   properties: {
-    environment: udttoudtenv.id
+    environment: udttoudtenvtf.id
     application: udttoudtapp.id
     connections: {
       externalresource: {
@@ -63,7 +63,7 @@ resource udttoudtchild 'Test.Resources/externalResource@2023-10-01-preview' = {
   name: 'udttoudtchild'
   location: 'global'
   properties: {
-    environment: udttoudtenv.id
+    environment: udttoudtenvtf.id
     application: udttoudtapp.id
     configMap: '{"app1.sample.properties":"property1=value1\\nproperty2=value2","app2.sample.properties":"property3=value3\\nproperty4=value4"}'
   }


### PR DESCRIPTION
## Summary
Enforces the "one environment per Kubernetes namespace" constraint consistently for `Radius.Core/environments`, and makes the namespace immutable once set.

Previously the check was scoped to a single Radius resource group, so creating an environment in a *different* resource group silently bypassed it. Two environments then deployed into the same namespace and their Kubernetes resources collided — deploying the same application to both left only one Deployment and Service on the cluster.

The new rules for `Radius.Core/environments`:

| Operation | Behavior |
| --- | --- |
| Create | Namespace must not be claimed by any other environment |
| Update, namespace unchanged | No uniqueness check runs at all |
| Update, namespace changed | Rejected — `400 NamespaceImmutable` |
| Update, Kubernetes provider removed | Rejected — `400 NamespaceImmutable` |
| Update, claiming a namespace for the first time | Uniqueness check runs |

Immutability is what makes this safe to ship: because the namespace cannot change after create, an update that leaves it alone cannot introduce a conflict, so the check is skipped entirely. Writes that only touch other properties — `rad recipe register`, `rad env update`, and the environment updates cascaded by `rad recipepack delete` — never fail because of a namespace the caller did not intend to modify.

**`Applications.Core/environments` enforcement is deliberately unchanged.** It remains scoped to the current resource group and resource type. That type is on a deprecation path, and widening it would start failing writes on existing installs that already have duplicate namespaces. The only change there is the error surface: a distinct `NamespaceAlreadyInUse` code and a message naming the conflicting environment, replacing the raw conflict blob.

Note: With a plane-wide constraint, defaulting every environment to `default` would make the second `rad env create` fail unless users always passed `--kubernetes-namespace`.


## Reason for change
Fixes #12420
Per the discussion on the issue, the chosen direction was to enforce it consistently rather than remove it, plus a clearer error message.

## How to test

**Cross-resource-group conflict is now caught:**

```bash
rad group create g1 && rad group create g2
rad env create env1 -g g1 --kubernetes-namespace shared --preview
rad env create env2 -g g2 --kubernetes-namespace shared --preview   # now fails
```

Expect a `NamespaceAlreadyInUse` error naming `.../g1/providers/Radius.Core/environments/env1`. Before this change the second command succeeded.

**Namespace is immutable:**

```bash
rad env update env1 -g g1 --kubernetes-namespace other --preview   # rejected
rad env update env1 -g g1 --clear-kubernetes --preview             # rejected
```

**Unrelated writes are unaffected** (the important regression check):

```bash
rad recipe register myrecipe -e env1 -g g1 --template-kind bicep --template-path <path>
rad env update env1 -g g1 --azure-subscription-id <id> --azure-resource-group <rg> --preview
```

Both must succeed, including on installs that already have duplicate namespaces across groups.

**Legacy type is untouched:** repeat the first scenario without `--preview`; the second create must still succeed (group-scoped enforcement), only with a clearer error when it does conflict within one group.

Automated:

```bash
go test ./pkg/corerp/frontend/... ./pkg/cli/cmd/env/... ./pkg/cli/cmd/radinit/... ./pkg/cli/clients/... ./pkg/armrpc/...
```

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `pkg/corerp/frontend/controller/util/namespace.go` | **New.** `FindEnvironmentNamespaceConflict` searches the whole plane across both environment resource types, iterating all matches while skipping the resource under change and ACI environments. Plus the conflict and immutability message builders. |
| `pkg/corerp/frontend/controller/util/namespace_test.go` | **New.** Covers cross-group and cross-type conflicts, self-exclusion, iterating past self to a later conflict, ACI exemption, and the recursive plane-wide query shape. |
| `pkg/corerp/frontend/controller/util/query.go` | Adds `findResourcesRecursive` (sets `ScopeRecursive`). Deliberately passes no `QueryOptions`: the Postgres client applies filters in Go *after* the SQL `LIMIT`, so a limit would silently reduce this to a first-page-only check. |
| `pkg/corerp/frontend/controller/environments/v20250801preview/createorupdateenvironment.go` | Adds `validateNamespace` and `existingNamespace`, implementing the create-vs-update rules above. |
| `pkg/corerp/frontend/controller/environments/v20250801preview/createorupdateenvironment_test.go` | Adds uniqueness and immutability test suites; existing update/patch cases now assert **no** uniqueness query is issued. |
| `pkg/corerp/frontend/controller/environments/createorupdateenvironment.go` | Legacy controller: enforcement unchanged; returns the new error code and message. |
| `pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go` | Adds a test asserting the improved error **and** that the query stays non-recursive and single-type. |
| `pkg/armrpc/api/v1/errorcodes.go` | Adds `NamespaceAlreadyInUse` and `NamespaceImmutable`. |
| `pkg/armrpc/rest/results.go` | Adds `NewConflictResponseWithCode` and `NewBadRequestResponseWithCode`. |
| `pkg/cli/clients/errors.go`, `pkg/cli/clients/errors_test.go` | Adds `IsNamespaceAlreadyInUseError`, keyed on the error **code** rather than HTTP 409 — `PrepareResource` also returns 409 for in-flight provisioning. |
| `pkg/cli/cmd/env/create/create.go` | Friendly message on namespace conflict. |
| `pkg/cli/cmd/env/create/preview/create.go` | Friendly message on namespace conflict. The `default` namespace default is unchanged. |
| `pkg/cli/cmd/env/update/preview/update.go`, `pkg/cli/cmd/env/update/preview/update_test.go` | Rejects namespace changes and `--clear-kubernetes` client-side for fast feedback; the server enforces independently. |
| `pkg/cli/cmd/radinit/preview/environment.go` | Validates the namespace prompt with Kubernetes namespace rules instead of resource-name rules — the prompt asks for a namespace, but a value like `MyNamespace` previously passed the CLI and failed server-side. |


## Breaking changes scoped to new `Radius.Core/environments` (preview). No impact on `Applications.Core` users.

- The Kubernetes namespace is now immutable after an environment is created. Changing it requires creating a new environment.
- `--clear-kubernetes` is rejected on an environment that has a namespace.


