### PR TITLE
Add RabbitMQ to the default Kubernetes Recipe Pack

### DIFF
--- a/pkg/cli/recipepack/recipepack.go
+++ b/pkg/cli/recipepack/recipepack.go
@@ -257,6 +257,10 @@ func GetCoreTypesRecipeInfo() []CoreTypesRecipeInfo {
 			ResourceType: "Radius.Data/mySqlDatabases",
 			Source:       "ghcr.io/radius-project/kube-recipes/mysqldatabases:" + resolveRecipeTag("Radius.Data/mySqlDatabases", isEdge),
 		},
+		{
+			ResourceType: "Radius.Messaging/rabbitMQ",
+			Source:       "ghcr.io/radius-project/kube-recipes/rabbitmq:" + resolveRecipeTag("Radius.Messaging/rabbitMQ", isEdge),
+		},
 	}
 }
 

--- a/pkg/cli/recipepack/recipepack_test.go
+++ b/pkg/cli/recipepack/recipepack_test.go
@@ -32,7 +32,7 @@ func Test_GetDefaultRecipePackDefinition(t *testing.T) {
 	definitions := GetCoreTypesRecipeInfo()
 
 	// Verify we have the expected number of definitions
-	require.Len(t, definitions, 5)
+	require.Len(t, definitions, 6)
 
 	// Verify expected resource types
 	expectedResourceTypes := []string{
@@ -41,6 +41,7 @@ func Test_GetDefaultRecipePackDefinition(t *testing.T) {
 		"Radius.Compute/routes",
 		"Radius.Security/secrets",
 		"Radius.Data/mySqlDatabases",
+		"Radius.Messaging/rabbitMQ",
 	}
 	actualResourceTypes := make([]string, len(definitions))
 	for i, def := range definitions {
@@ -48,6 +49,10 @@ func Test_GetDefaultRecipePackDefinition(t *testing.T) {
 		require.NotEmpty(t, def.Source, "Source should not be empty for %s", def.ResourceType)
 	}
 	require.ElementsMatch(t, expectedResourceTypes, actualResourceTypes)
+	require.Contains(t, definitions, CoreTypesRecipeInfo{
+		ResourceType: "Radius.Messaging/rabbitMQ",
+		Source:       "ghcr.io/radius-project/kube-recipes/rabbitmq:edge",
+	})
 }
 
 func Test_GetDefaultRecipePackDefinition_UsesEdgeTagForEdgeChannel(t *testing.T) {

--- a/test/functional-portable/corerp/noncloud/resources/rabbitmq_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/rabbitmq_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/kubernetes"
+	"github.com/radius-project/radius/test/rp"
+	"github.com/radius-project/radius/test/step"
+	"github.com/radius-project/radius/test/validation"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Test_RabbitMQ deploys a Radius.Messaging/rabbitMQ resource using the default
+// preview-environment recipe pack and validates the recipe-provisioned broker.
+func Test_RabbitMQ(t *testing.T) {
+	template := "testdata/corerp-resources-rabbitmq.bicep"
+	name := "corerp-resources-rabbitmq"
+	resourceName := "rabbitmq"
+	appNamespace := "corerp-resources-rabbitmq"
+
+	test := rp.NewRPTest(t, name, []rp.TestStep{
+		{
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
+					{
+						Name: name,
+						Type: validation.CoreApplicationsResource,
+					},
+					{
+						Name: resourceName,
+						Type: validation.MessagingRabbitMQResource,
+						App:  name,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					appNamespace: {
+						validation.NewK8sPodForResource(name, resourceName),
+						validation.NewK8sServiceForResource(name, resourceName),
+					},
+				},
+			},
+			PostStepVerify: func(ctx context.Context, t *testing.T, test rp.RPTest) {
+				labelset := kubernetes.MakeSelectorLabels(name, resourceName)
+				deployments, err := test.Options.K8sClient.AppsV1().Deployments(appNamespace).List(ctx, metav1.ListOptions{
+					LabelSelector: labels.SelectorFromSet(labelset).String(),
+				})
+				require.NoError(t, err)
+				require.Len(t, deployments.Items, 1, "expected one RabbitMQ Deployment")
+
+				deployment := deployments.Items[0]
+				require.Equal(t, int32(1), deployment.Status.AvailableReplicas, "RabbitMQ Deployment should have one available replica")
+				require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+				require.Equal(t, "rabbitmq", deployment.Spec.Template.Spec.Containers[0].Name)
+				require.Len(t, deployment.Spec.Template.Spec.Containers[0].Ports, 1)
+				require.Equal(t, int32(5672), deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
+			},
+		},
+	})
+
+	preSetup, previewEnvID := rp.NewPreviewEnvPreSetup(name, test.Options.Workspace.Scope, appNamespace)
+	test.PreSetup = preSetup
+	test.Steps[0].Executor = step.NewDeployExecutor(template, fmt.Sprintf("environment=%s", previewEnvID))
+
+	test.Test(t)
+}

--- a/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-rabbitmq.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-rabbitmq.bicep
@@ -1,0 +1,26 @@
+extension radius
+
+@description('Specifies the location for resources.')
+param location string = 'global'
+
+@description('Specifies the environment for resources.')
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'corerp-resources-rabbitmq'
+  location: location
+  properties: {
+    environment: environment
+  }
+}
+
+resource rabbitmq 'Radius.Messaging/rabbitMQ@2025-08-01-preview' = {
+  name: 'rabbitmq'
+  location: location
+  properties: {
+    environment: environment
+    application: app.id
+    queue: 'jobs'
+    username: 'radius'
+  }
+}

--- a/test/validation/shared.go
+++ b/test/validation/shared.go
@@ -57,6 +57,9 @@ const (
 	// Radius.Data resource types (new provider).
 	DataMySQLDatabasesResource = "radius.data/mySqlDatabases"
 
+	// Radius.Messaging resource types (new provider).
+	MessagingRabbitMQResource = "radius.messaging/rabbitMQ"
+
 	RabbitMQQueuesResource          = "applications.messaging/rabbitMQQueues"
 	DaprPubSubBrokersResource       = "applications.dapr/pubSubBrokers"
 	DaprSecretStoresResource        = "applications.dapr/secretStores"


### PR DESCRIPTION
## Summary

- add the `Radius.Messaging/rabbitMQ` Kubernetes Recipe to the CLI-created default Recipe Pack
- use the existing `ghcr.io/radius-project/kube-recipes/rabbitmq` OCI source with Radius channel-aware tag resolution
- align `rad install kubernetes` with the RabbitMQ entry already present in the resource-types-contrib Kubernetes default Recipe Pack
- add a focused E2E that deploys `Radius.Messaging/rabbitMQ@2025-08-01-preview` without an explicit Recipe through a preview environment and validates the Radius resources plus the Recipe-created running Pod, Service, and RabbitMQ Deployment on port 5672

## Validation

- `go test ./pkg/cli/recipepack`
- `go test ./test/functional-portable/corerp/noncloud/resources -run '^$'`
- `$HOME/.rad/bin/bicep build --no-restore test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-rabbitmq.bicep --stdout`
- `git diff --check`

The targeted E2E requires the Radius functional-test cluster and binaries, which are not available in the local workspace, so its deployed execution is covered by PR CI.