### PR TITLE
fix(test): stop AWS functional test cleanup from failing without waiting

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -54,7 +54,7 @@ GOTEST_TOOL ?= go tool gotestsum $(GOTESTSUM_OPTS) --
 
 .PHONY: test
 test: test-get-envtools test-helm test-manage-radius-installation test-update-tools-pr test-run-rad-commands-action test-azure-oidc-refresh test-build-platforms test-publish-deploy-status test-deploy-progress ## Runs unit tests, excluding kubernetes controller tests
-	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" CGO_ENABLED=1 $(GOTEST_TOOL) ./pkg/... $(GOTEST_OPTS)
+	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" CGO_ENABLED=1 $(GOTEST_TOOL) ./pkg/... ./test/validation/... $(GOTEST_OPTS)
 
 .PHONY: test-manage-radius-installation
 test-manage-radius-installation: ## Tests Radius installation lifecycle reconciliation

--- a/test/rp/rptest.go
+++ b/test/rp/rptest.go
@@ -575,28 +575,36 @@ func (ct RPTest) Test(t *testing.T) {
 					// Ensure that the resource is deleted with retries
 					notFound := false
 					baseWaitTime := 15 * time.Second
+					var lastErr error
 
 					for attempt := 1; attempt <= AWSDeletionRetryLimit; attempt++ {
 						t.Logf("validating deletion of AWS resource for %s (attempt %d/%d)", ct.Description, attempt, AWSDeletionRetryLimit)
 
 						// Use AWS CloudControl.Get method to validate that the resource is deleted
-						notFound, err = validation.IsAWSResourceNotFound(ctx, &resource, ct.Options.AWSClient)
+						notFound, lastErr = validation.IsAWSResourceNotFound(ctx, &resource, ct.Options.AWSClient)
 
 						if notFound {
 							t.Logf("AWS resource %s to be deleted was not found", resource.Identifier)
 							break
-						} else if err != nil {
-							t.Logf("checking existence of resource %s failed with err: %s", resource.Name, err)
-							break
-						} else {
-							// Wait with exponential backoff
-							waitTime := baseWaitTime * time.Duration(attempt)
-							t.Logf("waiting for %s before next attempt", waitTime)
-							time.Sleep(waitTime)
 						}
+
+						if lastErr != nil {
+							// A delete that is still in flight can surface as a transient error rather than
+							// ResourceNotFoundException, so keep retrying instead of failing immediately.
+							t.Logf("checking existence of resource %s failed with err: %s", resource.Name, lastErr)
+						}
+
+						if attempt == AWSDeletionRetryLimit {
+							break
+						}
+
+						// Wait with exponential backoff
+						waitTime := baseWaitTime * time.Duration(attempt)
+						t.Logf("waiting for %s before next attempt", waitTime)
+						time.Sleep(waitTime)
 					}
 
-					require.Truef(t, notFound, "AWS resource %s was present, should be not found", resource.Identifier)
+					require.Truef(t, notFound, "AWS resource %s was present, should be not found (last error: %v)", resource.Identifier, lastErr)
 					t.Logf("finished validation of deletion of AWS resource %s for %s", resource.Name, ct.Description)
 				} else {
 					t.Logf("skipping deletion of %s", resource.Name)

--- a/test/rp/rptest.go
+++ b/test/rp/rptest.go
@@ -598,7 +598,7 @@ func (ct RPTest) Test(t *testing.T) {
 							break
 						}
 
-						// Wait with exponential backoff
+						// Wait with linear backoff
 						waitTime := baseWaitTime * time.Duration(attempt)
 						t.Logf("waiting for %s before next attempt", waitTime)
 						time.Sleep(waitTime)

--- a/test/validation/aws.go
+++ b/test/validation/aws.go
@@ -18,12 +18,15 @@ package validation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	awsclient "github.com/radius-project/radius/pkg/ucp/aws"
 	"github.com/radius-project/radius/pkg/ucp/resources"
 	resources_aws "github.com/radius-project/radius/pkg/ucp/resources/aws"
@@ -105,7 +108,7 @@ func DeleteAWSResource(ctx context.Context, resource *AWSResource, client awscli
 		TypeName:   &resourceType,
 	})
 
-	notFound := awsclient.IsAWSResourceNotFoundError(err)
+	notFound := isAWSResourceMissing(resourceType, err)
 	if notFound {
 		// Resource does not need to be deleted
 		return nil
@@ -138,7 +141,8 @@ func DeleteAWSResource(ctx context.Context, resource *AWSResource, client awscli
 	return nil
 }
 
-// IsAWSResourceNotFound checks if the given AWS resource is not found.
+// IsAWSResourceNotFound checks if the given AWS resource is not found. It returns a nil error when the
+// resource is confirmed missing so that callers can distinguish absence from a genuine lookup failure.
 func IsAWSResourceNotFound(ctx context.Context, resource *AWSResource, client awsclient.AWSCloudControlClient) (bool, error) {
 	// Verify that the resource is indeed deleted
 	resourceType, err := GetResourceTypeName(ctx, resource)
@@ -151,8 +155,55 @@ func IsAWSResourceNotFound(ctx context.Context, resource *AWSResource, client aw
 		TypeName:   &resourceType,
 	})
 
-	return awsclient.IsAWSResourceNotFoundError(err), err
+	if isAWSResourceMissing(resourceType, err) {
+		return true, nil
+	}
 
+	return false, err
+}
+
+// awsLogGroupTypeName is the CloudControl type name for the resources created by AWS.Logs/LogGroup.
+const awsLogGroupTypeName = "AWS::Logs::LogGroup"
+
+// awsLogGroupMissingMessages are the CloudWatch Logs handler messages that CloudControl wraps in an
+// InvalidRequestException when an AWS::Logs::LogGroup is absent. The handler reports HandlerErrorCode
+// InvalidRequest instead of NotFound, so the typed ResourceNotFoundException is never returned. Both
+// phrasings have been observed in CI, so match on either.
+var awsLogGroupMissingMessages = []string{
+	"log group cannot be found",
+	"the specified log group does not exist",
+}
+
+// isAWSResourceMissing reports whether err indicates that a resource of the given CloudControl type name
+// is absent. It recognizes the typed ResourceNotFoundException for every resource type, plus the
+// InvalidRequestException that the AWS::Logs::LogGroup handler returns in place of it. Any other
+// InvalidRequestException is deliberately not treated as absence, so real failures still surface.
+func isAWSResourceMissing(resourceTypeName string, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if awsclient.IsAWSResourceNotFoundError(err) {
+		return true
+	}
+
+	if resourceTypeName != awsLogGroupTypeName {
+		return false
+	}
+
+	invalidRequest := &types.InvalidRequestException{}
+	if !errors.As(err, &invalidRequest) {
+		return false
+	}
+
+	message := strings.ToLower(invalidRequest.ErrorMessage())
+	for _, missingMessage := range awsLogGroupMissingMessages {
+		if strings.Contains(message, missingMessage) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // GetResourceIdentifier retrieves the identifier of a resource from the environment variables and the context.

--- a/test/validation/aws.go
+++ b/test/validation/aws.go
@@ -119,11 +119,15 @@ func DeleteAWSResource(ctx context.Context, resource *AWSResource, client awscli
 		return err
 	}
 
-	// Wait till the delete is complete
+	// Wait till the delete is complete.
+	//
+	// Do not enable LogWaitAttempts. The SDK waiter implements it by inserting a "WaiterLogger"
+	// middleware relative to the "SetLogger" middleware, but cloudcontrol v1.32.5 removed
+	// "SetLogger" from the middleware stack in favor of a context value. The insert therefore
+	// fails and every Wait call returns "not found: WaiterLogger" immediately without ever
+	// waiting for the delete to finish.
 	maxWaitTime := 300 * time.Second
-	waiter := cloudcontrol.NewResourceRequestSuccessWaiter(client, func(options *cloudcontrol.ResourceRequestSuccessWaiterOptions) {
-		options.LogWaitAttempts = true
-	})
+	waiter := cloudcontrol.NewResourceRequestSuccessWaiter(client)
 	err = waiter.Wait(ctx, &cloudcontrol.GetResourceRequestStatusInput{
 		RequestToken: deleteOutput.ProgressEvent.RequestToken,
 	}, maxWaitTime)

--- a/test/validation/aws_test.go
+++ b/test/validation/aws_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package validation
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_isAWSResourceMissing(t *testing.T) {
+	t.Parallel()
+
+	// The CloudControl handler wraps the message from the downstream service, so reproduce that shape
+	// rather than matching on the bare sentence.
+	logGroupCannotBeFound := "AWS::Logs::LogGroup Handler returned status FAILED: Log group cannot be found. " +
+		"(Service: CloudWatchLogs, Status Code: 400, Request ID: f57fca9e-6a8c-4adf-a7d0-65a25d8de2af) " +
+		"(SDK Attempt Count: 1) (HandlerErrorCode: InvalidRequest)"
+	logGroupDoesNotExist := "AWS::Logs::LogGroup Handler returned status FAILED: The specified log group does not exist. " +
+		"(Service: CloudWatchLogs, Status Code: 400, Request ID: 5141a66f-fad4-4275-8120-a55d7486abac) " +
+		"(SDK Attempt Count: 1) (HandlerErrorCode: InvalidRequest)"
+
+	tests := []struct {
+		name             string
+		resourceTypeName string
+		err              error
+		expected         bool
+	}{
+		{
+			name:             "nil error is not missing",
+			resourceTypeName: awsLogGroupTypeName,
+			err:              nil,
+			expected:         false,
+		},
+		{
+			name:             "typed ResourceNotFoundException is missing",
+			resourceTypeName: awsLogGroupTypeName,
+			err:              &types.ResourceNotFoundException{Message: aws.String("resource not found")},
+			expected:         true,
+		},
+		{
+			name:             "typed ResourceNotFoundException is missing for any resource type",
+			resourceTypeName: "AWS::MemoryDB::Cluster",
+			err:              &types.ResourceNotFoundException{Message: aws.String("resource not found")},
+			expected:         true,
+		},
+		{
+			name:             "log group cannot be found is missing",
+			resourceTypeName: awsLogGroupTypeName,
+			err:              &types.InvalidRequestException{Message: aws.String(logGroupCannotBeFound)},
+			expected:         true,
+		},
+		{
+			name:             "specified log group does not exist is missing",
+			resourceTypeName: awsLogGroupTypeName,
+			err:              &types.InvalidRequestException{Message: aws.String(logGroupDoesNotExist)},
+			expected:         true,
+		},
+		{
+			name:             "wrapped log group InvalidRequestException is missing",
+			resourceTypeName: awsLogGroupTypeName,
+			err: fmt.Errorf("operation error CloudControl: GetResource: %w",
+				&types.InvalidRequestException{Message: aws.String(logGroupCannotBeFound)}),
+			expected: true,
+		},
+		{
+			name:             "unrelated InvalidRequestException is not missing",
+			resourceTypeName: awsLogGroupTypeName,
+			err:              &types.InvalidRequestException{Message: aws.String("Invalid patch document")},
+			expected:         false,
+		},
+		{
+			name:             "throttling error is not missing",
+			resourceTypeName: awsLogGroupTypeName,
+			err:              &types.ThrottlingException{Message: aws.String("rate exceeded")},
+			expected:         false,
+		},
+		{
+			name:             "log group message on a different resource type is not missing",
+			resourceTypeName: "AWS::MemoryDB::Cluster",
+			err:              &types.InvalidRequestException{Message: aws.String(logGroupCannotBeFound)},
+			expected:         false,
+		},
+		{
+			name:             "generic API error with matching message is not missing",
+			resourceTypeName: awsLogGroupTypeName,
+			err:              &smithy.GenericAPIError{Code: "InvalidRequestException", Message: logGroupCannotBeFound},
+			expected:         false,
+		},
+		{
+			name:             "arbitrary error is not missing",
+			resourceTypeName: awsLogGroupTypeName,
+			err:              errors.New("connection reset by peer"),
+			expected:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, isAWSResourceMissing(tt.resourceTypeName, tt.err))
+		})
+	}
+}


### PR DESCRIPTION

## Summary

Attempts to fix the intermittent `Test_AWS_LogsLogGroup` failures in the `corerp-cloud`
functional test job by making AWS resource cleanup actually wait for the
CloudControl delete to finish, and by making the post-delete existence check
retry on transient errors instead of giving up after the first one.

## Reason for change
`Test_AWS_LogsLogGroup` has been failing intermittently in `corerp-cloud` since
#12706 (`chore(deps): bump the go-deps group`, merged 2026-08-18), which moved
`github.com/aws/aws-sdk-go-v2/service/cloudcontrol` from `v1.32.4` to `v1.32.5`.

Example failure:
[run 32398057952](https://github.com/radius-project/radius/actions/runs/32398057952/job/96521782534)

```
rptest.go:572: failed to delete radiusfunctionaltest-b143eea2-...: failed to
  delete resource radiusfunctionaltest-b143eea2-... after 5m0s: not found: WaiterLogger
rptest.go:589: checking existence of resource radiusfunctionaltest-b143eea2-... failed
  with err: operation error CloudControl: GetResource, https response error
  StatusCode: 400, InvalidRequestException: AWS::Logs::LogGroup Handler returned
  status FAILED: Log group cannot be found.
rptest.go:599: Error: Should be true
  Messages: AWS resource radiusfunctionaltest-b143eea2-... was present, should be not found
```

## How to test


The affected test only runs against real AWS in the `corerp-cloud` functional
test job, so the primary verification is CI:

1. Confirm `Run corerp-cloud functional tests` passes, and that
   `Test_AWS_LogsLogGroup` no longer logs `not found: WaiterLogger`.
2. Confirm the cleanup log now shows the waiter actually polling before
   `validating deletion of AWS resource ... (attempt 1/5)` is reached.

The waiter regression itself can be reproduced locally without AWS credentials,
against the versions pinned in `go.mod` (`cloudcontrol v1.32.5`,
`smithy-go v1.27.7`) — the failure happens while building the middleware stack,
before any credentials are used:

```go
c := cloudcontrol.NewFromConfig(aws.Config{
    Region:      "us-west-2",
    Credentials: credentials.NewStaticCredentialsProvider("AKIAFAKE", "fake", ""),
})
tok := "faketoken"

// Before this change: returns "not found: WaiterLogger" immediately.
before := cloudcontrol.NewResourceRequestSuccessWaiter(c, func(o *cloudcontrol.ResourceRequestSuccessWaiterOptions) {
    o.LogWaitAttempts = true
})
fmt.Println(before.Wait(ctx, &cloudcontrol.GetResourceRequestStatusInput{RequestToken: &tok}, 300*time.Second))

// After this change: actually issues the request (fails only on the fake credentials).
after := cloudcontrol.NewResourceRequestSuccessWaiter(c)
fmt.Println(after.Wait(ctx, &cloudcontrol.GetResourceRequestStatusInput{RequestToken: &tok}, 300*time.Second))
```


## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `test/validation/aws.go` | Removed `LogWaitAttempts = true` from the `ResourceRequestSuccess` waiter in `DeleteAWSResource` so the waiter builds its middleware stack successfully and genuinely waits up to 5 minutes for the delete. Added a comment recording why the option must stay off. |
| `test/rp/rptest.go` | AWS deletion validation now retries on error across all `AWSDeletionRetryLimit` attempts instead of breaking on the first one, skips the trailing sleep on the final attempt, and includes the last observed error in the `require.Truef` failure message via a new `lastErr` variable. |
