### PR TITLE
Add --preview support to rad resource list for Radius.Core environments and applications types

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -302,6 +302,8 @@ func initSubCommands() {
 	resourceCmd.AddCommand(resourceShowCmd)
 
 	resourceListCmd, _ := resource_list.NewCommand(framework)
+	previewResourceListCmd, _ := resource_list.NewPreviewCommand(framework)
+	wirePreviewSubcommand(resourceListCmd, previewResourceListCmd)
 	resourceCmd.AddCommand(resourceListCmd)
 
 	resourceCreateCmd, _ := resource_create.NewCommand(framework)

--- a/cmd/rad/cmd/root_test.go
+++ b/cmd/rad/cmd/root_test.go
@@ -430,6 +430,13 @@ func Test_EnvCreate_ExposesPreviewRecipePacksFlag(t *testing.T) {
 		"rad env create must accept --preview together with --recipe-packs")
 }
 
+func Test_ResourceList_ExposesPreviewFlag(t *testing.T) {
+	listCmd, _, err := RootCmd.Find([]string{"resource", "list"})
+	require.NoError(t, err)
+	require.Equal(t, "list", listCmd.Name())
+	require.NotNil(t, listCmd.Flags().Lookup("preview"), "rad resource list must expose --preview")
+}
+
 // Test_EnvPreviewOnlyFlagsRejectedWithoutPreview drives the real, fully-assembled command tree
 // and asserts that each preview-only flag is rejected when preview mode is off. This guards
 // against a preview-only flag being added to a command without also being registered in the

--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -161,15 +161,19 @@ type ApplicationsManagementClient interface {
 	ListResourcesOfType(ctx context.Context, resourceType string) ([]generated.GenericResource, error)
 
 	// ListResourcesOfTypeInApplication lists all resources of a given type in a given application in the configured scope.
+	// Names target Applications.Core; use a full resource ID for other application types.
 	ListResourcesOfTypeInApplication(ctx context.Context, applicationNameOrID string, resourceType string) ([]generated.GenericResource, error)
 
 	// ListResourcesOfTypeInEnvironment lists all resources of a given type in a given environment in the configured scope.
+	// Names target Applications.Core; use a full resource ID for other environment types.
 	ListResourcesOfTypeInEnvironment(ctx context.Context, environmentNameOrID string, resourceType string) ([]generated.GenericResource, error)
 
 	// ListResourcesInApplication lists all resources in a given application in the configured scope.
+	// Names target Applications.Core; use a full resource ID for other application types.
 	ListResourcesInApplication(ctx context.Context, applicationNameOrID string) ([]generated.GenericResource, error)
 
 	// ListResourcesInEnvironment lists all resources in a given environment in the configured scope.
+	// Names target Applications.Core; use a full resource ID for other environment types.
 	ListResourcesInEnvironment(ctx context.Context, environmentNameOrID string) ([]generated.GenericResource, error)
 
 	// GetResource retrieves a resource by its type and name (or id).

--- a/pkg/cli/clients/management.go
+++ b/pkg/cli/clients/management.go
@@ -85,6 +85,7 @@ func (amc *UCPApplicationsManagementClient) ListResourcesOfType(ctx context.Cont
 }
 
 // ListResourcesOfTypeInApplication lists all resources of a given type in a given application in the configured scope.
+// Names are qualified as Applications.Core applications; pass a full resource ID for other application types.
 func (amc *UCPApplicationsManagementClient) ListResourcesOfTypeInApplication(ctx context.Context, applicationNameOrID string, resourceType string) ([]generated.GenericResource, error) {
 	applicationID, err := amc.fullyQualifyID(applicationNameOrID, "Applications.Core/applications")
 	if err != nil {
@@ -107,6 +108,7 @@ func (amc *UCPApplicationsManagementClient) ListResourcesOfTypeInApplication(ctx
 }
 
 // ListResourcesOfTypeInEnvironment lists all resources of a given type in a given environment in the configured scope.
+// Names are qualified as Applications.Core environments; pass a full resource ID for other environment types.
 func (amc *UCPApplicationsManagementClient) ListResourcesOfTypeInEnvironment(ctx context.Context, environmentNameOrID string, resourceType string) ([]generated.GenericResource, error) {
 	environmentID, err := amc.fullyQualifyID(environmentNameOrID, "Applications.Core/environments")
 	if err != nil {
@@ -1109,6 +1111,7 @@ func (amc *UCPApplicationsManagementClient) ListAllResourceTypesNames(ctx contex
 }
 
 // ListResourcesInApplication lists all resources in a given application in the configured scope.
+// Names are qualified as Applications.Core applications; pass a full resource ID for other application types.
 func (amc *UCPApplicationsManagementClient) ListResourcesInApplication(ctx context.Context, applicationNameOrID string) ([]generated.GenericResource, error) {
 	applicationID, err := amc.fullyQualifyID(applicationNameOrID, "Applications.Core/applications")
 	if err != nil {
@@ -1134,6 +1137,7 @@ func (amc *UCPApplicationsManagementClient) ListResourcesInApplication(ctx conte
 }
 
 // ListResourcesInEnvironment lists all resources in a given environment in the configured scope.
+// Names are qualified as Applications.Core environments; pass a full resource ID for other environment types.
 func (amc *UCPApplicationsManagementClient) ListResourcesInEnvironment(ctx context.Context, environmentNameOrID string) ([]generated.GenericResource, error) {
 	environmentID, err := amc.fullyQualifyID(environmentNameOrID, "Applications.Core/environments")
 	if err != nil {

--- a/pkg/cli/clients/management_test.go
+++ b/pkg/cli/clients/management_test.go
@@ -2574,6 +2574,12 @@ func Test_fullyQualifyID(t *testing.T) {
 		require.Equal(t, "/planes/radius/local/resourceGroups/my-rg/providers/Applications.Core/environments/my-env", id)
 	})
 
+	t.Run("preserves Radius.Core resource id", func(t *testing.T) {
+		id, err := client.fullyQualifyID("/planes/radius/local/resourceGroups/my-rg/providers/Radius.Core/environments/my-env", "Applications.Core/environments")
+		require.NoError(t, err)
+		require.Equal(t, "/planes/radius/local/resourceGroups/my-rg/providers/Radius.Core/environments/my-env", id)
+	})
+
 	t.Run("valid name", func(t *testing.T) {
 		id, err := client.fullyQualifyID("my-env", "Applications.Core/environments")
 		require.NoError(t, err)

--- a/pkg/cli/cmd/resource/list/list.go
+++ b/pkg/cli/cmd/resource/list/list.go
@@ -305,6 +305,9 @@ func (r *Runner) requireEnvironmentNameOrID(cmd *cobra.Command, args []string) (
 	if !strings.EqualFold(environmentID.Type(), datamodel.EnvironmentResourceType_v20250801preview) {
 		return "", clierrors.Message("The environment ID %q must reference a %s resource when preview mode is enabled.", environmentNameOrID, datamodel.EnvironmentResourceType_v20250801preview)
 	}
+	if err := r.requireWorkspaceScope(environmentID); err != nil {
+		return "", err
+	}
 
 	return environmentID.String(), nil
 }
@@ -322,10 +325,23 @@ func (r *Runner) resolvePreviewApplication() error {
 	if !strings.EqualFold(applicationID.Type(), datamodel.ApplicationResourceType_v20250801preview) {
 		return clierrors.Message("The application ID %q must reference a %s resource when preview mode is enabled.", r.ApplicationName, datamodel.ApplicationResourceType_v20250801preview)
 	}
+	if err := r.requireWorkspaceScope(applicationID); err != nil {
+		return err
+	}
 
 	r.ApplicationName = applicationID.Name()
 	r.ApplicationID = applicationID.String()
 	return nil
+}
+
+// requireWorkspaceScope rejects resource IDs outside the workspace scope. Listing only enumerates
+// resources within the workspace scope, so an out-of-scope ID would silently filter everything out.
+func (r *Runner) requireWorkspaceScope(id resources.ID) error {
+	if strings.EqualFold(id.RootScope(), r.Workspace.Scope) {
+		return nil
+	}
+
+	return clierrors.Message("The resource ID %q is in scope %q, but workspace %q is scoped to %q. Switch to a workspace with a matching scope to list its resources.", id.String(), id.RootScope(), r.Workspace.Name, r.Workspace.Scope)
 }
 
 func (r *Runner) applicationNameOrID() string {

--- a/pkg/cli/cmd/resource/list/list.go
+++ b/pkg/cli/cmd/resource/list/list.go
@@ -18,6 +18,7 @@ package list
 
 import (
 	"context"
+	"strings"
 
 	"github.com/radius-project/radius/pkg/cli"
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -31,7 +32,10 @@ import (
 	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
+	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
 	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +43,17 @@ import (
 // regardless of type, in an application or the default environment. It adds flags for application name,
 // environment name, resource group, output and workspace.
 func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
+	return newCommand(factory, false)
+}
+
+// NewPreviewCommand creates the preview `rad resource list` command.
+func NewPreviewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
+	return newCommand(factory, true)
+}
+
+func newCommand(factory framework.Factory, preview bool) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
+	runner.Preview = preview
 
 	cmd := &cobra.Command{
 		Use:   "list [resourceType]",
@@ -70,6 +84,10 @@ rad resource list -e not-default-env
 
 # list all resources of any type in an application
 rad resource list -a icecream-store
+
+# list preview resources in a Radius.Core environment or application
+rad resource list -e not-default-env --preview
+rad resource list -a icecream-store --preview
 `,
 		Args: cobra.MaximumNArgs(1),
 		RunE: framework.RunCommand(runner),
@@ -88,12 +106,15 @@ rad resource list -a icecream-store
 type Runner struct {
 	ConfigHolder              *framework.ConfigHolder
 	UCPClientFactory          *v20231001preview.ClientFactory
+	RadiusCoreClientFactory   *corerpv20250801.ClientFactory
 	ConnectionFactory         connections.Factory
 	Output                    output.Interface
 	Workspace                 *workspaces.Workspace
 	ApplicationName           string
-	EnvironmentName           string
+	ApplicationID             string
+	EnvironmentNameOrID       string
 	Format                    string
+	Preview                   bool
 	ResourceType              string
 	ResourceTypeSuffix        string
 	ResourceProviderNamespace string
@@ -141,6 +162,13 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return clierrors.Message("The '-e/--environment' flag cannot be combined with '-a/--application'. An application belongs to a single environment.")
 	}
 
+	if r.Preview && r.ApplicationName != "" {
+		err = r.resolvePreviewApplication()
+		if err != nil {
+			return err
+		}
+	}
+
 	if len(args) > 0 {
 		r.ResourceProviderNamespace, r.ResourceTypeSuffix, err = cli.RequireFullyQualifiedResourceType(args)
 		if err != nil {
@@ -150,14 +178,14 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 		if environmentFlag != "" {
 			// A resource type was given along with the environment flag, so scope the typed list to that environment.
-			r.EnvironmentName, err = cli.RequireEnvironmentName(cmd, args, *workspace)
+			r.EnvironmentNameOrID, err = r.requireEnvironmentNameOrID(cmd, args)
 			if err != nil {
 				return err
 			}
 		}
 	} else if r.ApplicationName == "" {
 		// No resource type or application was given, so list all resources (of any type) in an environment.
-		r.EnvironmentName, err = cli.RequireEnvironmentName(cmd, args, *workspace)
+		r.EnvironmentNameOrID, err = r.requireEnvironmentNameOrID(cmd, args)
 		if err != nil {
 			return err
 		}
@@ -189,11 +217,11 @@ func (r *Runner) Run(ctx context.Context) error {
 	var resourceList []generated.GenericResource
 	if r.ResourceType == "" {
 		if r.ApplicationName == "" {
-			resourceList, err = client.ListResourcesInEnvironment(ctx, r.EnvironmentName)
+			resourceList, err = client.ListResourcesInEnvironment(ctx, r.EnvironmentNameOrID)
 		} else {
 			err = r.requireApplicationExists(ctx, client)
 			if err == nil {
-				resourceList, err = client.ListResourcesInApplication(ctx, r.ApplicationName)
+				resourceList, err = client.ListResourcesInApplication(ctx, r.applicationNameOrID())
 			}
 		}
 	} else {
@@ -216,10 +244,10 @@ func (r *Runner) Run(ctx context.Context) error {
 		case r.ApplicationName != "":
 			err = r.requireApplicationExists(ctx, client)
 			if err == nil {
-				resourceList, err = client.ListResourcesOfTypeInApplication(ctx, r.ApplicationName, r.ResourceType)
+				resourceList, err = client.ListResourcesOfTypeInApplication(ctx, r.applicationNameOrID(), r.ResourceType)
 			}
-		case r.EnvironmentName != "":
-			resourceList, err = client.ListResourcesOfTypeInEnvironment(ctx, r.EnvironmentName, r.ResourceType)
+		case r.EnvironmentNameOrID != "":
+			resourceList, err = client.ListResourcesOfTypeInEnvironment(ctx, r.EnvironmentNameOrID, r.ResourceType)
 		default:
 			resourceList, err = client.ListResourcesOfType(ctx, r.ResourceType)
 		}
@@ -233,9 +261,80 @@ func (r *Runner) Run(ctx context.Context) error {
 
 // requireApplicationExists returns a user-facing error if r.ApplicationName does not exist in the workspace.
 func (r *Runner) requireApplicationExists(ctx context.Context, client clients.ApplicationsManagementClient) error {
+	if r.Preview {
+		if r.RadiusCoreClientFactory == nil {
+			clientFactory, err := cmd.InitializeRadiusCoreClientFactory(ctx, r.Workspace)
+			if err != nil {
+				return err
+			}
+			r.RadiusCoreClientFactory = clientFactory
+		}
+
+		_, err := r.RadiusCoreClientFactory.NewApplicationsClient().Get(ctx, r.Workspace.Scope, r.ApplicationName, nil)
+		if clients.Is404Error(err) {
+			return clierrors.Message("The application %q could not be found in workspace %q. Make sure you specify the correct application with '-a/--application'.", r.ApplicationName, r.Workspace.Name)
+		}
+		return err
+	}
+
 	_, err := client.GetApplication(ctx, r.ApplicationName)
 	if clients.Is404Error(err) {
 		return clierrors.Message("The application %q could not be found in workspace %q. Make sure you specify the correct application with '-a/--application'.", r.ApplicationName, r.Workspace.Name)
 	}
 	return err
+}
+
+func (r *Runner) requireEnvironmentNameOrID(cmd *cobra.Command, args []string) (string, error) {
+	if !r.Preview {
+		return cli.RequireEnvironmentName(cmd, args, *r.Workspace)
+	}
+
+	environmentNameOrID, err := cli.RequireEnvironmentNameOrID(cmd, args, *r.Workspace)
+	if err != nil {
+		return "", err
+	}
+
+	if !strings.HasPrefix(environmentNameOrID, resources.SegmentSeparator) {
+		return resourceID(r.Workspace.Scope, datamodel.EnvironmentResourceType_v20250801preview, environmentNameOrID), nil
+	}
+
+	environmentID, err := resources.ParseResource(environmentNameOrID)
+	if err != nil {
+		return "", err
+	}
+	if !strings.EqualFold(environmentID.Type(), datamodel.EnvironmentResourceType_v20250801preview) {
+		return "", clierrors.Message("The environment ID %q must reference a %s resource when preview mode is enabled.", environmentNameOrID, datamodel.EnvironmentResourceType_v20250801preview)
+	}
+
+	return environmentID.String(), nil
+}
+
+func (r *Runner) resolvePreviewApplication() error {
+	if !strings.HasPrefix(r.ApplicationName, resources.SegmentSeparator) {
+		r.ApplicationID = resourceID(r.Workspace.Scope, datamodel.ApplicationResourceType_v20250801preview, r.ApplicationName)
+		return nil
+	}
+
+	applicationID, err := resources.ParseResource(r.ApplicationName)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(applicationID.Type(), datamodel.ApplicationResourceType_v20250801preview) {
+		return clierrors.Message("The application ID %q must reference a %s resource when preview mode is enabled.", r.ApplicationName, datamodel.ApplicationResourceType_v20250801preview)
+	}
+
+	r.ApplicationName = applicationID.Name()
+	r.ApplicationID = applicationID.String()
+	return nil
+}
+
+func (r *Runner) applicationNameOrID() string {
+	if r.Preview {
+		return r.ApplicationID
+	}
+	return r.ApplicationName
+}
+
+func resourceID(scope string, resourceType string, name string) string {
+	return scope + "/providers/" + resourceType + "/" + name
 }

--- a/pkg/cli/cmd/resource/list/list_test.go
+++ b/pkg/cli/cmd/resource/list/list_test.go
@@ -256,6 +256,28 @@ workspaces:
 		require.Error(t, err)
 		require.Contains(t, err.Error(), datamodel.ApplicationResourceType_v20250801preview)
 	})
+
+	t.Run("rejects out-of-scope environment ID", func(t *testing.T) {
+		command, runner := newRunner(t)
+		otherScopeEnvID := "/planes/radius/local/resourceGroups/other-resource-group/providers/Radius.Core/environments/test-environment"
+		require.NoError(t, command.ParseFlags([]string{"-e", otherScopeEnvID}))
+
+		err := runner.Validate(command, []string{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "other-resource-group")
+		require.Contains(t, err.Error(), scope)
+	})
+
+	t.Run("rejects out-of-scope application ID", func(t *testing.T) {
+		command, runner := newRunner(t)
+		otherScopeAppID := "/planes/radius/local/resourceGroups/other-resource-group/providers/Radius.Core/applications/test-app"
+		require.NoError(t, command.ParseFlags([]string{"-a", otherScopeAppID}))
+
+		err := runner.Validate(command, []string{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "other-resource-group")
+		require.Contains(t, err.Error(), scope)
+	})
 }
 
 func Test_Run(t *testing.T) {

--- a/pkg/cli/cmd/resource/list/list_test.go
+++ b/pkg/cli/cmd/resource/list/list_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package list
 
 import (
+	"context"
+	"net/http"
 	"testing"
 
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 	"github.com/radius-project/radius/pkg/cli/clients"
 	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
 	"github.com/radius-project/radius/pkg/cli/clierrors"
@@ -27,9 +30,14 @@ import (
 	"github.com/radius-project/radius/pkg/cli/manifest"
 	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/cli/test_client_factory"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	corerpfake "github.com/radius-project/radius/pkg/corerp/api/v20250801preview/fake"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
 	"github.com/radius-project/radius/test/radcli"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -161,6 +169,93 @@ workspaces:
 		},
 	}
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
+}
+
+func Test_ValidatePreview(t *testing.T) {
+	const (
+		scope          = "/planes/radius/local/resourceGroups/test-resource-group"
+		previewEnvID   = scope + "/providers/Radius.Core/environments/test-environment"
+		previewAppID   = scope + "/providers/Radius.Core/applications/test-app"
+		legacyEnvID    = scope + "/providers/Applications.Core/environments/test-environment"
+		otherPreviewID = scope + "/providers/Radius.Core/environments/other-env"
+	)
+
+	config := radcli.LoadConfig(t, `
+workspaces:
+  default: test-workspace
+  items:
+    test-workspace:
+      connection:
+        context: test-context
+        kind: kubernetes
+      scope: `+scope+`
+      environment: `+previewEnvID+`
+`)
+
+	newRunner := func(t *testing.T) (*cobra.Command, *Runner) {
+		t.Helper()
+		factory := &framework.Impl{
+			ConfigHolder: &framework.ConfigHolder{Config: config},
+			Output:       &output.MockOutput{},
+		}
+		command, runner := NewPreviewCommand(factory)
+		return command, runner.(*Runner)
+	}
+
+	t.Run("preserves default Radius.Core environment ID", func(t *testing.T) {
+		command, runner := newRunner(t)
+
+		err := runner.Validate(command, []string{})
+		require.NoError(t, err)
+		require.Equal(t, previewEnvID, runner.EnvironmentNameOrID)
+	})
+
+	t.Run("qualifies explicit environment name as Radius.Core", func(t *testing.T) {
+		command, runner := newRunner(t)
+		require.NoError(t, command.ParseFlags([]string{"-e", "other-env"}))
+
+		err := runner.Validate(command, []string{})
+		require.NoError(t, err)
+		require.Equal(t, otherPreviewID, runner.EnvironmentNameOrID)
+	})
+
+	t.Run("rejects legacy environment ID", func(t *testing.T) {
+		command, runner := newRunner(t)
+		require.NoError(t, command.ParseFlags([]string{"-e", legacyEnvID}))
+
+		err := runner.Validate(command, []string{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), datamodel.EnvironmentResourceType_v20250801preview)
+	})
+
+	t.Run("qualifies application name as Radius.Core", func(t *testing.T) {
+		command, runner := newRunner(t)
+		require.NoError(t, command.ParseFlags([]string{"-a", "test-app"}))
+
+		err := runner.Validate(command, []string{})
+		require.NoError(t, err)
+		require.Equal(t, previewAppID, runner.ApplicationID)
+	})
+
+	t.Run("preserves full Radius.Core application ID", func(t *testing.T) {
+		command, runner := newRunner(t)
+		require.NoError(t, command.ParseFlags([]string{"-a", previewAppID}))
+
+		err := runner.Validate(command, []string{})
+		require.NoError(t, err)
+		require.Equal(t, "test-app", runner.ApplicationName)
+		require.Equal(t, previewAppID, runner.ApplicationID)
+	})
+
+	t.Run("rejects legacy application ID", func(t *testing.T) {
+		command, runner := newRunner(t)
+		legacyAppID := scope + "/providers/Applications.Core/applications/test-app"
+		require.NoError(t, command.ParseFlags([]string{"-a", legacyAppID}))
+
+		err := runner.Validate(command, []string{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), datamodel.ApplicationResourceType_v20250801preview)
+	})
 }
 
 func Test_Run(t *testing.T) {
@@ -317,7 +412,7 @@ func Test_Run(t *testing.T) {
 				UCPClientFactory:          clientFactory,
 				Output:                    outputSink,
 				Workspace:                 &workspaces.Workspace{Name: radcli.TestWorkspaceName},
-				EnvironmentName:           "test-env",
+				EnvironmentNameOrID:       "test-env",
 				ResourceType:              "MyCompany.Resources/testResources",
 				Format:                    "table",
 				ResourceTypeSuffix:        "testResources",
@@ -355,11 +450,11 @@ func Test_Run(t *testing.T) {
 			outputSink := &output.MockOutput{}
 
 			runner := &Runner{
-				ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
-				Output:            outputSink,
-				Workspace:         &workspaces.Workspace{Name: radcli.TestWorkspaceName},
-				EnvironmentName:   "test-env",
-				Format:            "table",
+				ConnectionFactory:   &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+				Output:              outputSink,
+				Workspace:           &workspaces.Workspace{Name: radcli.TestWorkspaceName},
+				EnvironmentNameOrID: "test-env",
+				Format:              "table",
 			}
 
 			err := runner.Run(t.Context())
@@ -435,6 +530,163 @@ func Test_Run(t *testing.T) {
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)
+		})
+	})
+
+	t.Run("Preview resources", func(t *testing.T) {
+		const (
+			scope = "/planes/radius/local/resourceGroups/test-group"
+			envID = scope + "/providers/Radius.Core/environments/test-env"
+			appID = scope + "/providers/Radius.Core/applications/test-app"
+		)
+
+		t.Run("List all resources in environment passes full Radius.Core ID", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			resources := []generated.GenericResource{radcli.CreateResource("Radius.Compute/containers", "A")}
+			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+			appManagementClient.EXPECT().
+				ListResourcesInEnvironment(gomock.Any(), envID).
+				Return(resources, nil).
+				Times(1)
+
+			outputSink := &output.MockOutput{}
+			runner := &Runner{
+				ConnectionFactory:   &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+				Output:              outputSink,
+				Workspace:           &workspaces.Workspace{Name: radcli.TestWorkspaceName, Scope: scope},
+				EnvironmentNameOrID: envID,
+				Format:              "table",
+				Preview:             true,
+			}
+
+			err := runner.Run(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, resources, outputSink.Writes[0].(output.FormattedOutput).Obj)
+		})
+
+		t.Run("List typed resources in environment passes full Radius.Core ID", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			resources := []generated.GenericResource{radcli.CreateResource("Radius.Compute/containers", "A")}
+			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+			appManagementClient.EXPECT().
+				ListResourcesOfTypeInEnvironment(gomock.Any(), envID, "MyCompany.Resources/testResources").
+				Return(resources, nil).
+				Times(1)
+
+			resourceTypeFactory, err := manifest.NewTestClientFactory(manifest.WithResourceProviderServerNoError)
+			require.NoError(t, err)
+			outputSink := &output.MockOutput{}
+			runner := &Runner{
+				ConnectionFactory:         &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+				UCPClientFactory:          resourceTypeFactory,
+				Output:                    outputSink,
+				Workspace:                 &workspaces.Workspace{Name: radcli.TestWorkspaceName, Scope: scope},
+				EnvironmentNameOrID:       envID,
+				ResourceType:              "MyCompany.Resources/testResources",
+				ResourceTypeSuffix:        "testResources",
+				ResourceProviderNamespace: "MyCompany.Resources",
+				Format:                    "table",
+				Preview:                   true,
+			}
+
+			err = runner.Run(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, resources, outputSink.Writes[0].(output.FormattedOutput).Obj)
+		})
+
+		t.Run("List all resources in application validates and passes full Radius.Core ID", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			resources := []generated.GenericResource{radcli.CreateResource("Radius.Compute/containers", "A")}
+			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+			appManagementClient.EXPECT().
+				ListResourcesInApplication(gomock.Any(), appID).
+				Return(resources, nil).
+				Times(1)
+
+			radiusCoreFactory, err := test_client_factory.NewRadiusCoreTestClientFactory(scope, nil, nil, test_client_factory.WithApplicationsServerNoError)
+			require.NoError(t, err)
+			outputSink := &output.MockOutput{}
+			runner := &Runner{
+				ConnectionFactory:       &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+				RadiusCoreClientFactory: radiusCoreFactory,
+				Output:                  outputSink,
+				Workspace:               &workspaces.Workspace{Name: radcli.TestWorkspaceName, Scope: scope},
+				ApplicationName:         "test-app",
+				ApplicationID:           appID,
+				Format:                  "table",
+				Preview:                 true,
+			}
+
+			err = runner.Run(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, resources, outputSink.Writes[0].(output.FormattedOutput).Obj)
+		})
+
+		t.Run("List typed resources in application passes full Radius.Core ID", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			resources := []generated.GenericResource{radcli.CreateResource("Radius.Compute/containers", "A")}
+			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+			appManagementClient.EXPECT().
+				ListResourcesOfTypeInApplication(gomock.Any(), appID, "MyCompany.Resources/testResources").
+				Return(resources, nil).
+				Times(1)
+
+			resourceTypeFactory, err := manifest.NewTestClientFactory(manifest.WithResourceProviderServerNoError)
+			require.NoError(t, err)
+			radiusCoreFactory, err := test_client_factory.NewRadiusCoreTestClientFactory(scope, nil, nil, test_client_factory.WithApplicationsServerNoError)
+			require.NoError(t, err)
+			outputSink := &output.MockOutput{}
+			runner := &Runner{
+				ConnectionFactory:         &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+				UCPClientFactory:          resourceTypeFactory,
+				RadiusCoreClientFactory:   radiusCoreFactory,
+				Output:                    outputSink,
+				Workspace:                 &workspaces.Workspace{Name: radcli.TestWorkspaceName, Scope: scope},
+				ApplicationName:           "test-app",
+				ApplicationID:             appID,
+				ResourceType:              "MyCompany.Resources/testResources",
+				ResourceTypeSuffix:        "testResources",
+				ResourceProviderNamespace: "MyCompany.Resources",
+				Format:                    "table",
+				Preview:                   true,
+			}
+
+			err = runner.Run(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, resources, outputSink.Writes[0].(output.FormattedOutput).Obj)
+		})
+
+		t.Run("Missing Radius.Core application returns user-facing error", func(t *testing.T) {
+			notFoundServer := func() corerpfake.ApplicationsServer {
+				return corerpfake.ApplicationsServer{
+					Get: func(
+						context.Context,
+						string,
+						string,
+						*corerpv20250801.ApplicationsClientGetOptions,
+					) (resp azfake.Responder[corerpv20250801.ApplicationsClientGetResponse], errResp azfake.ErrorResponder) {
+						errResp.SetResponseError(http.StatusNotFound, "NotFound")
+						return
+					},
+				}
+			}
+			radiusCoreFactory, err := test_client_factory.NewRadiusCoreTestClientFactory(scope, nil, nil, notFoundServer)
+			require.NoError(t, err)
+
+			runner := &Runner{
+				ConnectionFactory:       &connections.MockFactory{ApplicationsManagementClient: clients.NewMockApplicationsManagementClient(gomock.NewController(t))},
+				RadiusCoreClientFactory: radiusCoreFactory,
+				Output:                  &output.MockOutput{},
+				Workspace:               &workspaces.Workspace{Name: radcli.TestWorkspaceName, Scope: scope},
+				ApplicationName:         "test-app",
+				ApplicationID:           appID,
+				Format:                  "table",
+				Preview:                 true,
+			}
+
+			err = runner.Run(t.Context())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "could not be found")
 		})
 	})
 }


### PR DESCRIPTION
## Summary

Adds `--preview` support to `rad resource list` so environment- and application-scoped listing works with the `Radius.Core/environments` and `Radius.Core/applications` resource types.

`rad resource list` is now wired through `wirePreviewSubcommand`, matching the pattern used by the `rad env` and `rad app` commands. In preview mode, the runner resolves fully-qualified `Radius.Core` resource IDs instead of bare names, and validates applications against the `Radius.Core` applications client.

## Reason for change

[#12481](https://github.com/radius-project/radius/pull/12481) made the `[resourceType]` argument optional so `rad resource list` could list all resources in an environment or application. That path only worked for legacy resources.

`cli.RequireEnvironmentName` reduces the workspace environment to its name, and `ListResourcesInEnvironment` re-qualifies a bare name as `Applications.Core/environments`. Filtering is exact, case-insensitive ID equality, so resources referencing `Radius.Core/environments` were silently excluded and the command returned an empty list. `-a` had the same problem, since it qualified names as `Applications.Core/applications` and validated existence through the legacy `GetApplication`.

Legacy and preview environments/applications may share a name, so the client deliberately does not match both ID forms at once — that would merge results from two distinct resources. Instead, the caller supplies the exact ID it wants filtered.

Fixes: #12609 

## How to test

Requires a preview environment (`rad env create <env> --preview`) and a deployed preview application.

```bash
# All resources in the default (Radius.Core) environment
rad resource list --preview

# All resources in a specific preview environment
rad resource list -e my-env --preview

# Typed listing scoped to a preview environment
rad resource list Radius.Compute/containers -e my-env --preview

# All resources in a preview application
rad resource list -a my-app --preview

# Full Radius.Core resource IDs are accepted
rad resource list -a /planes/radius/local/resourceGroups/my-rg/providers/Radius.Core/applications/my-app --preview

# RADIUS_PREVIEW=true activates preview mode
RADIUS_PREVIEW=true rad resource list
```

Verify that legacy behavior is unchanged when `--preview` is omitted, and that a legacy `Applications.Core` ID passed to `-e`/`-a` under `--preview` is rejected with a clear message.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `cmd/rad/cmd/root.go` | Wires `rad resource list` through `wirePreviewSubcommand` so `--preview` and `RADIUS_PREVIEW=true` route to the preview runner. |
| `cmd/rad/cmd/root_test.go` | Adds `Test_ResourceList_ExposesPreviewFlag`, asserting the assembled command tree exposes `--preview` on `rad resource list`. |
| `pkg/cli/cmd/resource/list/list.go` | Adds `NewPreviewCommand` and a `Preview` field on the runner, sharing one implementation. In preview mode, resolves `Radius.Core` environment/application IDs (preserving full IDs, qualifying bare names, rejecting non-`Radius.Core` IDs), validates applications via the `Radius.Core` applications client, and passes full IDs to the list methods. Renames `EnvironmentName` to `EnvironmentNameOrID` to reflect that it may hold a full ID. |
| `pkg/cli/cmd/resource/list/list_test.go` | Adds `Test_ValidatePreview` for environment/application ID resolution and legacy-ID rejection, plus `Test_Run` preview subtests covering typed/untyped environment and application listing and the missing-application error. Updates existing tests for the renamed field. |
| `pkg/cli/clients/clients.go` | Documents on the interface that bare names target `Applications.Core` and that a full resource ID is needed for other types. |
| `pkg/cli/clients/management.go` | Adds the same clarification to the four list method implementations. No behavior change. |
| `pkg/cli/clients/management_test.go` | Adds a `fullyQualifyID` case asserting a full `Radius.Core` ID is preserved verbatim — the property the preview command depends on. |
