### PR TITLE
ci: update condition for build-and-push-cli job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,8 +69,7 @@ jobs:
   build-and-push-cli:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     needs: [changes]
-    # if: github.repository == 'radius-project/radius' && needs.changes.outputs.only_changed != 'true'
-    if: github.repository == 'radius-project/radius'
+    if: github.repository == 'radius-project/radius' && needs.changes.outputs.only_changed != 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
Adjust the condition for the build-and-push-cli job to ensure it only runs when the `only_changed` output is not true. This change improves the job's execution logic.