### PR TITLE
fix(recipes): reject mappings to undeclared module outputs

### DIFF
--- a/eng/design-notes/recipes/2026-05-direct-recipe-modules.md
+++ b/eng/design-notes/recipes/2026-05-direct-recipe-modules.md
@@ -357,8 +357,8 @@ Radius determines sensitivity from the Resource Type schema — any output mappe
 
 ## Edge cases
 
-1. **Module with no outputs** — A module that produces no outputs results in an empty Values map on the resource. The resource is still created successfully but has no populated properties from the Recipe. Radius logs a warning indicating that the module produced no outputs to help platform engineers catch misconfiguration early.
-2. **Output name mismatch** — If the `outputs` mapping references a module output that does not exist, the mapped property is left empty (nil) on the resource. Radius logs a warning indicating the unresolved output name, so platform engineers can identify and fix the mapping without blocking deployment.
+1. **Module with no outputs** — A module that declares no outputs succeeds when the Recipe configures no output mappings. If the Recipe maps an undeclared output, Radius returns `InvalidRecipeOutputs` before deployment.
+2. **Missing mapped output** — Radius rejects `outputs` and `outputs.secrets` mappings that reference undeclared module outputs. If a declared output is absent or null at runtime, an ordinary `outputs` mapping remains unset, while an `outputs.secrets` mapping fails with `InvalidRecipeOutputs` rather than silently clearing previously materialized secret data.
 3. **Required parameters not supplied** — If the module requires an input variable that is not provided through `parameters` or environment-level `recipeParameters`, Radius surfaces the error from IaC engine indicating which variable is missing.
 4. **Invalid `{{context.*}}` expression path** — If a template expression references a context path that does not exist (e.g., `{{context.resource.properties.nonexistent}}`), the expression resolves to an empty string. The IaC engine may then fail if the parameter requires a non-empty value.
 5. **Large module with many unused variables** — Some community modules expose dozens of input variables with defaults. Only variables explicitly mapped in `parameters` are passed; all others use the module's defaults. This is expected behavior.

--- a/pkg/recipes/driver/bicep/bicep.go
+++ b/pkg/recipes/driver/bicep/bicep.go
@@ -18,6 +18,7 @@ package bicep
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	reflect "reflect"
 	"slices"
@@ -54,6 +55,7 @@ const (
 	deploymentPrefix = "recipe"
 	pollFrequency    = time.Second * 5
 	recipeParameters = "parameters"
+	recipeOutputs    = "outputs"
 )
 
 var _ driver.Driver = (*bicepDriver)(nil)
@@ -118,6 +120,13 @@ func (d *bicepDriver) Execute(ctx context.Context, opts driver.ExecuteOptions) (
 	}
 	metrics.DefaultRecipeEngineMetrics.RecordRecipeDownloadDuration(ctx, downloadStartTime,
 		metrics.NewRecipeAttributes(metrics.RecipeEngineOperationDownloadRecipe, opts.Recipe.Name, &opts.Definition, metrics.SuccessfulOperationState))
+
+	if err := validateOutputMappings(opts.Definition, recipeData); err != nil {
+		if _, ok := errors.AsType[*recipes_util.OutputMappingError](err); ok {
+			return nil, recipes.NewRecipeError(recipes.InvalidRecipeOutputs, err.Error(), recipes_util.RecipeSetupError, recipes.GetErrorDetails(err))
+		}
+		return nil, recipes.NewRecipeError(recipes.RecipeLanguageFailure, err.Error(), recipes_util.RecipeSetupError, recipes.GetErrorDetails(err))
+	}
 
 	// create the context object to be passed to the recipe deployment
 	recipeContext, err := recipecontext.New(&opts.Recipe, &opts.Configuration)
@@ -326,6 +335,32 @@ func (d *bicepDriver) GetRecipeMetadata(ctx context.Context, opts driver.BaseOpt
 	}
 
 	return recipeData, nil
+}
+
+func validateOutputMappings(definition recipes.EnvironmentDefinition, recipeData map[string]any) error {
+	if len(definition.Outputs) == 0 && len(definition.SecretOutputs) == 0 {
+		return nil
+	}
+
+	declaredOutputs := []string{}
+	rawOutputs, ok := recipeData[recipeOutputs]
+	if ok && rawOutputs != nil {
+		outputs, ok := rawOutputs.(map[string]any)
+		if !ok {
+			return errors.New("recipe outputs must be an object")
+		}
+
+		declaredOutputs = make([]string, 0, len(outputs))
+		for outputName := range outputs {
+			declaredOutputs = append(declaredOutputs, outputName)
+		}
+	}
+
+	if err := recipes_util.ValidateOutputsMapping(declaredOutputs, definition.Outputs, definition.SecretOutputs); err != nil {
+		return fmt.Errorf("recipe %q for resource type %q: %w", definition.Name, definition.ResourceType, err)
+	}
+
+	return nil
 }
 
 func hasContextParameter(recipeData map[string]any) bool {

--- a/pkg/recipes/driver/bicep/bicep.go
+++ b/pkg/recipes/driver/bicep/bicep.go
@@ -122,10 +122,7 @@ func (d *bicepDriver) Execute(ctx context.Context, opts driver.ExecuteOptions) (
 		metrics.NewRecipeAttributes(metrics.RecipeEngineOperationDownloadRecipe, opts.Recipe.Name, &opts.Definition, metrics.SuccessfulOperationState))
 
 	if err := validateOutputMappings(opts.Definition, recipeData); err != nil {
-		if _, ok := errors.AsType[*recipes_util.OutputMappingError](err); ok {
-			return nil, recipes.NewRecipeError(recipes.InvalidRecipeOutputs, err.Error(), recipes_util.RecipeSetupError, recipes.GetErrorDetails(err))
-		}
-		return nil, recipes.NewRecipeError(recipes.RecipeLanguageFailure, err.Error(), recipes_util.RecipeSetupError, recipes.GetErrorDetails(err))
+		return nil, recipes.NewRecipeError(recipes.InvalidRecipeOutputs, err.Error(), recipes_util.RecipeSetupError, recipes.GetErrorDetails(err))
 	}
 
 	// create the context object to be passed to the recipe deployment
@@ -195,6 +192,9 @@ func (d *bicepDriver) Execute(ctx context.Context, opts driver.ExecuteOptions) (
 
 	recipeResponse, err := d.prepareRecipeResponse(opts.BaseOptions.Definition, resp.Properties.Outputs, resp.Properties.OutputResources)
 	if err != nil {
+		if _, ok := errors.AsType[*recipes_util.MissingOutputValuesError](err); ok {
+			return nil, recipes.NewRecipeError(recipes.InvalidRecipeOutputs, err.Error(), recipes_util.ExecutionError, recipes.GetErrorDetails(err))
+		}
 		return nil, recipes.NewRecipeError(recipes.InvalidRecipeOutputs, fmt.Sprintf("failed to read the recipe output %q: %s", recipes.ResultPropertyName, err.Error()), recipes_util.ExecutionError, recipes.GetErrorDetails(err))
 	}
 
@@ -342,12 +342,15 @@ func validateOutputMappings(definition recipes.EnvironmentDefinition, recipeData
 		return nil
 	}
 
-	declaredOutputs := []string{}
+	var declaredOutputs []string
 	rawOutputs, ok := recipeData[recipeOutputs]
 	if ok && rawOutputs != nil {
 		outputs, ok := rawOutputs.(map[string]any)
 		if !ok {
-			return errors.New("recipe outputs must be an object")
+			return fmt.Errorf(
+				"recipe %q for resource type %q: recipe outputs must be an object",
+				definition.Name,
+				definition.ResourceType)
 		}
 
 		declaredOutputs = make([]string, 0, len(outputs))
@@ -356,11 +359,12 @@ func validateOutputMappings(definition recipes.EnvironmentDefinition, recipeData
 		}
 	}
 
-	if err := recipes_util.ValidateOutputsMapping(declaredOutputs, definition.Outputs, definition.SecretOutputs); err != nil {
-		return fmt.Errorf("recipe %q for resource type %q: %w", definition.Name, definition.ResourceType, err)
-	}
-
-	return nil
+	return recipes_util.ValidateOutputsMapping(
+		definition.Name,
+		definition.ResourceType,
+		declaredOutputs,
+		definition.Outputs,
+		definition.SecretOutputs)
 }
 
 func hasContextParameter(recipeData map[string]any) bool {
@@ -452,32 +456,35 @@ func newProviderConfig(resourceGroup string, envProviders coredm.Providers) clie
 // collection. For us this mostly means Kubernetes resources - the user has to be explicit.
 func (d *bicepDriver) prepareRecipeResponse(definition recipes.EnvironmentDefinition, outputs any, resources []*armdeployments.ResourceReference) (*recipes.RecipeOutput, error) {
 	recipeResponse := &recipes.RecipeOutput{}
-	out, ok := outputs.(map[string]any)
-	if ok && len(out) > 0 {
-		hasOutputsMapping := len(definition.Outputs) > 0 || len(definition.SecretOutputs) > 0
-		_, hasResultOutput := out[recipes.ResultPropertyName]
+	out, _ := outputs.(map[string]any)
+	hasOutputsMapping := len(definition.Outputs) > 0 || len(definition.SecretOutputs) > 0
+	_, hasResultOutput := out[recipes.ResultPropertyName]
 
-		switch {
-		case hasOutputsMapping:
-			// Direct module with an outputs mapping — collect all ARM outputs flat (splitting
-			// secure-typed outputs into secrets), then apply the mapping.
-			values, secrets := collectARMOutputs(out)
-			recipeResponse.Values, recipeResponse.Secrets = recipes_util.ApplyOutputsMapping(values, secrets, definition.Outputs, definition.SecretOutputs)
-		case hasResultOutput:
-			// Wrapped recipe — use the existing 'result' output parsing.
-			if result, ok := out[recipes.ResultPropertyName].(map[string]any); ok {
-				if resultValue, ok := result["value"].(map[string]any); ok {
-					err := recipeResponse.PrepareRecipeResponse(resultValue)
-					if err != nil {
-						return &recipes.RecipeOutput{}, err
-					}
+	switch {
+	case hasOutputsMapping:
+		// Direct module with an outputs mapping — collect all ARM outputs flat (splitting
+		// secure-typed outputs into secrets), then apply the mapping.
+		values, secrets := collectARMOutputs(out)
+		mappedValues, mappedSecrets, err := recipes_util.ApplyOutputsMapping(values, secrets, definition.Outputs, definition.SecretOutputs)
+		if err != nil {
+			return &recipes.RecipeOutput{}, fmt.Errorf("recipe %q for resource type %q: %w", definition.Name, definition.ResourceType, err)
+		}
+		recipeResponse.Values = mappedValues
+		recipeResponse.Secrets = mappedSecrets
+	case len(out) > 0 && hasResultOutput:
+		// Wrapped recipe — use the existing 'result' output parsing.
+		if result, ok := out[recipes.ResultPropertyName].(map[string]any); ok {
+			if resultValue, ok := result["value"].(map[string]any); ok {
+				err := recipeResponse.PrepareRecipeResponse(resultValue)
+				if err != nil {
+					return &recipes.RecipeOutput{}, err
 				}
 			}
-		default:
-			// Direct module without a mapping — pass through all ARM outputs unchanged, routing
-			// secure-typed outputs to Secrets so they are not exposed as plain values.
-			recipeResponse.Values, recipeResponse.Secrets = collectARMOutputs(out)
 		}
+	case len(out) > 0:
+		// Direct module without a mapping — pass through all ARM outputs unchanged, routing
+		// secure-typed outputs to Secrets so they are not exposed as plain values.
+		recipeResponse.Values, recipeResponse.Secrets = collectARMOutputs(out)
 	}
 
 	recipeResponse.Status = &rpv1.RecipeStatus{

--- a/pkg/recipes/driver/bicep/bicep_test.go
+++ b/pkg/recipes/driver/bicep/bicep_test.go
@@ -557,7 +557,7 @@ func Test_Bicep_Execute_InvalidOutputMappingDoesNotDeploy(t *testing.T) {
 	require.Equal(t, &recipes.RecipeError{
 		ErrorDetails: v1.ErrorDetails{
 			Code:    recipes.InvalidRecipeOutputs,
-			Message: `recipe "mongo-azure" for resource type "Applications.Datastores/mongoDatabases": invalid outputs mapping: no declared module output matches "secrets.connectionString" -> "primaryConnectionString"; available module outputs: none`,
+			Message: `recipe "mongo-azure" for resource type "Applications.Datastores/mongoDatabases": invalid outputs mapping: no declared module output matches secrets["connectionString"] -> "primaryConnectionString"; available module outputs: none`,
 		},
 		DeploymentStatus: recipes_util.RecipeSetupError,
 	}, err)
@@ -595,15 +595,27 @@ func Test_ValidateOutputMappings(t *testing.T) {
 					"endpoint": map[string]any{"type": "string"},
 				},
 			},
-			expectedError: `recipe "test-recipe" for resource type "Test.Resources/widgets": invalid outputs mapping: no declared module output matches "secrets.connectionString" -> "missing"; available module outputs: "endpoint"`,
+			expectedError: `recipe "test-recipe" for resource type "Test.Resources/widgets": invalid outputs mapping: no declared module output matches secrets["connectionString"] -> "missing"; available module outputs: "endpoint"`,
 		},
 		{
 			name: "rejects non-object outputs collection",
 			definition: recipes.EnvironmentDefinition{
-				Outputs: map[string]string{"host": "endpoint"},
+				Name:         "test-recipe",
+				ResourceType: "Test.Resources/widgets",
+				Outputs:      map[string]string{"host": "endpoint"},
 			},
 			recipeData:    map[string]any{recipeOutputs: "invalid"},
-			expectedError: "recipe outputs must be an object",
+			expectedError: `recipe "test-recipe" for resource type "Test.Resources/widgets": recipe outputs must be an object`,
+		},
+		{
+			name: "rejects mapping when template declares no outputs",
+			definition: recipes.EnvironmentDefinition{
+				Name:         "test-recipe",
+				ResourceType: "Test.Resources/widgets",
+				Outputs:      map[string]string{"host": "endpoint"},
+			},
+			recipeData:    map[string]any{},
+			expectedError: `recipe "test-recipe" for resource type "Test.Resources/widgets": invalid outputs mapping: no declared module output matches outputs["host"] -> "endpoint"; available module outputs: none`,
 		},
 		{
 			name:       "skips template output parsing when no mappings are configured",
@@ -876,6 +888,26 @@ func Test_Bicep_PrepareRecipeResponse_DirectModule(t *testing.T) {
 			require.Equal(t, tt.expectedResponse, resp)
 		})
 	}
+}
+
+func Test_Bicep_PrepareRecipeResponse_MissingSecretOutput(t *testing.T) {
+	d := &bicepDriver{}
+	definition := recipes.EnvironmentDefinition{
+		Name:          "eventhub",
+		ResourceType:  "Demo.Messaging/kafka",
+		SecretOutputs: map[string]string{"connectionString": "primaryConnectionString"},
+	}
+	outputs := map[string]any{
+		"name":                    map[string]any{"type": "string", "value": "myhub"},
+		"primaryConnectionString": map[string]any{"type": "string", "value": nil},
+	}
+
+	response, err := d.prepareRecipeResponse(definition, outputs, nil)
+	require.Equal(t, &recipes.RecipeOutput{}, response)
+	require.EqualError(t, err, `recipe "eventhub" for resource type "Demo.Messaging/kafka": invalid outputs mapping: missing deployment output values for secrets["connectionString"] -> "primaryConnectionString"; available deployment outputs: "name"`)
+
+	var missingOutputErr *recipes_util.MissingOutputValuesError
+	require.ErrorAs(t, err, &missingOutputErr)
 }
 
 func Test_WrapARMParameters(t *testing.T) {

--- a/pkg/recipes/driver/bicep/bicep_test.go
+++ b/pkg/recipes/driver/bicep/bicep_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package bicep
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -28,6 +30,7 @@ import (
 	"github.com/radius-project/radius/pkg/recipes"
 	"github.com/radius-project/radius/pkg/recipes/driver"
 	"github.com/radius-project/radius/pkg/recipes/recipecontext"
+	recipes_util "github.com/radius-project/radius/pkg/recipes/util"
 	"github.com/radius-project/radius/pkg/rp/util/registrytest"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	clients "github.com/radius-project/radius/pkg/sdk/clients"
@@ -37,6 +40,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
+
+type deploymentClientSpy struct {
+	clients.ResourceDeploymentsClient
+	createOrUpdateCalls int
+}
+
+func (s *deploymentClientSpy) CreateOrUpdate(_ context.Context, _ clients.Deployment, _, _ string) (clients.Poller[clients.ClientCreateOrUpdateResponse], error) {
+	s.createOrUpdateCalls++
+	return nil, errors.New("unexpected deployment")
+}
 
 func Test_CreateRecipeParameters_NoContextParameter(t *testing.T) {
 	devParams := map[string]any{}
@@ -511,6 +524,104 @@ func Test_Bicep_GetRecipeMetadata_Error(t *testing.T) {
 	}
 	expErr.ErrorDetails.Message = strings.Replace(expErr.ErrorDetails.Message, "<REPLACE_HOST>", ts.URL.Host, -1)
 	require.Equal(t, actualErr, &expErr)
+}
+
+func Test_Bicep_Execute_InvalidOutputMappingDoesNotDeploy(t *testing.T) {
+	ts := registrytest.NewFakeRegistryServer(t)
+	t.Cleanup(ts.CloseServer)
+
+	deploymentClient := &deploymentClientSpy{}
+	driverBicep := &bicepDriver{
+		DeploymentClient: deploymentClient,
+		RegistryClient:   ts.TestServer.Client(),
+	}
+
+	output, err := driverBicep.Execute(t.Context(), driver.ExecuteOptions{
+		BaseOptions: driver.BaseOptions{
+			Recipe: recipes.ResourceMetadata{
+				Name:          "mongo",
+				ResourceID:    "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Datastores/mongoDatabases/mongo",
+				EnvironmentID: "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Core/environments/env",
+			},
+			Definition: recipes.EnvironmentDefinition{
+				Name:          "mongo-azure",
+				Driver:        recipes.TemplateKindBicep,
+				TemplatePath:  ts.TestImageURL,
+				ResourceType:  "Applications.Datastores/mongoDatabases",
+				SecretOutputs: map[string]string{"connectionString": "primaryConnectionString"},
+			},
+		},
+	})
+
+	require.Nil(t, output)
+	require.Equal(t, &recipes.RecipeError{
+		ErrorDetails: v1.ErrorDetails{
+			Code:    recipes.InvalidRecipeOutputs,
+			Message: `recipe "mongo-azure" for resource type "Applications.Datastores/mongoDatabases": invalid outputs mapping: no declared module output matches "secrets.connectionString" -> "primaryConnectionString"; available module outputs: none`,
+		},
+		DeploymentStatus: recipes_util.RecipeSetupError,
+	}, err)
+	require.Zero(t, deploymentClient.createOrUpdateCalls)
+}
+
+func Test_ValidateOutputMappings(t *testing.T) {
+	tests := []struct {
+		name          string
+		definition    recipes.EnvironmentDefinition
+		recipeData    map[string]any
+		expectedError string
+	}{
+		{
+			name: "accepts declared outputs",
+			definition: recipes.EnvironmentDefinition{
+				Outputs: map[string]string{"endpoint": "endpoint", "password": "password"},
+			},
+			recipeData: map[string]any{
+				recipeOutputs: map[string]any{
+					"endpoint": map[string]any{"type": "string"},
+					"password": map[string]any{"type": "securestring"},
+				},
+			},
+		},
+		{
+			name: "rejects undeclared output",
+			definition: recipes.EnvironmentDefinition{
+				Name:          "test-recipe",
+				ResourceType:  "Test.Resources/widgets",
+				SecretOutputs: map[string]string{"connectionString": "missing"},
+			},
+			recipeData: map[string]any{
+				recipeOutputs: map[string]any{
+					"endpoint": map[string]any{"type": "string"},
+				},
+			},
+			expectedError: `recipe "test-recipe" for resource type "Test.Resources/widgets": invalid outputs mapping: no declared module output matches "secrets.connectionString" -> "missing"; available module outputs: "endpoint"`,
+		},
+		{
+			name: "rejects non-object outputs collection",
+			definition: recipes.EnvironmentDefinition{
+				Outputs: map[string]string{"host": "endpoint"},
+			},
+			recipeData:    map[string]any{recipeOutputs: "invalid"},
+			expectedError: "recipe outputs must be an object",
+		},
+		{
+			name:       "skips template output parsing when no mappings are configured",
+			recipeData: map[string]any{recipeOutputs: "invalid"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOutputMappings(tt.definition, tt.recipeData)
+			if tt.expectedError != "" {
+				require.EqualError(t, err, tt.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
 }
 
 func Test_GetGCOutputResources(t *testing.T) {

--- a/pkg/recipes/driver/terraform/terraform.go
+++ b/pkg/recipes/driver/terraform/terraform.go
@@ -127,6 +127,9 @@ func (d *terraformDriver) Execute(ctx context.Context, opts driver.ExecuteOption
 
 	recipeOutputs, err := d.prepareRecipeResponse(ctx, opts.BaseOptions.Definition, opts.Configuration, tfState)
 	if err != nil {
+		if _, ok := errors.AsType[*recipes_util.MissingOutputValuesError](err); ok {
+			return nil, recipes.NewRecipeError(recipes.InvalidRecipeOutputs, err.Error(), recipes_util.ExecutionError, recipes.GetErrorDetails(err))
+		}
 		return nil, recipes.NewRecipeError(recipes.InvalidRecipeOutputs, fmt.Sprintf("failed to read the recipe output %q: %s", recipes.ResultPropertyName, err.Error()), recipes_util.ExecutionError, recipes.GetErrorDetails(err))
 	}
 
@@ -200,16 +203,25 @@ func (d *terraformDriver) prepareRecipeResponse(ctx context.Context, definition 
 	}
 
 	recipeResponse := &recipes.RecipeOutput{}
-	if tfState.Values != nil && tfState.Values.Outputs != nil {
-		moduleOutputs := tfState.Values.Outputs
-		hasOutputsMapping := len(definition.Outputs) > 0 || len(definition.SecretOutputs) > 0
-		_, hasResultOutput := moduleOutputs[recipes.ResultPropertyName]
+	var moduleOutputs map[string]*tfjson.StateOutput
+	if tfState.Values != nil {
+		moduleOutputs = tfState.Values.Outputs
+	}
 
-		if hasOutputsMapping {
-			// Direct module with outputs mapping — collect all outputs flat, then apply mapping.
-			values, secrets := collectFlatOutputs(moduleOutputs)
-			recipeResponse.Values, recipeResponse.Secrets = recipes_util.ApplyOutputsMapping(values, secrets, definition.Outputs, definition.SecretOutputs)
-		} else if hasResultOutput {
+	hasOutputsMapping := len(definition.Outputs) > 0 || len(definition.SecretOutputs) > 0
+	_, hasResultOutput := moduleOutputs[recipes.ResultPropertyName]
+
+	if hasOutputsMapping {
+		// Direct module with outputs mapping — collect all outputs flat, then apply mapping.
+		values, secrets := collectFlatOutputs(moduleOutputs)
+		mappedValues, mappedSecrets, err := recipes_util.ApplyOutputsMapping(values, secrets, definition.Outputs, definition.SecretOutputs)
+		if err != nil {
+			return &recipes.RecipeOutput{}, fmt.Errorf("recipe %q for resource type %q: %w", definition.Name, definition.ResourceType, err)
+		}
+		recipeResponse.Values = mappedValues
+		recipeResponse.Secrets = mappedSecrets
+	} else if moduleOutputs != nil {
+		if hasResultOutput {
 			// Wrapped recipe — use existing result output parsing.
 			if result, ok := moduleOutputs[recipes.ResultPropertyName].Value.(map[string]any); ok {
 				err := recipeResponse.PrepareRecipeResponse(result)

--- a/pkg/recipes/driver/terraform/terraform.go
+++ b/pkg/recipes/driver/terraform/terraform.go
@@ -118,6 +118,10 @@ func (d *terraformDriver) Execute(ctx context.Context, opts driver.ExecuteOption
 	}
 
 	if err != nil {
+		// OutputMappingError is raised before apply and must be reported as a setup failure.
+		if _, ok := errors.AsType[*recipes_util.OutputMappingError](err); ok {
+			return nil, recipes.NewRecipeError(recipes.InvalidRecipeOutputs, err.Error(), recipes_util.RecipeSetupError, recipes.GetErrorDetails(err))
+		}
 		return nil, recipes.NewRecipeError(recipes.RecipeDeploymentFailed, err.Error(), recipes_util.ExecutionError, recipes.GetErrorDetails(err))
 	}
 

--- a/pkg/recipes/driver/terraform/terraform_test.go
+++ b/pkg/recipes/driver/terraform/terraform_test.go
@@ -19,6 +19,7 @@ package terraform
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -33,6 +34,7 @@ import (
 
 	"github.com/radius-project/radius/pkg/recipes/driver"
 	"github.com/radius-project/radius/pkg/recipes/terraform"
+	recipes_util "github.com/radius-project/radius/pkg/recipes/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -168,6 +170,47 @@ func Test_Terraform_Execute_DeploymentFailure(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Equal(t, err, &recipeError)
+	verifyDirectoryCleanup(t, tfDriver.options.Path, armCtx.OperationID.String())
+}
+
+func Test_Terraform_Execute_InvalidOutputMapping(t *testing.T) {
+	// The executor returns OutputMappingError before apply. The driver should classify it as a
+	// setup error.
+	invalidMappingErr := recipes_util.ValidateOutputsMapping(
+		[]string{"endpoint"},
+		map[string]string{"host": "missing"},
+		nil)
+	require.Error(t, invalidMappingErr)
+	invalidMappingErr = fmt.Errorf(`recipe "redis-azure" for resource type "Applications.Datastores/redisCaches": %w`, invalidMappingErr)
+
+	ctx := t.Context()
+	armCtx := &v1.ARMRequestContext{
+		OperationID: uuid.New(),
+	}
+	ctx = v1.WithARMRequestContext(ctx, armCtx)
+
+	tfExecutor, tfDriver := setup(t)
+	envConfig, recipeMetadata, envRecipe := buildTestInputs()
+	envRecipe.Outputs = map[string]string{"host": "missing"}
+
+	tfExecutor.EXPECT().Deploy(ctx, gomock.Any()).Times(1).Return(nil, invalidMappingErr)
+
+	output, err := tfDriver.Execute(ctx, driver.ExecuteOptions{
+		BaseOptions: driver.BaseOptions{
+			Configuration: envConfig,
+			Recipe:        recipeMetadata,
+			Definition:    envRecipe,
+		},
+	})
+
+	require.Nil(t, output)
+	require.Equal(t, &recipes.RecipeError{
+		ErrorDetails: v1.ErrorDetails{
+			Code:    recipes.InvalidRecipeOutputs,
+			Message: `recipe "redis-azure" for resource type "Applications.Datastores/redisCaches": invalid outputs mapping: no declared module output matches "host" -> "missing"; available module outputs: "endpoint"`,
+		},
+		DeploymentStatus: recipes_util.RecipeSetupError,
+	}, err)
 	verifyDirectoryCleanup(t, tfDriver.options.Path, armCtx.OperationID.String())
 }
 

--- a/pkg/recipes/driver/terraform/terraform_test.go
+++ b/pkg/recipes/driver/terraform/terraform_test.go
@@ -19,7 +19,6 @@ package terraform
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -174,44 +173,67 @@ func Test_Terraform_Execute_DeploymentFailure(t *testing.T) {
 }
 
 func Test_Terraform_Execute_InvalidOutputMapping(t *testing.T) {
-	// The executor returns OutputMappingError before apply. The driver should classify it as a
-	// setup error.
 	invalidMappingErr := recipes_util.ValidateOutputsMapping(
+		"redis-azure",
+		"Applications.Datastores/redisCaches",
 		[]string{"endpoint"},
 		map[string]string{"host": "missing"},
 		nil)
 	require.Error(t, invalidMappingErr)
-	invalidMappingErr = fmt.Errorf(`recipe "redis-azure" for resource type "Applications.Datastores/redisCaches": %w`, invalidMappingErr)
 
-	ctx := t.Context()
-	armCtx := &v1.ARMRequestContext{
-		OperationID: uuid.New(),
+	tests := []struct {
+		name           string
+		executionError error
+		expectedCode   string
+		expectedStatus recipes_util.RecipeDeploymentStatus
+	}{
+		{
+			name:           "classifies OutputMappingError as setup error",
+			executionError: invalidMappingErr,
+			expectedCode:   recipes.InvalidRecipeOutputs,
+			expectedStatus: recipes_util.RecipeSetupError,
+		},
+		{
+			name:           "does not classify plain error with same message as setup error",
+			executionError: errors.New(invalidMappingErr.Error()),
+			expectedCode:   recipes.RecipeDeploymentFailed,
+			expectedStatus: recipes_util.ExecutionError,
+		},
 	}
-	ctx = v1.WithARMRequestContext(ctx, armCtx)
 
-	tfExecutor, tfDriver := setup(t)
-	envConfig, recipeMetadata, envRecipe := buildTestInputs()
-	envRecipe.Outputs = map[string]string{"host": "missing"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			armCtx := &v1.ARMRequestContext{
+				OperationID: uuid.New(),
+			}
+			ctx = v1.WithARMRequestContext(ctx, armCtx)
 
-	tfExecutor.EXPECT().Deploy(ctx, gomock.Any()).Times(1).Return(nil, invalidMappingErr)
+			tfExecutor, tfDriver := setup(t)
+			envConfig, recipeMetadata, envRecipe := buildTestInputs()
+			envRecipe.Outputs = map[string]string{"host": "missing"}
 
-	output, err := tfDriver.Execute(ctx, driver.ExecuteOptions{
-		BaseOptions: driver.BaseOptions{
-			Configuration: envConfig,
-			Recipe:        recipeMetadata,
-			Definition:    envRecipe,
-		},
-	})
+			tfExecutor.EXPECT().Deploy(ctx, gomock.Any()).Times(1).Return(nil, tt.executionError)
 
-	require.Nil(t, output)
-	require.Equal(t, &recipes.RecipeError{
-		ErrorDetails: v1.ErrorDetails{
-			Code:    recipes.InvalidRecipeOutputs,
-			Message: `recipe "redis-azure" for resource type "Applications.Datastores/redisCaches": invalid outputs mapping: no declared module output matches "host" -> "missing"; available module outputs: "endpoint"`,
-		},
-		DeploymentStatus: recipes_util.RecipeSetupError,
-	}, err)
-	verifyDirectoryCleanup(t, tfDriver.options.Path, armCtx.OperationID.String())
+			output, err := tfDriver.Execute(ctx, driver.ExecuteOptions{
+				BaseOptions: driver.BaseOptions{
+					Configuration: envConfig,
+					Recipe:        recipeMetadata,
+					Definition:    envRecipe,
+				},
+			})
+
+			require.Nil(t, output)
+			require.Equal(t, &recipes.RecipeError{
+				ErrorDetails: v1.ErrorDetails{
+					Code:    tt.expectedCode,
+					Message: invalidMappingErr.Error(),
+				},
+				DeploymentStatus: tt.expectedStatus,
+			}, err)
+			verifyDirectoryCleanup(t, tfDriver.options.Path, armCtx.OperationID.String())
+		})
+	}
 }
 
 func Test_Terraform_Execute_OutputsFailure(t *testing.T) {
@@ -503,6 +525,46 @@ func Test_Terraform_Delete_Failure(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Equal(t, &expErr, err)
+	verifyDirectoryCleanup(t, tfDriver.options.Path, armCtx.OperationID.String())
+}
+
+func Test_Terraform_Execute_MissingSecretOutput(t *testing.T) {
+	ctx := t.Context()
+	armCtx := &v1.ARMRequestContext{
+		OperationID: uuid.New(),
+	}
+	ctx = v1.WithARMRequestContext(ctx, armCtx)
+
+	tfExecutor, tfDriver := setup(t)
+	envConfig, recipeMetadata, envRecipe := buildTestInputs()
+	envRecipe.SecretOutputs = map[string]string{"connectionString": "primaryConnectionString"}
+
+	tfExecutor.EXPECT().Deploy(ctx, gomock.Any()).Times(1).Return(&tfjson.State{
+		Values: &tfjson.StateValues{
+			Outputs: map[string]*tfjson.StateOutput{
+				"name":                    {Value: "myhub"},
+				"primaryConnectionString": {Value: nil},
+			},
+			RootModule: &tfjson.StateModule{},
+		},
+	}, nil)
+
+	output, err := tfDriver.Execute(ctx, driver.ExecuteOptions{
+		BaseOptions: driver.BaseOptions{
+			Configuration: envConfig,
+			Recipe:        recipeMetadata,
+			Definition:    envRecipe,
+		},
+	})
+
+	require.Nil(t, output)
+	require.Equal(t, &recipes.RecipeError{
+		ErrorDetails: v1.ErrorDetails{
+			Code:    recipes.InvalidRecipeOutputs,
+			Message: `recipe "redis-azure" for resource type "Applications.Datastores/redisCaches": invalid outputs mapping: missing deployment output values for secrets["connectionString"] -> "primaryConnectionString"; available deployment outputs: "name"`,
+		},
+		DeploymentStatus: recipes_util.ExecutionError,
+	}, err)
 	verifyDirectoryCleanup(t, tfDriver.options.Path, armCtx.OperationID.String())
 }
 
@@ -1115,6 +1177,30 @@ func Test_Terraform_PrepareRecipeResponse_DirectModule(t *testing.T) {
 			require.Equal(t, tt.expectedResponse, recipeResponse)
 		})
 	}
+}
+
+func Test_Terraform_PrepareRecipeResponse_MissingSecretOutput(t *testing.T) {
+	d := &terraformDriver{}
+	definition := recipes.EnvironmentDefinition{
+		Name:          "eventhub",
+		ResourceType:  "Demo.Messaging/kafka",
+		SecretOutputs: map[string]string{"connectionString": "primaryConnectionString"},
+	}
+	state := &tfjson.State{
+		Values: &tfjson.StateValues{
+			Outputs: map[string]*tfjson.StateOutput{
+				"name":                    {Value: "myhub"},
+				"primaryConnectionString": {Value: nil},
+			},
+		},
+	}
+
+	response, err := d.prepareRecipeResponse(t.Context(), definition, recipes.Configuration{}, state)
+	require.Equal(t, &recipes.RecipeOutput{}, response)
+	require.EqualError(t, err, `recipe "eventhub" for resource type "Demo.Messaging/kafka": invalid outputs mapping: missing deployment output values for secrets["connectionString"] -> "primaryConnectionString"; available deployment outputs: "name"`)
+
+	var missingOutputErr *recipes_util.MissingOutputValuesError
+	require.ErrorAs(t, err, &missingOutputErr)
 }
 
 func Test_FindSecretIDs(t *testing.T) {

--- a/pkg/recipes/terraform/config/config.go
+++ b/pkg/recipes/terraform/config/config.go
@@ -298,8 +298,7 @@ func (cfg *TerraformConfig) AddOutputs(localModuleName string) error {
 }
 
 // AddMappedOutputs generates an output block for each module output referenced by the outputs
-// mapping. This is used for direct modules that do not produce a wrapped "result" output but
-// declare individual outputs that should be mapped to resource properties.
+// mapping. Explicit mappings take precedence when a module also produces a wrapped "result" output.
 //
 // Each generated output is marked sensitive according to the module's own output declaration
 // (sensitivity), because Terraform requires a re-exported sensitive value to be marked sensitive.

--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -32,6 +32,7 @@ import (
 	"github.com/radius-project/radius/pkg/components/kubernetesclient/kubernetesclientprovider"
 	"github.com/radius-project/radius/pkg/components/metrics"
 	"github.com/radius-project/radius/pkg/components/secret/secretprovider"
+	"github.com/radius-project/radius/pkg/recipes"
 	"github.com/radius-project/radius/pkg/recipes/paramresolver"
 	"github.com/radius-project/radius/pkg/recipes/recipecontext"
 	"github.com/radius-project/radius/pkg/recipes/terraform/config"
@@ -47,6 +48,14 @@ import (
 var (
 	// ErrRecipeNameEmpty is the error when the recipe name is empty.
 	ErrRecipeNameEmpty = errors.New("recipe name cannot be empty")
+)
+
+// outputMappingValidationMode controls declaration validation during configuration generation.
+type outputMappingValidationMode int
+
+const (
+	requireValidOutputMappings outputMappingValidationMode = iota
+	skipOutputMappingValidation
 )
 
 var _ TerraformExecutor = (*executor)(nil)
@@ -89,7 +98,7 @@ func (e *executor) Deploy(ctx context.Context, options Options) (*tfjson.State, 
 	}
 
 	// Create Terraform config in the working directory
-	kubernetesBackendSuffix, err := e.generateConfig(ctx, tf, options)
+	kubernetesBackendSuffix, err := e.generateConfig(ctx, tf, options, requireValidOutputMappings)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +143,7 @@ func (e *executor) Delete(ctx context.Context, options Options) error {
 	}
 
 	// Create Terraform config in the working directory
-	kubernetesBackendSuffix, err := e.generateConfig(ctx, tf, options)
+	kubernetesBackendSuffix, err := e.generateConfig(ctx, tf, options, skipOutputMappingValidation)
 	if err != nil {
 		return err
 	}
@@ -316,7 +325,7 @@ func splitEnvVar(envVars []string) map[string]string {
 }
 
 // generateConfig generates Terraform configuration with required inputs for the module, providers and backend to be initialized and applied.
-func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, options Options) (string, error) {
+func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, options Options, validationMode outputMappingValidationMode) (string, error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 	workingDir := tf.WorkingDir()
 
@@ -327,6 +336,10 @@ func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, opt
 
 	loadedModule, err := downloadAndInspect(ctx, tf, options)
 	if err != nil {
+		return "", err
+	}
+
+	if err := validateOutputMappings(options.EnvRecipe, loadedModule, validationMode); err != nil {
 		return "", err
 	}
 
@@ -435,6 +448,23 @@ func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, opt
 	}
 
 	return secretSuffix, nil
+}
+
+func validateOutputMappings(definition *recipes.EnvironmentDefinition, module *moduleInspectResult, validationMode outputMappingValidationMode) error {
+	if validationMode == skipOutputMappingValidation {
+		return nil
+	}
+
+	declaredOutputs := make([]string, 0, len(module.OutputSensitivity))
+	for outputName := range module.OutputSensitivity {
+		declaredOutputs = append(declaredOutputs, outputName)
+	}
+
+	if err := recipes_util.ValidateOutputsMapping(declaredOutputs, definition.Outputs, definition.SecretOutputs); err != nil {
+		return fmt.Errorf("recipe %q for resource type %q: %w", definition.Name, definition.ResourceType, err)
+	}
+
+	return nil
 }
 
 // getTerraformConfig initializes the Terraform json config with provided module source and saves it

--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -339,8 +339,11 @@ func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, opt
 		return "", err
 	}
 
-	if err := validateOutputMappings(options.EnvRecipe, loadedModule, validationMode); err != nil {
-		return "", err
+	useOutputMappings := usesOutputMappings(options.EnvRecipe, loadedModule, validationMode)
+	if useOutputMappings {
+		if err := validateOutputMappings(options.EnvRecipe, loadedModule, validationMode); err != nil {
+			return "", err
+		}
 	}
 
 	// Generate Terraform providers configuration for required providers and add it to the Terraform configuration.
@@ -415,13 +418,9 @@ func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, opt
 			tfConfig.Module[options.EnvRecipe.Name].SetParams(config.RecipeParams(resolvedParams))
 		}
 	}
-	if loadedModule.ResultOutputExists {
-		if err = tfConfig.AddOutputs(options.EnvRecipe.Name); err != nil {
-			return "", err
-		}
-	} else if len(options.EnvRecipe.Outputs) > 0 || len(options.EnvRecipe.SecretOutputs) > 0 {
-		// Direct module with an outputs and/or secretOutputs mapping: generate an output block for each
-		// referenced module output so the values are available in the Terraform state for output mapping.
+	if useOutputMappings {
+		// Explicit mappings take precedence over a wrapped result output during deployment, matching
+		// prepareRecipeResponse. Generate each referenced output so it is available in Terraform state.
 		if err = tfConfig.AddMappedOutputs(options.EnvRecipe.Name, options.EnvRecipe.Outputs, loadedModule.OutputSensitivity, false); err != nil {
 			return "", err
 		}
@@ -429,6 +428,10 @@ func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, opt
 		// a module output the module did not itself mark sensitive (e.g. AVM primaryConnectionString) is
 		// still redacted in Terraform's stdout/stderr, which Radius streams into logs.
 		if err = tfConfig.AddMappedOutputs(options.EnvRecipe.Name, options.EnvRecipe.SecretOutputs, loadedModule.OutputSensitivity, true); err != nil {
+			return "", err
+		}
+	} else if loadedModule.ResultOutputExists {
+		if err = tfConfig.AddOutputs(options.EnvRecipe.Name); err != nil {
 			return "", err
 		}
 	} else {
@@ -450,6 +453,11 @@ func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, opt
 	return secretSuffix, nil
 }
 
+func usesOutputMappings(definition *recipes.EnvironmentDefinition, module *moduleInspectResult, validationMode outputMappingValidationMode) bool {
+	hasMappings := len(definition.Outputs) > 0 || len(definition.SecretOutputs) > 0
+	return hasMappings && (validationMode == requireValidOutputMappings || !module.ResultOutputExists)
+}
+
 func validateOutputMappings(definition *recipes.EnvironmentDefinition, module *moduleInspectResult, validationMode outputMappingValidationMode) error {
 	if validationMode == skipOutputMappingValidation {
 		return nil
@@ -460,11 +468,12 @@ func validateOutputMappings(definition *recipes.EnvironmentDefinition, module *m
 		declaredOutputs = append(declaredOutputs, outputName)
 	}
 
-	if err := recipes_util.ValidateOutputsMapping(declaredOutputs, definition.Outputs, definition.SecretOutputs); err != nil {
-		return fmt.Errorf("recipe %q for resource type %q: %w", definition.Name, definition.ResourceType, err)
-	}
-
-	return nil
+	return recipes_util.ValidateOutputsMapping(
+		definition.Name,
+		definition.ResourceType,
+		declaredOutputs,
+		definition.Outputs,
+		definition.SecretOutputs)
 }
 
 // getTerraformConfig initializes the Terraform json config with provided module source and saves it

--- a/pkg/recipes/terraform/execute_test.go
+++ b/pkg/recipes/terraform/execute_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package terraform
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	reflect "reflect"
@@ -42,35 +43,45 @@ const (
 )
 
 func TestMain(m *testing.M) {
+	exitCode := 0
 	if os.Getenv(terraformGetTestHelper) == "1" {
-		if commandLog := os.Getenv(terraformCommandLog); commandLog != "" && len(os.Args) > 1 {
-			file, err := os.OpenFile(commandLog, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-			if err != nil {
-				os.Exit(1)
-			}
-			if _, err := file.WriteString(os.Args[1] + "\n"); err != nil {
-				_ = file.Close()
-				os.Exit(1)
-			}
-			if err := file.Close(); err != nil {
-				os.Exit(1)
-			}
+		if err := runTerraformTestHelper(); err != nil {
+			fmt.Fprintf(os.Stderr, "terraform test helper failed: %v\n", err)
+			exitCode = 1
 		}
-
-		moduleDir := filepath.Join(".terraform", "modules", "test-recipe")
-		if err := os.MkdirAll(moduleDir, 0755); err != nil {
-			os.Exit(1)
-		}
-		if err := os.WriteFile(
-			filepath.Join(moduleDir, "outputs.tf"),
-			[]byte(`output "endpoint" { value = "declared" }`),
-			0644); err != nil {
-			os.Exit(1)
-		}
-		os.Exit(0)
+	} else {
+		exitCode = m.Run()
 	}
 
-	os.Exit(m.Run())
+	os.Exit(exitCode) //nolint:forbidigo // This is OK inside the TestMain function.
+}
+
+func runTerraformTestHelper() error {
+	if commandLog := os.Getenv(terraformCommandLog); commandLog != "" && len(os.Args) > 1 {
+		file, err := os.OpenFile(commandLog, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return fmt.Errorf("opening command log: %w", err)
+		}
+		if _, err := file.WriteString(os.Args[1] + "\n"); err != nil {
+			_ = file.Close()
+			return fmt.Errorf("writing command log: %w", err)
+		}
+		if err := file.Close(); err != nil {
+			return fmt.Errorf("closing command log: %w", err)
+		}
+	}
+
+	moduleDir := filepath.Join(".terraform", "modules", "test-recipe")
+	if err := os.MkdirAll(moduleDir, 0755); err != nil {
+		return fmt.Errorf("creating test module directory: %w", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(moduleDir, "outputs.tf"),
+		[]byte(`output "endpoint" { value = "declared" }`),
+		0644); err != nil {
+		return fmt.Errorf("writing test module outputs: %w", err)
+	}
+	return nil
 }
 
 func TestDeleteSkipsOutputMappingValidation(t *testing.T) {

--- a/pkg/recipes/terraform/execute_test.go
+++ b/pkg/recipes/terraform/execute_test.go
@@ -23,11 +23,115 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/radius-project/radius/pkg/components/kubernetesclient/kubernetesclientprovider"
 	dm "github.com/radius-project/radius/pkg/corerp/datamodel"
 	"github.com/radius-project/radius/pkg/recipes"
 	"github.com/radius-project/radius/pkg/recipes/terraform/config"
+	"github.com/radius-project/radius/pkg/recipes/terraform/config/backends"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
+
+const (
+	terraformGetTestHelper = "RADIUS_TERRAFORM_GET_TEST_HELPER"
+	terraformCommandLog    = "RADIUS_TERRAFORM_COMMAND_LOG"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv(terraformGetTestHelper) == "1" {
+		if commandLog := os.Getenv(terraformCommandLog); commandLog != "" && len(os.Args) > 1 {
+			file, err := os.OpenFile(commandLog, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				os.Exit(1)
+			}
+			if _, err := file.WriteString(os.Args[1] + "\n"); err != nil {
+				_ = file.Close()
+				os.Exit(1)
+			}
+			if err := file.Close(); err != nil {
+				os.Exit(1)
+			}
+		}
+
+		moduleDir := filepath.Join(".terraform", "modules", "test-recipe")
+		if err := os.MkdirAll(moduleDir, 0755); err != nil {
+			os.Exit(1)
+		}
+		if err := os.WriteFile(
+			filepath.Join(moduleDir, "outputs.tf"),
+			[]byte(`output "endpoint" { value = "declared" }`),
+			0644); err != nil {
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestDeleteSkipsOutputMappingValidation(t *testing.T) {
+	globalDir := t.TempDir()
+	t.Setenv("TERRAFORM_TEST_GLOBAL_DIR", globalDir)
+	t.Setenv(terraformGetTestHelper, "1")
+	commandLog := filepath.Join(t.TempDir(), "terraform-commands.log")
+	t.Setenv(terraformCommandLog, commandLog)
+
+	require.NoError(t, os.Symlink(os.Args[0], filepath.Join(globalDir, "terraform")))
+	require.NoError(t, os.WriteFile(filepath.Join(globalDir, ".terraform-ready"), nil, 0644))
+
+	globalTerraformMutex.Lock()
+	previousGlobalTerraformReady := globalTerraformReady
+	globalTerraformReady = true
+	globalTerraformMutex.Unlock()
+	t.Cleanup(func() {
+		globalTerraformMutex.Lock()
+		globalTerraformReady = previousGlobalTerraformReady
+		globalTerraformMutex.Unlock()
+	})
+
+	resourceRecipe := &recipes.ResourceMetadata{
+		Name:          "widget",
+		ResourceID:    "/planes/radius/local/resourceGroups/test-rg/providers/Test.Resources/widgets/widget",
+		EnvironmentID: "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Core/environments/test-env",
+	}
+	kubernetesClient := fake.NewSimpleClientset()
+	kubernetesClient.Fake.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		getAction := action.(k8stesting.GetAction)
+		return true, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      getAction.GetName(),
+				Namespace: backends.RadiusNamespace,
+			},
+		}, nil
+	})
+	kubernetesClient.Fake.PrependReactor("delete", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, nil
+	})
+	kubernetesClients := kubernetesclientprovider.KubernetesClientProvider{}
+	kubernetesClients.SetClientGoClient(kubernetesClient)
+
+	e := executor{kubernetesClients: kubernetesClients}
+	err := e.Delete(t.Context(), Options{
+		RootDir:   t.TempDir(),
+		EnvConfig: &recipes.Configuration{},
+		EnvRecipe: &recipes.EnvironmentDefinition{
+			Name:         "test-recipe",
+			TemplatePath: "test/module/source",
+			ResourceType: "Test.Resources/widgets",
+			Outputs:      map[string]string{"host": "missing"},
+		},
+		ResourceRecipe: resourceRecipe,
+	})
+	require.NoError(t, err)
+
+	commands, err := os.ReadFile(commandLog)
+	require.NoError(t, err)
+	require.Contains(t, string(commands), "destroy\n")
+}
 
 func TestGenerateConfig(t *testing.T) {
 	configTests := []struct {
@@ -76,6 +180,27 @@ func TestGenerateConfig(t *testing.T) {
 	}
 }
 
+func TestGenerateConfigRejectsInvalidOutputMappingBeforeProviderSetup(t *testing.T) {
+	workingDir := t.TempDir()
+	tf, err := tfexec.NewTerraform(workingDir, os.Args[0])
+	require.NoError(t, err)
+	require.NoError(t, tf.SetEnv(map[string]string{terraformGetTestHelper: "1"}))
+
+	options := Options{
+		EnvRecipe: &recipes.EnvironmentDefinition{
+			Name:         "test-recipe",
+			TemplatePath: "test/module/source",
+			ResourceType: "Test.Resources/widgets",
+			Outputs:      map[string]string{"host": "missing"},
+		},
+		ResourceRecipe: &recipes.ResourceMetadata{},
+	}
+
+	e := executor{}
+	_, err = e.generateConfig(t.Context(), tf, options, requireValidOutputMappings)
+	require.EqualError(t, err, `recipe "test-recipe" for resource type "Test.Resources/widgets": invalid outputs mapping: no declared module output matches outputs["host"] -> "missing"; available module outputs: "endpoint"`)
+}
+
 func TestValidateOutputMappings(t *testing.T) {
 	definition := &recipes.EnvironmentDefinition{
 		Name:          "service-bus",
@@ -90,10 +215,48 @@ func TestValidateOutputMappings(t *testing.T) {
 	}
 
 	err := validateOutputMappings(definition, module, requireValidOutputMappings)
-	require.EqualError(t, err, `recipe "service-bus" for resource type "Applications.Messaging/rabbitMQQueues": invalid outputs mapping: no declared module output matches "secrets.connectionString" -> "primaryConnectionString"; available module outputs: "endpoint"`)
+	require.EqualError(t, err, `recipe "service-bus" for resource type "Applications.Messaging/rabbitMQQueues": invalid outputs mapping: no declared module output matches secrets["connectionString"] -> "primaryConnectionString"; available module outputs: "endpoint"`)
 
 	err = validateOutputMappings(definition, module, skipOutputMappingValidation)
 	require.NoError(t, err)
+}
+
+func TestUsesOutputMappings(t *testing.T) {
+	definition := &recipes.EnvironmentDefinition{
+		Outputs: map[string]string{"host": "endpoint"},
+	}
+
+	tests := []struct {
+		name           string
+		hasResult      bool
+		validationMode outputMappingValidationMode
+		expected       bool
+	}{
+		{
+			name:           "deploy uses mappings instead of result",
+			hasResult:      true,
+			validationMode: requireValidOutputMappings,
+			expected:       true,
+		},
+		{
+			name:           "delete preserves result behavior",
+			hasResult:      true,
+			validationMode: skipOutputMappingValidation,
+			expected:       false,
+		},
+		{
+			name:           "direct module deletion keeps mapped outputs",
+			validationMode: skipOutputMappingValidation,
+			expected:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			module := &moduleInspectResult{ResultOutputExists: tt.hasResult}
+			require.Equal(t, tt.expected, usesOutputMappings(definition, module, tt.validationMode))
+		})
+	}
 }
 
 func Test_GetTerraformConfig(t *testing.T) {

--- a/pkg/recipes/terraform/execute_test.go
+++ b/pkg/recipes/terraform/execute_test.go
@@ -69,11 +69,31 @@ func TestGenerateConfig(t *testing.T) {
 			require.NoError(t, err)
 
 			e := executor{}
-			_, err = e.generateConfig(ctx, tf, tc.opts)
+			_, err = e.generateConfig(ctx, tf, tc.opts, requireValidOutputMappings)
 			require.Error(t, err)
 			require.ErrorContains(t, err, tc.err)
 		})
 	}
+}
+
+func TestValidateOutputMappings(t *testing.T) {
+	definition := &recipes.EnvironmentDefinition{
+		Name:          "service-bus",
+		ResourceType:  "Applications.Messaging/rabbitMQQueues",
+		Outputs:       map[string]string{"host": "endpoint"},
+		SecretOutputs: map[string]string{"connectionString": "primaryConnectionString"},
+	}
+	module := &moduleInspectResult{
+		OutputSensitivity: map[string]bool{
+			"endpoint": false,
+		},
+	}
+
+	err := validateOutputMappings(definition, module, requireValidOutputMappings)
+	require.EqualError(t, err, `recipe "service-bus" for resource type "Applications.Messaging/rabbitMQQueues": invalid outputs mapping: no declared module output matches "secrets.connectionString" -> "primaryConnectionString"; available module outputs: "endpoint"`)
+
+	err = validateOutputMappings(definition, module, skipOutputMappingValidation)
+	require.NoError(t, err)
 }
 
 func Test_GetTerraformConfig(t *testing.T) {

--- a/pkg/recipes/terraform/module.go
+++ b/pkg/recipes/terraform/module.go
@@ -175,6 +175,7 @@ func inspectModule(workingDir string, recipe *recipes.EnvironmentDefinition) (*m
 		result.ResultOutputExists = true
 	}
 	for name, output := range mod.Outputs {
+		result.OutputSensitivity[name] = false
 		if output != nil {
 			result.OutputSensitivity[name] = output.Sensitive
 		}

--- a/pkg/recipes/util/outputs.go
+++ b/pkg/recipes/util/outputs.go
@@ -16,6 +16,63 @@ limitations under the License.
 
 package util
 
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// OutputMappingError reports mappings that refer to undeclared module outputs.
+type OutputMappingError struct {
+	missingMappings  []string
+	availableOutputs []string
+}
+
+// Error describes invalid mappings and lists the module's declared outputs.
+func (e *OutputMappingError) Error() string {
+	return fmt.Sprintf(
+		"invalid outputs mapping: no declared module output matches %s; available module outputs: %s",
+		strings.Join(e.missingMappings, ", "),
+		formatOutputNames(e.availableOutputs))
+}
+
+// ValidateOutputsMapping checks every mapping against the module's declared outputs.
+func ValidateOutputsMapping(declaredOutputs []string, outputsMap map[string]string, secretOutputsMap map[string]string) error {
+	declared := make(map[string]struct{}, len(declaredOutputs))
+	for _, outputName := range declaredOutputs {
+		declared[outputName] = struct{}{}
+	}
+
+	missingMappings := []string{}
+	for propertyName, outputName := range outputsMap {
+		if _, ok := declared[outputName]; !ok {
+			missingMappings = append(missingMappings, fmt.Sprintf("%q -> %q", propertyName, outputName))
+		}
+	}
+
+	for propertyName, outputName := range secretOutputsMap {
+		if _, ok := declared[outputName]; !ok {
+			missingMappings = append(missingMappings, fmt.Sprintf("%q -> %q", "secrets."+propertyName, outputName))
+		}
+	}
+
+	if len(missingMappings) == 0 {
+		return nil
+	}
+
+	availableOutputs := make([]string, 0, len(declared))
+	for outputName := range declared {
+		availableOutputs = append(availableOutputs, outputName)
+	}
+	sort.Strings(missingMappings)
+	sort.Strings(availableOutputs)
+
+	return &OutputMappingError{
+		missingMappings:  missingMappings,
+		availableOutputs: availableOutputs,
+	}
+}
+
 // ApplyOutputsMapping renames a direct module's outputs onto resource property names.
 //
 // Keys in outputsMap and secretOutputsMap are resource property names; values are module output names.
@@ -61,4 +118,16 @@ func ApplyOutputsMapping(values map[string]any, secrets map[string]any, outputsM
 	}
 
 	return mappedValues, mappedSecrets
+}
+
+func formatOutputNames(outputNames []string) string {
+	if len(outputNames) == 0 {
+		return "none"
+	}
+
+	quotedOutputs := make([]string, len(outputNames))
+	for i, outputName := range outputNames {
+		quotedOutputs[i] = fmt.Sprintf("%q", outputName)
+	}
+	return strings.Join(quotedOutputs, ", ")
 }

--- a/pkg/recipes/util/outputs.go
+++ b/pkg/recipes/util/outputs.go
@@ -24,37 +24,45 @@ import (
 
 // OutputMappingError reports mappings that refer to undeclared module outputs.
 type OutputMappingError struct {
-	missingMappings  []string
-	availableOutputs []string
+	// MissingMappings contains the deterministically ordered invalid mapping descriptions.
+	MissingMappings []string
+	// AvailableOutputs contains the deterministically ordered module output names.
+	AvailableOutputs []string
+}
+
+// MissingOutputValuesError reports secret mappings whose deployment output is missing or null.
+type MissingOutputValuesError struct {
+	// MissingMappings contains the deterministically ordered mappings without runtime values.
+	MissingMappings []string
+	// AvailableOutputs contains the deterministically ordered non-null deployment output names.
+	AvailableOutputs []string
 }
 
 // Error describes invalid mappings and lists the module's declared outputs.
 func (e *OutputMappingError) Error() string {
 	return fmt.Sprintf(
 		"invalid outputs mapping: no declared module output matches %s; available module outputs: %s",
-		strings.Join(e.missingMappings, ", "),
-		formatOutputNames(e.availableOutputs))
+		strings.Join(e.MissingMappings, ", "),
+		formatOutputNames(e.AvailableOutputs))
+}
+
+// Error describes missing secret values and lists the non-null deployment outputs.
+func (e *MissingOutputValuesError) Error() string {
+	return fmt.Sprintf(
+		"invalid outputs mapping: missing deployment output values for %s; available deployment outputs: %s",
+		strings.Join(e.MissingMappings, ", "),
+		formatOutputNames(e.AvailableOutputs))
 }
 
 // ValidateOutputsMapping checks every mapping against the module's declared outputs.
-func ValidateOutputsMapping(declaredOutputs []string, outputsMap map[string]string, secretOutputsMap map[string]string) error {
+func ValidateOutputsMapping(recipeName string, resourceType string, declaredOutputs []string, outputsMap map[string]string, secretOutputsMap map[string]string) error {
 	declared := make(map[string]struct{}, len(declaredOutputs))
 	for _, outputName := range declaredOutputs {
 		declared[outputName] = struct{}{}
 	}
 
-	missingMappings := []string{}
-	for propertyName, outputName := range outputsMap {
-		if _, ok := declared[outputName]; !ok {
-			missingMappings = append(missingMappings, fmt.Sprintf("%q -> %q", propertyName, outputName))
-		}
-	}
-
-	for propertyName, outputName := range secretOutputsMap {
-		if _, ok := declared[outputName]; !ok {
-			missingMappings = append(missingMappings, fmt.Sprintf("%q -> %q", "secrets."+propertyName, outputName))
-		}
-	}
+	missingMappings := findMissingMappings("outputs", declared, outputsMap)
+	missingMappings = append(missingMappings, findMissingMappings("secrets", declared, secretOutputsMap)...)
 
 	if len(missingMappings) == 0 {
 		return nil
@@ -67,10 +75,20 @@ func ValidateOutputsMapping(declaredOutputs []string, outputsMap map[string]stri
 	sort.Strings(missingMappings)
 	sort.Strings(availableOutputs)
 
-	return &OutputMappingError{
-		missingMappings:  missingMappings,
-		availableOutputs: availableOutputs,
+	return fmt.Errorf("recipe %q for resource type %q: %w", recipeName, resourceType, &OutputMappingError{
+		MissingMappings:  missingMappings,
+		AvailableOutputs: availableOutputs,
+	})
+}
+
+func findMissingMappings(label string, declared map[string]struct{}, mappings map[string]string) []string {
+	missingMappings := []string{}
+	for propertyName, outputName := range mappings {
+		if _, ok := declared[outputName]; !ok {
+			missingMappings = append(missingMappings, formatMapping(label, propertyName, outputName))
+		}
 	}
+	return missingMappings
 }
 
 // ApplyOutputsMapping renames a direct module's outputs onto resource property names.
@@ -83,8 +101,10 @@ func ValidateOutputsMapping(declaredOutputs []string, outputsMap map[string]stri
 //     `primaryConnectionString`, which the module declares as a plain string) to be treated as a secret.
 //
 // When both maps are empty, the original values and secrets are returned unchanged (nil maps are normalized
-// to empty maps so callers always receive non-nil maps).
-func ApplyOutputsMapping(values map[string]any, secrets map[string]any, outputsMap map[string]string, secretOutputsMap map[string]string) (map[string]any, map[string]any) {
+// to empty maps so callers always receive non-nil maps). Missing or null ordinary outputs are omitted.
+// Missing or null secret outputs return MissingOutputValuesError because silently dropping them could clear
+// previously materialized secret data.
+func ApplyOutputsMapping(values map[string]any, secrets map[string]any, outputsMap map[string]string, secretOutputsMap map[string]string) (map[string]any, map[string]any, error) {
 	if len(outputsMap) == 0 && len(secretOutputsMap) == 0 {
 		if values == nil {
 			values = map[string]any{}
@@ -92,7 +112,7 @@ func ApplyOutputsMapping(values map[string]any, secrets map[string]any, outputsM
 		if secrets == nil {
 			secrets = map[string]any{}
 		}
-		return values, secrets
+		return values, secrets, nil
 	}
 
 	mappedValues := make(map[string]any)
@@ -100,24 +120,65 @@ func ApplyOutputsMapping(values map[string]any, secrets map[string]any, outputsM
 
 	// outputsMap: preserve the module's own value/secret classification.
 	for propertyName, outputName := range outputsMap {
-		if val, ok := values[outputName]; ok {
+		if val, ok := nonNullOutput(values, outputName); ok {
 			mappedValues[propertyName] = val
 		}
-		if val, ok := secrets[outputName]; ok {
+		if val, ok := nonNullOutput(secrets, outputName); ok {
 			mappedSecrets[propertyName] = val
 		}
 	}
 
 	// secretOutputsMap: always emit as a secret, whether the module declared the output sensitive or not.
+	missingSecretMappings := []string{}
 	for propertyName, outputName := range secretOutputsMap {
-		if val, ok := secrets[outputName]; ok {
+		if val, ok := nonNullOutput(secrets, outputName); ok {
 			mappedSecrets[propertyName] = val
-		} else if val, ok := values[outputName]; ok {
+		} else if val, ok := nonNullOutput(values, outputName); ok {
 			mappedSecrets[propertyName] = val
+		} else {
+			missingSecretMappings = append(missingSecretMappings, formatMapping("secrets", propertyName, outputName))
 		}
 	}
 
-	return mappedValues, mappedSecrets
+	if len(missingSecretMappings) > 0 {
+		sort.Strings(missingSecretMappings)
+		return nil, nil, &MissingOutputValuesError{
+			MissingMappings:  missingSecretMappings,
+			AvailableOutputs: availableOutputNames(values, secrets),
+		}
+	}
+
+	return mappedValues, mappedSecrets, nil
+}
+
+func nonNullOutput(outputs map[string]any, outputName string) (any, bool) {
+	value, ok := outputs[outputName]
+	return value, ok && value != nil
+}
+
+func availableOutputNames(values map[string]any, secrets map[string]any) []string {
+	available := make(map[string]struct{}, len(values)+len(secrets))
+	for outputName, value := range values {
+		if value != nil {
+			available[outputName] = struct{}{}
+		}
+	}
+	for outputName, value := range secrets {
+		if value != nil {
+			available[outputName] = struct{}{}
+		}
+	}
+
+	outputNames := make([]string, 0, len(available))
+	for outputName := range available {
+		outputNames = append(outputNames, outputName)
+	}
+	sort.Strings(outputNames)
+	return outputNames
+}
+
+func formatMapping(label string, propertyName string, outputName string) string {
+	return fmt.Sprintf("%s[%q] -> %q", label, propertyName, outputName)
 }
 
 func formatOutputNames(outputNames []string) string {

--- a/pkg/recipes/util/outputs_test.go
+++ b/pkg/recipes/util/outputs_test.go
@@ -25,11 +25,13 @@ import (
 
 func Test_ValidateOutputsMapping(t *testing.T) {
 	tests := []struct {
-		name             string
-		declaredOutputs  []string
-		outputsMap       map[string]string
-		secretOutputsMap map[string]string
-		expectedError    string
+		name              string
+		declaredOutputs   []string
+		outputsMap        map[string]string
+		secretOutputsMap  map[string]string
+		expectedError     string
+		expectedMissing   []string
+		expectedAvailable []string
 	}{
 		{
 			name:             "accepts declared mappings",
@@ -38,22 +40,47 @@ func Test_ValidateOutputsMapping(t *testing.T) {
 			secretOutputsMap: map[string]string{"connectionString": "primaryConnectionString"},
 		},
 		{
-			name:             "reports undeclared mappings and available outputs",
-			declaredOutputs:  []string{"zeta", "alpha"},
-			outputsMap:       map[string]string{"host": "missingHost"},
-			secretOutputsMap: map[string]string{"connectionString": "missingSecret"},
-			expectedError:    `invalid outputs mapping: no declared module output matches "host" -> "missingHost", "secrets.connectionString" -> "missingSecret"; available module outputs: "alpha", "zeta"`,
+			name:              "reports undeclared mappings and available outputs",
+			declaredOutputs:   []string{"zeta", "alpha"},
+			outputsMap:        map[string]string{"host": "missingHost"},
+			secretOutputsMap:  map[string]string{"connectionString": "missingSecret"},
+			expectedError:     `recipe "test-recipe" for resource type "Test.Resources/widgets": invalid outputs mapping: no declared module output matches outputs["host"] -> "missingHost", secrets["connectionString"] -> "missingSecret"; available module outputs: "alpha", "zeta"`,
+			expectedMissing:   []string{`outputs["host"] -> "missingHost"`, `secrets["connectionString"] -> "missingSecret"`},
+			expectedAvailable: []string{"alpha", "zeta"},
 		},
 		{
-			name:             "reports when the module declares no outputs",
-			secretOutputsMap: map[string]string{"connectionString": "primaryConnectionString"},
-			expectedError:    `invalid outputs mapping: no declared module output matches "secrets.connectionString" -> "primaryConnectionString"; available module outputs: none`,
+			name:              "reports when the module declares no outputs",
+			secretOutputsMap:  map[string]string{"connectionString": "primaryConnectionString"},
+			expectedError:     `recipe "test-recipe" for resource type "Test.Resources/widgets": invalid outputs mapping: no declared module output matches secrets["connectionString"] -> "primaryConnectionString"; available module outputs: none`,
+			expectedMissing:   []string{`secrets["connectionString"] -> "primaryConnectionString"`},
+			expectedAvailable: []string{},
+		},
+		{
+			name:              "reports empty module output name",
+			declaredOutputs:   []string{"endpoint"},
+			outputsMap:        map[string]string{"host": ""},
+			expectedError:     `recipe "test-recipe" for resource type "Test.Resources/widgets": invalid outputs mapping: no declared module output matches outputs["host"] -> ""; available module outputs: "endpoint"`,
+			expectedMissing:   []string{`outputs["host"] -> ""`},
+			expectedAvailable: []string{"endpoint"},
+		},
+		{
+			name:              "distinguishes mapping categories when property names overlap",
+			outputsMap:        map[string]string{"secrets.connectionString": "missingValue"},
+			secretOutputsMap:  map[string]string{"connectionString": "missingSecret"},
+			expectedError:     `recipe "test-recipe" for resource type "Test.Resources/widgets": invalid outputs mapping: no declared module output matches outputs["secrets.connectionString"] -> "missingValue", secrets["connectionString"] -> "missingSecret"; available module outputs: none`,
+			expectedMissing:   []string{`outputs["secrets.connectionString"] -> "missingValue"`, `secrets["connectionString"] -> "missingSecret"`},
+			expectedAvailable: []string{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateOutputsMapping(tt.declaredOutputs, tt.outputsMap, tt.secretOutputsMap)
+			err := ValidateOutputsMapping(
+				"test-recipe",
+				"Test.Resources/widgets",
+				tt.declaredOutputs,
+				tt.outputsMap,
+				tt.secretOutputsMap)
 			if tt.expectedError == "" {
 				require.NoError(t, err)
 				return
@@ -62,19 +89,24 @@ func Test_ValidateOutputsMapping(t *testing.T) {
 			var mappingErr *OutputMappingError
 			require.ErrorAs(t, err, &mappingErr)
 			require.EqualError(t, err, tt.expectedError)
+			require.Equal(t, tt.expectedMissing, mappingErr.MissingMappings)
+			require.Equal(t, tt.expectedAvailable, mappingErr.AvailableOutputs)
 		})
 	}
 }
 
 func Test_ApplyOutputsMapping(t *testing.T) {
 	tests := []struct {
-		name             string
-		values           map[string]any
-		secrets          map[string]any
-		outputsMap       map[string]string
-		secretOutputsMap map[string]string
-		expectedValues   map[string]any
-		expectedSecrets  map[string]any
+		name              string
+		values            map[string]any
+		secrets           map[string]any
+		outputsMap        map[string]string
+		secretOutputsMap  map[string]string
+		expectedValues    map[string]any
+		expectedSecrets   map[string]any
+		expectedError     string
+		expectedMissing   []string
+		expectedAvailable []string
 	}{
 		{
 			name:            "nil outputs map passes through values",
@@ -158,18 +190,48 @@ func Test_ApplyOutputsMapping(t *testing.T) {
 			expectedSecrets:  map[string]any{"accessKey": "abc123"},
 		},
 		{
-			name:             "secretOutputs with missing module output is skipped",
-			values:           map[string]any{"name": "myhub"},
-			secrets:          map[string]any{},
-			secretOutputsMap: map[string]string{"connectionString": "nonexistent"},
-			expectedValues:   map[string]any{},
-			expectedSecrets:  map[string]any{},
+			name:              "secretOutputs with missing module output fails",
+			values:            map[string]any{"name": "myhub"},
+			secrets:           map[string]any{},
+			secretOutputsMap:  map[string]string{"connectionString": "nonexistent"},
+			expectedError:     `invalid outputs mapping: missing deployment output values for secrets["connectionString"] -> "nonexistent"; available deployment outputs: "name"`,
+			expectedMissing:   []string{`secrets["connectionString"] -> "nonexistent"`},
+			expectedAvailable: []string{"name"},
+		},
+		{
+			name:              "secretOutputs with null module output fails",
+			values:            map[string]any{"name": "myhub", "primaryConnectionString": nil},
+			secrets:           map[string]any{},
+			secretOutputsMap:  map[string]string{"connectionString": "primaryConnectionString"},
+			expectedError:     `invalid outputs mapping: missing deployment output values for secrets["connectionString"] -> "primaryConnectionString"; available deployment outputs: "name"`,
+			expectedMissing:   []string{`secrets["connectionString"] -> "primaryConnectionString"`},
+			expectedAvailable: []string{"name"},
+		},
+		{
+			name:            "null ordinary output is skipped",
+			values:          map[string]any{"hostname": nil},
+			outputsMap:      map[string]string{"host": "hostname"},
+			expectedValues:  map[string]any{},
+			expectedSecrets: map[string]any{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			values, secrets := ApplyOutputsMapping(tt.values, tt.secrets, tt.outputsMap, tt.secretOutputsMap)
+			values, secrets, err := ApplyOutputsMapping(tt.values, tt.secrets, tt.outputsMap, tt.secretOutputsMap)
+			if tt.expectedError != "" {
+				require.EqualError(t, err, tt.expectedError)
+				require.Nil(t, values)
+				require.Nil(t, secrets)
+
+				var mappingErr *MissingOutputValuesError
+				require.ErrorAs(t, err, &mappingErr)
+				require.Equal(t, tt.expectedMissing, mappingErr.MissingMappings)
+				require.Equal(t, tt.expectedAvailable, mappingErr.AvailableOutputs)
+				return
+			}
+
+			require.NoError(t, err)
 			assert.Equal(t, tt.expectedValues, values)
 			assert.Equal(t, tt.expectedSecrets, secrets)
 		})

--- a/pkg/recipes/util/outputs_test.go
+++ b/pkg/recipes/util/outputs_test.go
@@ -20,7 +20,51 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func Test_ValidateOutputsMapping(t *testing.T) {
+	tests := []struct {
+		name             string
+		declaredOutputs  []string
+		outputsMap       map[string]string
+		secretOutputsMap map[string]string
+		expectedError    string
+	}{
+		{
+			name:             "accepts declared mappings",
+			declaredOutputs:  []string{"endpoint", "primaryConnectionString"},
+			outputsMap:       map[string]string{"host": "endpoint"},
+			secretOutputsMap: map[string]string{"connectionString": "primaryConnectionString"},
+		},
+		{
+			name:             "reports undeclared mappings and available outputs",
+			declaredOutputs:  []string{"zeta", "alpha"},
+			outputsMap:       map[string]string{"host": "missingHost"},
+			secretOutputsMap: map[string]string{"connectionString": "missingSecret"},
+			expectedError:    `invalid outputs mapping: no declared module output matches "host" -> "missingHost", "secrets.connectionString" -> "missingSecret"; available module outputs: "alpha", "zeta"`,
+		},
+		{
+			name:             "reports when the module declares no outputs",
+			secretOutputsMap: map[string]string{"connectionString": "primaryConnectionString"},
+			expectedError:    `invalid outputs mapping: no declared module output matches "secrets.connectionString" -> "primaryConnectionString"; available module outputs: none`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateOutputsMapping(tt.declaredOutputs, tt.outputsMap, tt.secretOutputsMap)
+			if tt.expectedError == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			var mappingErr *OutputMappingError
+			require.ErrorAs(t, err, &mappingErr)
+			require.EqualError(t, err, tt.expectedError)
+		})
+	}
+}
 
 func Test_ApplyOutputsMapping(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Radius now rejects recipe output mappings that name outputs the referenced Bicep or Terraform module does not declare. The drivers return `InvalidRecipeOutputs` with `setupError` before Bicep calls `CreateOrUpdate` or Terraform starts `apply`.

## Reason for change

The Service Bus recipe pack maps `primaryConnectionString`, but version `0.12.0` of the Service Bus AVM module does not declare that output:

```bicep
source: 'mcr.microsoft.com/bicep/avm/res/service-bus/namespace:0.12.0'
outputs: {
  secrets: {
    connectionString: 'primaryConnectionString'
  }
}
```

Radius previously omitted this Bicep mapping. The backing resource could report a healthy state without the expected secret, then the consuming resource failed with `InvalidTemplate`. That error pointed at the consumer instead of the invalid recipe mapping.

Both drivers already load module declarations before deployment. The Bicep driver now checks mappings against the top-level ARM template `outputs`. The Terraform driver checks them against the outputs found during module inspection. An invalid mapping reports the recipe name, resource type, bad mappings, and available module outputs:

```text
recipe "servicebus" for resource type "Radius.Resources/azureServiceBusNamespaces":
invalid outputs mapping: no declared module output matches
"secrets.connectionString" -> "primaryConnectionString"; available module outputs:
"location", "name", "resourceId", "serviceBusEndpoint"
```

The error orders invalid mappings and available outputs consistently.

This change is limited to declaration validation. Runtime output mapping, logging, sensitivity routing, duplicate mappings, wrapped `result` handling, and Terraform output generation remain unchanged. Terraform deletion skips only the new declaration check, so existing deletion behavior, including failures caused by stale mapped output references, stays the same.

Fixes #12647.

## How to test

```text
go test -count=1 ./pkg/recipes/util ./pkg/recipes/terraform/... ./pkg/recipes/driver/bicep ./pkg/recipes/driver/terraform ./pkg/rp/util/registrytest
```

The focused tests cover deterministic validation errors, Bicep rejection before the deployment client is called, Terraform `setupError` classification, and the Terraform deletion bypass.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `pkg/recipes/util/outputs.go` | Adds shared validation and deterministic diagnostics for undeclared output mappings. |
| `pkg/recipes/util/outputs_test.go` | Covers valid mappings, multiple invalid mappings, and modules with no declared outputs. |
| `pkg/recipes/driver/bicep/bicep.go` | Validates mappings against ARM template output declarations before deployment. |
| `pkg/recipes/driver/bicep/bicep_test.go` | Verifies validation and confirms that an invalid mapping does not call the deployment client. |
| `pkg/recipes/terraform/execute.go` | Validates mappings against inspected Terraform outputs before apply and skips the new check during deletion. |
| `pkg/recipes/terraform/execute_test.go` | Covers Terraform declaration validation and the deletion bypass. |
| `pkg/recipes/driver/terraform/terraform.go` | Classifies declaration failures as `InvalidRecipeOutputs` with `setupError`. |
| `pkg/recipes/driver/terraform/terraform_test.go` | Covers Terraform driver error classification. |