### PR TITLE
Add container images to default Kubernetes recipe pack

### DIFF
--- a/pkg/cli/recipepack/recipepack.go
+++ b/pkg/cli/recipepack/recipepack.go
@@ -238,6 +238,10 @@ func GetCoreTypesRecipeInfo() []CoreTypesRecipeInfo {
 			Source:       "ghcr.io/radius-project/kube-recipes/containers:" + resolveRecipeTag("Radius.Compute/containers", isEdge),
 		},
 		{
+			ResourceType: "Radius.Compute/containerImages",
+			Source:       "ghcr.io/radius-project/kube-recipes/containerimages:" + resolveRecipeTag("Radius.Compute/containerImages", isEdge),
+		},
+		{
 			ResourceType: "Radius.Compute/persistentVolumes",
 			Source:       "ghcr.io/radius-project/kube-recipes/persistentvolumes:" + resolveRecipeTag("Radius.Compute/persistentVolumes", isEdge),
 		},

--- a/pkg/cli/recipepack/recipepack_test.go
+++ b/pkg/cli/recipepack/recipepack_test.go
@@ -32,11 +32,12 @@ func Test_GetDefaultRecipePackDefinition(t *testing.T) {
 	definitions := GetCoreTypesRecipeInfo()
 
 	// Verify we have the expected number of definitions
-	require.Len(t, definitions, 5)
+	require.Len(t, definitions, 6)
 
 	// Verify expected resource types
 	expectedResourceTypes := []string{
 		"Radius.Compute/containers",
+		"Radius.Compute/containerImages",
 		"Radius.Compute/persistentVolumes",
 		"Radius.Compute/routes",
 		"Radius.Security/secrets",
@@ -48,6 +49,8 @@ func Test_GetDefaultRecipePackDefinition(t *testing.T) {
 		require.NotEmpty(t, def.Source, "Source should not be empty for %s", def.ResourceType)
 	}
 	require.ElementsMatch(t, expectedResourceTypes, actualResourceTypes)
+
+	require.Equal(t, "ghcr.io/radius-project/kube-recipes/containerimages:edge", definitions[1].Source)
 }
 
 func Test_GetDefaultRecipePackDefinition_UsesEdgeTagForEdgeChannel(t *testing.T) {


### PR DESCRIPTION
## Summary

- add the existing `Radius.Compute/containerImages` Kubernetes Bicep Recipe to the default Recipe Pack created by `rad install kubernetes`
- use the published `ghcr.io/radius-project/kube-recipes/containerimages` artifact with the existing edge/release SHA tag resolution
- update focused Recipe Pack tests for the new entry and source

## Testing

- `go test ./pkg/cli/recipepack`
- `git diff --check`