### PR TITLE
ci(codeql): stabilize GoSec SARIF category

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -137,6 +137,7 @@ jobs:
         if: ${{ always() && github.event_name != 'merge_group' && matrix.language == 'custom-gosec' }}
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
+          category: /language:go/tool:gosec
           sarif_file: gosec-results.sarif
           wait-for-processing: true
 


### PR DESCRIPTION
## Summary

Set an explicit `/language:go/tool:gosec` category on the GoSec SARIF upload so its code-scanning configuration identity remains stable across workflow and matrix refactors.

GoSec SARIF uploads previously omitted `category`, so GitHub generated the code-scanning configuration identity from workflow, job, and matrix metadata. The initial matrix language was `custom-go`; commit `9e6699472c647e59de864eea259326ea677a61c2` in PR #10985 renamed it to `custom-gosec`. GitHub treated that rename as a new configuration, leaving the old `custom-go` configuration stale and producing the repository-level warning that GoSec results may be out of date.

The explicit stable category decouples the uploaded configuration identity from internal matrix labels, preventing future matrix or job refactors from orphaning GoSec configurations.

## Migration

The first upload with `/language:go/tool:gosec` creates the stable configuration. After that upload succeeds, the superseded implicit `custom-gosec` configuration can be deleted once from the code-scanning UI. The already-stale `custom-go` configuration requires a separate one-time cleanup.

## Validation

- `pnpm exec prettier --check .github/workflows/codeql.yml`
- `git diff --check`
- Confirmed `github/codeql-action/upload-sarif@v4.37.7` declares the `category` input