### PR TITLE
Fix invalid YAML in deploy workflow templates (arch placeholder quoting)

### DIFF
--- a/.github/extension/run-rad-commands-aws.yml
+++ b/.github/extension/run-rad-commands-aws.yml
@@ -42,8 +42,8 @@ env:
   # ${{ vars.RADIUS_BUILD_PLATFORMS || 'linux/amd64,linux/arm64' }}. When a
   # template does not opt in, the unsubstituted placeholder disables the feature
   # and the containerImages recipe's default platforms apply (existing behavior).
-  TARGET_CLUSTER_ARCH_MODE: '{{TARGET_CLUSTER_ARCH_MODE}}'
-  TARGET_CLUSTER_ARCH_FALLBACK_PLATFORMS: '{{TARGET_CLUSTER_ARCH_FALLBACK_PLATFORMS}}'
+  TARGET_CLUSTER_ARCH_MODE: "{{TARGET_CLUSTER_ARCH_MODE}}"
+  TARGET_CLUSTER_ARCH_FALLBACK_PLATFORMS: "{{TARGET_CLUSTER_ARCH_FALLBACK_PLATFORMS}}"
 
 jobs:
   deploy:

--- a/.github/extension/run-rad-commands-azure.yml
+++ b/.github/extension/run-rad-commands-azure.yml
@@ -42,8 +42,8 @@ env:
   # ${{ vars.RADIUS_BUILD_PLATFORMS || 'linux/amd64,linux/arm64' }}. When a
   # template does not opt in, the unsubstituted placeholder disables the feature
   # and the containerImages recipe's default platforms apply (existing behavior).
-  TARGET_CLUSTER_ARCH_MODE: '{{TARGET_CLUSTER_ARCH_MODE}}'
-  TARGET_CLUSTER_ARCH_FALLBACK_PLATFORMS: '{{TARGET_CLUSTER_ARCH_FALLBACK_PLATFORMS}}'
+  TARGET_CLUSTER_ARCH_MODE: "{{TARGET_CLUSTER_ARCH_MODE}}"
+  TARGET_CLUSTER_ARCH_FALLBACK_PLATFORMS: "{{TARGET_CLUSTER_ARCH_FALLBACK_PLATFORMS}}"
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary

These deploy workflow templates are rendered by substituting `{{...}}` placeholders. For the architecture placeholders, the tooling injects a GitHub Actions expression whose string-literal default is **single-quoted** (GHA requires single quotes for string literals):

```
${{ vars.RADIUS_BUILD_ARCH_MODE || 'detect' }}
```

But these templates wrapped the placeholder scalar in **single** quotes:

```yaml
TARGET_CLUSTER_ARCH_MODE: '{{TARGET_CLUSTER_ARCH_MODE}}'
```

After substitution the quotes nest and YAML terminates the scalar early, producing invalid YAML:

```yaml
TARGET_CLUSTER_ARCH_MODE: '${{ vars.RADIUS_BUILD_ARCH_MODE || 'detect' }}'
```

Every Azure and AWS deploy dispatch then failed with `HTTP 422: failed to parse workflow ... error in your yaml syntax`.

## Fix

In both `.github/extension/run-rad-commands-azure.yml` and `.github/extension/run-rad-commands-aws.yml`, the two architecture placeholder scalars are changed from single to **double** quotes:

```yaml
TARGET_CLUSTER_ARCH_MODE: "{{TARGET_CLUSTER_ARCH_MODE}}"
TARGET_CLUSTER_ARCH_FALLBACK_PLATFORMS: "{{TARGET_CLUSTER_ARCH_FALLBACK_PLATFORMS}}"
```

The rendered result then becomes valid YAML — the outer double quotes safely contain the inner single-quoted GHA string literal:

```yaml
TARGET_CLUSTER_ARCH_MODE: "${{ vars.RADIUS_BUILD_ARCH_MODE || 'detect' }}"
```

The other single-quoted scalars (`APP_FILE: '{{APP_FILE}}'`, `default: '{{ENV}}'`, `environment: ${{ inputs.environment || '{{ENV}}' }}`) inject plain values that contain no single quotes, so they remain valid and are left unchanged.

## Verification

- Both provider files parse as valid YAML.
- Simulated the substitution (`{{TARGET_CLUSTER_ARCH_MODE}}` → `${{ vars.RADIUS_BUILD_ARCH_MODE || 'detect' }}` and `{{TARGET_CLUSTER_ARCH_FALLBACK_PLATFORMS}}` → `${{ vars.RADIUS_BUILD_PLATFORMS || 'linux/amd64,linux/arm64' }}`) in temp copies of each file and confirmed they still parse as valid YAML, with the GHA expression preserved intact as the string value.

## Related

- Regression introduced by the single-quoting in #12640