### PR TITLE
fix(typespec): preserve Go packages during generation

### DIFF
--- a/build/generate.mk
+++ b/build/generate.mk
@@ -87,7 +87,7 @@ generate-cleanup: ## Deletes all generated code.
 # TypeSpec project's configured module and package name remain authoritative.
 define generate-typespec-go-client
 @set -e; \
-	output_dir=$$(mktemp -d); \
+	output_dir=$$(mktemp -d "$${TMPDIR:-/tmp}/radius-typespec-go.XXXXXX"); \
 	trap 'rm -rf "$$output_dir"' EXIT; \
 	(cd "$(1)" && pnpm exec tsp compile . --emit=@azure-tools/typespec-go --option="@azure-tools/typespec-go.emitter-output-dir=$$output_dir"); \
 	rm -f "$(2)"/zz_generated_*.go; \

--- a/build/generate.mk
+++ b/build/generate.mk
@@ -82,80 +82,63 @@ generate-cleanup: ## Deletes all generated code.
 	find . -type f -name 'zz_*.go' ! -name 'zz_*.deepcopy.go' -delete
 	@echo "$(ARROW) Done."
 
+# typespec-go 0.16 infers the Go module from a parent go.mod when the emitter
+# output is inside the repository. Generate outside the repository so each
+# TypeSpec project's configured module and package name remain authoritative.
+define generate-typespec-go-client
+@set -e; \
+	output_dir=$$(mktemp -d); \
+	trap 'rm -rf "$$output_dir"' EXIT; \
+	(cd "$(1)" && pnpm exec tsp compile . --emit=@azure-tools/typespec-go --option="@azure-tools/typespec-go.emitter-output-dir=$$output_dir"); \
+	rm -f "$(2)"/zz_generated_*.go; \
+	cp "$$output_dir"/zz_generated_*.go "$(2)/"; \
+	if [ "$(3)" = "true" ]; then \
+		rm -f "$(2)"/fake/zz_generated_*.go; \
+		cp "$$output_dir"/fake/zz_generated_*.go "$(2)/fake/"; \
+	fi; \
+	go fmt "./$(2)/..."
+endef
+
 .PHONY: generate-rad-corerp-client
 generate-rad-corerp-client: generate-tsp-installed generate-openapi-spec ## Generates the corerp client SDK (TypeSpec Go emitter).
 	@echo "$(ARROW) Generating 'pkg/corerp/api/v20231001preview'"
-	cd typespec/Applications.Core && pnpm exec tsp compile . --emit=@azure-tools/typespec-go
-	rm -f pkg/corerp/api/v20231001preview/zz_generated_*.go
-	cp typespec/Applications.Core/.tsp-go-tmp/zz_generated_*.go pkg/corerp/api/v20231001preview/
-	rm -rf typespec/Applications.Core/.tsp-go-tmp
-	go fmt ./pkg/corerp/api/v20231001preview/...
+	$(call generate-typespec-go-client,typespec/Applications.Core,pkg/corerp/api/v20231001preview,false)
 	@echo "$(ARROW) Done."
 
 .PHONY: generate-rad-corerp-client-2025-08-01-preview
 generate-rad-corerp-client-2025-08-01-preview: generate-tsp-installed generate-openapi-spec ## Generates the corerp client SDK for 2025-08-01-preview (TypeSpec Go emitter).
 	@echo "$(ARROW) Generating 'pkg/corerp/api/v20250801preview'"
-	cd typespec/Radius.Core && pnpm exec tsp compile . --emit=@azure-tools/typespec-go
-	rm -f pkg/corerp/api/v20250801preview/zz_generated_*.go
-	rm -f pkg/corerp/api/v20250801preview/fake/zz_generated_*.go
-	cp typespec/Radius.Core/.tsp-go-tmp/zz_generated_*.go pkg/corerp/api/v20250801preview/
-	cp typespec/Radius.Core/.tsp-go-tmp/fake/zz_generated_*.go pkg/corerp/api/v20250801preview/fake/
-	rm -rf typespec/Radius.Core/.tsp-go-tmp
-	go fmt ./pkg/corerp/api/v20250801preview/...
+	$(call generate-typespec-go-client,typespec/Radius.Core,pkg/corerp/api/v20250801preview,true)
 	@echo "$(ARROW) Done."
 
 .PHONY: generate-rad-datastoresrp-client
 generate-rad-datastoresrp-client: generate-tsp-installed generate-openapi-spec ## Generates the datastoresrp client SDK (TypeSpec Go emitter).
 	@echo "$(ARROW) Generating 'pkg/datastoresrp/api/v20231001preview'"
-	cd typespec/Applications.Datastores && pnpm exec tsp compile . --emit=@azure-tools/typespec-go
-	rm -f pkg/datastoresrp/api/v20231001preview/zz_generated_*.go
-	cp typespec/Applications.Datastores/.tsp-go-tmp/zz_generated_*.go pkg/datastoresrp/api/v20231001preview/
-	rm -rf typespec/Applications.Datastores/.tsp-go-tmp
-	go fmt ./pkg/datastoresrp/api/v20231001preview/...
+	$(call generate-typespec-go-client,typespec/Applications.Datastores,pkg/datastoresrp/api/v20231001preview,false)
 	@echo "$(ARROW) Done."
 
 .PHONY: generate-rad-messagingrp-client
 generate-rad-messagingrp-client: generate-tsp-installed generate-openapi-spec ## Generates the messagingrp client SDK (TypeSpec Go emitter).
 	@echo "$(ARROW) Generating 'pkg/messagingrp/api/v20231001preview'"
-	cd typespec/Applications.Messaging && pnpm exec tsp compile . --emit=@azure-tools/typespec-go
-	rm -f pkg/messagingrp/api/v20231001preview/zz_generated_*.go
-	cp typespec/Applications.Messaging/.tsp-go-tmp/zz_generated_*.go pkg/messagingrp/api/v20231001preview/
-	rm -rf typespec/Applications.Messaging/.tsp-go-tmp
-	go fmt ./pkg/messagingrp/api/v20231001preview/...
+	$(call generate-typespec-go-client,typespec/Applications.Messaging,pkg/messagingrp/api/v20231001preview,false)
 	@echo "$(ARROW) Done."
 
 .PHONY: generate-rad-daprrp-client
 generate-rad-daprrp-client: generate-tsp-installed generate-openapi-spec ## Generates the daprrp client SDK (TypeSpec Go emitter).
 	@echo "$(ARROW) Generating 'pkg/daprrp/api/v20231001preview'"
-	cd typespec/Applications.Dapr && pnpm exec tsp compile . --emit=@azure-tools/typespec-go
-	rm -f pkg/daprrp/api/v20231001preview/zz_generated_*.go
-	cp typespec/Applications.Dapr/.tsp-go-tmp/zz_generated_*.go pkg/daprrp/api/v20231001preview/
-	rm -rf typespec/Applications.Dapr/.tsp-go-tmp
-	go fmt ./pkg/daprrp/api/v20231001preview/...
+	$(call generate-typespec-go-client,typespec/Applications.Dapr,pkg/daprrp/api/v20231001preview,false)
 	@echo "$(ARROW) Done."
 
 .PHONY: generate-rad-ucp-client
 generate-rad-ucp-client: generate-tsp-installed test-ucp-spec-examples ## Generates the UCP client SDK (TypeSpec Go emitter).
 	@echo "$(ARROW) Generating 'pkg/ucp/api/v20231001preview'"
-	cd typespec/UCP && pnpm exec tsp compile . --emit=@azure-tools/typespec-go
-	rm -f pkg/ucp/api/v20231001preview/zz_generated_*.go
-	rm -f pkg/ucp/api/v20231001preview/fake/zz_generated_*.go
-	cp typespec/UCP/.tsp-go-tmp/zz_generated_*.go pkg/ucp/api/v20231001preview/
-	cp typespec/UCP/.tsp-go-tmp/fake/zz_generated_*.go pkg/ucp/api/v20231001preview/fake/
-	rm -rf typespec/UCP/.tsp-go-tmp
-	go fmt ./pkg/ucp/api/v20231001preview/...
+	$(call generate-typespec-go-client,typespec/UCP,pkg/ucp/api/v20231001preview,true)
 	@echo "$(ARROW) Done."
 
 .PHONY: generate-genericcliclient
 generate-genericcliclient: generate-tsp-installed ## Generates the generic CLI client SDK (TypeSpec Go emitter).
 	@echo "$(ARROW) Generating 'pkg/cli/clients_new/generated'"
-	cd typespec/GenericResource && pnpm exec tsp compile . --emit=@azure-tools/typespec-go
-	rm -f pkg/cli/clients_new/generated/zz_generated_*.go
-	rm -f pkg/cli/clients_new/generated/fake/zz_generated_*.go
-	cp typespec/GenericResource/.tsp-go-tmp/zz_generated_*.go pkg/cli/clients_new/generated/
-	cp typespec/GenericResource/.tsp-go-tmp/fake/zz_generated_*.go pkg/cli/clients_new/generated/fake/
-	rm -rf typespec/GenericResource/.tsp-go-tmp
-	go fmt ./pkg/cli/clients_new/generated/...
+	$(call generate-typespec-go-client,typespec/GenericResource,pkg/cli/clients_new/generated,true)
 	@echo "$(ARROW) Done."
 
 .PHONY: generate-go

--- a/docs/contributing/contributing-code/contributing-code-schema-changes/README.md
+++ b/docs/contributing/contributing-code/contributing-code-schema-changes/README.md
@@ -34,7 +34,7 @@ make generate
 `make generate` runs the full pipeline: it deletes stale generated code, compiles the resource-provider namespaces' TypeSpec to OpenAPI specs (`make generate-openapi-spec` — `UCP`, `Applications.Core`, `Applications.Dapr`, `Applications.Messaging`, `Applications.Datastores`, and `Radius.Core`), runs the TypeSpec Go emitter to produce each namespace's Go client, runs `go generate ./...` (mockgen), generates the Bicep extensibility types, and generates the CRDs. (Not every TypeSpec project emits OpenAPI — for example `typespec/GenericResource` produces only the generic CLI Go client via `make generate-genericcliclient`.) The two halves of the pipeline are:
 
 - **TypeSpec → Swagger.** The [`@azure-tools/typespec-autorest`](https://github.com/Azure/typespec-azure) emitter writes each API namespace's OpenAPI document to `swagger/specification/<service>/resource-manager/<service-name>/<status>/<version>/openapi.json`. The output directory is set per namespace by the `emitter-output-dir` option in that namespace's `tspconfig.yaml` (for example `typespec/Applications.Core/tspconfig.yaml` emits to `swagger/specification/applications`).
-- **TypeSpec → Go.** The [`@azure-tools/typespec-go`](https://github.com/Azure/typespec-azure) emitter writes generated client code to a temporary `.tsp-go-tmp` folder, which the per-namespace `make generate-rad-<namespace>-client` targets copy into the matching `pkg/<namespace>/api/<version>/` directory and run `go fmt` over. Generated files are prefixed `zz_generated_`.
+- **TypeSpec → Go.** The per-namespace `make generate-rad-<namespace>-client` targets create a fresh directory under `${TMPDIR:-/tmp}` for each [`@azure-tools/typespec-go`](https://github.com/Azure/typespec-azure) invocation. Generating outside the repository prevents the emitter from replacing the module configured in the namespace's `tspconfig.yaml` with the repository's root Go module. Each target copies the generated client into the matching `pkg/<namespace>/api/<version>/` directory, runs `go fmt`, and removes the temporary directory. Generated files are prefixed `zz_generated_`.
 
 #### Alternative: generate a single namespace manually
 
@@ -46,13 +46,13 @@ You normally only need `make generate`. To regenerate one namespace by hand, run
    cd typespec/Applications.Core && pnpm exec tsp compile .
    ```
 
-2. Generate the Go client for that namespace with the TypeSpec Go emitter:
+2. Generate and copy the Go client for that namespace with its Make target:
 
    ```bash
-   cd typespec/Applications.Core && pnpm exec tsp compile . --emit=@azure-tools/typespec-go
+   make generate-rad-corerp-client
    ```
 
-   The emitter configuration lives in each namespace's `tspconfig.yaml` (under the `@azure-tools/typespec-go` options block). The generated files land in `.tsp-go-tmp` and must be copied into the matching `pkg/<namespace>/api/<version>/` directory; the per-namespace `make generate-rad-<namespace>-client` targets (for example `make generate-rad-corerp-client`) automate that copy-and-format step, so prefer them over copying by hand.
+   The emitter configuration lives in each namespace's `tspconfig.yaml` under the `@azure-tools/typespec-go` options block. Use the Make target instead of invoking the Go emitter directly because the target creates an external temporary output directory, copies the generated files into the configured package, formats them, and cleans up the temporary directory.
 
 ### 3. Wire up and test the change
 

--- a/hack/bicep-types-radius/src/typespec-bicep-types/package.json
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@azure-tools/typespec-azure-resource-manager": "^0.69.0",
-    "@typespec/compiler": "^1.14.0",
+    "@typespec/compiler": "^1.15.0",
     "@typespec/http": "^1.15.0",
     "@typespec/openapi": "^1.15.0",
     "@typespec/versioning": "^0.85.0"
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@azure-tools/typespec-azure-resource-manager": "^0.71.0",
     "@types/node": "^26.2.0",
-    "@typespec/compiler": "^1.14.0",
+    "@typespec/compiler": "^1.15.0",
     "@typespec/http": "^1.15.0",
     "@typespec/openapi": "^1.15.0",
     "@typespec/versioning": "^0.85.0",

--- a/hack/bicep-types-radius/src/typespec-bicep-types/pnpm-lock.yaml
+++ b/hack/bicep-types-radius/src/typespec-bicep-types/pnpm-lock.yaml
@@ -14,22 +14,22 @@ importers:
     devDependencies:
       '@azure-tools/typespec-azure-resource-manager':
         specifier: ^0.71.0
-        version: 0.71.0(@azure-tools/typespec-azure-core@0.69.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))(@typespec/rest@0.83.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))))(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))(@typespec/openapi@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))))(@typespec/rest@0.83.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))))(@typespec/versioning@0.85.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))
+        version: 0.71.0(@azure-tools/typespec-azure-core@0.69.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))(@typespec/rest@0.83.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))))(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))(@typespec/openapi@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))))(@typespec/rest@0.83.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))))(@typespec/versioning@0.85.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
       '@typespec/compiler':
-        specifier: ^1.14.0
-        version: 1.14.0(@types/node@26.2.0)
+        specifier: ^1.15.0
+        version: 1.15.0(@types/node@26.2.0)
       '@typespec/http':
         specifier: ^1.15.0
-        version: 1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))
+        version: 1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))
       '@typespec/openapi':
         specifier: ^1.15.0
-        version: 1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))
+        version: 1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))
       '@typespec/versioning':
         specifier: ^0.85.0
-        version: 0.85.0(@typespec/compiler@1.14.0(@types/node@26.2.0))
+        version: 0.85.0(@typespec/compiler@1.15.0(@types/node@26.2.0))
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -464,8 +464,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@typespec/compiler@1.14.0':
-    resolution: {integrity: sha512-RRN0LGVDlonG/IbB2b4mvRjdCo6LywwB9/J8lOp6UaH7vtaFnKe5FL+rpxhof4rXx/zI/4OWnQO6c01bTCz4/Q==}
+  '@typespec/compiler@1.15.0':
+    resolution: {integrity: sha512-NbCIRAIzyozchlSaGPVuyV43bC+y+OpXYCuT+8M8kt35Ln9zWzLFcIt7irofQ5QUXBZrHsBFpI5fTOFdCGeWCA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -531,8 +531,8 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
     engines: {node: '>=12'}
 
   ansi-styles@6.2.3:
@@ -1026,20 +1026,20 @@ packages:
 
 snapshots:
 
-  '@azure-tools/typespec-azure-core@0.69.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))(@typespec/rest@0.83.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))))':
+  '@azure-tools/typespec-azure-core@0.69.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))(@typespec/rest@0.83.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))))':
     dependencies:
-      '@typespec/compiler': 1.14.0(@types/node@26.2.0)
-      '@typespec/http': 1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))
-      '@typespec/rest': 0.83.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))
+      '@typespec/compiler': 1.15.0(@types/node@26.2.0)
+      '@typespec/http': 1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))
+      '@typespec/rest': 0.83.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))
 
-  '@azure-tools/typespec-azure-resource-manager@0.71.0(@azure-tools/typespec-azure-core@0.69.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))(@typespec/rest@0.83.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))))(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))(@typespec/openapi@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))))(@typespec/rest@0.83.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))))(@typespec/versioning@0.85.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))':
+  '@azure-tools/typespec-azure-resource-manager@0.71.0(@azure-tools/typespec-azure-core@0.69.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))(@typespec/rest@0.83.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))))(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))(@typespec/openapi@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))))(@typespec/rest@0.83.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))))(@typespec/versioning@0.85.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))':
     dependencies:
-      '@azure-tools/typespec-azure-core': 0.69.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))(@typespec/rest@0.83.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))))
-      '@typespec/compiler': 1.14.0(@types/node@26.2.0)
-      '@typespec/http': 1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))
-      '@typespec/openapi': 1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))
-      '@typespec/rest': 0.83.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))
-      '@typespec/versioning': 0.85.0(@typespec/compiler@1.14.0(@types/node@26.2.0))
+      '@azure-tools/typespec-azure-core': 0.69.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))(@typespec/rest@0.83.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))))
+      '@typespec/compiler': 1.15.0(@types/node@26.2.0)
+      '@typespec/http': 1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))
+      '@typespec/openapi': 1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))
+      '@typespec/rest': 0.83.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))
+      '@typespec/versioning': 0.85.0(@typespec/compiler@1.15.0(@types/node@26.2.0))
       change-case: 5.4.4
       pluralize: 8.0.0
 
@@ -1332,7 +1332,7 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@typespec/compiler@1.14.0(@types/node@26.2.0)':
+  '@typespec/compiler@1.15.0(@types/node@26.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@inquirer/prompts': 8.5.2(@types/node@26.2.0)
@@ -1353,23 +1353,23 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))':
+  '@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))':
     dependencies:
-      '@typespec/compiler': 1.14.0(@types/node@26.2.0)
+      '@typespec/compiler': 1.15.0(@types/node@26.2.0)
 
-  '@typespec/openapi@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))':
+  '@typespec/openapi@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))':
     dependencies:
-      '@typespec/compiler': 1.14.0(@types/node@26.2.0)
-      '@typespec/http': 1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))
+      '@typespec/compiler': 1.15.0(@types/node@26.2.0)
+      '@typespec/http': 1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))
 
-  '@typespec/rest@0.83.0(@typespec/compiler@1.14.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0)))':
+  '@typespec/rest@0.83.0(@typespec/compiler@1.15.0(@types/node@26.2.0))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0)))':
     dependencies:
-      '@typespec/compiler': 1.14.0(@types/node@26.2.0)
-      '@typespec/http': 1.15.0(@typespec/compiler@1.14.0(@types/node@26.2.0))
+      '@typespec/compiler': 1.15.0(@types/node@26.2.0)
+      '@typespec/http': 1.15.0(@typespec/compiler@1.15.0(@types/node@26.2.0))
 
-  '@typespec/versioning@0.85.0(@typespec/compiler@1.14.0(@types/node@26.2.0))':
+  '@typespec/versioning@0.85.0(@typespec/compiler@1.15.0(@types/node@26.2.0))':
     dependencies:
-      '@typespec/compiler': 1.14.0(@types/node@26.2.0)
+      '@typespec/compiler': 1.15.0(@types/node@26.2.0)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -1419,7 +1419,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  ansi-regex@6.2.2: {}
+  ansi-regex@6.3.0: {}
 
   ansi-styles@6.2.3: {}
 
@@ -1663,7 +1663,7 @@ snapshots:
 
   strip-ansi@7.2.0:
     dependencies:
-      ansi-regex: 6.2.2
+      ansi-regex: 6.3.0
 
   tar@7.5.22:
     dependencies:

--- a/pkg/cli/clients_new/generated/zz_generated_genericresources_client.go
+++ b/pkg/cli/clients_new/generated/zz_generated_genericresources_client.go
@@ -75,8 +75,7 @@ func (client *GenericResourcesClient) createOrUpdate(ctx context.Context, resour
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -143,8 +142,7 @@ func (client *GenericResourcesClient) deleteOperation(ctx context.Context, resou
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -189,12 +187,7 @@ func (client *GenericResourcesClient) Get(ctx context.Context, resourceName stri
 	if err != nil {
 		return GenericResourcesClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return GenericResourcesClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -224,8 +217,11 @@ func (client *GenericResourcesClient) getCreateRequest(ctx context.Context, reso
 }
 
 // getHandleResponse handles the Get response.
-func (client *GenericResourcesClient) getHandleResponse(resp *http.Response) (GenericResourcesClientGetResponse, error) {
+func (client *GenericResourcesClient) getHandleResponse(resp *http.Response, successCodes ...int) (GenericResourcesClientGetResponse, error) {
 	result := GenericResourcesClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GenericResource); err != nil {
 		return GenericResourcesClientGetResponse{}, err
 	}
@@ -246,42 +242,56 @@ func (client *GenericResourcesClient) NewListByRootScopePager(options *GenericRe
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByRootScopeCreateRequest(ctx, options)
-			}, nil)
+			req, err := client.listByRootScopeCreateRequest(ctx, nextLink, options)
 			if err != nil {
 				return GenericResourcesClientListByRootScopeResponse{}, err
 			}
-			return client.listByRootScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return GenericResourcesClientListByRootScopeResponse{}, err
+			}
+			return client.listByRootScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByRootScopeCreateRequest creates the ListByRootScope request.
-func (client *GenericResourcesClient) listByRootScopeCreateRequest(ctx context.Context, _ *GenericResourcesClientListByRootScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/{resourceType}"
-	if client.resourceType == "" {
-		return nil, errors.New("parameter client.resourceType cannot be empty")
+func (client *GenericResourcesClient) listByRootScopeCreateRequest(ctx context.Context, nextLink string, _ *GenericResourcesClientListByRootScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/{resourceType}"
+		if client.resourceType == "" {
+			return nil, errors.New("parameter client.resourceType cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{resourceType}", client.resourceType)
+		if client.rootScope == "" {
+			return nil, errors.New("parameter client.rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{resourceType}", client.resourceType)
-	if client.rootScope == "" {
-		return nil, errors.New("parameter client.rootScope cannot be empty")
-	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByRootScopeHandleResponse handles the ListByRootScope response.
-func (client *GenericResourcesClient) listByRootScopeHandleResponse(resp *http.Response) (GenericResourcesClientListByRootScopeResponse, error) {
+func (client *GenericResourcesClient) listByRootScopeHandleResponse(resp *http.Response, successCodes ...int) (GenericResourcesClientListByRootScopeResponse, error) {
 	result := GenericResourcesClientListByRootScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GenericResourcesList); err != nil {
 		return GenericResourcesClientListByRootScopeResponse{}, err
 	}
@@ -304,12 +314,7 @@ func (client *GenericResourcesClient) ListSecrets(ctx context.Context, resourceN
 	if err != nil {
 		return GenericResourcesClientListSecretsResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return GenericResourcesClientListSecretsResponse{}, err
-	}
-	resp, err := client.listSecretsHandleResponse(httpResp)
-	return resp, err
+	return client.listSecretsHandleResponse(httpResp, http.StatusOK)
 }
 
 // listSecretsCreateRequest creates the ListSecrets request.
@@ -339,8 +344,11 @@ func (client *GenericResourcesClient) listSecretsCreateRequest(ctx context.Conte
 }
 
 // listSecretsHandleResponse handles the ListSecrets response.
-func (client *GenericResourcesClient) listSecretsHandleResponse(resp *http.Response) (GenericResourcesClientListSecretsResponse, error) {
+func (client *GenericResourcesClient) listSecretsHandleResponse(resp *http.Response, successCodes ...int) (GenericResourcesClientListSecretsResponse, error) {
 	result := GenericResourcesClientListSecretsResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
 		return GenericResourcesClientListSecretsResponse{}, err
 	}

--- a/pkg/cli/clients_new/generated/zz_generated_models_serde.go
+++ b/pkg/cli/clients_new/generated/zz_generated_models_serde.go
@@ -97,10 +97,10 @@ func (g *GenericResourcesList) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SystemData.
 func (s SystemData) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populateTime[datetime.RFC3339](objectMap, "createdAt", s.CreatedAt)
+	populateTime[datetime.RFC3339](objectMap, "createdAt", s.CreatedAt, true)
 	populate(objectMap, "createdBy", s.CreatedBy)
 	populate(objectMap, "createdByType", s.CreatedByType)
-	populateTime[datetime.RFC3339](objectMap, "lastModifiedAt", s.LastModifiedAt)
+	populateTime[datetime.RFC3339](objectMap, "lastModifiedAt", s.LastModifiedAt, true)
 	populate(objectMap, "lastModifiedBy", s.LastModifiedBy)
 	populate(objectMap, "lastModifiedByType", s.LastModifiedByType)
 	return json.Marshal(objectMap)
@@ -151,13 +151,17 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func populateTime[T dateTimeConstraints](m map[string]any, k string, t *time.Time) {
+func populateTime[T dateTimeConstraints](m map[string]any, k string, t *time.Time, utc bool) {
 	if t == nil {
 		return
 	} else if azcore.IsNullValue(t) {
 		m[k] = nil
 	} else if !reflect.ValueOf(t).IsNil() {
-		newTime := T(*t)
+		tt := *t
+		if utc {
+			tt = tt.UTC()
+		}
+		newTime := T(tt)
 		m[k] = (*T)(&newTime)
 	}
 }
@@ -167,7 +171,7 @@ func unpopulate(data json.RawMessage, fn string, v any) error {
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {
-		return fmt.Errorf("struct field %s: %v", fn, err)
+		return fmt.Errorf("struct field %s: %s", fn, err.Error())
 	}
 	return nil
 }
@@ -178,7 +182,7 @@ func unpopulateTime[T dateTimeConstraints](data json.RawMessage, fn string, t **
 	}
 	var aux T
 	if err := json.Unmarshal(data, &aux); err != nil {
-		return fmt.Errorf("struct field %s: %v", fn, err)
+		return fmt.Errorf("struct field %s: %s", fn, err.Error())
 	}
 	newTime := time.Time(aux)
 	*t = &newTime

--- a/pkg/corerp/api/v20231001preview/zz_generated_applications_client.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_applications_client.go
@@ -55,12 +55,7 @@ func (client *ApplicationsClient) CreateOrUpdate(ctx context.Context, rootScope 
 	if err != nil {
 		return ApplicationsClientCreateOrUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return ApplicationsClientCreateOrUpdateResponse{}, err
-	}
-	resp, err := client.createOrUpdateHandleResponse(httpResp)
-	return resp, err
+	return client.createOrUpdateHandleResponse(httpResp, http.StatusOK, http.StatusCreated)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -90,8 +85,11 @@ func (client *ApplicationsClient) createOrUpdateCreateRequest(ctx context.Contex
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ApplicationsClient) createOrUpdateHandleResponse(resp *http.Response) (ApplicationsClientCreateOrUpdateResponse, error) {
+func (client *ApplicationsClient) createOrUpdateHandleResponse(resp *http.Response, successCodes ...int) (ApplicationsClientCreateOrUpdateResponse, error) {
 	result := ApplicationsClientCreateOrUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationResource); err != nil {
 		return ApplicationsClientCreateOrUpdateResponse{}, err
 	}
@@ -115,8 +113,7 @@ func (client *ApplicationsClient) Delete(ctx context.Context, rootScope string, 
 		return ApplicationsClientDeleteResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return ApplicationsClientDeleteResponse{}, err
+		return ApplicationsClientDeleteResponse{}, runtime.NewResponseError(httpResp)
 	}
 	return ApplicationsClientDeleteResponse{}, nil
 }
@@ -158,12 +155,7 @@ func (client *ApplicationsClient) Get(ctx context.Context, rootScope string, app
 	if err != nil {
 		return ApplicationsClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ApplicationsClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -189,8 +181,11 @@ func (client *ApplicationsClient) getCreateRequest(ctx context.Context, rootScop
 }
 
 // getHandleResponse handles the Get response.
-func (client *ApplicationsClient) getHandleResponse(resp *http.Response) (ApplicationsClientGetResponse, error) {
+func (client *ApplicationsClient) getHandleResponse(resp *http.Response, successCodes ...int) (ApplicationsClientGetResponse, error) {
 	result := ApplicationsClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationResource); err != nil {
 		return ApplicationsClientGetResponse{}, err
 	}
@@ -214,12 +209,7 @@ func (client *ApplicationsClient) GetGraph(ctx context.Context, rootScope string
 	if err != nil {
 		return ApplicationsClientGetGraphResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ApplicationsClientGetGraphResponse{}, err
-	}
-	resp, err := client.getGraphHandleResponse(httpResp)
-	return resp, err
+	return client.getGraphHandleResponse(httpResp, http.StatusOK)
 }
 
 // getGraphCreateRequest creates the GetGraph request.
@@ -249,8 +239,11 @@ func (client *ApplicationsClient) getGraphCreateRequest(ctx context.Context, roo
 }
 
 // getGraphHandleResponse handles the GetGraph response.
-func (client *ApplicationsClient) getGraphHandleResponse(resp *http.Response) (ApplicationsClientGetGraphResponse, error) {
+func (client *ApplicationsClient) getGraphHandleResponse(resp *http.Response, successCodes ...int) (ApplicationsClientGetGraphResponse, error) {
 	result := ApplicationsClientGetGraphResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGraphResponse); err != nil {
 		return ApplicationsClientGetGraphResponse{}, err
 	}
@@ -272,38 +265,52 @@ func (client *ApplicationsClient) NewListByScopePager(rootScope string, options 
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return ApplicationsClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return ApplicationsClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *ApplicationsClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *ApplicationsClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Core/applications"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *ApplicationsClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *ApplicationsClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Core/applications"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *ApplicationsClient) listByScopeHandleResponse(resp *http.Response) (ApplicationsClientListByScopeResponse, error) {
+func (client *ApplicationsClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (ApplicationsClientListByScopeResponse, error) {
 	result := ApplicationsClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationResourceListResult); err != nil {
 		return ApplicationsClientListByScopeResponse{}, err
 	}
@@ -327,12 +334,7 @@ func (client *ApplicationsClient) Update(ctx context.Context, rootScope string, 
 	if err != nil {
 		return ApplicationsClientUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ApplicationsClientUpdateResponse{}, err
-	}
-	resp, err := client.updateHandleResponse(httpResp)
-	return resp, err
+	return client.updateHandleResponse(httpResp, http.StatusOK)
 }
 
 // updateCreateRequest creates the Update request.
@@ -362,8 +364,11 @@ func (client *ApplicationsClient) updateCreateRequest(ctx context.Context, rootS
 }
 
 // updateHandleResponse handles the Update response.
-func (client *ApplicationsClient) updateHandleResponse(resp *http.Response) (ApplicationsClientUpdateResponse, error) {
+func (client *ApplicationsClient) updateHandleResponse(resp *http.Response, successCodes ...int) (ApplicationsClientUpdateResponse, error) {
 	result := ApplicationsClientUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationResource); err != nil {
 		return ApplicationsClientUpdateResponse{}, err
 	}

--- a/pkg/corerp/api/v20231001preview/zz_generated_containers_client.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_containers_client.go
@@ -73,8 +73,7 @@ func (client *ContainersClient) createOrUpdate(ctx context.Context, rootScope st
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -139,8 +138,7 @@ func (client *ContainersClient) deleteOperation(ctx context.Context, rootScope s
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -182,12 +180,7 @@ func (client *ContainersClient) Get(ctx context.Context, rootScope string, conta
 	if err != nil {
 		return ContainersClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ContainersClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -213,8 +206,11 @@ func (client *ContainersClient) getCreateRequest(ctx context.Context, rootScope 
 }
 
 // getHandleResponse handles the Get response.
-func (client *ContainersClient) getHandleResponse(resp *http.Response) (ContainersClientGetResponse, error) {
+func (client *ContainersClient) getHandleResponse(resp *http.Response, successCodes ...int) (ContainersClientGetResponse, error) {
 	result := ContainersClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ContainerResource); err != nil {
 		return ContainersClientGetResponse{}, err
 	}
@@ -236,38 +232,52 @@ func (client *ContainersClient) NewListByScopePager(rootScope string, options *C
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return ContainersClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return ContainersClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *ContainersClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *ContainersClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Core/containers"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *ContainersClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *ContainersClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Core/containers"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *ContainersClient) listByScopeHandleResponse(resp *http.Response) (ContainersClientListByScopeResponse, error) {
+func (client *ContainersClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (ContainersClientListByScopeResponse, error) {
 	result := ContainersClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ContainerResourceListResult); err != nil {
 		return ContainersClientListByScopeResponse{}, err
 	}
@@ -309,8 +319,7 @@ func (client *ContainersClient) update(ctx context.Context, rootScope string, co
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/corerp/api/v20231001preview/zz_generated_environments_client.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_environments_client.go
@@ -55,12 +55,7 @@ func (client *EnvironmentsClient) CreateOrUpdate(ctx context.Context, rootScope 
 	if err != nil {
 		return EnvironmentsClientCreateOrUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return EnvironmentsClientCreateOrUpdateResponse{}, err
-	}
-	resp, err := client.createOrUpdateHandleResponse(httpResp)
-	return resp, err
+	return client.createOrUpdateHandleResponse(httpResp, http.StatusOK, http.StatusCreated)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -90,8 +85,11 @@ func (client *EnvironmentsClient) createOrUpdateCreateRequest(ctx context.Contex
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *EnvironmentsClient) createOrUpdateHandleResponse(resp *http.Response) (EnvironmentsClientCreateOrUpdateResponse, error) {
+func (client *EnvironmentsClient) createOrUpdateHandleResponse(resp *http.Response, successCodes ...int) (EnvironmentsClientCreateOrUpdateResponse, error) {
 	result := EnvironmentsClientCreateOrUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.EnvironmentResource); err != nil {
 		return EnvironmentsClientCreateOrUpdateResponse{}, err
 	}
@@ -115,8 +113,7 @@ func (client *EnvironmentsClient) Delete(ctx context.Context, rootScope string, 
 		return EnvironmentsClientDeleteResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return EnvironmentsClientDeleteResponse{}, err
+		return EnvironmentsClientDeleteResponse{}, runtime.NewResponseError(httpResp)
 	}
 	return EnvironmentsClientDeleteResponse{}, nil
 }
@@ -158,12 +155,7 @@ func (client *EnvironmentsClient) Get(ctx context.Context, rootScope string, env
 	if err != nil {
 		return EnvironmentsClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return EnvironmentsClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -189,8 +181,11 @@ func (client *EnvironmentsClient) getCreateRequest(ctx context.Context, rootScop
 }
 
 // getHandleResponse handles the Get response.
-func (client *EnvironmentsClient) getHandleResponse(resp *http.Response) (EnvironmentsClientGetResponse, error) {
+func (client *EnvironmentsClient) getHandleResponse(resp *http.Response, successCodes ...int) (EnvironmentsClientGetResponse, error) {
 	result := EnvironmentsClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.EnvironmentResource); err != nil {
 		return EnvironmentsClientGetResponse{}, err
 	}
@@ -215,12 +210,7 @@ func (client *EnvironmentsClient) GetMetadata(ctx context.Context, rootScope str
 	if err != nil {
 		return EnvironmentsClientGetMetadataResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return EnvironmentsClientGetMetadataResponse{}, err
-	}
-	resp, err := client.getMetadataHandleResponse(httpResp)
-	return resp, err
+	return client.getMetadataHandleResponse(httpResp, http.StatusOK)
 }
 
 // getMetadataCreateRequest creates the GetMetadata request.
@@ -250,8 +240,11 @@ func (client *EnvironmentsClient) getMetadataCreateRequest(ctx context.Context, 
 }
 
 // getMetadataHandleResponse handles the GetMetadata response.
-func (client *EnvironmentsClient) getMetadataHandleResponse(resp *http.Response) (EnvironmentsClientGetMetadataResponse, error) {
+func (client *EnvironmentsClient) getMetadataHandleResponse(resp *http.Response, successCodes ...int) (EnvironmentsClientGetMetadataResponse, error) {
 	result := EnvironmentsClientGetMetadataResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RecipeGetMetadataResponse); err != nil {
 		return EnvironmentsClientGetMetadataResponse{}, err
 	}
@@ -273,38 +266,52 @@ func (client *EnvironmentsClient) NewListByScopePager(rootScope string, options 
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return EnvironmentsClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return EnvironmentsClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *EnvironmentsClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *EnvironmentsClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Core/environments"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *EnvironmentsClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *EnvironmentsClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Core/environments"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *EnvironmentsClient) listByScopeHandleResponse(resp *http.Response) (EnvironmentsClientListByScopeResponse, error) {
+func (client *EnvironmentsClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (EnvironmentsClientListByScopeResponse, error) {
 	result := EnvironmentsClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.EnvironmentResourceListResult); err != nil {
 		return EnvironmentsClientListByScopeResponse{}, err
 	}
@@ -328,12 +335,7 @@ func (client *EnvironmentsClient) Update(ctx context.Context, rootScope string, 
 	if err != nil {
 		return EnvironmentsClientUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return EnvironmentsClientUpdateResponse{}, err
-	}
-	resp, err := client.updateHandleResponse(httpResp)
-	return resp, err
+	return client.updateHandleResponse(httpResp, http.StatusOK)
 }
 
 // updateCreateRequest creates the Update request.
@@ -363,8 +365,11 @@ func (client *EnvironmentsClient) updateCreateRequest(ctx context.Context, rootS
 }
 
 // updateHandleResponse handles the Update response.
-func (client *EnvironmentsClient) updateHandleResponse(resp *http.Response) (EnvironmentsClientUpdateResponse, error) {
+func (client *EnvironmentsClient) updateHandleResponse(resp *http.Response, successCodes ...int) (EnvironmentsClientUpdateResponse, error) {
 	result := EnvironmentsClientUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.EnvironmentResource); err != nil {
 		return EnvironmentsClientUpdateResponse{}, err
 	}

--- a/pkg/corerp/api/v20231001preview/zz_generated_extenders_client.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_extenders_client.go
@@ -73,8 +73,7 @@ func (client *ExtendersClient) createOrUpdate(ctx context.Context, rootScope str
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -139,8 +138,7 @@ func (client *ExtendersClient) deleteOperation(ctx context.Context, rootScope st
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -182,12 +180,7 @@ func (client *ExtendersClient) Get(ctx context.Context, rootScope string, extend
 	if err != nil {
 		return ExtendersClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ExtendersClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -213,8 +206,11 @@ func (client *ExtendersClient) getCreateRequest(ctx context.Context, rootScope s
 }
 
 // getHandleResponse handles the Get response.
-func (client *ExtendersClient) getHandleResponse(resp *http.Response) (ExtendersClientGetResponse, error) {
+func (client *ExtendersClient) getHandleResponse(resp *http.Response, successCodes ...int) (ExtendersClientGetResponse, error) {
 	result := ExtendersClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExtenderResource); err != nil {
 		return ExtendersClientGetResponse{}, err
 	}
@@ -236,38 +232,52 @@ func (client *ExtendersClient) NewListByScopePager(rootScope string, options *Ex
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return ExtendersClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return ExtendersClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *ExtendersClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *ExtendersClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Core/extenders"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *ExtendersClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *ExtendersClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Core/extenders"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *ExtendersClient) listByScopeHandleResponse(resp *http.Response) (ExtendersClientListByScopeResponse, error) {
+func (client *ExtendersClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (ExtendersClientListByScopeResponse, error) {
 	result := ExtendersClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExtenderResourceListResult); err != nil {
 		return ExtendersClientListByScopeResponse{}, err
 	}
@@ -291,12 +301,7 @@ func (client *ExtendersClient) ListSecrets(ctx context.Context, rootScope string
 	if err != nil {
 		return ExtendersClientListSecretsResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ExtendersClientListSecretsResponse{}, err
-	}
-	resp, err := client.listSecretsHandleResponse(httpResp)
-	return resp, err
+	return client.listSecretsHandleResponse(httpResp, http.StatusOK)
 }
 
 // listSecretsCreateRequest creates the ListSecrets request.
@@ -326,8 +331,11 @@ func (client *ExtendersClient) listSecretsCreateRequest(ctx context.Context, roo
 }
 
 // listSecretsHandleResponse handles the ListSecrets response.
-func (client *ExtendersClient) listSecretsHandleResponse(resp *http.Response) (ExtendersClientListSecretsResponse, error) {
+func (client *ExtendersClient) listSecretsHandleResponse(resp *http.Response, successCodes ...int) (ExtendersClientListSecretsResponse, error) {
 	result := ExtendersClientListSecretsResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExtenderListSecretResponse); err != nil {
 		return ExtendersClientListSecretsResponse{}, err
 	}
@@ -369,8 +377,7 @@ func (client *ExtendersClient) update(ctx context.Context, rootScope string, ext
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/corerp/api/v20231001preview/zz_generated_gateways_client.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_gateways_client.go
@@ -72,8 +72,7 @@ func (client *GatewaysClient) create(ctx context.Context, rootScope string, gate
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -140,8 +139,7 @@ func (client *GatewaysClient) createOrUpdate(ctx context.Context, rootScope stri
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -206,8 +204,7 @@ func (client *GatewaysClient) deleteOperation(ctx context.Context, rootScope str
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -249,12 +246,7 @@ func (client *GatewaysClient) Get(ctx context.Context, rootScope string, gateway
 	if err != nil {
 		return GatewaysClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return GatewaysClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -280,8 +272,11 @@ func (client *GatewaysClient) getCreateRequest(ctx context.Context, rootScope st
 }
 
 // getHandleResponse handles the Get response.
-func (client *GatewaysClient) getHandleResponse(resp *http.Response) (GatewaysClientGetResponse, error) {
+func (client *GatewaysClient) getHandleResponse(resp *http.Response, successCodes ...int) (GatewaysClientGetResponse, error) {
 	result := GatewaysClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GatewayResource); err != nil {
 		return GatewaysClientGetResponse{}, err
 	}
@@ -303,38 +298,52 @@ func (client *GatewaysClient) NewListByScopePager(rootScope string, options *Gat
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return GatewaysClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return GatewaysClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *GatewaysClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *GatewaysClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Core/gateways"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *GatewaysClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *GatewaysClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Core/gateways"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *GatewaysClient) listByScopeHandleResponse(resp *http.Response) (GatewaysClientListByScopeResponse, error) {
+func (client *GatewaysClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (GatewaysClientListByScopeResponse, error) {
 	result := GatewaysClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GatewayResourceListResult); err != nil {
 		return GatewaysClientListByScopeResponse{}, err
 	}

--- a/pkg/corerp/api/v20231001preview/zz_generated_models_serde.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_models_serde.go
@@ -3147,10 +3147,10 @@ func (s *SecretValueProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SystemData.
 func (s SystemData) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populateTime[datetime.RFC3339](objectMap, "createdAt", s.CreatedAt)
+	populateTime[datetime.RFC3339](objectMap, "createdAt", s.CreatedAt, true)
 	populate(objectMap, "createdBy", s.CreatedBy)
 	populate(objectMap, "createdByType", s.CreatedByType)
-	populateTime[datetime.RFC3339](objectMap, "lastModifiedAt", s.LastModifiedAt)
+	populateTime[datetime.RFC3339](objectMap, "lastModifiedAt", s.LastModifiedAt, true)
 	populate(objectMap, "lastModifiedBy", s.LastModifiedBy)
 	populate(objectMap, "lastModifiedByType", s.LastModifiedByType)
 	return json.Marshal(objectMap)
@@ -3505,13 +3505,17 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func populateTime[T dateTimeConstraints](m map[string]any, k string, t *time.Time) {
+func populateTime[T dateTimeConstraints](m map[string]any, k string, t *time.Time, utc bool) {
 	if t == nil {
 		return
 	} else if azcore.IsNullValue(t) {
 		m[k] = nil
 	} else if !reflect.ValueOf(t).IsNil() {
-		newTime := T(*t)
+		tt := *t
+		if utc {
+			tt = tt.UTC()
+		}
+		newTime := T(tt)
 		m[k] = (*T)(&newTime)
 	}
 }
@@ -3521,7 +3525,7 @@ func unpopulate(data json.RawMessage, fn string, v any) error {
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {
-		return fmt.Errorf("struct field %s: %v", fn, err)
+		return fmt.Errorf("struct field %s: %s", fn, err.Error())
 	}
 	return nil
 }
@@ -3532,7 +3536,7 @@ func unpopulateTime[T dateTimeConstraints](data json.RawMessage, fn string, t **
 	}
 	var aux T
 	if err := json.Unmarshal(data, &aux); err != nil {
-		return fmt.Errorf("struct field %s: %v", fn, err)
+		return fmt.Errorf("struct field %s: %s", fn, err.Error())
 	}
 	newTime := time.Time(aux)
 	*t = &newTime

--- a/pkg/corerp/api/v20231001preview/zz_generated_operations_client.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_operations_client.go
@@ -47,34 +47,48 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, nextLink, options)
 			if err != nil {
 				return OperationsClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return OperationsClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *OperationsClient) listCreateRequest(ctx context.Context, _ *OperationsClientListOptions) (*policy.Request, error) {
-	urlPath := "/providers/Applications.Core/operations"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+func (client *OperationsClient) listCreateRequest(ctx context.Context, nextLink string, _ *OperationsClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/providers/Applications.Core/operations"
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
+	}
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *OperationsClient) listHandleResponse(resp *http.Response) (OperationsClientListResponse, error) {
+func (client *OperationsClient) listHandleResponse(resp *http.Response, successCodes ...int) (OperationsClientListResponse, error) {
 	result := OperationsClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OperationListResult); err != nil {
 		return OperationsClientListResponse{}, err
 	}

--- a/pkg/corerp/api/v20231001preview/zz_generated_secretstores_client.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_secretstores_client.go
@@ -73,8 +73,7 @@ func (client *SecretStoresClient) createOrUpdate(ctx context.Context, rootScope 
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -140,8 +139,7 @@ func (client *SecretStoresClient) deleteOperation(ctx context.Context, rootScope
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -183,12 +181,7 @@ func (client *SecretStoresClient) Get(ctx context.Context, rootScope string, sec
 	if err != nil {
 		return SecretStoresClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return SecretStoresClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -214,8 +207,11 @@ func (client *SecretStoresClient) getCreateRequest(ctx context.Context, rootScop
 }
 
 // getHandleResponse handles the Get response.
-func (client *SecretStoresClient) getHandleResponse(resp *http.Response) (SecretStoresClientGetResponse, error) {
+func (client *SecretStoresClient) getHandleResponse(resp *http.Response, successCodes ...int) (SecretStoresClientGetResponse, error) {
 	result := SecretStoresClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretStoreResource); err != nil {
 		return SecretStoresClientGetResponse{}, err
 	}
@@ -237,38 +233,52 @@ func (client *SecretStoresClient) NewListByScopePager(rootScope string, options 
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return SecretStoresClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return SecretStoresClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *SecretStoresClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *SecretStoresClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Core/secretStores"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *SecretStoresClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *SecretStoresClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Core/secretStores"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *SecretStoresClient) listByScopeHandleResponse(resp *http.Response) (SecretStoresClientListByScopeResponse, error) {
+func (client *SecretStoresClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (SecretStoresClientListByScopeResponse, error) {
 	result := SecretStoresClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretStoreResourceListResult); err != nil {
 		return SecretStoresClientListByScopeResponse{}, err
 	}
@@ -293,12 +303,7 @@ func (client *SecretStoresClient) ListSecrets(ctx context.Context, rootScope str
 	if err != nil {
 		return SecretStoresClientListSecretsResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return SecretStoresClientListSecretsResponse{}, err
-	}
-	resp, err := client.listSecretsHandleResponse(httpResp)
-	return resp, err
+	return client.listSecretsHandleResponse(httpResp, http.StatusOK)
 }
 
 // listSecretsCreateRequest creates the ListSecrets request.
@@ -328,8 +333,11 @@ func (client *SecretStoresClient) listSecretsCreateRequest(ctx context.Context, 
 }
 
 // listSecretsHandleResponse handles the ListSecrets response.
-func (client *SecretStoresClient) listSecretsHandleResponse(resp *http.Response) (SecretStoresClientListSecretsResponse, error) {
+func (client *SecretStoresClient) listSecretsHandleResponse(resp *http.Response, successCodes ...int) (SecretStoresClientListSecretsResponse, error) {
 	result := SecretStoresClientListSecretsResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretStoreListSecretsResult); err != nil {
 		return SecretStoresClientListSecretsResponse{}, err
 	}
@@ -372,8 +380,7 @@ func (client *SecretStoresClient) update(ctx context.Context, rootScope string, 
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/corerp/api/v20231001preview/zz_generated_volumes_client.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_volumes_client.go
@@ -73,8 +73,7 @@ func (client *VolumesClient) createOrUpdate(ctx context.Context, rootScope strin
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -139,8 +138,7 @@ func (client *VolumesClient) deleteOperation(ctx context.Context, rootScope stri
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -182,12 +180,7 @@ func (client *VolumesClient) Get(ctx context.Context, rootScope string, volumeNa
 	if err != nil {
 		return VolumesClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return VolumesClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -213,8 +206,11 @@ func (client *VolumesClient) getCreateRequest(ctx context.Context, rootScope str
 }
 
 // getHandleResponse handles the Get response.
-func (client *VolumesClient) getHandleResponse(resp *http.Response) (VolumesClientGetResponse, error) {
+func (client *VolumesClient) getHandleResponse(resp *http.Response, successCodes ...int) (VolumesClientGetResponse, error) {
 	result := VolumesClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VolumeResource); err != nil {
 		return VolumesClientGetResponse{}, err
 	}
@@ -235,38 +231,52 @@ func (client *VolumesClient) NewListByScopePager(rootScope string, options *Volu
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return VolumesClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return VolumesClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *VolumesClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *VolumesClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Core/volumes"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *VolumesClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *VolumesClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Core/volumes"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *VolumesClient) listByScopeHandleResponse(resp *http.Response) (VolumesClientListByScopeResponse, error) {
+func (client *VolumesClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (VolumesClientListByScopeResponse, error) {
 	result := VolumesClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VolumeResourceListResult); err != nil {
 		return VolumesClientListByScopeResponse{}, err
 	}
@@ -308,8 +318,7 @@ func (client *VolumesClient) update(ctx context.Context, rootScope string, volum
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/corerp/api/v20250801preview/zz_generated_applications_client.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_applications_client.go
@@ -56,12 +56,7 @@ func (client *ApplicationsClient) CreateOrUpdate(ctx context.Context, rootScope 
 	if err != nil {
 		return ApplicationsClientCreateOrUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return ApplicationsClientCreateOrUpdateResponse{}, err
-	}
-	resp, err := client.createOrUpdateHandleResponse(httpResp)
-	return resp, err
+	return client.createOrUpdateHandleResponse(httpResp, http.StatusOK, http.StatusCreated)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -91,8 +86,11 @@ func (client *ApplicationsClient) createOrUpdateCreateRequest(ctx context.Contex
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ApplicationsClient) createOrUpdateHandleResponse(resp *http.Response) (ApplicationsClientCreateOrUpdateResponse, error) {
+func (client *ApplicationsClient) createOrUpdateHandleResponse(resp *http.Response, successCodes ...int) (ApplicationsClientCreateOrUpdateResponse, error) {
 	result := ApplicationsClientCreateOrUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationResource); err != nil {
 		return ApplicationsClientCreateOrUpdateResponse{}, err
 	}
@@ -117,8 +115,7 @@ func (client *ApplicationsClient) Delete(ctx context.Context, rootScope string, 
 		return ApplicationsClientDeleteResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return ApplicationsClientDeleteResponse{}, err
+		return ApplicationsClientDeleteResponse{}, runtime.NewResponseError(httpResp)
 	}
 	return ApplicationsClientDeleteResponse{}, nil
 }
@@ -161,12 +158,7 @@ func (client *ApplicationsClient) Get(ctx context.Context, rootScope string, app
 	if err != nil {
 		return ApplicationsClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ApplicationsClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -192,8 +184,11 @@ func (client *ApplicationsClient) getCreateRequest(ctx context.Context, rootScop
 }
 
 // getHandleResponse handles the Get response.
-func (client *ApplicationsClient) getHandleResponse(resp *http.Response) (ApplicationsClientGetResponse, error) {
+func (client *ApplicationsClient) getHandleResponse(resp *http.Response, successCodes ...int) (ApplicationsClientGetResponse, error) {
 	result := ApplicationsClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationResource); err != nil {
 		return ApplicationsClientGetResponse{}, err
 	}
@@ -218,12 +213,7 @@ func (client *ApplicationsClient) GetGraph(ctx context.Context, rootScope string
 	if err != nil {
 		return ApplicationsClientGetGraphResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ApplicationsClientGetGraphResponse{}, err
-	}
-	resp, err := client.getGraphHandleResponse(httpResp)
-	return resp, err
+	return client.getGraphHandleResponse(httpResp, http.StatusOK)
 }
 
 // getGraphCreateRequest creates the GetGraph request.
@@ -253,8 +243,11 @@ func (client *ApplicationsClient) getGraphCreateRequest(ctx context.Context, roo
 }
 
 // getGraphHandleResponse handles the GetGraph response.
-func (client *ApplicationsClient) getGraphHandleResponse(resp *http.Response) (ApplicationsClientGetGraphResponse, error) {
+func (client *ApplicationsClient) getGraphHandleResponse(resp *http.Response, successCodes ...int) (ApplicationsClientGetGraphResponse, error) {
 	result := ApplicationsClientGetGraphResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGraphResponse); err != nil {
 		return ApplicationsClientGetGraphResponse{}, err
 	}
@@ -277,38 +270,52 @@ func (client *ApplicationsClient) NewListByScopePager(rootScope string, options 
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return ApplicationsClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return ApplicationsClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *ApplicationsClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *ApplicationsClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Radius.Core/applications"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *ApplicationsClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *ApplicationsClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Radius.Core/applications"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20250801Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20250801Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *ApplicationsClient) listByScopeHandleResponse(resp *http.Response) (ApplicationsClientListByScopeResponse, error) {
+func (client *ApplicationsClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (ApplicationsClientListByScopeResponse, error) {
 	result := ApplicationsClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationResourceListResult); err != nil {
 		return ApplicationsClientListByScopeResponse{}, err
 	}
@@ -333,12 +340,7 @@ func (client *ApplicationsClient) Update(ctx context.Context, rootScope string, 
 	if err != nil {
 		return ApplicationsClientUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ApplicationsClientUpdateResponse{}, err
-	}
-	resp, err := client.updateHandleResponse(httpResp)
-	return resp, err
+	return client.updateHandleResponse(httpResp, http.StatusOK)
 }
 
 // updateCreateRequest creates the Update request.
@@ -368,8 +370,11 @@ func (client *ApplicationsClient) updateCreateRequest(ctx context.Context, rootS
 }
 
 // updateHandleResponse handles the Update response.
-func (client *ApplicationsClient) updateHandleResponse(resp *http.Response) (ApplicationsClientUpdateResponse, error) {
+func (client *ApplicationsClient) updateHandleResponse(resp *http.Response, successCodes ...int) (ApplicationsClientUpdateResponse, error) {
 	result := ApplicationsClientUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationResource); err != nil {
 		return ApplicationsClientUpdateResponse{}, err
 	}

--- a/pkg/corerp/api/v20250801preview/zz_generated_bicepsettings_client.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_bicepsettings_client.go
@@ -56,12 +56,7 @@ func (client *BicepSettingsClient) CreateOrUpdate(ctx context.Context, rootScope
 	if err != nil {
 		return BicepSettingsClientCreateOrUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return BicepSettingsClientCreateOrUpdateResponse{}, err
-	}
-	resp, err := client.createOrUpdateHandleResponse(httpResp)
-	return resp, err
+	return client.createOrUpdateHandleResponse(httpResp, http.StatusOK, http.StatusCreated)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -91,8 +86,11 @@ func (client *BicepSettingsClient) createOrUpdateCreateRequest(ctx context.Conte
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *BicepSettingsClient) createOrUpdateHandleResponse(resp *http.Response) (BicepSettingsClientCreateOrUpdateResponse, error) {
+func (client *BicepSettingsClient) createOrUpdateHandleResponse(resp *http.Response, successCodes ...int) (BicepSettingsClientCreateOrUpdateResponse, error) {
 	result := BicepSettingsClientCreateOrUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BicepSettingsResource); err != nil {
 		return BicepSettingsClientCreateOrUpdateResponse{}, err
 	}
@@ -117,8 +115,7 @@ func (client *BicepSettingsClient) Delete(ctx context.Context, rootScope string,
 		return BicepSettingsClientDeleteResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return BicepSettingsClientDeleteResponse{}, err
+		return BicepSettingsClientDeleteResponse{}, runtime.NewResponseError(httpResp)
 	}
 	return BicepSettingsClientDeleteResponse{}, nil
 }
@@ -161,12 +158,7 @@ func (client *BicepSettingsClient) Get(ctx context.Context, rootScope string, bi
 	if err != nil {
 		return BicepSettingsClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return BicepSettingsClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -192,8 +184,11 @@ func (client *BicepSettingsClient) getCreateRequest(ctx context.Context, rootSco
 }
 
 // getHandleResponse handles the Get response.
-func (client *BicepSettingsClient) getHandleResponse(resp *http.Response) (BicepSettingsClientGetResponse, error) {
+func (client *BicepSettingsClient) getHandleResponse(resp *http.Response, successCodes ...int) (BicepSettingsClientGetResponse, error) {
 	result := BicepSettingsClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BicepSettingsResource); err != nil {
 		return BicepSettingsClientGetResponse{}, err
 	}
@@ -216,38 +211,52 @@ func (client *BicepSettingsClient) NewListByScopePager(rootScope string, options
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return BicepSettingsClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return BicepSettingsClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *BicepSettingsClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *BicepSettingsClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Radius.Core/bicepSettings"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *BicepSettingsClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *BicepSettingsClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Radius.Core/bicepSettings"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20250801Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20250801Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *BicepSettingsClient) listByScopeHandleResponse(resp *http.Response) (BicepSettingsClientListByScopeResponse, error) {
+func (client *BicepSettingsClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (BicepSettingsClientListByScopeResponse, error) {
 	result := BicepSettingsClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BicepSettingsResourceListResult); err != nil {
 		return BicepSettingsClientListByScopeResponse{}, err
 	}
@@ -272,12 +281,7 @@ func (client *BicepSettingsClient) Update(ctx context.Context, rootScope string,
 	if err != nil {
 		return BicepSettingsClientUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return BicepSettingsClientUpdateResponse{}, err
-	}
-	resp, err := client.updateHandleResponse(httpResp)
-	return resp, err
+	return client.updateHandleResponse(httpResp, http.StatusOK)
 }
 
 // updateCreateRequest creates the Update request.
@@ -307,8 +311,11 @@ func (client *BicepSettingsClient) updateCreateRequest(ctx context.Context, root
 }
 
 // updateHandleResponse handles the Update response.
-func (client *BicepSettingsClient) updateHandleResponse(resp *http.Response) (BicepSettingsClientUpdateResponse, error) {
+func (client *BicepSettingsClient) updateHandleResponse(resp *http.Response, successCodes ...int) (BicepSettingsClientUpdateResponse, error) {
 	result := BicepSettingsClientUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BicepSettingsResource); err != nil {
 		return BicepSettingsClientUpdateResponse{}, err
 	}

--- a/pkg/corerp/api/v20250801preview/zz_generated_environments_client.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_environments_client.go
@@ -56,12 +56,7 @@ func (client *EnvironmentsClient) CreateOrUpdate(ctx context.Context, rootScope 
 	if err != nil {
 		return EnvironmentsClientCreateOrUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return EnvironmentsClientCreateOrUpdateResponse{}, err
-	}
-	resp, err := client.createOrUpdateHandleResponse(httpResp)
-	return resp, err
+	return client.createOrUpdateHandleResponse(httpResp, http.StatusOK, http.StatusCreated)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -91,8 +86,11 @@ func (client *EnvironmentsClient) createOrUpdateCreateRequest(ctx context.Contex
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *EnvironmentsClient) createOrUpdateHandleResponse(resp *http.Response) (EnvironmentsClientCreateOrUpdateResponse, error) {
+func (client *EnvironmentsClient) createOrUpdateHandleResponse(resp *http.Response, successCodes ...int) (EnvironmentsClientCreateOrUpdateResponse, error) {
 	result := EnvironmentsClientCreateOrUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.EnvironmentResource); err != nil {
 		return EnvironmentsClientCreateOrUpdateResponse{}, err
 	}
@@ -117,8 +115,7 @@ func (client *EnvironmentsClient) Delete(ctx context.Context, rootScope string, 
 		return EnvironmentsClientDeleteResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return EnvironmentsClientDeleteResponse{}, err
+		return EnvironmentsClientDeleteResponse{}, runtime.NewResponseError(httpResp)
 	}
 	return EnvironmentsClientDeleteResponse{}, nil
 }
@@ -161,12 +158,7 @@ func (client *EnvironmentsClient) Get(ctx context.Context, rootScope string, env
 	if err != nil {
 		return EnvironmentsClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return EnvironmentsClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -192,8 +184,11 @@ func (client *EnvironmentsClient) getCreateRequest(ctx context.Context, rootScop
 }
 
 // getHandleResponse handles the Get response.
-func (client *EnvironmentsClient) getHandleResponse(resp *http.Response) (EnvironmentsClientGetResponse, error) {
+func (client *EnvironmentsClient) getHandleResponse(resp *http.Response, successCodes ...int) (EnvironmentsClientGetResponse, error) {
 	result := EnvironmentsClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.EnvironmentResource); err != nil {
 		return EnvironmentsClientGetResponse{}, err
 	}
@@ -216,38 +211,52 @@ func (client *EnvironmentsClient) NewListByScopePager(rootScope string, options 
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return EnvironmentsClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return EnvironmentsClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *EnvironmentsClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *EnvironmentsClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Radius.Core/environments"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *EnvironmentsClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *EnvironmentsClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Radius.Core/environments"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20250801Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20250801Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *EnvironmentsClient) listByScopeHandleResponse(resp *http.Response) (EnvironmentsClientListByScopeResponse, error) {
+func (client *EnvironmentsClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (EnvironmentsClientListByScopeResponse, error) {
 	result := EnvironmentsClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.EnvironmentResourceListResult); err != nil {
 		return EnvironmentsClientListByScopeResponse{}, err
 	}
@@ -272,12 +281,7 @@ func (client *EnvironmentsClient) Update(ctx context.Context, rootScope string, 
 	if err != nil {
 		return EnvironmentsClientUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return EnvironmentsClientUpdateResponse{}, err
-	}
-	resp, err := client.updateHandleResponse(httpResp)
-	return resp, err
+	return client.updateHandleResponse(httpResp, http.StatusOK)
 }
 
 // updateCreateRequest creates the Update request.
@@ -307,8 +311,11 @@ func (client *EnvironmentsClient) updateCreateRequest(ctx context.Context, rootS
 }
 
 // updateHandleResponse handles the Update response.
-func (client *EnvironmentsClient) updateHandleResponse(resp *http.Response) (EnvironmentsClientUpdateResponse, error) {
+func (client *EnvironmentsClient) updateHandleResponse(resp *http.Response, successCodes ...int) (EnvironmentsClientUpdateResponse, error) {
 	result := EnvironmentsClientUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.EnvironmentResource); err != nil {
 		return EnvironmentsClientUpdateResponse{}, err
 	}

--- a/pkg/corerp/api/v20250801preview/zz_generated_models.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_models.go
@@ -369,12 +369,14 @@ type EnvironmentProperties struct {
 // that platform engineers configure for their developers. Every Radius Application is deployed to an Environment through
 // its `environment` property.
 // An Environment defines three things for the Applications deployed to it:
-// - **Where resources are deployed**: the target compute platform and cloud provider accounts, set through the `providers`
-// property.
-// - **Which Recipes are used**: the Recipe Packs whose Recipes provision the infrastructure backing application resources,
-// set through the `recipePacks` property.
-// - **Advanced Terraform and Bicep settings**: environment-wide Recipe parameters and Terraform or Bicep engine configuration
-// applied when Recipes run.
+//
+//   - **Where resources are deployed**: the target compute platform and cloud provider accounts, set through the `providers`
+//     property.
+//   - **Which Recipes are used**: the Recipe Packs whose Recipes provision the infrastructure backing application resources,
+//     set through the `recipePacks` property.
+//   - **Advanced Terraform and Bicep settings**: environment-wide Recipe parameters and Terraform or Bicep engine configuration
+//     applied when Recipes run.
+//
 // ## Defining an Environment
 // The simplest Environment can be created directly with the `rad environment create` command, without a Bicep file:
 // ```bash

--- a/pkg/corerp/api/v20250801preview/zz_generated_models_serde.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_models_serde.go
@@ -1316,10 +1316,10 @@ func (r *ResourceStatus) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SystemData.
 func (s SystemData) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populateTime[datetime.RFC3339](objectMap, "createdAt", s.CreatedAt)
+	populateTime[datetime.RFC3339](objectMap, "createdAt", s.CreatedAt, true)
 	populate(objectMap, "createdBy", s.CreatedBy)
 	populate(objectMap, "createdByType", s.CreatedByType)
-	populateTime[datetime.RFC3339](objectMap, "lastModifiedAt", s.LastModifiedAt)
+	populateTime[datetime.RFC3339](objectMap, "lastModifiedAt", s.LastModifiedAt, true)
 	populate(objectMap, "lastModifiedBy", s.LastModifiedBy)
 	populate(objectMap, "lastModifiedByType", s.LastModifiedByType)
 	return json.Marshal(objectMap)
@@ -1646,13 +1646,17 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func populateTime[T dateTimeConstraints](m map[string]any, k string, t *time.Time) {
+func populateTime[T dateTimeConstraints](m map[string]any, k string, t *time.Time, utc bool) {
 	if t == nil {
 		return
 	} else if azcore.IsNullValue(t) {
 		m[k] = nil
 	} else if !reflect.ValueOf(t).IsNil() {
-		newTime := T(*t)
+		tt := *t
+		if utc {
+			tt = tt.UTC()
+		}
+		newTime := T(tt)
 		m[k] = (*T)(&newTime)
 	}
 }
@@ -1662,7 +1666,7 @@ func unpopulate(data json.RawMessage, fn string, v any) error {
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {
-		return fmt.Errorf("struct field %s: %v", fn, err)
+		return fmt.Errorf("struct field %s: %s", fn, err.Error())
 	}
 	return nil
 }
@@ -1673,7 +1677,7 @@ func unpopulateTime[T dateTimeConstraints](data json.RawMessage, fn string, t **
 	}
 	var aux T
 	if err := json.Unmarshal(data, &aux); err != nil {
-		return fmt.Errorf("struct field %s: %v", fn, err)
+		return fmt.Errorf("struct field %s: %s", fn, err.Error())
 	}
 	newTime := time.Time(aux)
 	*t = &newTime

--- a/pkg/corerp/api/v20250801preview/zz_generated_operations_client.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_operations_client.go
@@ -48,34 +48,48 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, nextLink, options)
 			if err != nil {
 				return OperationsClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return OperationsClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *OperationsClient) listCreateRequest(ctx context.Context, _ *OperationsClientListOptions) (*policy.Request, error) {
-	urlPath := "/providers/Radius.Core/operations"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+func (client *OperationsClient) listCreateRequest(ctx context.Context, nextLink string, _ *OperationsClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/providers/Radius.Core/operations"
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
+	}
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20250801Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20250801Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *OperationsClient) listHandleResponse(resp *http.Response) (OperationsClientListResponse, error) {
+func (client *OperationsClient) listHandleResponse(resp *http.Response, successCodes ...int) (OperationsClientListResponse, error) {
 	result := OperationsClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OperationListResult); err != nil {
 		return OperationsClientListResponse{}, err
 	}

--- a/pkg/corerp/api/v20250801preview/zz_generated_recipepacks_client.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_recipepacks_client.go
@@ -56,12 +56,7 @@ func (client *RecipePacksClient) CreateOrUpdate(ctx context.Context, rootScope s
 	if err != nil {
 		return RecipePacksClientCreateOrUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return RecipePacksClientCreateOrUpdateResponse{}, err
-	}
-	resp, err := client.createOrUpdateHandleResponse(httpResp)
-	return resp, err
+	return client.createOrUpdateHandleResponse(httpResp, http.StatusOK, http.StatusCreated)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -91,8 +86,11 @@ func (client *RecipePacksClient) createOrUpdateCreateRequest(ctx context.Context
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *RecipePacksClient) createOrUpdateHandleResponse(resp *http.Response) (RecipePacksClientCreateOrUpdateResponse, error) {
+func (client *RecipePacksClient) createOrUpdateHandleResponse(resp *http.Response, successCodes ...int) (RecipePacksClientCreateOrUpdateResponse, error) {
 	result := RecipePacksClientCreateOrUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RecipePackResource); err != nil {
 		return RecipePacksClientCreateOrUpdateResponse{}, err
 	}
@@ -117,8 +115,7 @@ func (client *RecipePacksClient) Delete(ctx context.Context, rootScope string, r
 		return RecipePacksClientDeleteResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return RecipePacksClientDeleteResponse{}, err
+		return RecipePacksClientDeleteResponse{}, runtime.NewResponseError(httpResp)
 	}
 	return RecipePacksClientDeleteResponse{}, nil
 }
@@ -161,12 +158,7 @@ func (client *RecipePacksClient) Get(ctx context.Context, rootScope string, reci
 	if err != nil {
 		return RecipePacksClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return RecipePacksClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -192,8 +184,11 @@ func (client *RecipePacksClient) getCreateRequest(ctx context.Context, rootScope
 }
 
 // getHandleResponse handles the Get response.
-func (client *RecipePacksClient) getHandleResponse(resp *http.Response) (RecipePacksClientGetResponse, error) {
+func (client *RecipePacksClient) getHandleResponse(resp *http.Response, successCodes ...int) (RecipePacksClientGetResponse, error) {
 	result := RecipePacksClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RecipePackResource); err != nil {
 		return RecipePacksClientGetResponse{}, err
 	}
@@ -216,38 +211,52 @@ func (client *RecipePacksClient) NewListByScopePager(rootScope string, options *
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return RecipePacksClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return RecipePacksClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *RecipePacksClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *RecipePacksClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Radius.Core/recipePacks"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *RecipePacksClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *RecipePacksClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Radius.Core/recipePacks"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20250801Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20250801Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *RecipePacksClient) listByScopeHandleResponse(resp *http.Response) (RecipePacksClientListByScopeResponse, error) {
+func (client *RecipePacksClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (RecipePacksClientListByScopeResponse, error) {
 	result := RecipePacksClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RecipePackResourceListResult); err != nil {
 		return RecipePacksClientListByScopeResponse{}, err
 	}
@@ -272,12 +281,7 @@ func (client *RecipePacksClient) Update(ctx context.Context, rootScope string, r
 	if err != nil {
 		return RecipePacksClientUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return RecipePacksClientUpdateResponse{}, err
-	}
-	resp, err := client.updateHandleResponse(httpResp)
-	return resp, err
+	return client.updateHandleResponse(httpResp, http.StatusOK)
 }
 
 // updateCreateRequest creates the Update request.
@@ -307,8 +311,11 @@ func (client *RecipePacksClient) updateCreateRequest(ctx context.Context, rootSc
 }
 
 // updateHandleResponse handles the Update response.
-func (client *RecipePacksClient) updateHandleResponse(resp *http.Response) (RecipePacksClientUpdateResponse, error) {
+func (client *RecipePacksClient) updateHandleResponse(resp *http.Response, successCodes ...int) (RecipePacksClientUpdateResponse, error) {
 	result := RecipePacksClientUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RecipePackResource); err != nil {
 		return RecipePacksClientUpdateResponse{}, err
 	}

--- a/pkg/corerp/api/v20250801preview/zz_generated_responses.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_responses.go
@@ -363,12 +363,14 @@ type EnvironmentsClientCreateOrUpdateResponse struct {
 	// The `Radius.Core/environments` Resource Type represents a Radius Environment: the deployment target that platform engineers
 	// configure for their developers. Every Radius Application is deployed to an Environment through its `environment` property.
 	// An Environment defines three things for the Applications deployed to it:
-	// - **Where resources are deployed**: the target compute platform and cloud provider accounts, set through the `providers`
-	// property.
-	// - **Which Recipes are used**: the Recipe Packs whose Recipes provision the infrastructure backing application resources,
-	// set through the `recipePacks` property.
-	// - **Advanced Terraform and Bicep settings**: environment-wide Recipe parameters and Terraform or Bicep engine configuration
-	// applied when Recipes run.
+	//
+	//   - **Where resources are deployed**: the target compute platform and cloud provider accounts, set through the `providers`
+	//     property.
+	//   - **Which Recipes are used**: the Recipe Packs whose Recipes provision the infrastructure backing application resources,
+	//     set through the `recipePacks` property.
+	//   - **Advanced Terraform and Bicep settings**: environment-wide Recipe parameters and Terraform or Bicep engine configuration
+	//     applied when Recipes run.
+	//
 	// ## Defining an Environment
 	// The simplest Environment can be created directly with the `rad environment create` command, without a Bicep file:
 	// ```bash
@@ -459,12 +461,14 @@ type EnvironmentsClientGetResponse struct {
 	// The `Radius.Core/environments` Resource Type represents a Radius Environment: the deployment target that platform engineers
 	// configure for their developers. Every Radius Application is deployed to an Environment through its `environment` property.
 	// An Environment defines three things for the Applications deployed to it:
-	// - **Where resources are deployed**: the target compute platform and cloud provider accounts, set through the `providers`
-	// property.
-	// - **Which Recipes are used**: the Recipe Packs whose Recipes provision the infrastructure backing application resources,
-	// set through the `recipePacks` property.
-	// - **Advanced Terraform and Bicep settings**: environment-wide Recipe parameters and Terraform or Bicep engine configuration
-	// applied when Recipes run.
+	//
+	//   - **Where resources are deployed**: the target compute platform and cloud provider accounts, set through the `providers`
+	//     property.
+	//   - **Which Recipes are used**: the Recipe Packs whose Recipes provision the infrastructure backing application resources,
+	//     set through the `recipePacks` property.
+	//   - **Advanced Terraform and Bicep settings**: environment-wide Recipe parameters and Terraform or Bicep engine configuration
+	//     applied when Recipes run.
+	//
 	// ## Defining an Environment
 	// The simplest Environment can be created directly with the `rad environment create` command, without a Bicep file:
 	// ```bash
@@ -556,12 +560,14 @@ type EnvironmentsClientUpdateResponse struct {
 	// The `Radius.Core/environments` Resource Type represents a Radius Environment: the deployment target that platform engineers
 	// configure for their developers. Every Radius Application is deployed to an Environment through its `environment` property.
 	// An Environment defines three things for the Applications deployed to it:
-	// - **Where resources are deployed**: the target compute platform and cloud provider accounts, set through the `providers`
-	// property.
-	// - **Which Recipes are used**: the Recipe Packs whose Recipes provision the infrastructure backing application resources,
-	// set through the `recipePacks` property.
-	// - **Advanced Terraform and Bicep settings**: environment-wide Recipe parameters and Terraform or Bicep engine configuration
-	// applied when Recipes run.
+	//
+	//   - **Where resources are deployed**: the target compute platform and cloud provider accounts, set through the `providers`
+	//     property.
+	//   - **Which Recipes are used**: the Recipe Packs whose Recipes provision the infrastructure backing application resources,
+	//     set through the `recipePacks` property.
+	//   - **Advanced Terraform and Bicep settings**: environment-wide Recipe parameters and Terraform or Bicep engine configuration
+	//     applied when Recipes run.
+	//
 	// ## Defining an Environment
 	// The simplest Environment can be created directly with the `rad environment create` command, without a Bicep file:
 	// ```bash

--- a/pkg/corerp/api/v20250801preview/zz_generated_terraformsettings_client.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_terraformsettings_client.go
@@ -56,12 +56,7 @@ func (client *TerraformSettingsClient) CreateOrUpdate(ctx context.Context, rootS
 	if err != nil {
 		return TerraformSettingsClientCreateOrUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return TerraformSettingsClientCreateOrUpdateResponse{}, err
-	}
-	resp, err := client.createOrUpdateHandleResponse(httpResp)
-	return resp, err
+	return client.createOrUpdateHandleResponse(httpResp, http.StatusOK, http.StatusCreated)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -91,8 +86,11 @@ func (client *TerraformSettingsClient) createOrUpdateCreateRequest(ctx context.C
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *TerraformSettingsClient) createOrUpdateHandleResponse(resp *http.Response) (TerraformSettingsClientCreateOrUpdateResponse, error) {
+func (client *TerraformSettingsClient) createOrUpdateHandleResponse(resp *http.Response, successCodes ...int) (TerraformSettingsClientCreateOrUpdateResponse, error) {
 	result := TerraformSettingsClientCreateOrUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TerraformSettingsResource); err != nil {
 		return TerraformSettingsClientCreateOrUpdateResponse{}, err
 	}
@@ -118,8 +116,7 @@ func (client *TerraformSettingsClient) Delete(ctx context.Context, rootScope str
 		return TerraformSettingsClientDeleteResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return TerraformSettingsClientDeleteResponse{}, err
+		return TerraformSettingsClientDeleteResponse{}, runtime.NewResponseError(httpResp)
 	}
 	return TerraformSettingsClientDeleteResponse{}, nil
 }
@@ -162,12 +159,7 @@ func (client *TerraformSettingsClient) Get(ctx context.Context, rootScope string
 	if err != nil {
 		return TerraformSettingsClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return TerraformSettingsClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -193,8 +185,11 @@ func (client *TerraformSettingsClient) getCreateRequest(ctx context.Context, roo
 }
 
 // getHandleResponse handles the Get response.
-func (client *TerraformSettingsClient) getHandleResponse(resp *http.Response) (TerraformSettingsClientGetResponse, error) {
+func (client *TerraformSettingsClient) getHandleResponse(resp *http.Response, successCodes ...int) (TerraformSettingsClientGetResponse, error) {
 	result := TerraformSettingsClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TerraformSettingsResource); err != nil {
 		return TerraformSettingsClientGetResponse{}, err
 	}
@@ -217,38 +212,52 @@ func (client *TerraformSettingsClient) NewListByScopePager(rootScope string, opt
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return TerraformSettingsClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return TerraformSettingsClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *TerraformSettingsClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *TerraformSettingsClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Radius.Core/terraformSettings"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *TerraformSettingsClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *TerraformSettingsClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Radius.Core/terraformSettings"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20250801Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20250801Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *TerraformSettingsClient) listByScopeHandleResponse(resp *http.Response) (TerraformSettingsClientListByScopeResponse, error) {
+func (client *TerraformSettingsClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (TerraformSettingsClientListByScopeResponse, error) {
 	result := TerraformSettingsClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TerraformSettingsResourceListResult); err != nil {
 		return TerraformSettingsClientListByScopeResponse{}, err
 	}
@@ -274,12 +283,7 @@ func (client *TerraformSettingsClient) Update(ctx context.Context, rootScope str
 	if err != nil {
 		return TerraformSettingsClientUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return TerraformSettingsClientUpdateResponse{}, err
-	}
-	resp, err := client.updateHandleResponse(httpResp)
-	return resp, err
+	return client.updateHandleResponse(httpResp, http.StatusOK)
 }
 
 // updateCreateRequest creates the Update request.
@@ -309,8 +313,11 @@ func (client *TerraformSettingsClient) updateCreateRequest(ctx context.Context, 
 }
 
 // updateHandleResponse handles the Update response.
-func (client *TerraformSettingsClient) updateHandleResponse(resp *http.Response) (TerraformSettingsClientUpdateResponse, error) {
+func (client *TerraformSettingsClient) updateHandleResponse(resp *http.Response, successCodes ...int) (TerraformSettingsClientUpdateResponse, error) {
 	result := TerraformSettingsClientUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TerraformSettingsResource); err != nil {
 		return TerraformSettingsClientUpdateResponse{}, err
 	}

--- a/pkg/daprrp/api/v20231001preview/zz_generated_configurationstores_client.go
+++ b/pkg/daprrp/api/v20231001preview/zz_generated_configurationstores_client.go
@@ -73,8 +73,7 @@ func (client *ConfigurationStoresClient) createOrUpdate(ctx context.Context, roo
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -140,8 +139,7 @@ func (client *ConfigurationStoresClient) deleteOperation(ctx context.Context, ro
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -183,12 +181,7 @@ func (client *ConfigurationStoresClient) Get(ctx context.Context, rootScope stri
 	if err != nil {
 		return ConfigurationStoresClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ConfigurationStoresClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -214,8 +207,11 @@ func (client *ConfigurationStoresClient) getCreateRequest(ctx context.Context, r
 }
 
 // getHandleResponse handles the Get response.
-func (client *ConfigurationStoresClient) getHandleResponse(resp *http.Response) (ConfigurationStoresClientGetResponse, error) {
+func (client *ConfigurationStoresClient) getHandleResponse(resp *http.Response, successCodes ...int) (ConfigurationStoresClientGetResponse, error) {
 	result := ConfigurationStoresClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DaprConfigurationStoreResource); err != nil {
 		return ConfigurationStoresClientGetResponse{}, err
 	}
@@ -237,38 +233,52 @@ func (client *ConfigurationStoresClient) NewListByScopePager(rootScope string, o
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return ConfigurationStoresClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return ConfigurationStoresClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *ConfigurationStoresClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *ConfigurationStoresClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Dapr/configurationStores"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *ConfigurationStoresClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *ConfigurationStoresClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Dapr/configurationStores"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *ConfigurationStoresClient) listByScopeHandleResponse(resp *http.Response) (ConfigurationStoresClientListByScopeResponse, error) {
+func (client *ConfigurationStoresClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (ConfigurationStoresClientListByScopeResponse, error) {
 	result := ConfigurationStoresClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DaprConfigurationStoreResourceListResult); err != nil {
 		return ConfigurationStoresClientListByScopeResponse{}, err
 	}
@@ -311,8 +321,7 @@ func (client *ConfigurationStoresClient) update(ctx context.Context, rootScope s
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/daprrp/api/v20231001preview/zz_generated_models_serde.go
+++ b/pkg/daprrp/api/v20231001preview/zz_generated_models_serde.go
@@ -1136,10 +1136,10 @@ func (r *ResourceStatus) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SystemData.
 func (s SystemData) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populateTime[datetime.RFC3339](objectMap, "createdAt", s.CreatedAt)
+	populateTime[datetime.RFC3339](objectMap, "createdAt", s.CreatedAt, true)
 	populate(objectMap, "createdBy", s.CreatedBy)
 	populate(objectMap, "createdByType", s.CreatedByType)
-	populateTime[datetime.RFC3339](objectMap, "lastModifiedAt", s.LastModifiedAt)
+	populateTime[datetime.RFC3339](objectMap, "lastModifiedAt", s.LastModifiedAt, true)
 	populate(objectMap, "lastModifiedBy", s.LastModifiedBy)
 	populate(objectMap, "lastModifiedByType", s.LastModifiedByType)
 	return json.Marshal(objectMap)
@@ -1190,13 +1190,17 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func populateTime[T dateTimeConstraints](m map[string]any, k string, t *time.Time) {
+func populateTime[T dateTimeConstraints](m map[string]any, k string, t *time.Time, utc bool) {
 	if t == nil {
 		return
 	} else if azcore.IsNullValue(t) {
 		m[k] = nil
 	} else if !reflect.ValueOf(t).IsNil() {
-		newTime := T(*t)
+		tt := *t
+		if utc {
+			tt = tt.UTC()
+		}
+		newTime := T(tt)
 		m[k] = (*T)(&newTime)
 	}
 }
@@ -1206,7 +1210,7 @@ func unpopulate(data json.RawMessage, fn string, v any) error {
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {
-		return fmt.Errorf("struct field %s: %v", fn, err)
+		return fmt.Errorf("struct field %s: %s", fn, err.Error())
 	}
 	return nil
 }
@@ -1217,7 +1221,7 @@ func unpopulateTime[T dateTimeConstraints](data json.RawMessage, fn string, t **
 	}
 	var aux T
 	if err := json.Unmarshal(data, &aux); err != nil {
-		return fmt.Errorf("struct field %s: %v", fn, err)
+		return fmt.Errorf("struct field %s: %s", fn, err.Error())
 	}
 	newTime := time.Time(aux)
 	*t = &newTime

--- a/pkg/daprrp/api/v20231001preview/zz_generated_operations_client.go
+++ b/pkg/daprrp/api/v20231001preview/zz_generated_operations_client.go
@@ -47,34 +47,48 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, nextLink, options)
 			if err != nil {
 				return OperationsClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return OperationsClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *OperationsClient) listCreateRequest(ctx context.Context, _ *OperationsClientListOptions) (*policy.Request, error) {
-	urlPath := "/providers/Applications.Dapr/operations"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+func (client *OperationsClient) listCreateRequest(ctx context.Context, nextLink string, _ *OperationsClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/providers/Applications.Dapr/operations"
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
+	}
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *OperationsClient) listHandleResponse(resp *http.Response) (OperationsClientListResponse, error) {
+func (client *OperationsClient) listHandleResponse(resp *http.Response, successCodes ...int) (OperationsClientListResponse, error) {
 	result := OperationsClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OperationListResult); err != nil {
 		return OperationsClientListResponse{}, err
 	}

--- a/pkg/daprrp/api/v20231001preview/zz_generated_pubsubbrokers_client.go
+++ b/pkg/daprrp/api/v20231001preview/zz_generated_pubsubbrokers_client.go
@@ -73,8 +73,7 @@ func (client *PubSubBrokersClient) createOrUpdate(ctx context.Context, rootScope
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -140,8 +139,7 @@ func (client *PubSubBrokersClient) deleteOperation(ctx context.Context, rootScop
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -183,12 +181,7 @@ func (client *PubSubBrokersClient) Get(ctx context.Context, rootScope string, pu
 	if err != nil {
 		return PubSubBrokersClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return PubSubBrokersClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -214,8 +207,11 @@ func (client *PubSubBrokersClient) getCreateRequest(ctx context.Context, rootSco
 }
 
 // getHandleResponse handles the Get response.
-func (client *PubSubBrokersClient) getHandleResponse(resp *http.Response) (PubSubBrokersClientGetResponse, error) {
+func (client *PubSubBrokersClient) getHandleResponse(resp *http.Response, successCodes ...int) (PubSubBrokersClientGetResponse, error) {
 	result := PubSubBrokersClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DaprPubSubBrokerResource); err != nil {
 		return PubSubBrokersClientGetResponse{}, err
 	}
@@ -237,38 +233,52 @@ func (client *PubSubBrokersClient) NewListByScopePager(rootScope string, options
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return PubSubBrokersClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return PubSubBrokersClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *PubSubBrokersClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *PubSubBrokersClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Dapr/pubSubBrokers"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *PubSubBrokersClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *PubSubBrokersClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Dapr/pubSubBrokers"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *PubSubBrokersClient) listByScopeHandleResponse(resp *http.Response) (PubSubBrokersClientListByScopeResponse, error) {
+func (client *PubSubBrokersClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (PubSubBrokersClientListByScopeResponse, error) {
 	result := PubSubBrokersClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DaprPubSubBrokerResourceListResult); err != nil {
 		return PubSubBrokersClientListByScopeResponse{}, err
 	}
@@ -311,8 +321,7 @@ func (client *PubSubBrokersClient) update(ctx context.Context, rootScope string,
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/daprrp/api/v20231001preview/zz_generated_secretstores_client.go
+++ b/pkg/daprrp/api/v20231001preview/zz_generated_secretstores_client.go
@@ -73,8 +73,7 @@ func (client *SecretStoresClient) createOrUpdate(ctx context.Context, rootScope 
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -140,8 +139,7 @@ func (client *SecretStoresClient) deleteOperation(ctx context.Context, rootScope
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -183,12 +181,7 @@ func (client *SecretStoresClient) Get(ctx context.Context, rootScope string, sec
 	if err != nil {
 		return SecretStoresClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return SecretStoresClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -214,8 +207,11 @@ func (client *SecretStoresClient) getCreateRequest(ctx context.Context, rootScop
 }
 
 // getHandleResponse handles the Get response.
-func (client *SecretStoresClient) getHandleResponse(resp *http.Response) (SecretStoresClientGetResponse, error) {
+func (client *SecretStoresClient) getHandleResponse(resp *http.Response, successCodes ...int) (SecretStoresClientGetResponse, error) {
 	result := SecretStoresClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DaprSecretStoreResource); err != nil {
 		return SecretStoresClientGetResponse{}, err
 	}
@@ -237,38 +233,52 @@ func (client *SecretStoresClient) NewListByScopePager(rootScope string, options 
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return SecretStoresClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return SecretStoresClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *SecretStoresClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *SecretStoresClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Dapr/secretStores"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *SecretStoresClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *SecretStoresClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Dapr/secretStores"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *SecretStoresClient) listByScopeHandleResponse(resp *http.Response) (SecretStoresClientListByScopeResponse, error) {
+func (client *SecretStoresClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (SecretStoresClientListByScopeResponse, error) {
 	result := SecretStoresClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DaprSecretStoreResourceListResult); err != nil {
 		return SecretStoresClientListByScopeResponse{}, err
 	}
@@ -311,8 +321,7 @@ func (client *SecretStoresClient) update(ctx context.Context, rootScope string, 
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/daprrp/api/v20231001preview/zz_generated_statestores_client.go
+++ b/pkg/daprrp/api/v20231001preview/zz_generated_statestores_client.go
@@ -73,8 +73,7 @@ func (client *StateStoresClient) createOrUpdate(ctx context.Context, rootScope s
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -139,8 +138,7 @@ func (client *StateStoresClient) deleteOperation(ctx context.Context, rootScope 
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -182,12 +180,7 @@ func (client *StateStoresClient) Get(ctx context.Context, rootScope string, stat
 	if err != nil {
 		return StateStoresClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return StateStoresClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -213,8 +206,11 @@ func (client *StateStoresClient) getCreateRequest(ctx context.Context, rootScope
 }
 
 // getHandleResponse handles the Get response.
-func (client *StateStoresClient) getHandleResponse(resp *http.Response) (StateStoresClientGetResponse, error) {
+func (client *StateStoresClient) getHandleResponse(resp *http.Response, successCodes ...int) (StateStoresClientGetResponse, error) {
 	result := StateStoresClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DaprStateStoreResource); err != nil {
 		return StateStoresClientGetResponse{}, err
 	}
@@ -236,38 +232,52 @@ func (client *StateStoresClient) NewListByScopePager(rootScope string, options *
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return StateStoresClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return StateStoresClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *StateStoresClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *StateStoresClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Dapr/stateStores"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *StateStoresClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *StateStoresClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Dapr/stateStores"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *StateStoresClient) listByScopeHandleResponse(resp *http.Response) (StateStoresClientListByScopeResponse, error) {
+func (client *StateStoresClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (StateStoresClientListByScopeResponse, error) {
 	result := StateStoresClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DaprStateStoreResourceListResult); err != nil {
 		return StateStoresClientListByScopeResponse{}, err
 	}
@@ -309,8 +319,7 @@ func (client *StateStoresClient) update(ctx context.Context, rootScope string, s
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/datastoresrp/api/v20231001preview/zz_generated_models_serde.go
+++ b/pkg/datastoresrp/api/v20231001preview/zz_generated_models_serde.go
@@ -1096,10 +1096,10 @@ func (s *SQLDatabaseSecrets) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SystemData.
 func (s SystemData) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populateTime[datetime.RFC3339](objectMap, "createdAt", s.CreatedAt)
+	populateTime[datetime.RFC3339](objectMap, "createdAt", s.CreatedAt, true)
 	populate(objectMap, "createdBy", s.CreatedBy)
 	populate(objectMap, "createdByType", s.CreatedByType)
-	populateTime[datetime.RFC3339](objectMap, "lastModifiedAt", s.LastModifiedAt)
+	populateTime[datetime.RFC3339](objectMap, "lastModifiedAt", s.LastModifiedAt, true)
 	populate(objectMap, "lastModifiedBy", s.LastModifiedBy)
 	populate(objectMap, "lastModifiedByType", s.LastModifiedByType)
 	return json.Marshal(objectMap)
@@ -1150,13 +1150,17 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func populateTime[T dateTimeConstraints](m map[string]any, k string, t *time.Time) {
+func populateTime[T dateTimeConstraints](m map[string]any, k string, t *time.Time, utc bool) {
 	if t == nil {
 		return
 	} else if azcore.IsNullValue(t) {
 		m[k] = nil
 	} else if !reflect.ValueOf(t).IsNil() {
-		newTime := T(*t)
+		tt := *t
+		if utc {
+			tt = tt.UTC()
+		}
+		newTime := T(tt)
 		m[k] = (*T)(&newTime)
 	}
 }
@@ -1166,7 +1170,7 @@ func unpopulate(data json.RawMessage, fn string, v any) error {
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {
-		return fmt.Errorf("struct field %s: %v", fn, err)
+		return fmt.Errorf("struct field %s: %s", fn, err.Error())
 	}
 	return nil
 }
@@ -1177,7 +1181,7 @@ func unpopulateTime[T dateTimeConstraints](data json.RawMessage, fn string, t **
 	}
 	var aux T
 	if err := json.Unmarshal(data, &aux); err != nil {
-		return fmt.Errorf("struct field %s: %v", fn, err)
+		return fmt.Errorf("struct field %s: %s", fn, err.Error())
 	}
 	newTime := time.Time(aux)
 	*t = &newTime

--- a/pkg/datastoresrp/api/v20231001preview/zz_generated_mongodatabases_client.go
+++ b/pkg/datastoresrp/api/v20231001preview/zz_generated_mongodatabases_client.go
@@ -73,8 +73,7 @@ func (client *MongoDatabasesClient) createOrUpdate(ctx context.Context, rootScop
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -140,8 +139,7 @@ func (client *MongoDatabasesClient) deleteOperation(ctx context.Context, rootSco
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -183,12 +181,7 @@ func (client *MongoDatabasesClient) Get(ctx context.Context, rootScope string, m
 	if err != nil {
 		return MongoDatabasesClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return MongoDatabasesClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -214,8 +207,11 @@ func (client *MongoDatabasesClient) getCreateRequest(ctx context.Context, rootSc
 }
 
 // getHandleResponse handles the Get response.
-func (client *MongoDatabasesClient) getHandleResponse(resp *http.Response) (MongoDatabasesClientGetResponse, error) {
+func (client *MongoDatabasesClient) getHandleResponse(resp *http.Response, successCodes ...int) (MongoDatabasesClientGetResponse, error) {
 	result := MongoDatabasesClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MongoDatabaseResource); err != nil {
 		return MongoDatabasesClientGetResponse{}, err
 	}
@@ -237,38 +233,52 @@ func (client *MongoDatabasesClient) NewListByScopePager(rootScope string, option
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return MongoDatabasesClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return MongoDatabasesClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *MongoDatabasesClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *MongoDatabasesClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Datastores/mongoDatabases"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *MongoDatabasesClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *MongoDatabasesClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Datastores/mongoDatabases"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *MongoDatabasesClient) listByScopeHandleResponse(resp *http.Response) (MongoDatabasesClientListByScopeResponse, error) {
+func (client *MongoDatabasesClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (MongoDatabasesClientListByScopeResponse, error) {
 	result := MongoDatabasesClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MongoDatabaseResourceListResult); err != nil {
 		return MongoDatabasesClientListByScopeResponse{}, err
 	}
@@ -293,12 +303,7 @@ func (client *MongoDatabasesClient) ListSecrets(ctx context.Context, rootScope s
 	if err != nil {
 		return MongoDatabasesClientListSecretsResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return MongoDatabasesClientListSecretsResponse{}, err
-	}
-	resp, err := client.listSecretsHandleResponse(httpResp)
-	return resp, err
+	return client.listSecretsHandleResponse(httpResp, http.StatusOK)
 }
 
 // listSecretsCreateRequest creates the ListSecrets request.
@@ -328,8 +333,11 @@ func (client *MongoDatabasesClient) listSecretsCreateRequest(ctx context.Context
 }
 
 // listSecretsHandleResponse handles the ListSecrets response.
-func (client *MongoDatabasesClient) listSecretsHandleResponse(resp *http.Response) (MongoDatabasesClientListSecretsResponse, error) {
+func (client *MongoDatabasesClient) listSecretsHandleResponse(resp *http.Response, successCodes ...int) (MongoDatabasesClientListSecretsResponse, error) {
 	result := MongoDatabasesClientListSecretsResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MongoDatabaseListSecretsResult); err != nil {
 		return MongoDatabasesClientListSecretsResponse{}, err
 	}
@@ -372,8 +380,7 @@ func (client *MongoDatabasesClient) update(ctx context.Context, rootScope string
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/datastoresrp/api/v20231001preview/zz_generated_operations_client.go
+++ b/pkg/datastoresrp/api/v20231001preview/zz_generated_operations_client.go
@@ -47,34 +47,48 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, nextLink, options)
 			if err != nil {
 				return OperationsClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return OperationsClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *OperationsClient) listCreateRequest(ctx context.Context, _ *OperationsClientListOptions) (*policy.Request, error) {
-	urlPath := "/providers/Applications.Datastores/operations"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+func (client *OperationsClient) listCreateRequest(ctx context.Context, nextLink string, _ *OperationsClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/providers/Applications.Datastores/operations"
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
+	}
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *OperationsClient) listHandleResponse(resp *http.Response) (OperationsClientListResponse, error) {
+func (client *OperationsClient) listHandleResponse(resp *http.Response, successCodes ...int) (OperationsClientListResponse, error) {
 	result := OperationsClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OperationListResult); err != nil {
 		return OperationsClientListResponse{}, err
 	}

--- a/pkg/datastoresrp/api/v20231001preview/zz_generated_rediscaches_client.go
+++ b/pkg/datastoresrp/api/v20231001preview/zz_generated_rediscaches_client.go
@@ -73,8 +73,7 @@ func (client *RedisCachesClient) createOrUpdate(ctx context.Context, rootScope s
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -139,8 +138,7 @@ func (client *RedisCachesClient) deleteOperation(ctx context.Context, rootScope 
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -182,12 +180,7 @@ func (client *RedisCachesClient) Get(ctx context.Context, rootScope string, redi
 	if err != nil {
 		return RedisCachesClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return RedisCachesClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -213,8 +206,11 @@ func (client *RedisCachesClient) getCreateRequest(ctx context.Context, rootScope
 }
 
 // getHandleResponse handles the Get response.
-func (client *RedisCachesClient) getHandleResponse(resp *http.Response) (RedisCachesClientGetResponse, error) {
+func (client *RedisCachesClient) getHandleResponse(resp *http.Response, successCodes ...int) (RedisCachesClientGetResponse, error) {
 	result := RedisCachesClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RedisCacheResource); err != nil {
 		return RedisCachesClientGetResponse{}, err
 	}
@@ -236,38 +232,52 @@ func (client *RedisCachesClient) NewListByScopePager(rootScope string, options *
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return RedisCachesClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return RedisCachesClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *RedisCachesClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *RedisCachesClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Datastores/redisCaches"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *RedisCachesClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *RedisCachesClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Datastores/redisCaches"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *RedisCachesClient) listByScopeHandleResponse(resp *http.Response) (RedisCachesClientListByScopeResponse, error) {
+func (client *RedisCachesClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (RedisCachesClientListByScopeResponse, error) {
 	result := RedisCachesClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RedisCacheResourceListResult); err != nil {
 		return RedisCachesClientListByScopeResponse{}, err
 	}
@@ -291,12 +301,7 @@ func (client *RedisCachesClient) ListSecrets(ctx context.Context, rootScope stri
 	if err != nil {
 		return RedisCachesClientListSecretsResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return RedisCachesClientListSecretsResponse{}, err
-	}
-	resp, err := client.listSecretsHandleResponse(httpResp)
-	return resp, err
+	return client.listSecretsHandleResponse(httpResp, http.StatusOK)
 }
 
 // listSecretsCreateRequest creates the ListSecrets request.
@@ -326,8 +331,11 @@ func (client *RedisCachesClient) listSecretsCreateRequest(ctx context.Context, r
 }
 
 // listSecretsHandleResponse handles the ListSecrets response.
-func (client *RedisCachesClient) listSecretsHandleResponse(resp *http.Response) (RedisCachesClientListSecretsResponse, error) {
+func (client *RedisCachesClient) listSecretsHandleResponse(resp *http.Response, successCodes ...int) (RedisCachesClientListSecretsResponse, error) {
 	result := RedisCachesClientListSecretsResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RedisCacheListSecretsResult); err != nil {
 		return RedisCachesClientListSecretsResponse{}, err
 	}
@@ -369,8 +377,7 @@ func (client *RedisCachesClient) update(ctx context.Context, rootScope string, r
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/datastoresrp/api/v20231001preview/zz_generated_sqldatabases_client.go
+++ b/pkg/datastoresrp/api/v20231001preview/zz_generated_sqldatabases_client.go
@@ -73,8 +73,7 @@ func (client *SQLDatabasesClient) createOrUpdate(ctx context.Context, rootScope 
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -140,8 +139,7 @@ func (client *SQLDatabasesClient) deleteOperation(ctx context.Context, rootScope
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -183,12 +181,7 @@ func (client *SQLDatabasesClient) Get(ctx context.Context, rootScope string, sql
 	if err != nil {
 		return SQLDatabasesClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return SQLDatabasesClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -214,8 +207,11 @@ func (client *SQLDatabasesClient) getCreateRequest(ctx context.Context, rootScop
 }
 
 // getHandleResponse handles the Get response.
-func (client *SQLDatabasesClient) getHandleResponse(resp *http.Response) (SQLDatabasesClientGetResponse, error) {
+func (client *SQLDatabasesClient) getHandleResponse(resp *http.Response, successCodes ...int) (SQLDatabasesClientGetResponse, error) {
 	result := SQLDatabasesClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLDatabaseResource); err != nil {
 		return SQLDatabasesClientGetResponse{}, err
 	}
@@ -237,38 +233,52 @@ func (client *SQLDatabasesClient) NewListByScopePager(rootScope string, options 
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return SQLDatabasesClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return SQLDatabasesClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *SQLDatabasesClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *SQLDatabasesClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Datastores/sqlDatabases"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *SQLDatabasesClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *SQLDatabasesClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Datastores/sqlDatabases"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *SQLDatabasesClient) listByScopeHandleResponse(resp *http.Response) (SQLDatabasesClientListByScopeResponse, error) {
+func (client *SQLDatabasesClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (SQLDatabasesClientListByScopeResponse, error) {
 	result := SQLDatabasesClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLDatabaseResourceListResult); err != nil {
 		return SQLDatabasesClientListByScopeResponse{}, err
 	}
@@ -293,12 +303,7 @@ func (client *SQLDatabasesClient) ListSecrets(ctx context.Context, rootScope str
 	if err != nil {
 		return SQLDatabasesClientListSecretsResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return SQLDatabasesClientListSecretsResponse{}, err
-	}
-	resp, err := client.listSecretsHandleResponse(httpResp)
-	return resp, err
+	return client.listSecretsHandleResponse(httpResp, http.StatusOK)
 }
 
 // listSecretsCreateRequest creates the ListSecrets request.
@@ -328,8 +333,11 @@ func (client *SQLDatabasesClient) listSecretsCreateRequest(ctx context.Context, 
 }
 
 // listSecretsHandleResponse handles the ListSecrets response.
-func (client *SQLDatabasesClient) listSecretsHandleResponse(resp *http.Response) (SQLDatabasesClientListSecretsResponse, error) {
+func (client *SQLDatabasesClient) listSecretsHandleResponse(resp *http.Response, successCodes ...int) (SQLDatabasesClientListSecretsResponse, error) {
 	result := SQLDatabasesClientListSecretsResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLDatabaseListSecretsResult); err != nil {
 		return SQLDatabasesClientListSecretsResponse{}, err
 	}
@@ -372,8 +380,7 @@ func (client *SQLDatabasesClient) update(ctx context.Context, rootScope string, 
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/messagingrp/api/v20231001preview/zz_generated_models_serde.go
+++ b/pkg/messagingrp/api/v20231001preview/zz_generated_models_serde.go
@@ -666,10 +666,10 @@ func (r *ResourceStatus) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SystemData.
 func (s SystemData) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populateTime[datetime.RFC3339](objectMap, "createdAt", s.CreatedAt)
+	populateTime[datetime.RFC3339](objectMap, "createdAt", s.CreatedAt, true)
 	populate(objectMap, "createdBy", s.CreatedBy)
 	populate(objectMap, "createdByType", s.CreatedByType)
-	populateTime[datetime.RFC3339](objectMap, "lastModifiedAt", s.LastModifiedAt)
+	populateTime[datetime.RFC3339](objectMap, "lastModifiedAt", s.LastModifiedAt, true)
 	populate(objectMap, "lastModifiedBy", s.LastModifiedBy)
 	populate(objectMap, "lastModifiedByType", s.LastModifiedByType)
 	return json.Marshal(objectMap)
@@ -720,13 +720,17 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func populateTime[T dateTimeConstraints](m map[string]any, k string, t *time.Time) {
+func populateTime[T dateTimeConstraints](m map[string]any, k string, t *time.Time, utc bool) {
 	if t == nil {
 		return
 	} else if azcore.IsNullValue(t) {
 		m[k] = nil
 	} else if !reflect.ValueOf(t).IsNil() {
-		newTime := T(*t)
+		tt := *t
+		if utc {
+			tt = tt.UTC()
+		}
+		newTime := T(tt)
 		m[k] = (*T)(&newTime)
 	}
 }
@@ -736,7 +740,7 @@ func unpopulate(data json.RawMessage, fn string, v any) error {
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {
-		return fmt.Errorf("struct field %s: %v", fn, err)
+		return fmt.Errorf("struct field %s: %s", fn, err.Error())
 	}
 	return nil
 }
@@ -747,7 +751,7 @@ func unpopulateTime[T dateTimeConstraints](data json.RawMessage, fn string, t **
 	}
 	var aux T
 	if err := json.Unmarshal(data, &aux); err != nil {
-		return fmt.Errorf("struct field %s: %v", fn, err)
+		return fmt.Errorf("struct field %s: %s", fn, err.Error())
 	}
 	newTime := time.Time(aux)
 	*t = &newTime

--- a/pkg/messagingrp/api/v20231001preview/zz_generated_operations_client.go
+++ b/pkg/messagingrp/api/v20231001preview/zz_generated_operations_client.go
@@ -47,34 +47,48 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, nextLink, options)
 			if err != nil {
 				return OperationsClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return OperationsClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *OperationsClient) listCreateRequest(ctx context.Context, _ *OperationsClientListOptions) (*policy.Request, error) {
-	urlPath := "/providers/Applications.Messaging/operations"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+func (client *OperationsClient) listCreateRequest(ctx context.Context, nextLink string, _ *OperationsClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/providers/Applications.Messaging/operations"
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
+	}
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *OperationsClient) listHandleResponse(resp *http.Response) (OperationsClientListResponse, error) {
+func (client *OperationsClient) listHandleResponse(resp *http.Response, successCodes ...int) (OperationsClientListResponse, error) {
 	result := OperationsClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OperationListResult); err != nil {
 		return OperationsClientListResponse{}, err
 	}

--- a/pkg/messagingrp/api/v20231001preview/zz_generated_rabbitmqqueues_client.go
+++ b/pkg/messagingrp/api/v20231001preview/zz_generated_rabbitmqqueues_client.go
@@ -73,8 +73,7 @@ func (client *RabbitMQQueuesClient) createOrUpdate(ctx context.Context, rootScop
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -140,8 +139,7 @@ func (client *RabbitMQQueuesClient) deleteOperation(ctx context.Context, rootSco
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -183,12 +181,7 @@ func (client *RabbitMQQueuesClient) Get(ctx context.Context, rootScope string, r
 	if err != nil {
 		return RabbitMQQueuesClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return RabbitMQQueuesClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -214,8 +207,11 @@ func (client *RabbitMQQueuesClient) getCreateRequest(ctx context.Context, rootSc
 }
 
 // getHandleResponse handles the Get response.
-func (client *RabbitMQQueuesClient) getHandleResponse(resp *http.Response) (RabbitMQQueuesClientGetResponse, error) {
+func (client *RabbitMQQueuesClient) getHandleResponse(resp *http.Response, successCodes ...int) (RabbitMQQueuesClientGetResponse, error) {
 	result := RabbitMQQueuesClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RabbitMQQueueResource); err != nil {
 		return RabbitMQQueuesClientGetResponse{}, err
 	}
@@ -237,38 +233,52 @@ func (client *RabbitMQQueuesClient) NewListByScopePager(rootScope string, option
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listByScopeCreateRequest(ctx, rootScope, options)
-			}, nil)
+			req, err := client.listByScopeCreateRequest(ctx, rootScope, nextLink, options)
 			if err != nil {
 				return RabbitMQQueuesClientListByScopeResponse{}, err
 			}
-			return client.listByScopeHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return RabbitMQQueuesClientListByScopeResponse{}, err
+			}
+			return client.listByScopeHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listByScopeCreateRequest creates the ListByScope request.
-func (client *RabbitMQQueuesClient) listByScopeCreateRequest(ctx context.Context, rootScope string, _ *RabbitMQQueuesClientListByScopeOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Applications.Messaging/rabbitMQQueues"
-	if rootScope == "" {
-		return nil, errors.New("parameter rootScope cannot be empty")
+func (client *RabbitMQQueuesClient) listByScopeCreateRequest(ctx context.Context, rootScope string, nextLink string, _ *RabbitMQQueuesClientListByScopeOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/{rootScope}/providers/Applications.Messaging/rabbitMQQueues"
+		if rootScope == "" {
+			return nil, errors.New("parameter rootScope cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", rootScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listByScopeHandleResponse handles the ListByScope response.
-func (client *RabbitMQQueuesClient) listByScopeHandleResponse(resp *http.Response) (RabbitMQQueuesClientListByScopeResponse, error) {
+func (client *RabbitMQQueuesClient) listByScopeHandleResponse(resp *http.Response, successCodes ...int) (RabbitMQQueuesClientListByScopeResponse, error) {
 	result := RabbitMQQueuesClientListByScopeResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RabbitMQQueueResourceListResult); err != nil {
 		return RabbitMQQueuesClientListByScopeResponse{}, err
 	}
@@ -293,12 +303,7 @@ func (client *RabbitMQQueuesClient) ListSecrets(ctx context.Context, rootScope s
 	if err != nil {
 		return RabbitMQQueuesClientListSecretsResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return RabbitMQQueuesClientListSecretsResponse{}, err
-	}
-	resp, err := client.listSecretsHandleResponse(httpResp)
-	return resp, err
+	return client.listSecretsHandleResponse(httpResp, http.StatusOK)
 }
 
 // listSecretsCreateRequest creates the ListSecrets request.
@@ -328,8 +333,11 @@ func (client *RabbitMQQueuesClient) listSecretsCreateRequest(ctx context.Context
 }
 
 // listSecretsHandleResponse handles the ListSecrets response.
-func (client *RabbitMQQueuesClient) listSecretsHandleResponse(resp *http.Response) (RabbitMQQueuesClientListSecretsResponse, error) {
+func (client *RabbitMQQueuesClient) listSecretsHandleResponse(resp *http.Response, successCodes ...int) (RabbitMQQueuesClientListSecretsResponse, error) {
 	result := RabbitMQQueuesClientListSecretsResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RabbitMQListSecretsResult); err != nil {
 		return RabbitMQQueuesClientListSecretsResponse{}, err
 	}
@@ -372,8 +380,7 @@ func (client *RabbitMQQueuesClient) update(ctx context.Context, rootScope string
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/ucp/api/v20231001preview/fake/zz_generated_resourcetypes_server.go
+++ b/pkg/ucp/api/v20231001preview/fake/zz_generated_resourcetypes_server.go
@@ -288,10 +288,10 @@ func (r *ResourceTypesServerTransport) dispatchGetIcon(req *http.Request) (*http
 		return nil, err
 	}
 	if val := server.GetResponse(respr).CacheControl; val != nil {
-		resp.Header.Set("cache-control", "public, max-age=31536000, immutable")
+		resp.Header.Set("Cache-Control", "public, max-age=31536000, immutable")
 	}
 	if val := server.GetResponse(respr).ContentType; val != nil {
-		resp.Header.Set("content-type", "image/svg+xml")
+		resp.Header.Set("Content-Type", "image/svg+xml")
 	}
 	return resp, nil
 }

--- a/pkg/ucp/api/v20231001preview/zz_generated_apiversions_client.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_apiversions_client.go
@@ -75,8 +75,7 @@ func (client *APIVersionsClient) createOrUpdate(ctx context.Context, planeName s
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -151,8 +150,7 @@ func (client *APIVersionsClient) deleteOperation(ctx context.Context, planeName 
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -204,12 +202,7 @@ func (client *APIVersionsClient) Get(ctx context.Context, planeName string, reso
 	if err != nil {
 		return APIVersionsClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return APIVersionsClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -243,8 +236,11 @@ func (client *APIVersionsClient) getCreateRequest(ctx context.Context, planeName
 }
 
 // getHandleResponse handles the Get response.
-func (client *APIVersionsClient) getHandleResponse(resp *http.Response) (APIVersionsClientGetResponse, error) {
+func (client *APIVersionsClient) getHandleResponse(resp *http.Response, successCodes ...int) (APIVersionsClientGetResponse, error) {
 	result := APIVersionsClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.APIVersionResource); err != nil {
 		return APIVersionsClientGetResponse{}, err
 	}
@@ -267,46 +263,60 @@ func (client *APIVersionsClient) NewListPager(planeName string, resourceProvider
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, planeName, resourceProviderName, resourceTypeName, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, planeName, resourceProviderName, resourceTypeName, nextLink, options)
 			if err != nil {
 				return APIVersionsClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return APIVersionsClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *APIVersionsClient) listCreateRequest(ctx context.Context, planeName string, resourceProviderName string, resourceTypeName string, _ *APIVersionsClientListOptions) (*policy.Request, error) {
-	urlPath := "/planes/radius/{planeName}/providers/System.Resources/resourceproviders/{resourceProviderName}/resourcetypes/{resourceTypeName}/apiversions"
-	if planeName == "" {
-		return nil, errors.New("parameter planeName cannot be empty")
+func (client *APIVersionsClient) listCreateRequest(ctx context.Context, planeName string, resourceProviderName string, resourceTypeName string, nextLink string, _ *APIVersionsClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/planes/radius/{planeName}/providers/System.Resources/resourceproviders/{resourceProviderName}/resourcetypes/{resourceTypeName}/apiversions"
+		if planeName == "" {
+			return nil, errors.New("parameter planeName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+		if resourceProviderName == "" {
+			return nil, errors.New("parameter resourceProviderName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{resourceProviderName}", url.PathEscape(resourceProviderName))
+		if resourceTypeName == "" {
+			return nil, errors.New("parameter resourceTypeName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{resourceTypeName}", url.PathEscape(resourceTypeName))
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
-	if resourceProviderName == "" {
-		return nil, errors.New("parameter resourceProviderName cannot be empty")
-	}
-	urlPath = strings.ReplaceAll(urlPath, "{resourceProviderName}", url.PathEscape(resourceProviderName))
-	if resourceTypeName == "" {
-		return nil, errors.New("parameter resourceTypeName cannot be empty")
-	}
-	urlPath = strings.ReplaceAll(urlPath, "{resourceTypeName}", url.PathEscape(resourceTypeName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *APIVersionsClient) listHandleResponse(resp *http.Response) (APIVersionsClientListResponse, error) {
+func (client *APIVersionsClient) listHandleResponse(resp *http.Response, successCodes ...int) (APIVersionsClientListResponse, error) {
 	result := APIVersionsClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.APIVersionResourceListResult); err != nil {
 		return APIVersionsClientListResponse{}, err
 	}

--- a/pkg/ucp/api/v20231001preview/zz_generated_awscredentials_client.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_awscredentials_client.go
@@ -55,12 +55,7 @@ func (client *AwsCredentialsClient) CreateOrUpdate(ctx context.Context, planeNam
 	if err != nil {
 		return AwsCredentialsClientCreateOrUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return AwsCredentialsClientCreateOrUpdateResponse{}, err
-	}
-	resp, err := client.createOrUpdateHandleResponse(httpResp)
-	return resp, err
+	return client.createOrUpdateHandleResponse(httpResp, http.StatusOK, http.StatusCreated)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -90,8 +85,11 @@ func (client *AwsCredentialsClient) createOrUpdateCreateRequest(ctx context.Cont
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *AwsCredentialsClient) createOrUpdateHandleResponse(resp *http.Response) (AwsCredentialsClientCreateOrUpdateResponse, error) {
+func (client *AwsCredentialsClient) createOrUpdateHandleResponse(resp *http.Response, successCodes ...int) (AwsCredentialsClientCreateOrUpdateResponse, error) {
 	result := AwsCredentialsClientCreateOrUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AwsCredentialResource); err != nil {
 		return AwsCredentialsClientCreateOrUpdateResponse{}, err
 	}
@@ -115,8 +113,7 @@ func (client *AwsCredentialsClient) Delete(ctx context.Context, planeName string
 		return AwsCredentialsClientDeleteResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return AwsCredentialsClientDeleteResponse{}, err
+		return AwsCredentialsClientDeleteResponse{}, runtime.NewResponseError(httpResp)
 	}
 	return AwsCredentialsClientDeleteResponse{}, nil
 }
@@ -158,12 +155,7 @@ func (client *AwsCredentialsClient) Get(ctx context.Context, planeName string, c
 	if err != nil {
 		return AwsCredentialsClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return AwsCredentialsClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -189,8 +181,11 @@ func (client *AwsCredentialsClient) getCreateRequest(ctx context.Context, planeN
 }
 
 // getHandleResponse handles the Get response.
-func (client *AwsCredentialsClient) getHandleResponse(resp *http.Response) (AwsCredentialsClientGetResponse, error) {
+func (client *AwsCredentialsClient) getHandleResponse(resp *http.Response, successCodes ...int) (AwsCredentialsClientGetResponse, error) {
 	result := AwsCredentialsClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AwsCredentialResource); err != nil {
 		return AwsCredentialsClientGetResponse{}, err
 	}
@@ -211,38 +206,52 @@ func (client *AwsCredentialsClient) NewListPager(planeName string, options *AwsC
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, planeName, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, planeName, nextLink, options)
 			if err != nil {
 				return AwsCredentialsClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return AwsCredentialsClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *AwsCredentialsClient) listCreateRequest(ctx context.Context, planeName string, _ *AwsCredentialsClientListOptions) (*policy.Request, error) {
-	urlPath := "/planes/aws/{planeName}/providers/System.AWS/credentials"
-	if planeName == "" {
-		return nil, errors.New("parameter planeName cannot be empty")
+func (client *AwsCredentialsClient) listCreateRequest(ctx context.Context, planeName string, nextLink string, _ *AwsCredentialsClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/planes/aws/{planeName}/providers/System.AWS/credentials"
+		if planeName == "" {
+			return nil, errors.New("parameter planeName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *AwsCredentialsClient) listHandleResponse(resp *http.Response) (AwsCredentialsClientListResponse, error) {
+func (client *AwsCredentialsClient) listHandleResponse(resp *http.Response, successCodes ...int) (AwsCredentialsClientListResponse, error) {
 	result := AwsCredentialsClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AwsCredentialResourceListResult); err != nil {
 		return AwsCredentialsClientListResponse{}, err
 	}
@@ -266,12 +275,7 @@ func (client *AwsCredentialsClient) Update(ctx context.Context, planeName string
 	if err != nil {
 		return AwsCredentialsClientUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return AwsCredentialsClientUpdateResponse{}, err
-	}
-	resp, err := client.updateHandleResponse(httpResp)
-	return resp, err
+	return client.updateHandleResponse(httpResp, http.StatusOK)
 }
 
 // updateCreateRequest creates the Update request.
@@ -301,8 +305,11 @@ func (client *AwsCredentialsClient) updateCreateRequest(ctx context.Context, pla
 }
 
 // updateHandleResponse handles the Update response.
-func (client *AwsCredentialsClient) updateHandleResponse(resp *http.Response) (AwsCredentialsClientUpdateResponse, error) {
+func (client *AwsCredentialsClient) updateHandleResponse(resp *http.Response, successCodes ...int) (AwsCredentialsClientUpdateResponse, error) {
 	result := AwsCredentialsClientUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AwsCredentialResource); err != nil {
 		return AwsCredentialsClientUpdateResponse{}, err
 	}

--- a/pkg/ucp/api/v20231001preview/zz_generated_awsplanes_client.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_awsplanes_client.go
@@ -72,8 +72,7 @@ func (client *AwsPlanesClient) createOrUpdate(ctx context.Context, planeName str
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -133,8 +132,7 @@ func (client *AwsPlanesClient) deleteOperation(ctx context.Context, planeName st
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -171,12 +169,7 @@ func (client *AwsPlanesClient) Get(ctx context.Context, planeName string, option
 	if err != nil {
 		return AwsPlanesClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return AwsPlanesClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -198,8 +191,11 @@ func (client *AwsPlanesClient) getCreateRequest(ctx context.Context, planeName s
 }
 
 // getHandleResponse handles the Get response.
-func (client *AwsPlanesClient) getHandleResponse(resp *http.Response) (AwsPlanesClientGetResponse, error) {
+func (client *AwsPlanesClient) getHandleResponse(resp *http.Response, successCodes ...int) (AwsPlanesClientGetResponse, error) {
 	result := AwsPlanesClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AwsPlaneResource); err != nil {
 		return AwsPlanesClientGetResponse{}, err
 	}
@@ -219,34 +215,48 @@ func (client *AwsPlanesClient) NewListPager(options *AwsPlanesClientListOptions)
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, nextLink, options)
 			if err != nil {
 				return AwsPlanesClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return AwsPlanesClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *AwsPlanesClient) listCreateRequest(ctx context.Context, _ *AwsPlanesClientListOptions) (*policy.Request, error) {
-	urlPath := "/planes/aws"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+func (client *AwsPlanesClient) listCreateRequest(ctx context.Context, nextLink string, _ *AwsPlanesClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/planes/aws"
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
+	}
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *AwsPlanesClient) listHandleResponse(resp *http.Response) (AwsPlanesClientListResponse, error) {
+func (client *AwsPlanesClient) listHandleResponse(resp *http.Response, successCodes ...int) (AwsPlanesClientListResponse, error) {
 	result := AwsPlanesClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AwsPlaneResourceListResult); err != nil {
 		return AwsPlanesClientListResponse{}, err
 	}
@@ -287,8 +297,7 @@ func (client *AwsPlanesClient) update(ctx context.Context, planeName string, pro
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/ucp/api/v20231001preview/zz_generated_azurecredentials_client.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_azurecredentials_client.go
@@ -55,12 +55,7 @@ func (client *AzureCredentialsClient) CreateOrUpdate(ctx context.Context, planeN
 	if err != nil {
 		return AzureCredentialsClientCreateOrUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return AzureCredentialsClientCreateOrUpdateResponse{}, err
-	}
-	resp, err := client.createOrUpdateHandleResponse(httpResp)
-	return resp, err
+	return client.createOrUpdateHandleResponse(httpResp, http.StatusOK, http.StatusCreated)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -90,8 +85,11 @@ func (client *AzureCredentialsClient) createOrUpdateCreateRequest(ctx context.Co
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *AzureCredentialsClient) createOrUpdateHandleResponse(resp *http.Response) (AzureCredentialsClientCreateOrUpdateResponse, error) {
+func (client *AzureCredentialsClient) createOrUpdateHandleResponse(resp *http.Response, successCodes ...int) (AzureCredentialsClientCreateOrUpdateResponse, error) {
 	result := AzureCredentialsClientCreateOrUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AzureCredentialResource); err != nil {
 		return AzureCredentialsClientCreateOrUpdateResponse{}, err
 	}
@@ -115,8 +113,7 @@ func (client *AzureCredentialsClient) Delete(ctx context.Context, planeName stri
 		return AzureCredentialsClientDeleteResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return AzureCredentialsClientDeleteResponse{}, err
+		return AzureCredentialsClientDeleteResponse{}, runtime.NewResponseError(httpResp)
 	}
 	return AzureCredentialsClientDeleteResponse{}, nil
 }
@@ -158,12 +155,7 @@ func (client *AzureCredentialsClient) Get(ctx context.Context, planeName string,
 	if err != nil {
 		return AzureCredentialsClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return AzureCredentialsClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -189,8 +181,11 @@ func (client *AzureCredentialsClient) getCreateRequest(ctx context.Context, plan
 }
 
 // getHandleResponse handles the Get response.
-func (client *AzureCredentialsClient) getHandleResponse(resp *http.Response) (AzureCredentialsClientGetResponse, error) {
+func (client *AzureCredentialsClient) getHandleResponse(resp *http.Response, successCodes ...int) (AzureCredentialsClientGetResponse, error) {
 	result := AzureCredentialsClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AzureCredentialResource); err != nil {
 		return AzureCredentialsClientGetResponse{}, err
 	}
@@ -212,38 +207,52 @@ func (client *AzureCredentialsClient) NewListPager(planeName string, options *Az
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, planeName, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, planeName, nextLink, options)
 			if err != nil {
 				return AzureCredentialsClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return AzureCredentialsClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *AzureCredentialsClient) listCreateRequest(ctx context.Context, planeName string, _ *AzureCredentialsClientListOptions) (*policy.Request, error) {
-	urlPath := "/planes/azure/{planeName}/providers/System.Azure/credentials"
-	if planeName == "" {
-		return nil, errors.New("parameter planeName cannot be empty")
+func (client *AzureCredentialsClient) listCreateRequest(ctx context.Context, planeName string, nextLink string, _ *AzureCredentialsClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/planes/azure/{planeName}/providers/System.Azure/credentials"
+		if planeName == "" {
+			return nil, errors.New("parameter planeName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *AzureCredentialsClient) listHandleResponse(resp *http.Response) (AzureCredentialsClientListResponse, error) {
+func (client *AzureCredentialsClient) listHandleResponse(resp *http.Response, successCodes ...int) (AzureCredentialsClientListResponse, error) {
 	result := AzureCredentialsClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AzureCredentialResourceListResult); err != nil {
 		return AzureCredentialsClientListResponse{}, err
 	}
@@ -267,12 +276,7 @@ func (client *AzureCredentialsClient) Update(ctx context.Context, planeName stri
 	if err != nil {
 		return AzureCredentialsClientUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return AzureCredentialsClientUpdateResponse{}, err
-	}
-	resp, err := client.updateHandleResponse(httpResp)
-	return resp, err
+	return client.updateHandleResponse(httpResp, http.StatusOK)
 }
 
 // updateCreateRequest creates the Update request.
@@ -302,8 +306,11 @@ func (client *AzureCredentialsClient) updateCreateRequest(ctx context.Context, p
 }
 
 // updateHandleResponse handles the Update response.
-func (client *AzureCredentialsClient) updateHandleResponse(resp *http.Response) (AzureCredentialsClientUpdateResponse, error) {
+func (client *AzureCredentialsClient) updateHandleResponse(resp *http.Response, successCodes ...int) (AzureCredentialsClientUpdateResponse, error) {
 	result := AzureCredentialsClientUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AzureCredentialResource); err != nil {
 		return AzureCredentialsClientUpdateResponse{}, err
 	}

--- a/pkg/ucp/api/v20231001preview/zz_generated_azureplanes_client.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_azureplanes_client.go
@@ -72,8 +72,7 @@ func (client *AzurePlanesClient) createOrUpdate(ctx context.Context, planeName s
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -133,8 +132,7 @@ func (client *AzurePlanesClient) deleteOperation(ctx context.Context, planeName 
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -171,12 +169,7 @@ func (client *AzurePlanesClient) Get(ctx context.Context, planeName string, opti
 	if err != nil {
 		return AzurePlanesClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return AzurePlanesClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -198,8 +191,11 @@ func (client *AzurePlanesClient) getCreateRequest(ctx context.Context, planeName
 }
 
 // getHandleResponse handles the Get response.
-func (client *AzurePlanesClient) getHandleResponse(resp *http.Response) (AzurePlanesClientGetResponse, error) {
+func (client *AzurePlanesClient) getHandleResponse(resp *http.Response, successCodes ...int) (AzurePlanesClientGetResponse, error) {
 	result := AzurePlanesClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AzurePlaneResource); err != nil {
 		return AzurePlanesClientGetResponse{}, err
 	}
@@ -219,34 +215,48 @@ func (client *AzurePlanesClient) NewListPager(options *AzurePlanesClientListOpti
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, nextLink, options)
 			if err != nil {
 				return AzurePlanesClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return AzurePlanesClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *AzurePlanesClient) listCreateRequest(ctx context.Context, _ *AzurePlanesClientListOptions) (*policy.Request, error) {
-	urlPath := "/planes/azure"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+func (client *AzurePlanesClient) listCreateRequest(ctx context.Context, nextLink string, _ *AzurePlanesClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/planes/azure"
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
+	}
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *AzurePlanesClient) listHandleResponse(resp *http.Response) (AzurePlanesClientListResponse, error) {
+func (client *AzurePlanesClient) listHandleResponse(resp *http.Response, successCodes ...int) (AzurePlanesClientListResponse, error) {
 	result := AzurePlanesClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AzurePlaneResourceListResult); err != nil {
 		return AzurePlanesClientListResponse{}, err
 	}
@@ -287,8 +297,7 @@ func (client *AzurePlanesClient) update(ctx context.Context, planeName string, p
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/ucp/api/v20231001preview/zz_generated_locations_client.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_locations_client.go
@@ -76,8 +76,7 @@ func (client *LocationsClient) createOrUpdate(ctx context.Context, planeName str
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -147,8 +146,7 @@ func (client *LocationsClient) deleteOperation(ctx context.Context, planeName st
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -195,12 +193,7 @@ func (client *LocationsClient) Get(ctx context.Context, planeName string, resour
 	if err != nil {
 		return LocationsClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return LocationsClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -230,8 +223,11 @@ func (client *LocationsClient) getCreateRequest(ctx context.Context, planeName s
 }
 
 // getHandleResponse handles the Get response.
-func (client *LocationsClient) getHandleResponse(resp *http.Response) (LocationsClientGetResponse, error) {
+func (client *LocationsClient) getHandleResponse(resp *http.Response, successCodes ...int) (LocationsClientGetResponse, error) {
 	result := LocationsClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LocationResource); err != nil {
 		return LocationsClientGetResponse{}, err
 	}
@@ -253,42 +249,56 @@ func (client *LocationsClient) NewListPager(planeName string, resourceProviderNa
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, planeName, resourceProviderName, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, planeName, resourceProviderName, nextLink, options)
 			if err != nil {
 				return LocationsClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return LocationsClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *LocationsClient) listCreateRequest(ctx context.Context, planeName string, resourceProviderName string, _ *LocationsClientListOptions) (*policy.Request, error) {
-	urlPath := "/planes/radius/{planeName}/providers/System.Resources/resourceproviders/{resourceProviderName}/locations"
-	if planeName == "" {
-		return nil, errors.New("parameter planeName cannot be empty")
+func (client *LocationsClient) listCreateRequest(ctx context.Context, planeName string, resourceProviderName string, nextLink string, _ *LocationsClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/planes/radius/{planeName}/providers/System.Resources/resourceproviders/{resourceProviderName}/locations"
+		if planeName == "" {
+			return nil, errors.New("parameter planeName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+		if resourceProviderName == "" {
+			return nil, errors.New("parameter resourceProviderName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{resourceProviderName}", url.PathEscape(resourceProviderName))
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
-	if resourceProviderName == "" {
-		return nil, errors.New("parameter resourceProviderName cannot be empty")
-	}
-	urlPath = strings.ReplaceAll(urlPath, "{resourceProviderName}", url.PathEscape(resourceProviderName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *LocationsClient) listHandleResponse(resp *http.Response) (LocationsClientListResponse, error) {
+func (client *LocationsClient) listHandleResponse(resp *http.Response, successCodes ...int) (LocationsClientListResponse, error) {
 	result := LocationsClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LocationResourceListResult); err != nil {
 		return LocationsClientListResponse{}, err
 	}

--- a/pkg/ucp/api/v20231001preview/zz_generated_models_serde.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_models_serde.go
@@ -1871,10 +1871,10 @@ func (r *ResourceTypeSummaryResultAPIVersion) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SystemData.
 func (s SystemData) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populateTime[datetime.RFC3339](objectMap, "createdAt", s.CreatedAt)
+	populateTime[datetime.RFC3339](objectMap, "createdAt", s.CreatedAt, true)
 	populate(objectMap, "createdBy", s.CreatedBy)
 	populate(objectMap, "createdByType", s.CreatedByType)
-	populateTime[datetime.RFC3339](objectMap, "lastModifiedAt", s.LastModifiedAt)
+	populateTime[datetime.RFC3339](objectMap, "lastModifiedAt", s.LastModifiedAt, true)
 	populate(objectMap, "lastModifiedBy", s.LastModifiedBy)
 	populate(objectMap, "lastModifiedByType", s.LastModifiedByType)
 	return json.Marshal(objectMap)
@@ -1925,13 +1925,17 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func populateTime[T dateTimeConstraints](m map[string]any, k string, t *time.Time) {
+func populateTime[T dateTimeConstraints](m map[string]any, k string, t *time.Time, utc bool) {
 	if t == nil {
 		return
 	} else if azcore.IsNullValue(t) {
 		m[k] = nil
 	} else if !reflect.ValueOf(t).IsNil() {
-		newTime := T(*t)
+		tt := *t
+		if utc {
+			tt = tt.UTC()
+		}
+		newTime := T(tt)
 		m[k] = (*T)(&newTime)
 	}
 }
@@ -1941,7 +1945,7 @@ func unpopulate(data json.RawMessage, fn string, v any) error {
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {
-		return fmt.Errorf("struct field %s: %v", fn, err)
+		return fmt.Errorf("struct field %s: %s", fn, err.Error())
 	}
 	return nil
 }
@@ -1952,7 +1956,7 @@ func unpopulateTime[T dateTimeConstraints](data json.RawMessage, fn string, t **
 	}
 	var aux T
 	if err := json.Unmarshal(data, &aux); err != nil {
-		return fmt.Errorf("struct field %s: %v", fn, err)
+		return fmt.Errorf("struct field %s: %s", fn, err.Error())
 	}
 	newTime := time.Time(aux)
 	*t = &newTime

--- a/pkg/ucp/api/v20231001preview/zz_generated_planes_client.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_planes_client.go
@@ -48,34 +48,48 @@ func (client *PlanesClient) NewListPlanesPager(options *PlanesClientListPlanesOp
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listPlanesCreateRequest(ctx, options)
-			}, nil)
+			req, err := client.listPlanesCreateRequest(ctx, nextLink, options)
 			if err != nil {
 				return PlanesClientListPlanesResponse{}, err
 			}
-			return client.listPlanesHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return PlanesClientListPlanesResponse{}, err
+			}
+			return client.listPlanesHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listPlanesCreateRequest creates the ListPlanes request.
-func (client *PlanesClient) listPlanesCreateRequest(ctx context.Context, _ *PlanesClientListPlanesOptions) (*policy.Request, error) {
-	urlPath := "/planes"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+func (client *PlanesClient) listPlanesCreateRequest(ctx context.Context, nextLink string, _ *PlanesClientListPlanesOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/planes"
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
+	}
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listPlanesHandleResponse handles the ListPlanes response.
-func (client *PlanesClient) listPlanesHandleResponse(resp *http.Response) (PlanesClientListPlanesResponse, error) {
+func (client *PlanesClient) listPlanesHandleResponse(resp *http.Response, successCodes ...int) (PlanesClientListPlanesResponse, error) {
 	result := PlanesClientListPlanesResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GenericPlaneResourceListResult); err != nil {
 		return PlanesClientListPlanesResponse{}, err
 	}

--- a/pkg/ucp/api/v20231001preview/zz_generated_radiusplanes_client.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_radiusplanes_client.go
@@ -72,8 +72,7 @@ func (client *RadiusPlanesClient) createOrUpdate(ctx context.Context, planeName 
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -134,8 +133,7 @@ func (client *RadiusPlanesClient) deleteOperation(ctx context.Context, planeName
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -172,12 +170,7 @@ func (client *RadiusPlanesClient) Get(ctx context.Context, planeName string, opt
 	if err != nil {
 		return RadiusPlanesClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return RadiusPlanesClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -199,8 +192,11 @@ func (client *RadiusPlanesClient) getCreateRequest(ctx context.Context, planeNam
 }
 
 // getHandleResponse handles the Get response.
-func (client *RadiusPlanesClient) getHandleResponse(resp *http.Response) (RadiusPlanesClientGetResponse, error) {
+func (client *RadiusPlanesClient) getHandleResponse(resp *http.Response, successCodes ...int) (RadiusPlanesClientGetResponse, error) {
 	result := RadiusPlanesClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RadiusPlaneResource); err != nil {
 		return RadiusPlanesClientGetResponse{}, err
 	}
@@ -220,34 +216,48 @@ func (client *RadiusPlanesClient) NewListPager(options *RadiusPlanesClientListOp
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, nextLink, options)
 			if err != nil {
 				return RadiusPlanesClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return RadiusPlanesClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *RadiusPlanesClient) listCreateRequest(ctx context.Context, _ *RadiusPlanesClientListOptions) (*policy.Request, error) {
-	urlPath := "/planes/radius"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+func (client *RadiusPlanesClient) listCreateRequest(ctx context.Context, nextLink string, _ *RadiusPlanesClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/planes/radius"
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
+	}
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *RadiusPlanesClient) listHandleResponse(resp *http.Response) (RadiusPlanesClientListResponse, error) {
+func (client *RadiusPlanesClient) listHandleResponse(resp *http.Response, successCodes ...int) (RadiusPlanesClientListResponse, error) {
 	result := RadiusPlanesClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RadiusPlaneResourceListResult); err != nil {
 		return RadiusPlanesClientListResponse{}, err
 	}
@@ -289,8 +299,7 @@ func (client *RadiusPlanesClient) update(ctx context.Context, planeName string, 
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }

--- a/pkg/ucp/api/v20231001preview/zz_generated_resourcegroups_client.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_resourcegroups_client.go
@@ -55,12 +55,7 @@ func (client *ResourceGroupsClient) CreateOrUpdate(ctx context.Context, planeNam
 	if err != nil {
 		return ResourceGroupsClientCreateOrUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return ResourceGroupsClientCreateOrUpdateResponse{}, err
-	}
-	resp, err := client.createOrUpdateHandleResponse(httpResp)
-	return resp, err
+	return client.createOrUpdateHandleResponse(httpResp, http.StatusOK, http.StatusCreated)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -90,8 +85,11 @@ func (client *ResourceGroupsClient) createOrUpdateCreateRequest(ctx context.Cont
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ResourceGroupsClient) createOrUpdateHandleResponse(resp *http.Response) (ResourceGroupsClientCreateOrUpdateResponse, error) {
+func (client *ResourceGroupsClient) createOrUpdateHandleResponse(resp *http.Response, successCodes ...int) (ResourceGroupsClientCreateOrUpdateResponse, error) {
 	result := ResourceGroupsClientCreateOrUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ResourceGroupResource); err != nil {
 		return ResourceGroupsClientCreateOrUpdateResponse{}, err
 	}
@@ -115,8 +113,7 @@ func (client *ResourceGroupsClient) Delete(ctx context.Context, planeName string
 		return ResourceGroupsClientDeleteResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return ResourceGroupsClientDeleteResponse{}, err
+		return ResourceGroupsClientDeleteResponse{}, runtime.NewResponseError(httpResp)
 	}
 	return ResourceGroupsClientDeleteResponse{}, nil
 }
@@ -158,12 +155,7 @@ func (client *ResourceGroupsClient) Get(ctx context.Context, planeName string, r
 	if err != nil {
 		return ResourceGroupsClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ResourceGroupsClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -189,8 +181,11 @@ func (client *ResourceGroupsClient) getCreateRequest(ctx context.Context, planeN
 }
 
 // getHandleResponse handles the Get response.
-func (client *ResourceGroupsClient) getHandleResponse(resp *http.Response) (ResourceGroupsClientGetResponse, error) {
+func (client *ResourceGroupsClient) getHandleResponse(resp *http.Response, successCodes ...int) (ResourceGroupsClientGetResponse, error) {
 	result := ResourceGroupsClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ResourceGroupResource); err != nil {
 		return ResourceGroupsClientGetResponse{}, err
 	}
@@ -211,38 +206,52 @@ func (client *ResourceGroupsClient) NewListPager(planeName string, options *Reso
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, planeName, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, planeName, nextLink, options)
 			if err != nil {
 				return ResourceGroupsClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return ResourceGroupsClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *ResourceGroupsClient) listCreateRequest(ctx context.Context, planeName string, _ *ResourceGroupsClientListOptions) (*policy.Request, error) {
-	urlPath := "/planes/radius/{planeName}/resourcegroups"
-	if planeName == "" {
-		return nil, errors.New("parameter planeName cannot be empty")
+func (client *ResourceGroupsClient) listCreateRequest(ctx context.Context, planeName string, nextLink string, _ *ResourceGroupsClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/planes/radius/{planeName}/resourcegroups"
+		if planeName == "" {
+			return nil, errors.New("parameter planeName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *ResourceGroupsClient) listHandleResponse(resp *http.Response) (ResourceGroupsClientListResponse, error) {
+func (client *ResourceGroupsClient) listHandleResponse(resp *http.Response, successCodes ...int) (ResourceGroupsClientListResponse, error) {
 	result := ResourceGroupsClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ResourceGroupResourceListResult); err != nil {
 		return ResourceGroupsClientListResponse{}, err
 	}
@@ -266,12 +275,7 @@ func (client *ResourceGroupsClient) Update(ctx context.Context, planeName string
 	if err != nil {
 		return ResourceGroupsClientUpdateResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ResourceGroupsClientUpdateResponse{}, err
-	}
-	resp, err := client.updateHandleResponse(httpResp)
-	return resp, err
+	return client.updateHandleResponse(httpResp, http.StatusOK)
 }
 
 // updateCreateRequest creates the Update request.
@@ -301,8 +305,11 @@ func (client *ResourceGroupsClient) updateCreateRequest(ctx context.Context, pla
 }
 
 // updateHandleResponse handles the Update response.
-func (client *ResourceGroupsClient) updateHandleResponse(resp *http.Response) (ResourceGroupsClientUpdateResponse, error) {
+func (client *ResourceGroupsClient) updateHandleResponse(resp *http.Response, successCodes ...int) (ResourceGroupsClientUpdateResponse, error) {
 	result := ResourceGroupsClientUpdateResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ResourceGroupResource); err != nil {
 		return ResourceGroupsClientUpdateResponse{}, err
 	}

--- a/pkg/ucp/api/v20231001preview/zz_generated_resourceproviders_client.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_resourceproviders_client.go
@@ -74,8 +74,7 @@ func (client *ResourceProvidersClient) createOrUpdate(ctx context.Context, plane
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -141,8 +140,7 @@ func (client *ResourceProvidersClient) deleteOperation(ctx context.Context, plan
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -184,12 +182,7 @@ func (client *ResourceProvidersClient) Get(ctx context.Context, planeName string
 	if err != nil {
 		return ResourceProvidersClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ResourceProvidersClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -215,8 +208,11 @@ func (client *ResourceProvidersClient) getCreateRequest(ctx context.Context, pla
 }
 
 // getHandleResponse handles the Get response.
-func (client *ResourceProvidersClient) getHandleResponse(resp *http.Response) (ResourceProvidersClientGetResponse, error) {
+func (client *ResourceProvidersClient) getHandleResponse(resp *http.Response, successCodes ...int) (ResourceProvidersClientGetResponse, error) {
 	result := ResourceProvidersClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ResourceProviderResource); err != nil {
 		return ResourceProvidersClientGetResponse{}, err
 	}
@@ -241,12 +237,7 @@ func (client *ResourceProvidersClient) GetProviderSummary(ctx context.Context, p
 	if err != nil {
 		return ResourceProvidersClientGetProviderSummaryResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ResourceProvidersClientGetProviderSummaryResponse{}, err
-	}
-	resp, err := client.getProviderSummaryHandleResponse(httpResp)
-	return resp, err
+	return client.getProviderSummaryHandleResponse(httpResp, http.StatusOK)
 }
 
 // getProviderSummaryCreateRequest creates the GetProviderSummary request.
@@ -275,8 +266,11 @@ func (client *ResourceProvidersClient) getProviderSummaryCreateRequest(ctx conte
 }
 
 // getProviderSummaryHandleResponse handles the GetProviderSummary response.
-func (client *ResourceProvidersClient) getProviderSummaryHandleResponse(resp *http.Response) (ResourceProvidersClientGetProviderSummaryResponse, error) {
+func (client *ResourceProvidersClient) getProviderSummaryHandleResponse(resp *http.Response, successCodes ...int) (ResourceProvidersClientGetProviderSummaryResponse, error) {
 	result := ResourceProvidersClientGetProviderSummaryResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ResourceProviderSummary); err != nil {
 		return ResourceProvidersClientGetProviderSummaryResponse{}, err
 	}
@@ -298,38 +292,52 @@ func (client *ResourceProvidersClient) NewListPager(planeName string, options *R
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, planeName, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, planeName, nextLink, options)
 			if err != nil {
 				return ResourceProvidersClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return ResourceProvidersClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *ResourceProvidersClient) listCreateRequest(ctx context.Context, planeName string, _ *ResourceProvidersClientListOptions) (*policy.Request, error) {
-	urlPath := "/planes/radius/{planeName}/providers/System.Resources/resourceproviders"
-	if planeName == "" {
-		return nil, errors.New("parameter planeName cannot be empty")
+func (client *ResourceProvidersClient) listCreateRequest(ctx context.Context, planeName string, nextLink string, _ *ResourceProvidersClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/planes/radius/{planeName}/providers/System.Resources/resourceproviders"
+		if planeName == "" {
+			return nil, errors.New("parameter planeName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *ResourceProvidersClient) listHandleResponse(resp *http.Response) (ResourceProvidersClientListResponse, error) {
+func (client *ResourceProvidersClient) listHandleResponse(resp *http.Response, successCodes ...int) (ResourceProvidersClientListResponse, error) {
 	result := ResourceProvidersClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ResourceProviderResourceListResult); err != nil {
 		return ResourceProvidersClientListResponse{}, err
 	}
@@ -352,38 +360,52 @@ func (client *ResourceProvidersClient) NewListProviderSummariesPager(planeName s
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listProviderSummariesCreateRequest(ctx, planeName, options)
-			}, nil)
+			req, err := client.listProviderSummariesCreateRequest(ctx, planeName, nextLink, options)
 			if err != nil {
 				return ResourceProvidersClientListProviderSummariesResponse{}, err
 			}
-			return client.listProviderSummariesHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return ResourceProvidersClientListProviderSummariesResponse{}, err
+			}
+			return client.listProviderSummariesHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listProviderSummariesCreateRequest creates the ListProviderSummaries request.
-func (client *ResourceProvidersClient) listProviderSummariesCreateRequest(ctx context.Context, planeName string, _ *ResourceProvidersClientListProviderSummariesOptions) (*policy.Request, error) {
-	urlPath := "/planes/radius/{planeName}/providers"
-	if planeName == "" {
-		return nil, errors.New("parameter planeName cannot be empty")
+func (client *ResourceProvidersClient) listProviderSummariesCreateRequest(ctx context.Context, planeName string, nextLink string, _ *ResourceProvidersClientListProviderSummariesOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/planes/radius/{planeName}/providers"
+		if planeName == "" {
+			return nil, errors.New("parameter planeName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listProviderSummariesHandleResponse handles the ListProviderSummaries response.
-func (client *ResourceProvidersClient) listProviderSummariesHandleResponse(resp *http.Response) (ResourceProvidersClientListProviderSummariesResponse, error) {
+func (client *ResourceProvidersClient) listProviderSummariesHandleResponse(resp *http.Response, successCodes ...int) (ResourceProvidersClientListProviderSummariesResponse, error) {
 	result := ResourceProvidersClientListProviderSummariesResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PagedResourceProviderSummary); err != nil {
 		return ResourceProvidersClientListProviderSummariesResponse{}, err
 	}

--- a/pkg/ucp/api/v20231001preview/zz_generated_resources_client.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_resources_client.go
@@ -52,42 +52,56 @@ func (client *ResourcesClient) NewListPager(planeName string, resourceGroupName 
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, planeName, resourceGroupName, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, planeName, resourceGroupName, nextLink, options)
 			if err != nil {
 				return ResourcesClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return ResourcesClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *ResourcesClient) listCreateRequest(ctx context.Context, planeName string, resourceGroupName string, _ *ResourcesClientListOptions) (*policy.Request, error) {
-	urlPath := "/planes/radius/{planeName}/resourcegroups/{resourceGroupName}/resources"
-	if planeName == "" {
-		return nil, errors.New("parameter planeName cannot be empty")
+func (client *ResourcesClient) listCreateRequest(ctx context.Context, planeName string, resourceGroupName string, nextLink string, _ *ResourcesClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/planes/radius/{planeName}/resourcegroups/{resourceGroupName}/resources"
+		if planeName == "" {
+			return nil, errors.New("parameter planeName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+		if resourceGroupName == "" {
+			return nil, errors.New("parameter resourceGroupName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
-	if resourceGroupName == "" {
-		return nil, errors.New("parameter resourceGroupName cannot be empty")
-	}
-	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *ResourcesClient) listHandleResponse(resp *http.Response) (ResourcesClientListResponse, error) {
+func (client *ResourcesClient) listHandleResponse(resp *http.Response, successCodes ...int) (ResourcesClientListResponse, error) {
 	result := ResourcesClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GenericResourceListResult); err != nil {
 		return ResourcesClientListResponse{}, err
 	}

--- a/pkg/ucp/api/v20231001preview/zz_generated_resourcetypes_client.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_resourcetypes_client.go
@@ -74,8 +74,7 @@ func (client *ResourceTypesClient) createOrUpdate(ctx context.Context, planeName
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -146,8 +145,7 @@ func (client *ResourceTypesClient) deleteOperation(ctx context.Context, planeNam
 		return nil, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		err = runtime.NewResponseError(httpResp)
-		return nil, err
+		return nil, runtime.NewResponseError(httpResp)
 	}
 	return httpResp, nil
 }
@@ -194,12 +192,7 @@ func (client *ResourceTypesClient) Get(ctx context.Context, planeName string, re
 	if err != nil {
 		return ResourceTypesClientGetResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ResourceTypesClientGetResponse{}, err
-	}
-	resp, err := client.getHandleResponse(httpResp)
-	return resp, err
+	return client.getHandleResponse(httpResp, http.StatusOK)
 }
 
 // getCreateRequest creates the Get request.
@@ -229,8 +222,11 @@ func (client *ResourceTypesClient) getCreateRequest(ctx context.Context, planeNa
 }
 
 // getHandleResponse handles the Get response.
-func (client *ResourceTypesClient) getHandleResponse(resp *http.Response) (ResourceTypesClientGetResponse, error) {
+func (client *ResourceTypesClient) getHandleResponse(resp *http.Response, successCodes ...int) (ResourceTypesClientGetResponse, error) {
 	result := ResourceTypesClientGetResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ResourceTypeResource); err != nil {
 		return ResourceTypesClientGetResponse{}, err
 	}
@@ -257,12 +253,7 @@ func (client *ResourceTypesClient) GetIcon(ctx context.Context, planeName string
 	if err != nil {
 		return ResourceTypesClientGetIconResponse{}, err
 	}
-	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
-		err = runtime.NewResponseError(httpResp)
-		return ResourceTypesClientGetIconResponse{}, err
-	}
-	resp, err := client.getIconHandleResponse(httpResp)
-	return resp, err
+	return client.getIconHandleResponse(httpResp, http.StatusOK)
 }
 
 // getIconCreateRequest creates the GetIcon request.
@@ -297,14 +288,18 @@ func (client *ResourceTypesClient) getIconCreateRequest(ctx context.Context, pla
 }
 
 // getIconHandleResponse handles the GetIcon response.
-func (client *ResourceTypesClient) getIconHandleResponse(resp *http.Response) (ResourceTypesClientGetIconResponse, error) {
-	result := ResourceTypesClientGetIconResponse{Body: resp.Body}
-	if val := resp.Header.Get("cache-control"); val != "" {
+func (client *ResourceTypesClient) getIconHandleResponse(resp *http.Response, successCodes ...int) (ResourceTypesClientGetIconResponse, error) {
+	result := ResourceTypesClientGetIconResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
+	if val := resp.Header.Get("Cache-Control"); val != "" {
 		result.CacheControl = &val
 	}
-	if val := resp.Header.Get("content-type"); val != "" {
+	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
 	}
+	result.Body = resp.Body
 	return result, nil
 }
 
@@ -323,42 +318,56 @@ func (client *ResourceTypesClient) NewListPager(planeName string, resourceProvid
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, planeName, resourceProviderName, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, planeName, resourceProviderName, nextLink, options)
 			if err != nil {
 				return ResourceTypesClientListResponse{}, err
 			}
-			return client.listHandleResponse(resp)
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return ResourceTypesClientListResponse{}, err
+			}
+			return client.listHandleResponse(resp, http.StatusOK)
 		},
 	})
 }
 
 // listCreateRequest creates the List request.
-func (client *ResourceTypesClient) listCreateRequest(ctx context.Context, planeName string, resourceProviderName string, _ *ResourceTypesClientListOptions) (*policy.Request, error) {
-	urlPath := "/planes/radius/{planeName}/providers/System.Resources/resourceproviders/{resourceProviderName}/resourcetypes"
-	if planeName == "" {
-		return nil, errors.New("parameter planeName cannot be empty")
+func (client *ResourceTypesClient) listCreateRequest(ctx context.Context, planeName string, resourceProviderName string, nextLink string, _ *ResourceTypesClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/planes/radius/{planeName}/providers/System.Resources/resourceproviders/{resourceProviderName}/resourcetypes"
+		if planeName == "" {
+			return nil, errors.New("parameter planeName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+		if resourceProviderName == "" {
+			return nil, errors.New("parameter resourceProviderName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{resourceProviderName}", url.PathEscape(resourceProviderName))
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
-	if resourceProviderName == "" {
-		return nil, errors.New("parameter resourceProviderName cannot be empty")
-	}
-	urlPath = strings.ReplaceAll(urlPath, "{resourceProviderName}", url.PathEscape(resourceProviderName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", version20231001Preview)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", version20231001Preview)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 
 // listHandleResponse handles the List response.
-func (client *ResourceTypesClient) listHandleResponse(resp *http.Response) (ResourceTypesClientListResponse, error) {
+func (client *ResourceTypesClient) listHandleResponse(resp *http.Response, successCodes ...int) (ResourceTypesClientListResponse, error) {
 	result := ResourceTypesClientListResponse{}
+	if !runtime.HasStatusCode(resp, successCodes...) {
+		return result, runtime.NewResponseError(resp)
+	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ResourceTypeResourceListResult); err != nil {
 		return ResourceTypesClientListResponse{}, err
 	}

--- a/typespec/package.json
+++ b/typespec/package.json
@@ -6,16 +6,16 @@
   "author": "Radius Authors",
   "type": "module",
   "dependencies": {
-    "@azure-tools/typespec-autorest": "^0.70.1",
-    "@azure-tools/typespec-azure-core": "^0.70.0",
-    "@azure-tools/typespec-azure-resource-manager": "^0.70.0",
-    "@azure-tools/typespec-client-generator-core": "^0.70.0",
-    "@azure-tools/typespec-go": "^0.15.0",
-    "@typespec/compiler": "^1.14.0",
-    "@typespec/http": "^1.14.0",
-    "@typespec/openapi": "^1.14.0",
-    "@typespec/rest": "^0.84.0",
-    "@typespec/versioning": "^0.84.0"
+    "@azure-tools/typespec-autorest": "^0.71.0",
+    "@azure-tools/typespec-azure-core": "^0.71.0",
+    "@azure-tools/typespec-azure-resource-manager": "^0.71.0",
+    "@azure-tools/typespec-client-generator-core": "^0.71.0",
+    "@azure-tools/typespec-go": "^0.16.0",
+    "@typespec/compiler": "^1.15.0",
+    "@typespec/http": "^1.15.0",
+    "@typespec/openapi": "^1.15.0",
+    "@typespec/rest": "^0.85.0",
+    "@typespec/versioning": "^0.85.0"
   },
   "devDependencies": {
     "oav": "4.0.4"

--- a/typespec/pnpm-lock.yaml
+++ b/typespec/pnpm-lock.yaml
@@ -9,35 +9,35 @@ importers:
   .:
     dependencies:
       '@azure-tools/typespec-autorest':
-        specifier: ^0.70.1
-        version: 0.70.1(4f396ab9d12448ab5fd32cffbb377f36)
+        specifier: ^0.71.0
+        version: 0.71.0(8ee3e5df800f54db4c437191ca71c809)
       '@azure-tools/typespec-azure-core':
-        specifier: ^0.70.0
-        version: 0.70.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))(@typespec/rest@0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))))
+        specifier: ^0.71.0
+        version: 0.71.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))(@typespec/rest@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))))
       '@azure-tools/typespec-azure-resource-manager':
-        specifier: ^0.70.0
-        version: 0.70.0(28778900fc6276a14858389967e8ca09)
+        specifier: ^0.71.0
+        version: 0.71.0(b8f46e1f3e79b358972250cf47469ef2)
       '@azure-tools/typespec-client-generator-core':
-        specifier: ^0.70.0
-        version: 0.70.0(d19e497f65e111f8cd7036f39b2592ee)
+        specifier: ^0.71.0
+        version: 0.71.0(63bec598fecc25d2783ca742340009fb)
       '@azure-tools/typespec-go':
-        specifier: ^0.15.0
-        version: 0.15.0(a73b8779a403e09dc757da46936d523b)
+        specifier: ^0.16.0
+        version: 0.16.0(5113a2cf024b1a92b251387909c31654)
       '@typespec/compiler':
-        specifier: ^1.14.0
-        version: 1.14.0(@types/node@25.9.3)
+        specifier: ^1.15.0
+        version: 1.15.0(@types/node@25.9.3)
       '@typespec/http':
-        specifier: ^1.14.0
-        version: 1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))
+        specifier: ^1.15.0
+        version: 1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))
       '@typespec/openapi':
-        specifier: ^1.14.0
-        version: 1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))
+        specifier: ^1.15.0
+        version: 1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))
       '@typespec/rest':
-        specifier: ^0.84.0
-        version: 0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))
+        specifier: ^0.85.0
+        version: 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))
       '@typespec/versioning':
-        specifier: ^0.84.0
-        version: 0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
+        specifier: ^0.85.0
+        version: 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
     devDependencies:
       oav:
         specifier: 4.0.4
@@ -67,41 +67,41 @@ packages:
   '@azure-tools/openapi-tools-common@1.2.2':
     resolution: {integrity: sha512-r6oBkNsND1sA+ZjHlE1vTf2hUj4RUnbD9KG9uksEKnLVC6oOD5WuJYCO5y4xDzWWuR0x+9gImovQqXAE7ZXYfg==}
 
-  '@azure-tools/typespec-autorest@0.70.1':
-    resolution: {integrity: sha512-UK9QLeI+SDiM66JTd5QshjGLhPDfgTZcthszKkJZjXPlxhocFm1ryk5x/glpRjr/POwHGg6I58eIltuToaO1vw==}
+  '@azure-tools/typespec-autorest@0.71.0':
+    resolution: {integrity: sha512-J2RPB4Sl0ClQflNdIw5QPEn+IWcnF824ILx6g1evXjNJ1/i3CnVJJZ4aetAw/BS2xOsXxyzR5q474Tou2GxlcQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@azure-tools/typespec-azure-core': ^0.70.0
-      '@azure-tools/typespec-azure-resource-manager': ^0.70.0
-      '@azure-tools/typespec-client-generator-core': ^0.70.0
-      '@typespec/compiler': ^1.14.0
-      '@typespec/http': ^1.14.0
-      '@typespec/openapi': ^1.14.0
-      '@typespec/rest': ^0.84.0
-      '@typespec/versioning': ^0.84.0
-      '@typespec/xml': ^0.84.0
+      '@azure-tools/typespec-azure-core': ^0.71.0
+      '@azure-tools/typespec-azure-resource-manager': ^0.71.0
+      '@azure-tools/typespec-client-generator-core': ^0.71.0
+      '@typespec/compiler': ^1.15.0
+      '@typespec/http': ^1.15.0
+      '@typespec/openapi': ^1.15.0
+      '@typespec/rest': ^0.85.0
+      '@typespec/versioning': ^0.85.0
+      '@typespec/xml': ^0.85.0
     peerDependenciesMeta:
       '@typespec/xml':
         optional: true
 
-  '@azure-tools/typespec-azure-core@0.70.0':
-    resolution: {integrity: sha512-8MojHWRtTLKycJJ98IMoXX/5b9tTo3F0d3Iu20OKoCsORnSDG2NfjOWHJVW63oxA2t8VTlqC6J8BDcnRihygQQ==}
+  '@azure-tools/typespec-azure-core@0.71.0':
+    resolution: {integrity: sha512-T/8y9A+33BenWgma6P7JrD9UeM9HakkBHEiQv8dQl67JXSFGOOvUZRHzCsmrCIE1VutmXJfS+LHiPCACGQVisg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@typespec/compiler': ^1.14.0
-      '@typespec/http': ^1.14.0
-      '@typespec/rest': ^0.84.0
+      '@typespec/compiler': ^1.15.0
+      '@typespec/http': ^1.15.0
+      '@typespec/rest': ^0.85.0
 
-  '@azure-tools/typespec-azure-resource-manager@0.70.0':
-    resolution: {integrity: sha512-hVrbbsOhU3EQ2yQTppCqsGQwY/HcVZPOINtFkoUo+PUVBmCFXyqLkTO4jvUbsp/LvJEwoQ8aEA8Y35f7VWT5uw==}
+  '@azure-tools/typespec-azure-resource-manager@0.71.0':
+    resolution: {integrity: sha512-XuKKaStmACD8UAKpN7uf2tSRhM6oqaiCBsc7eIu2NGDE0XSkJ/5BIsmnabYohaXSGO1MZjNcY3V8YS9KqJhd0w==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@azure-tools/typespec-azure-core': ^0.70.0
-      '@typespec/compiler': ^1.14.0
-      '@typespec/http': ^1.14.0
-      '@typespec/openapi': ^1.14.0
-      '@typespec/rest': ^0.84.0
-      '@typespec/versioning': ^0.84.0
+      '@azure-tools/typespec-azure-core': ^0.71.0
+      '@typespec/compiler': ^1.15.0
+      '@typespec/http': ^1.15.0
+      '@typespec/openapi': ^1.15.0
+      '@typespec/rest': ^0.85.0
+      '@typespec/versioning': ^0.85.0
 
   '@azure-tools/typespec-azure-rulesets@0.70.0':
     resolution: {integrity: sha512-Uxxl/18oryDwk2S+aYx6cIqiyjmoMeFDGmjuQ72a+aw6u8mZjgahMxNsY0ShvGLSchjsDqsVGaUlazXGXakVrw==}
@@ -112,39 +112,39 @@ packages:
       '@azure-tools/typespec-client-generator-core': ^0.70.0
       '@typespec/compiler': ^1.14.0
 
-  '@azure-tools/typespec-client-generator-core@0.70.0':
-    resolution: {integrity: sha512-8yxOYJfID3wp3FLQYNIa3kbmR5YLWjYtpB+i4u66quHTTQWWANHV1/o9f8xymAf+8fO9jbLo5tw1JerumxISWg==}
+  '@azure-tools/typespec-client-generator-core@0.71.0':
+    resolution: {integrity: sha512-uPIMTUpdl5YtsxIVEDREfJjuo9VEEFxyBzpzxEluLyMbMxsjgeenW/df4t0N34Ot+QduJVeGe+DzHGH16TaAAQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@azure-tools/typespec-azure-core': ^0.70.0
-      '@typespec/compiler': ^1.14.0
-      '@typespec/events': ^0.84.0
-      '@typespec/http': ^1.14.0
-      '@typespec/openapi': ^1.14.0
-      '@typespec/rest': ^0.84.0
-      '@typespec/sse': ^0.84.0
-      '@typespec/streams': ^0.84.0
-      '@typespec/versioning': ^0.84.0
-      '@typespec/xml': ^0.84.0
+      '@azure-tools/typespec-azure-core': ^0.71.0
+      '@typespec/compiler': ^1.15.0
+      '@typespec/events': ^0.85.0
+      '@typespec/http': ^1.15.0
+      '@typespec/openapi': ^1.15.0
+      '@typespec/rest': ^0.85.0
+      '@typespec/sse': ^0.85.0
+      '@typespec/streams': ^0.85.0
+      '@typespec/versioning': ^0.85.0
+      '@typespec/xml': ^0.85.0
 
-  '@azure-tools/typespec-go@0.15.0':
-    resolution: {integrity: sha512-asjcm5FI620poK4fIbscMZZyKIHWw7B1sERrkrMZGvzrWHZNP9XBQ45W3Jyoi0ijlTrSObisF9iatvQTRbFJpQ==}
+  '@azure-tools/typespec-go@0.16.0':
+    resolution: {integrity: sha512-7e2/ZO+xf0XLB2okW0qTRDKwbAawKH43E9rKZ7BcN4k+hpBWjtI9Yd70/v7sng4o78eYwg8bI6ngE+KVryp8Yg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@azure-tools/typespec-autorest': ^0.70.0
-      '@azure-tools/typespec-azure-core': ^0.70.0
-      '@azure-tools/typespec-azure-resource-manager': ^0.70.0
-      '@azure-tools/typespec-azure-rulesets': ^0.70.0
-      '@azure-tools/typespec-client-generator-core': ^0.70.0
-      '@typespec/compiler': ^1.14.0
-      '@typespec/events': ^0.84.0
-      '@typespec/http': ^1.14.0
-      '@typespec/openapi': ^1.14.0
-      '@typespec/rest': ^0.84.0
-      '@typespec/sse': ^0.84.0
-      '@typespec/streams': ^0.84.0
-      '@typespec/versioning': ^0.84.0
-      '@typespec/xml': ^0.84.0
+      '@azure-tools/typespec-autorest': ^0.71.0
+      '@azure-tools/typespec-azure-core': ^0.71.0
+      '@azure-tools/typespec-azure-resource-manager': ^0.71.0
+      '@azure-tools/typespec-azure-rulesets': ^0.71.0
+      '@azure-tools/typespec-client-generator-core': ^0.71.0
+      '@typespec/compiler': ^1.15.0
+      '@typespec/events': ^0.85.0
+      '@typespec/http': ^1.15.0
+      '@typespec/openapi': ^1.15.0
+      '@typespec/rest': ^0.85.0
+      '@typespec/sse': ^0.85.0
+      '@typespec/streams': ^0.85.0
+      '@typespec/versioning': ^0.85.0
+      '@typespec/xml': ^0.85.0
 
   '@azure/openapi-markdown@0.9.4':
     resolution: {integrity: sha512-QBxabmf+64mQuyWRLsBoLKdvB7PH2U9RsyQMekorl17DOVEkgQxMsQdL/WMlz/V2wMyiI433FlrbdUiiFapfKg==}
@@ -386,67 +386,67 @@ packages:
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
 
-  '@typespec/compiler@1.14.0':
-    resolution: {integrity: sha512-RRN0LGVDlonG/IbB2b4mvRjdCo6LywwB9/J8lOp6UaH7vtaFnKe5FL+rpxhof4rXx/zI/4OWnQO6c01bTCz4/Q==}
+  '@typespec/compiler@1.15.0':
+    resolution: {integrity: sha512-NbCIRAIzyozchlSaGPVuyV43bC+y+OpXYCuT+8M8kt35Ln9zWzLFcIt7irofQ5QUXBZrHsBFpI5fTOFdCGeWCA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
-  '@typespec/events@0.83.0':
-    resolution: {integrity: sha512-3EP1EIjdLgwStgd2rGWaF/QqY7YRAt+DIYnnYG2VsdPwa8s2t6K6eJ9YJDXveeHImAkHs+cpFuwxnjKMl4hOyw==}
+  '@typespec/events@0.85.0':
+    resolution: {integrity: sha512-oFLsJ3EK3SGmVNR3kyON6SAVpj5ek0PWxz4Y2OrvsaD39ONswRnIVPolnr2P0KK/BV67Uo49VLISXPo5Wrkk3Q==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@typespec/compiler': ^1.13.0
+      '@typespec/compiler': ^1.15.0
 
-  '@typespec/http@1.14.0':
-    resolution: {integrity: sha512-W+heCzu8K63AVcoX8MachVWaRxSAMFWOI1yBTc2Kq8QHaJeDiLL5JbU8VfTZ4tL/6EoGSdKfIT5ZNRW7oVCzhg==}
+  '@typespec/http@1.15.0':
+    resolution: {integrity: sha512-LNyzYHyX3C0xyQQ262jhvIaVzTn7DqiDB2gz45w1m6ngJH9ArGU8XjO3o7PaZkl/nuB5MTpImnsXpHIV1rbi4Q==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@typespec/compiler': ^1.14.0
-      '@typespec/streams': ^0.84.0
+      '@typespec/compiler': ^1.15.0
+      '@typespec/streams': ^0.85.0
     peerDependenciesMeta:
       '@typespec/streams':
         optional: true
 
-  '@typespec/openapi@1.14.0':
-    resolution: {integrity: sha512-KL7kImPhCXRmxpHVt1k7TWaa4bb3NbSeUx2rxyxeq7lYZFllI6/NYRCTOI/5JOrbElWmmSxrajU9K9IAKI6PkQ==}
+  '@typespec/openapi@1.15.0':
+    resolution: {integrity: sha512-lHd3H5W23KOIGKyBPKpBLPHVOxcxuvqOBXGqlyPvGmHDgmD74mrUtHWxNoGx+QQESjx4tS8Tu6URNQBU6y6Q1Q==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@typespec/compiler': ^1.14.0
-      '@typespec/http': ^1.14.0
+      '@typespec/compiler': ^1.15.0
+      '@typespec/http': ^1.15.0
 
-  '@typespec/rest@0.84.0':
-    resolution: {integrity: sha512-9s5dDfRoHRPdtbVvkBasUx/RnMvwWMTuXRieSQDEji4gWGgxVu4Zt4MiEEKSfQrkMr3Aw0QjRCSxBxjMCHIOmA==}
+  '@typespec/rest@0.85.0':
+    resolution: {integrity: sha512-ogbot1wp8jLn0rSOzwHjMjgDot+1u7WFZOWluRHL3cuRw9l8+ZjlixBrkXZ84dKP54RoYUN3buBjfOZ7qyHeyg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@typespec/compiler': ^1.14.0
-      '@typespec/http': ^1.14.0
+      '@typespec/compiler': ^1.15.0
+      '@typespec/http': ^1.15.0
 
-  '@typespec/sse@0.83.0':
-    resolution: {integrity: sha512-04WNaju2rwBbcF5pG+HrKQtdcrmSGuTVziLHNA9XOqj1qM7Uon3+wo2g+ZZ3Z6tngfqQoTCPyDcRHqZtGRdNuw==}
+  '@typespec/sse@0.85.0':
+    resolution: {integrity: sha512-mi0CiZxod5pRYOM6PTGnioH5CJ2F9KpXvChuFr6ITx2TQiokDVzGTST8PiiU/TfnMP+4JE91fUWzJWkm0HLGUA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@typespec/compiler': ^1.13.0
-      '@typespec/events': ^0.83.0
-      '@typespec/http': ^1.13.0
-      '@typespec/streams': ^0.83.0
+      '@typespec/compiler': ^1.15.0
+      '@typespec/events': ^0.85.0
+      '@typespec/http': ^1.15.0
+      '@typespec/streams': ^0.85.0
 
-  '@typespec/streams@0.83.0':
-    resolution: {integrity: sha512-wbO6sdH1Uf+UwjxxsWdHQkjJ3wwiYsAKI+L66qnDYVXAFe02sUdMKd0mxH5o9ipGXE52MZ+yvZ52vHAD+g3RFQ==}
+  '@typespec/streams@0.85.0':
+    resolution: {integrity: sha512-okmKXZ0JMCC24DeQOJnKLhgf53619XsfSiJ73Q/QCL7KqFwWtuo+vzS6q760t05GyyDs546bYWcUwyO+4TMURQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@typespec/compiler': ^1.13.0
+      '@typespec/compiler': ^1.15.0
 
-  '@typespec/versioning@0.84.0':
-    resolution: {integrity: sha512-ZoDasTDj4z0mgFK+0cJL2+7DduCaTjvICHL2nQ/RBWc7nLgObaIYCjvXLno8WneDXnpxCAr7larN4/nlHEv9fg==}
+  '@typespec/versioning@0.85.0':
+    resolution: {integrity: sha512-8qIbWBnIWor3p9DFzcVz4xU4YK6PFgMia4+IDczhb5G4J9bYquK9gJSFNPfoF86Foq9nHad83swX25kxRiS6Jw==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@typespec/compiler': ^1.14.0
+      '@typespec/compiler': ^1.15.0
 
-  '@typespec/xml@0.84.0':
-    resolution: {integrity: sha512-3x0spgIrr4u3azkYaOxrlumtjoqPiUnJ/G5RwGBmUCAeE5F413MHf/AeIkmZ2ULT1gY3myabfZp8bOijTbMk7A==}
+  '@typespec/xml@0.85.0':
+    resolution: {integrity: sha512-N9MU5azHtZVbx9dApIdGkK9aAESj2icKk3jLpwgnVqD5Fg4OuE1RrtRX7Q1fcxBGo3fxpnMphIE18WAZGGLwlQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@typespec/compiler': ^1.14.0
+      '@typespec/compiler': ^1.15.0
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -466,8 +466,8 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
     engines: {node: '>=12'}
 
   ansi-styles@4.3.0:
@@ -1119,76 +1119,76 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@azure-tools/typespec-autorest@0.70.1(4f396ab9d12448ab5fd32cffbb377f36)':
+  '@azure-tools/typespec-autorest@0.71.0(8ee3e5df800f54db4c437191ca71c809)':
     dependencies:
-      '@azure-tools/typespec-azure-core': 0.70.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))(@typespec/rest@0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))))
-      '@azure-tools/typespec-azure-resource-manager': 0.70.0(28778900fc6276a14858389967e8ca09)
-      '@azure-tools/typespec-client-generator-core': 0.70.0(d19e497f65e111f8cd7036f39b2592ee)
-      '@typespec/compiler': 1.14.0(@types/node@25.9.3)
-      '@typespec/http': 1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))
-      '@typespec/openapi': 1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))
-      '@typespec/rest': 0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))
-      '@typespec/versioning': 0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
+      '@azure-tools/typespec-azure-core': 0.71.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))(@typespec/rest@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))))
+      '@azure-tools/typespec-azure-resource-manager': 0.71.0(b8f46e1f3e79b358972250cf47469ef2)
+      '@azure-tools/typespec-client-generator-core': 0.71.0(63bec598fecc25d2783ca742340009fb)
+      '@typespec/compiler': 1.15.0(@types/node@25.9.3)
+      '@typespec/http': 1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))
+      '@typespec/openapi': 1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))
+      '@typespec/rest': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))
+      '@typespec/versioning': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
       yaml: 2.9.0
     optionalDependencies:
-      '@typespec/xml': 0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
+      '@typespec/xml': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
 
-  '@azure-tools/typespec-azure-core@0.70.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))(@typespec/rest@0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))))':
+  '@azure-tools/typespec-azure-core@0.71.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))(@typespec/rest@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))))':
     dependencies:
-      '@typespec/compiler': 1.14.0(@types/node@25.9.3)
-      '@typespec/http': 1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))
-      '@typespec/rest': 0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))
+      '@typespec/compiler': 1.15.0(@types/node@25.9.3)
+      '@typespec/http': 1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))
+      '@typespec/rest': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))
 
-  '@azure-tools/typespec-azure-resource-manager@0.70.0(28778900fc6276a14858389967e8ca09)':
+  '@azure-tools/typespec-azure-resource-manager@0.71.0(b8f46e1f3e79b358972250cf47469ef2)':
     dependencies:
-      '@azure-tools/typespec-azure-core': 0.70.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))(@typespec/rest@0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))))
-      '@typespec/compiler': 1.14.0(@types/node@25.9.3)
-      '@typespec/http': 1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))
-      '@typespec/openapi': 1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))
-      '@typespec/rest': 0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))
-      '@typespec/versioning': 0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
+      '@azure-tools/typespec-azure-core': 0.71.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))(@typespec/rest@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))))
+      '@typespec/compiler': 1.15.0(@types/node@25.9.3)
+      '@typespec/http': 1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))
+      '@typespec/openapi': 1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))
+      '@typespec/rest': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))
+      '@typespec/versioning': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
       change-case: 5.4.4
       pluralize: 8.0.0
 
-  '@azure-tools/typespec-azure-rulesets@0.70.0(@azure-tools/typespec-azure-core@0.70.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))(@typespec/rest@0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))))(@azure-tools/typespec-azure-resource-manager@0.70.0(28778900fc6276a14858389967e8ca09))(@azure-tools/typespec-client-generator-core@0.70.0(d19e497f65e111f8cd7036f39b2592ee))(@typespec/compiler@1.14.0(@types/node@25.9.3))':
+  '@azure-tools/typespec-azure-rulesets@0.70.0(@azure-tools/typespec-azure-core@0.71.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))(@typespec/rest@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))))(@azure-tools/typespec-azure-resource-manager@0.71.0(b8f46e1f3e79b358972250cf47469ef2))(@azure-tools/typespec-client-generator-core@0.71.0(63bec598fecc25d2783ca742340009fb))(@typespec/compiler@1.15.0(@types/node@25.9.3))':
     dependencies:
-      '@azure-tools/typespec-azure-core': 0.70.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))(@typespec/rest@0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))))
-      '@azure-tools/typespec-azure-resource-manager': 0.70.0(28778900fc6276a14858389967e8ca09)
-      '@azure-tools/typespec-client-generator-core': 0.70.0(d19e497f65e111f8cd7036f39b2592ee)
-      '@typespec/compiler': 1.14.0(@types/node@25.9.3)
+      '@azure-tools/typespec-azure-core': 0.71.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))(@typespec/rest@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))))
+      '@azure-tools/typespec-azure-resource-manager': 0.71.0(b8f46e1f3e79b358972250cf47469ef2)
+      '@azure-tools/typespec-client-generator-core': 0.71.0(63bec598fecc25d2783ca742340009fb)
+      '@typespec/compiler': 1.15.0(@types/node@25.9.3)
 
-  '@azure-tools/typespec-client-generator-core@0.70.0(d19e497f65e111f8cd7036f39b2592ee)':
+  '@azure-tools/typespec-client-generator-core@0.71.0(63bec598fecc25d2783ca742340009fb)':
     dependencies:
-      '@azure-tools/typespec-azure-core': 0.70.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))(@typespec/rest@0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))))
-      '@typespec/compiler': 1.14.0(@types/node@25.9.3)
-      '@typespec/events': 0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
-      '@typespec/http': 1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))
-      '@typespec/openapi': 1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))
-      '@typespec/rest': 0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))
-      '@typespec/sse': 0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/events@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))
-      '@typespec/streams': 0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
-      '@typespec/versioning': 0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
-      '@typespec/xml': 0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
+      '@azure-tools/typespec-azure-core': 0.71.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))(@typespec/rest@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))))
+      '@typespec/compiler': 1.15.0(@types/node@25.9.3)
+      '@typespec/events': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
+      '@typespec/http': 1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))
+      '@typespec/openapi': 1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))
+      '@typespec/rest': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))
+      '@typespec/sse': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/events@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))
+      '@typespec/streams': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
+      '@typespec/versioning': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
+      '@typespec/xml': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
       change-case: 5.4.4
       pluralize: 8.0.0
       yaml: 2.9.0
 
-  '@azure-tools/typespec-go@0.15.0(a73b8779a403e09dc757da46936d523b)':
+  '@azure-tools/typespec-go@0.16.0(5113a2cf024b1a92b251387909c31654)':
     dependencies:
-      '@azure-tools/typespec-autorest': 0.70.1(4f396ab9d12448ab5fd32cffbb377f36)
-      '@azure-tools/typespec-azure-core': 0.70.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))(@typespec/rest@0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))))
-      '@azure-tools/typespec-azure-resource-manager': 0.70.0(28778900fc6276a14858389967e8ca09)
-      '@azure-tools/typespec-azure-rulesets': 0.70.0(@azure-tools/typespec-azure-core@0.70.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))(@typespec/rest@0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))))(@azure-tools/typespec-azure-resource-manager@0.70.0(28778900fc6276a14858389967e8ca09))(@azure-tools/typespec-client-generator-core@0.70.0(d19e497f65e111f8cd7036f39b2592ee))(@typespec/compiler@1.14.0(@types/node@25.9.3))
-      '@azure-tools/typespec-client-generator-core': 0.70.0(d19e497f65e111f8cd7036f39b2592ee)
-      '@typespec/compiler': 1.14.0(@types/node@25.9.3)
-      '@typespec/events': 0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
-      '@typespec/http': 1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))
-      '@typespec/openapi': 1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))
-      '@typespec/rest': 0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))
-      '@typespec/sse': 0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/events@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))
-      '@typespec/streams': 0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
-      '@typespec/versioning': 0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
-      '@typespec/xml': 0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
+      '@azure-tools/typespec-autorest': 0.71.0(8ee3e5df800f54db4c437191ca71c809)
+      '@azure-tools/typespec-azure-core': 0.71.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))(@typespec/rest@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))))
+      '@azure-tools/typespec-azure-resource-manager': 0.71.0(b8f46e1f3e79b358972250cf47469ef2)
+      '@azure-tools/typespec-azure-rulesets': 0.70.0(@azure-tools/typespec-azure-core@0.71.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))(@typespec/rest@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))))(@azure-tools/typespec-azure-resource-manager@0.71.0(b8f46e1f3e79b358972250cf47469ef2))(@azure-tools/typespec-client-generator-core@0.71.0(63bec598fecc25d2783ca742340009fb))(@typespec/compiler@1.15.0(@types/node@25.9.3))
+      '@azure-tools/typespec-client-generator-core': 0.71.0(63bec598fecc25d2783ca742340009fb)
+      '@typespec/compiler': 1.15.0(@types/node@25.9.3)
+      '@typespec/events': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
+      '@typespec/http': 1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))
+      '@typespec/openapi': 1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))
+      '@typespec/rest': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))
+      '@typespec/sse': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/events@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))
+      '@typespec/streams': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
+      '@typespec/versioning': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
+      '@typespec/xml': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
       semver: 7.8.5
 
   '@azure/openapi-markdown@0.9.4':
@@ -1447,7 +1447,7 @@ snapshots:
 
   '@types/triple-beam@1.3.5': {}
 
-  '@typespec/compiler@1.14.0(@types/node@25.9.3)':
+  '@typespec/compiler@1.15.0(@types/node@25.9.3)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@inquirer/prompts': 8.5.2(@types/node@25.9.3)
@@ -1468,44 +1468,44 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@typespec/events@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))':
+  '@typespec/events@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))':
     dependencies:
-      '@typespec/compiler': 1.14.0(@types/node@25.9.3)
+      '@typespec/compiler': 1.15.0(@types/node@25.9.3)
 
-  '@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))':
+  '@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))':
     dependencies:
-      '@typespec/compiler': 1.14.0(@types/node@25.9.3)
+      '@typespec/compiler': 1.15.0(@types/node@25.9.3)
     optionalDependencies:
-      '@typespec/streams': 0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
+      '@typespec/streams': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
 
-  '@typespec/openapi@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))':
+  '@typespec/openapi@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))':
     dependencies:
-      '@typespec/compiler': 1.14.0(@types/node@25.9.3)
-      '@typespec/http': 1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))
+      '@typespec/compiler': 1.15.0(@types/node@25.9.3)
+      '@typespec/http': 1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))
 
-  '@typespec/rest@0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))':
+  '@typespec/rest@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))':
     dependencies:
-      '@typespec/compiler': 1.14.0(@types/node@25.9.3)
-      '@typespec/http': 1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))
+      '@typespec/compiler': 1.15.0(@types/node@25.9.3)
+      '@typespec/http': 1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))
 
-  '@typespec/sse@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/events@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))(@typespec/http@1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))':
+  '@typespec/sse@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/events@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))(@typespec/http@1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))':
     dependencies:
-      '@typespec/compiler': 1.14.0(@types/node@25.9.3)
-      '@typespec/events': 0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
-      '@typespec/http': 1.14.0(@typespec/compiler@1.14.0(@types/node@25.9.3))(@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3)))
-      '@typespec/streams': 0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))
+      '@typespec/compiler': 1.15.0(@types/node@25.9.3)
+      '@typespec/events': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
+      '@typespec/http': 1.15.0(@typespec/compiler@1.15.0(@types/node@25.9.3))(@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3)))
+      '@typespec/streams': 0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))
 
-  '@typespec/streams@0.83.0(@typespec/compiler@1.14.0(@types/node@25.9.3))':
+  '@typespec/streams@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))':
     dependencies:
-      '@typespec/compiler': 1.14.0(@types/node@25.9.3)
+      '@typespec/compiler': 1.15.0(@types/node@25.9.3)
 
-  '@typespec/versioning@0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))':
+  '@typespec/versioning@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))':
     dependencies:
-      '@typespec/compiler': 1.14.0(@types/node@25.9.3)
+      '@typespec/compiler': 1.15.0(@types/node@25.9.3)
 
-  '@typespec/xml@0.84.0(@typespec/compiler@1.14.0(@types/node@25.9.3))':
+  '@typespec/xml@0.85.0(@typespec/compiler@1.15.0(@types/node@25.9.3))':
     dependencies:
-      '@typespec/compiler': 1.14.0(@types/node@25.9.3)
+      '@typespec/compiler': 1.15.0(@types/node@25.9.3)
 
   ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
@@ -1527,7 +1527,7 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.2.2: {}
+  ansi-regex@6.3.0: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -1984,7 +1984,7 @@ snapshots:
 
   strip-ansi@7.2.0:
     dependencies:
-      ansi-regex: 6.2.2
+      ansi-regex: 6.3.0
 
   tar@7.5.22:
     dependencies:


### PR DESCRIPTION
## Summary

The TypeSpec Go 0.16 upgrade in the Dependabot commit began using the repository's root `go.mod` instead of each TypeSpec project's configured module, causing generated clients to use `package radius`. This change generates outside the repository so the existing package names are preserved.

- include the grouped JavaScript dependency update from [Dependabot PR #12732](https://github.com/radius-project/radius/pull/12732); its commit `999710fc43e6ce75f8164d66d2bba351303d7c01` was cherry-picked into this branch as `2f00f17eb154dcab34cfba9728893f3860724498`
- generate TypeSpec Go clients in fresh temporary directories outside the repository so `@azure-tools/typespec-go` 0.16 retains each project's configured module and package name
- copy the generated clients back into their existing package directories and clean temporary output with a shell trap
- refresh generated Go clients with the upgraded emitter

## Updated packages

The dependency update includes one `@typespec/compiler` update under `hack/bicep-types-radius/src/typespec-bicep-types` and the following updates under `typespec`:

| Package | From | To |
| --- | --- | --- |
| [@azure-tools/typespec-azure-resource-manager](https://github.com/Azure/typespec-azure) | `0.70.0` | `0.71.0` |
| [@typespec/compiler](https://github.com/microsoft/typespec) | `1.14.0` | `1.15.0` |
| [@typespec/http](https://github.com/microsoft/typespec) | `1.14.0` | `1.15.0` |
| [@typespec/openapi](https://github.com/microsoft/typespec) | `1.14.0` | `1.15.0` |
| [@typespec/versioning](https://github.com/microsoft/typespec) | `0.84.0` | `0.85.0` |
| [@azure-tools/typespec-autorest](https://github.com/Azure/typespec-azure) | `0.70.1` | `0.71.0` |
| [@azure-tools/typespec-azure-core](https://github.com/Azure/typespec-azure) | `0.70.0` | `0.71.0` |
| [@azure-tools/typespec-client-generator-core](https://github.com/Azure/typespec-azure) | `0.70.0` | `0.71.0` |
| [@azure-tools/typespec-go](https://github.com/Azure/typespec-azure) | `0.15.0` | `0.16.0` |
| [@typespec/rest](https://github.com/microsoft/typespec) | `0.84.0` | `0.85.0` |

## Validation

- ran `make generate` in WSL
- verified CoreRP generated files retain `package v20231001preview`
- verified generated constructors remain present
- verified temporary emitter output is cleaned
- ran `git diff --check`