### PR TITLE
Fix deployed graph publisher enrichment

### DIFF
--- a/.github/extension/actions/publish-deploy-status/action.yml
+++ b/.github/extension/actions/publish-deploy-status/action.yml
@@ -90,7 +90,7 @@ runs:
         # Keep stderr out of STATUS_DIR: that directory is uploaded wholesale as the
         # artifact, so anything written there becomes part of the published payload.
         GRAPH_STDERR=$(mktemp)
-        if ! rad app graph --application "$APP_NAME" --preview --include-icons --output json > "$STATUS_DIR/deploy-graph.json" 2> "$GRAPH_STDERR"; then
+        if ! rad app graph "$APP_FILE" --application "$APP_NAME" --preview --include-icons --output json > "$STATUS_DIR/deploy-graph.json" 2> "$GRAPH_STDERR"; then
           echo "::warning::Failed to generate deployed graph; skipping publish."
           cat "$GRAPH_STDERR" || true
           emit_outputs "" false

--- a/.github/extension/actions/publish-deploy-status/publish-deploy-status_test.sh
+++ b/.github/extension/actions/publish-deploy-status/publish-deploy-status_test.sh
@@ -213,6 +213,10 @@ set -uo pipefail
 
 case "${1:-} ${2:-}" in
     "app graph")
+        if [[ "${3:-}" != "${APP_FILE:-}" ]]; then
+            echo "rad: app graph must receive APP_FILE as its positional argument" >&2
+            exit 64
+        fi
         if [[ "${RAD_GRAPH_SHOULD_FAIL:-false}" == "true" ]]; then
             echo "rad: application not found in environment" >&2
             exit 1


### PR DESCRIPTION
## Summary

- forward the deployed application Bicep file to `rad app graph`
- enforce `APP_FILE` positional argument forwarding in the publisher action test stub

## Testing

- `make test-publish-deploy-status test-extension-action-shell-syntax`

## Graph diff

Graph diff unavailable because this repository has no `.radius/app.bicep`; no graph markdown was generated.