### PR TITLE
Cancel superseded functional test runs

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -54,6 +54,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ format('{0}-{1}', github.workflow, (github.event_name == 'pull_request_target' && github.event.pull_request.number) || github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
 env:
   GOPROXY: https://proxy.golang.org
   # Azure Keyvault CSI driver chart version

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -49,6 +49,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ format('{0}-{1}', github.workflow, (github.event_name == 'pull_request' && github.event.pull_request.number) || github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   # Dapr runtime version. Must stay on the same minor line as the Dapr CLI
   # pinned in build/tools.yaml (DAPR_VERSION), which installs it.


### PR DESCRIPTION
## Current behavior

Every PR update starts a new full functional test workflow while the prior run continues. The prior run tests an obsolete SHA and cannot satisfy required checks for the latest commit, while overlapping runs consume duplicate runner and cloud resources and can interleave shared status updates.

## New behavior

A new PR run cancels only the older pending or in-progress run of the same functional workflow for the same PR. Cloud and non-cloud workflows remain independent, other PRs are unaffected, and `schedule`, `repository_dispatch`, `workflow_dispatch`, and `merge_group` runs use unique run-specific groups and are never cancelled by this policy. The newest commit retains the authoritative functional checks.