### PR TITLE
fix(test): recognize CloudControl InvalidRequestException for absent AWS::Logs::LogGroup

### DIFF
--- a/test/validation/aws.go
+++ b/test/validation/aws.go
@@ -18,12 +18,15 @@ package validation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	awsclient "github.com/radius-project/radius/pkg/ucp/aws"
 	"github.com/radius-project/radius/pkg/ucp/resources"
 	resources_aws "github.com/radius-project/radius/pkg/ucp/resources/aws"
@@ -35,7 +38,48 @@ const (
 	AWSRDSDBInstanceResourceType    = "AWS.RDS/DBInstance"
 	AWSLogsMetricFilterResourceType = "AWS.Logs/MetricFilter"
 	AWSLogsLogGroupResourceType     = "AWS.Logs/LogGroup"
+
+	// awsLogsLogGroupCloudControlType is the CloudControl TypeName (as returned by
+	// GetResourceTypeName) for AWS::Logs::LogGroup.
+	awsLogsLogGroupCloudControlType = "AWS::Logs::LogGroup"
 )
+
+// logGroupNotFoundMessages are the CloudControl InvalidRequestException messages returned by
+// the AWS::Logs::LogGroup resource handler when the underlying log group is already absent.
+// Unlike most resource types, this handler does not return a typed ResourceNotFoundException,
+// so cleanup validation must recognize these messages to avoid treating deletion as failed.
+var logGroupNotFoundMessages = []string{
+	"log group does not exist",
+	"log group cannot be found",
+}
+
+// isAWSResourceNotFoundError checks whether err indicates that the AWS resource identified by
+// resourceType (a CloudControl TypeName) is not found. It recognizes the typed
+// ResourceNotFoundException for all resource types, plus the known InvalidRequestException
+// messages that AWS::Logs::LogGroup returns instead of a typed not-found error.
+func isAWSResourceNotFoundError(resourceType string, err error) bool {
+	if awsclient.IsAWSResourceNotFoundError(err) {
+		return true
+	}
+
+	if resourceType != awsLogsLogGroupCloudControlType {
+		return false
+	}
+
+	var invalidRequest *types.InvalidRequestException
+	if !errors.As(err, &invalidRequest) {
+		return false
+	}
+
+	message := strings.ToLower(invalidRequest.ErrorMessage())
+	for _, known := range logGroupNotFoundMessages {
+		if strings.Contains(message, known) {
+			return true
+		}
+	}
+
+	return false
+}
 
 type AWSResource struct {
 	// Type of the resource (e.g. AWS.S3/Bucket)
@@ -105,7 +149,7 @@ func DeleteAWSResource(ctx context.Context, resource *AWSResource, client awscli
 		TypeName:   &resourceType,
 	})
 
-	notFound := awsclient.IsAWSResourceNotFoundError(err)
+	notFound := isAWSResourceNotFoundError(resourceType, err)
 	if notFound {
 		// Resource does not need to be deleted
 		return nil
@@ -147,7 +191,7 @@ func IsAWSResourceNotFound(ctx context.Context, resource *AWSResource, client aw
 		TypeName:   &resourceType,
 	})
 
-	return awsclient.IsAWSResourceNotFoundError(err), err
+	return isAWSResourceNotFoundError(resourceType, err), err
 
 }
 

--- a/test/validation/aws_test.go
+++ b/test/validation/aws_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package validation
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_IsAWSResourceNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		resourceType string
+		err          error
+		expected     bool
+	}{
+		{
+			name:         "typed ResourceNotFoundException is recognized for any resource type",
+			resourceType: "AWS::S3::Bucket",
+			err:          &types.ResourceNotFoundException{Message: aws.String("Resource not found")},
+			expected:     true,
+		},
+		{
+			name:         "log group InvalidRequestException: does not exist",
+			resourceType: awsLogsLogGroupCloudControlType,
+			err:          &types.InvalidRequestException{Message: aws.String("The specified log group does not exist.")},
+			expected:     true,
+		},
+		{
+			name:         "log group InvalidRequestException: cannot be found",
+			resourceType: awsLogsLogGroupCloudControlType,
+			err:          &types.InvalidRequestException{Message: aws.String("Log group cannot be found.")},
+			expected:     true,
+		},
+		{
+			name:         "log group InvalidRequestException with an unrelated message is not treated as not-found",
+			resourceType: awsLogsLogGroupCloudControlType,
+			err:          &types.InvalidRequestException{Message: aws.String("The request had invalid parameters.")},
+			expected:     false,
+		},
+		{
+			name:         "matching InvalidRequestException message is only recognized for AWS::Logs::LogGroup",
+			resourceType: "AWS::S3::Bucket",
+			err:          &types.InvalidRequestException{Message: aws.String("Log group cannot be found.")},
+			expected:     false,
+		},
+		{
+			name:         "generic error is not treated as not-found",
+			resourceType: awsLogsLogGroupCloudControlType,
+			err:          errors.New("some other error"),
+			expected:     false,
+		},
+		{
+			name:         "nil error is not treated as not-found",
+			resourceType: awsLogsLogGroupCloudControlType,
+			err:          nil,
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, isAWSResourceNotFoundError(tt.resourceType, tt.err))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes flaky AWS functional-test cleanup for `AWS::Logs::LogGroup` resources: CloudControl's `GetResource` returns an untyped `InvalidRequestException` (not the typed `ResourceNotFoundException`) when the underlying log group is already absent, so the cleanup/deletion-validation helpers in `test/validation/aws.go` treated the resource as still present and failed with `AWS resource ... was present, should be not found`.

## Reason for change

`test/validation.IsAWSResourceNotFound` and `DeleteAWSResource` both delegated solely to `pkg/ucp/aws.IsAWSResourceNotFoundError`, which only recognizes the typed CloudControl `ResourceNotFoundException`. The `AWS::Logs::LogGroup` resource handler is an exception: on a missing log group it returns `InvalidRequestException` with a message such as "The specified log group does not exist" or "Log group cannot be found". The retry loop in `test/rp/rptest.go` then received `notFound == false` with a non-nil error, stopped retrying, and the test failed even though the log group was actually gone (see the linked scheduled-run failures in the issue).

Fixes #<!-- issue number (optional) -->

## How to test

A resource-type-scoped helper `isAWSResourceNotFoundError` was added in `test/validation/aws.go`: it still delegates to the shared `awsclient.IsAWSResourceNotFoundError` for the typed exception (all resource types), and additionally recognizes the two known `InvalidRequestException` messages **only** when `resourceType == "AWS::Logs::LogGroup"`. This keeps the change scoped to the test-cleanup code path — the shared, production-facing `pkg/ucp/aws.IsAWSResourceNotFoundError` (used by 8 AWS proxy controller call sites for every resource type) is untouched, so there is no risk of misclassifying an unrelated resource's real `InvalidRequestException` as "not found" in production request handling.

Validation performed:
- `go build ./test/validation/... ./pkg/ucp/aws/...` — passes.
- `go test ./test/validation/... ./pkg/ucp/aws/... ./pkg/ucp/frontend/controller/awsproxy/...` — all pass.
- `go vet ./test/validation/...` and `gofmt -l` on changed files — clean.
- `golangci-lint run ./test/validation/...` — `0 issues`.
- Added `test/validation/aws_test.go` with a table-driven `Test_IsAWSResourceNotFoundError` covering: the typed exception for any resource type, both known log-group `InvalidRequestException` messages, an unrelated `InvalidRequestException` message under the log-group type (must stay `false`), the same matching message text under a *different* resource type (must stay `false`, proving the scoping gate works), a generic error, and a nil error. Verified with `git stash` that the log-group cases fail against the pre-fix code path and pass after the change.
- Not run: the live functional test `Test_AWS_LogsLogGroup` against a real AWS account (no AWS credentials/cluster available in this environment). The unit test above reproduces the exact defect (message-based absence not recognized) and proves the fix; the functional test would exercise the same code path end-to-end but requires live AWS infrastructure.
- Base branch (`main`) CI was green at the time of this change (`gh run list --branch main` showed the latest Unit Tests / CodeQL runs as `success`).

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `test/validation/aws.go` | Added `isAWSResourceNotFoundError`, gated on `resourceType == "AWS::Logs::LogGroup"`, to also recognize CloudControl's `InvalidRequestException` "log group does not exist" / "cannot be found" messages as not-found; used it from `DeleteAWSResource` and `IsAWSResourceNotFound` in place of the direct `awsclient.IsAWSResourceNotFoundError` call. |
| `test/validation/aws_test.go` | New table-driven unit test for `isAWSResourceNotFoundError` covering the typed exception, both log-group messages, the resource-type scoping gate, and negative cases. |

Fixes #12767