### PR TITLE
Improve OCI archive path handling

### DIFF
--- a/pkg/statearchive/oci/oci.go
+++ b/pkg/statearchive/oci/oci.go
@@ -30,7 +30,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -591,15 +590,10 @@ func unpackArchiveEntries(reader io.Reader, root string) error {
 
 func archivePath(root, name string) (string, error) {
 	cleanName := filepath.Clean(filepath.FromSlash(name))
-	if cleanName == "." || filepath.IsAbs(cleanName) || cleanName == ".." || strings.HasPrefix(cleanName, ".."+string(filepath.Separator)) {
+	if cleanName == "." || !filepath.IsLocal(cleanName) {
 		return "", fmt.Errorf("invalid archive path %q", name)
 	}
-	path := filepath.Join(root, cleanName)
-	rel, err := filepath.Rel(root, path)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("invalid archive path %q", name)
-	}
-	return path, nil
+	return filepath.Join(root, cleanName), nil
 }
 
 var (

--- a/pkg/statearchive/oci/oci_test.go
+++ b/pkg/statearchive/oci/oci_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -509,19 +510,52 @@ func TestCreateLayerPropagatesWriterErrors(t *testing.T) {
 }
 
 func TestArchivePathRejectsUnsafeNames(t *testing.T) {
-	for _, test := range []struct {
+	type testCase struct {
 		name string
 		path string
-	}{
+	}
+	tests := []testCase{
 		{name: "empty", path: ""},
 		{name: "current directory", path: "."},
 		{name: "parent directory", path: ".."},
 		{name: "parent directory file", path: "../state.txt"},
+		{name: "nested parent directory file", path: "nested/../../state.txt"},
+		{name: "native separator parent directory file", path: "nested" + string(filepath.Separator) + ".." + string(filepath.Separator) + ".." + string(filepath.Separator) + "state.txt"},
 		{name: "absolute", path: filepath.Join(t.TempDir(), "state.txt")},
-	} {
+	}
+	if runtime.GOOS == "windows" {
+		tests = append(tests,
+			testCase{name: "drive absolute", path: `C:\state.txt`},
+			testCase{name: "rooted", path: `\state.txt`},
+			testCase{name: "UNC", path: `\\server\share\state.txt`},
+			testCase{name: "reserved name", path: "CON"},
+		)
+	}
+
+	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := archivePath(t.TempDir(), test.path)
 			require.ErrorContains(t, err, "invalid archive path")
+		})
+	}
+}
+
+func TestArchivePathAcceptsLocalNames(t *testing.T) {
+	root := t.TempDir()
+	for _, test := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "file", path: "state.txt", want: filepath.Join(root, "state.txt")},
+		{name: "nested file", path: "nested/state.txt", want: filepath.Join(root, "nested", "state.txt")},
+		{name: "consecutive dots", path: "state..json", want: filepath.Join(root, "state..json")},
+		{name: "normalized file", path: "./nested/../state.txt", want: filepath.Join(root, "state.txt")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := archivePath(root, test.path)
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
 		})
 	}
 }
@@ -541,6 +575,35 @@ func TestUnpackArchiveEntriesRejectsNonRegularEntries(t *testing.T) {
 			require.ErrorContains(t, err, "unsupported archive entry")
 		})
 	}
+}
+
+func TestUnpackArchiveEntriesRejectsOutsidePath(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "archive")
+	require.NoError(t, os.Mkdir(root, 0o755))
+
+	outsidePath := filepath.Join(parent, "state.txt")
+	require.NoError(t, os.WriteFile(outsidePath, []byte("original"), 0o644))
+
+	var archive bytes.Buffer
+	writer := tar.NewWriter(&archive)
+	content := []byte("replacement")
+	require.NoError(t, writer.WriteHeader(&tar.Header{
+		Name:     "../state.txt",
+		Mode:     0o644,
+		Size:     int64(len(content)),
+		Typeflag: tar.TypeReg,
+	}))
+	_, err := writer.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	err = unpackArchiveEntries(&archive, root)
+	require.ErrorContains(t, err, "invalid archive path")
+	require.FileExists(t, outsidePath)
+	actual, err := os.ReadFile(outsidePath)
+	require.NoError(t, err)
+	require.Equal(t, []byte("original"), actual)
 }
 
 func TestUnpackArchiveRejectsInvalidArtifacts(t *testing.T) {


### PR DESCRIPTION
## Summary

Use `filepath.IsLocal` to validate normalized OCI archive entry paths before joining them to the extraction directory. Expand test coverage for local, normalized, platform-specific, and outside-root paths.

## Reason for change

The archive extraction code currently combines several path checks with a relative-path comparison. Using the standard library's local-path predicate makes the intended handling clearer and covers platform-specific path forms consistently.

## How to test

```console
go test ./pkg/statearchive/oci -run 'TestArchivePath|TestUnpackArchiveEntries' -count=1
go test ./pkg/statearchive/oci -count=1
make test-compile
```

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `pkg/statearchive/oci/oci.go` | Validate normalized archive entry paths with `filepath.IsLocal`. |
| `pkg/statearchive/oci/oci_test.go` | Add path-validation and extraction regression coverage. |