### PR TITLE
fix(chart): wait for Radius aggregated API readiness

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -886,6 +886,7 @@ jobs:
             --set "ucp.image=${CONTAINER_REGISTRY}/ucpd,ucp.tag=${REL_VERSION}" \
             --set "de.image=${DE_IMAGE},de.tag=${DE_TAG}" \
             --set "bicep.image=${CONTAINER_REGISTRY}/bicep,bicep.tag=${REL_VERSION}" \
+            --set "preupgrade.image=${CONTAINER_REGISTRY}/pre-upgrade,preupgrade.tag=${REL_VERSION}" \
             --set global.azureWorkloadIdentity.enabled=true \
             --set global.aws.irsa.enabled=true
 

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -886,7 +886,6 @@ jobs:
             --set "ucp.image=${CONTAINER_REGISTRY}/ucpd,ucp.tag=${REL_VERSION}" \
             --set "de.image=${DE_IMAGE},de.tag=${DE_TAG}" \
             --set "bicep.image=${CONTAINER_REGISTRY}/bicep,bicep.tag=${REL_VERSION}" \
-            --set "preupgrade.image=${CONTAINER_REGISTRY}/pre-upgrade,preupgrade.tag=${REL_VERSION}" \
             --set global.azureWorkloadIdentity.enabled=true \
             --set global.aws.irsa.enabled=true
 

--- a/cmd/pre-upgrade/cmd/root.go
+++ b/cmd/pre-upgrade/cmd/root.go
@@ -42,36 +42,36 @@ type Config struct {
 	RetryDelay    time.Duration
 }
 
-var rootCmd = &cobra.Command{
-	Use:   "pre-upgrade",
-	Short: "Pre-upgrade service",
-	Long:  `Pre-upgrade service for Radius, which performs checks before an upgrade.`,
-}
-
 // ExecuteWithContext executes the root command with the given context
 func ExecuteWithContext(ctx context.Context) error {
-	rootCmd.SetContext(ctx)
-	return Execute()
+	return NewCommand().ExecuteContext(ctx)
 }
 
 // Execute runs the root command and is the main entry point for the pre-upgrade CLI
 func Execute() error {
-	ctx := rootCmd.Context()
-	if ctx == nil {
-		ctx = context.Background()
+	return ExecuteWithContext(context.Background())
+}
+
+// NewCommand creates the pre-upgrade command.
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pre-upgrade",
+		Short: "Pre-upgrade service",
+		Long:  `Pre-upgrade service for Radius, which performs checks before an upgrade.`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPreflightChecks(cmd.Context())
+		},
 	}
 
-	// Parse configuration from environment
+	cmd.AddCommand(newWaitForControlPlaneCommand())
+	return cmd
+}
+
+func runPreflightChecks(ctx context.Context) error {
 	cfg := parseConfig()
 
-	// Set up logging using ucplog for consistency with other Radius containers
-	loggingOptions := &ucplog.LoggingOptions{
-		// These will be overridden by RADIUS_LOGGING_LEVEL and RADIUS_LOGGING_JSON env vars
-		Level: "info",
-		Json:  true,
-	}
-
-	logger, flush, err := ucplog.NewLogger("pre-upgrade", loggingOptions)
+	logger, flush, err := newLogger()
 	if err != nil {
 		return fmt.Errorf("failed to initialize logger: %w", err)
 	}
@@ -122,6 +122,14 @@ func Execute() error {
 
 	logger.Info("Preflight checks completed successfully")
 	return nil
+}
+
+func newLogger() (logr.Logger, func(), error) {
+	return ucplog.NewLogger("pre-upgrade", &ucplog.LoggingOptions{
+		// These will be overridden by RADIUS_LOGGING_LEVEL and RADIUS_LOGGING_JSON env vars.
+		Level: "info",
+		Json:  true,
+	})
 }
 
 // parseConfig parses configuration from environment variables

--- a/cmd/pre-upgrade/cmd/wait_for_control_plane.go
+++ b/cmd/pre-upgrade/cmd/wait_for_control_plane.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	radiusAggregatedAPIPath = "/apis/api.ucp.dev/v1alpha3"
+
+	defaultControlPlaneReadinessTimeout      = 60 * time.Second
+	defaultControlPlaneReadinessPollInterval = 2 * time.Second
+	defaultControlPlaneRequestTimeout        = 10 * time.Second
+	authorizationFailureThreshold            = 3
+)
+
+type waitForControlPlaneOptions struct {
+	timeout        time.Duration
+	pollInterval   time.Duration
+	requestTimeout time.Duration
+}
+
+type controlPlaneProbe func(context.Context) error
+
+func newWaitForControlPlaneCommand() *cobra.Command {
+	options := waitForControlPlaneOptions{
+		timeout:        defaultControlPlaneReadinessTimeout,
+		pollInterval:   defaultControlPlaneReadinessPollInterval,
+		requestTimeout: defaultControlPlaneRequestTimeout,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "wait-for-control-plane",
+		Short: "Wait for the Radius aggregated API to become available",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.validate(); err != nil {
+				return err
+			}
+
+			logger, flush, err := newLogger()
+			if err != nil {
+				return fmt.Errorf("failed to initialize logger: %w", err)
+			}
+			defer flush()
+
+			client, err := newInClusterDiscoveryClient()
+			if err != nil {
+				return err
+			}
+
+			return waitForControlPlane(cmd.Context(), options, logger, func(ctx context.Context) error {
+				return probeControlPlane(ctx, client, options.requestTimeout)
+			})
+		},
+	}
+
+	cmd.Flags().DurationVar(&options.timeout, "timeout", options.timeout, "Maximum time to wait for the Radius aggregated API")
+	cmd.Flags().DurationVar(&options.pollInterval, "poll-interval", options.pollInterval, "Delay between readiness probes")
+	cmd.Flags().DurationVar(&options.requestTimeout, "request-timeout", options.requestTimeout, "Timeout for each readiness probe")
+	return cmd
+}
+
+func (o waitForControlPlaneOptions) validate() error {
+	switch {
+	case o.timeout <= 0:
+		return fmt.Errorf("timeout must be greater than zero")
+	case o.pollInterval <= 0:
+		return fmt.Errorf("poll interval must be greater than zero")
+	case o.requestTimeout <= 0:
+		return fmt.Errorf("request timeout must be greater than zero")
+	default:
+		return nil
+	}
+}
+
+func newInClusterDiscoveryClient() (rest.Interface, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load in-cluster Kubernetes configuration: %w", err)
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+	return client.Discovery().RESTClient(), nil
+}
+
+func probeControlPlane(ctx context.Context, client rest.Interface, requestTimeout time.Duration) error {
+	probeCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+	return client.Get().AbsPath(radiusAggregatedAPIPath).Do(probeCtx).Error()
+}
+
+func waitForControlPlane(ctx context.Context, options waitForControlPlaneOptions, logger logr.Logger, probe controlPlaneProbe) error {
+	waitCtx, cancel := context.WithTimeout(ctx, options.timeout)
+	defer cancel()
+
+	started := time.Now()
+	attempts := 0
+	authorizationFailures := 0
+	var lastErr error
+
+	for {
+		attempts++
+		lastErr = probe(waitCtx)
+		if lastErr == nil {
+			logger.Info("Radius aggregated API is available", "attempts", attempts, "elapsed", time.Since(started))
+			return nil
+		}
+
+		if apierrors.IsUnauthorized(lastErr) || apierrors.IsForbidden(lastErr) {
+			authorizationFailures++
+		} else {
+			authorizationFailures = 0
+		}
+		if authorizationFailures >= authorizationFailureThreshold {
+			return fmt.Errorf("control plane readiness probe failed with a non-retryable authorization error after %d attempt(s): %w", attempts, lastErr)
+		}
+
+		logger.Info("Waiting for the Radius aggregated API", "attempt", attempts, "error", lastErr)
+
+		timer := time.NewTimer(options.pollInterval)
+		select {
+		case <-timer.C:
+		case <-waitCtx.Done():
+			timer.Stop()
+			return fmt.Errorf("Radius aggregated API did not become available within %s after %d attempt(s): %w (last probe failure: %v)",
+				options.timeout, attempts, waitCtx.Err(), lastErr)
+		}
+	}
+}

--- a/cmd/pre-upgrade/cmd/wait_for_control_plane_test.go
+++ b/cmd/pre-upgrade/cmd/wait_for_control_plane_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2026 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	restfake "k8s.io/client-go/rest/fake"
+)
+
+func TestWaitForControlPlaneRetriesServiceUnavailable(t *testing.T) {
+	attempts := 0
+	probe := func(context.Context) error {
+		attempts++
+		if attempts < 3 {
+			return apierrors.NewServiceUnavailable("aggregated API not available")
+		}
+		return nil
+	}
+
+	err := waitForControlPlane(t.Context(), testWaitOptions(), logr.Discard(), probe)
+	require.NoError(t, err)
+	require.Equal(t, 3, attempts)
+}
+
+func TestWaitForControlPlaneRetriesNotFound(t *testing.T) {
+	attempts := 0
+	probe := func(context.Context) error {
+		attempts++
+		if attempts == 1 {
+			return apierrors.NewNotFound(schema.GroupResource{Group: "apiregistration.k8s.io", Resource: "apiservices"}, "v1alpha3.api.ucp.dev")
+		}
+		return nil
+	}
+
+	err := waitForControlPlane(t.Context(), testWaitOptions(), logr.Discard(), probe)
+	require.NoError(t, err)
+	require.Equal(t, 2, attempts)
+}
+
+func TestWaitForControlPlaneReturnsLastErrorOnTimeout(t *testing.T) {
+	lastErr := errors.New("connection reset")
+	options := testWaitOptions()
+	options.timeout = 20 * time.Millisecond
+	options.pollInterval = 2 * time.Millisecond
+
+	err := waitForControlPlane(t.Context(), options, logr.Discard(), func(context.Context) error {
+		return lastErr
+	})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorContains(t, err, lastErr.Error())
+}
+
+func TestWaitForControlPlaneFailsRepeatedAuthorizationErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "unauthorized", err: apierrors.NewUnauthorized("missing token")},
+		{name: "forbidden", err: apierrors.NewForbidden(schema.GroupResource{Resource: "apis"}, "", errors.New("denied"))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attempts := 0
+			err := waitForControlPlane(t.Context(), testWaitOptions(), logr.Discard(), func(context.Context) error {
+				attempts++
+				return tt.err
+			})
+			require.Error(t, err)
+			require.ErrorContains(t, err, "non-retryable authorization error")
+			require.Equal(t, authorizationFailureThreshold, attempts)
+		})
+	}
+}
+
+func TestWaitForControlPlaneRetriesTransientAuthorizationError(t *testing.T) {
+	attempts := 0
+	err := waitForControlPlane(t.Context(), testWaitOptions(), logr.Discard(), func(context.Context) error {
+		attempts++
+		if attempts == 1 {
+			return apierrors.NewForbidden(schema.GroupResource{Resource: "apis"}, "", errors.New("RBAC propagation"))
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, attempts)
+}
+
+func TestWaitForControlPlaneBoundsHungProbe(t *testing.T) {
+	options := testWaitOptions()
+	options.timeout = 30 * time.Millisecond
+	options.requestTimeout = 5 * time.Millisecond
+	options.pollInterval = time.Millisecond
+
+	err := waitForControlPlane(t.Context(), options, logr.Discard(), func(ctx context.Context) error {
+		probeCtx, cancel := context.WithTimeout(ctx, options.requestTimeout)
+		defer cancel()
+		<-probeCtx.Done()
+		return probeCtx.Err()
+	})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestProbeControlPlaneUsesAggregatedAPIPath(t *testing.T) {
+	client := &restfake.RESTClient{
+		NegotiatedSerializer: kubernetesscheme.Codecs.WithoutConversion(),
+		GroupVersion:         schema.GroupVersion{},
+		Resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+		},
+	}
+
+	err := probeControlPlane(t.Context(), client, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, radiusAggregatedAPIPath, client.Req.URL.Path)
+}
+
+func TestProbeControlPlaneReportsServiceUnavailable(t *testing.T) {
+	client := &restfake.RESTClient{
+		NegotiatedSerializer: kubernetesscheme.Codecs.WithoutConversion(),
+		GroupVersion:         schema.GroupVersion{},
+		Resp: &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"kind":"Status","apiVersion":"v1","status":"Failure","message":"service unavailable","reason":"ServiceUnavailable","code":503}`,
+			)),
+		},
+	}
+
+	err := probeControlPlane(t.Context(), client, time.Second)
+	require.True(t, apierrors.IsServiceUnavailable(err), "expected ServiceUnavailable, got %v", err)
+	require.Equal(t, radiusAggregatedAPIPath, client.Req.URL.Path)
+}
+
+func TestNewCommandIncludesWaitForControlPlane(t *testing.T) {
+	cmd := NewCommand()
+
+	found, args, err := cmd.Find([]string{"wait-for-control-plane", "--timeout=15s"})
+	require.NoError(t, err)
+	require.Equal(t, "wait-for-control-plane", found.Name())
+	require.Equal(t, []string{"--timeout=15s"}, args)
+	require.NotNil(t, cmd.RunE, "the root command must preserve no-argument preflight behavior")
+}
+
+func TestWaitForControlPlaneOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		options waitForControlPlaneOptions
+	}{
+		{name: "timeout", options: waitForControlPlaneOptions{pollInterval: time.Second, requestTimeout: time.Second}},
+		{name: "poll interval", options: waitForControlPlaneOptions{timeout: time.Second, requestTimeout: time.Second}},
+		{name: "request timeout", options: waitForControlPlaneOptions{timeout: time.Second, pollInterval: time.Second}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, tt.options.validate())
+		})
+	}
+}
+
+func testWaitOptions() waitForControlPlaneOptions {
+	return waitForControlPlaneOptions{
+		timeout:        time.Second,
+		pollInterval:   time.Millisecond,
+		requestTimeout: 10 * time.Millisecond,
+	}
+}

--- a/deploy/Chart/templates/control-plane-readiness/clusterrole.yaml
+++ b/deploy/Chart/templates/control-plane-readiness/clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: radius-api-readiness
+  labels:
+    control-plane: radius-api-readiness
+    app.kubernetes.io/name: radius-api-readiness
+    app.kubernetes.io/part-of: radius
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - nonResourceURLs:
+      - /apis/api.ucp.dev/v1alpha3
+    verbs:
+      - get

--- a/deploy/Chart/templates/control-plane-readiness/clusterrolebinding.yaml
+++ b/deploy/Chart/templates/control-plane-readiness/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: radius-api-readiness
+  labels:
+    control-plane: radius-api-readiness
+    app.kubernetes.io/name: radius-api-readiness
+    app.kubernetes.io/part-of: radius
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: radius-api-readiness
+    namespace: "{{ .Release.Namespace }}"
+roleRef:
+  kind: ClusterRole
+  name: radius-api-readiness
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/Chart/templates/control-plane-readiness/job.yaml
+++ b/deploy/Chart/templates/control-plane-readiness/job.yaml
@@ -1,0 +1,48 @@
+{{- $appversion := include "radius.versiontag" . }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: radius-api-readiness
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    control-plane: radius-api-readiness
+    app.kubernetes.io/name: radius-api-readiness
+    app.kubernetes.io/part-of: radius
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-output-log-policy": hook-failed
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ add .Values.controlPlaneReadiness.timeoutSeconds 30 }}
+  ttlSecondsAfterFinished: {{ .Values.controlPlaneReadiness.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        control-plane: radius-api-readiness
+        app.kubernetes.io/name: radius-api-readiness
+        app.kubernetes.io/part-of: radius
+    spec:
+      restartPolicy: Never
+      serviceAccountName: radius-api-readiness
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: radius-api-readiness
+          image: "{{ include "radius.image" (dict "image" .Values.preupgrade.image "tag" (.Values.preupgrade.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
+          imagePullPolicy: Always
+          args:
+            - wait-for-control-plane
+            - "--timeout={{ .Values.controlPlaneReadiness.timeoutSeconds }}s"
+            - "--poll-interval={{ .Values.controlPlaneReadiness.pollIntervalSeconds }}s"
+            - "--request-timeout={{ .Values.controlPlaneReadiness.requestTimeoutSeconds }}s"
+          terminationMessagePolicy: FallbackToLogsOnError
+          resources:
+            {{- toYaml .Values.preupgrade.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.preupgrade.securityContext | nindent 12 }}
+      securityContext:
+        {{- toYaml .Values.preupgrade.podSecurityContext | nindent 8 }}

--- a/deploy/Chart/templates/control-plane-readiness/job.yaml
+++ b/deploy/Chart/templates/control-plane-readiness/job.yaml
@@ -5,14 +5,21 @@
 {{- $requestTimeoutSeconds := get $readiness "requestTimeoutSeconds" | default 10 }}
 {{- $ttlSecondsAfterFinished := get $readiness "ttlSecondsAfterFinished" | default 300 }}
 {{- $readinessImage := get $readiness "image" | default "" }}
+{{- $readinessTag := get $readiness "tag" | default "" }}
 {{- if not $readinessImage }}
-  {{- if contains "/" .Values.ucp.image }}
-    {{- $readinessImage = regexReplaceAll "/[^/]+$" .Values.ucp.image "/pre-upgrade" }}
+  {{- if ne .Values.preupgrade.image "pre-upgrade" }}
+    {{- $readinessImage = .Values.preupgrade.image }}
+    {{- $readinessTag = $readinessTag | default .Values.preupgrade.tag }}
   {{- else }}
-    {{- $readinessImage = "pre-upgrade" }}
+    {{- if contains "/" .Values.ucp.image }}
+      {{- $readinessImage = regexReplaceAll "/[^/]+$" .Values.ucp.image "/pre-upgrade" }}
+    {{- else }}
+      {{- $readinessImage = "pre-upgrade" }}
+    {{- end }}
+    {{- $readinessTag = $readinessTag | default .Values.ucp.tag }}
   {{- end }}
 {{- end }}
-{{- $readinessTag := get $readiness "tag" | default .Values.ucp.tag | default .Values.global.imageTag | default $appversion }}
+{{- $readinessTag = $readinessTag | default .Values.global.imageTag | default $appversion }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/deploy/Chart/templates/control-plane-readiness/job.yaml
+++ b/deploy/Chart/templates/control-plane-readiness/job.yaml
@@ -11,12 +11,17 @@
     {{- $readinessImage = .Values.preupgrade.image }}
     {{- $readinessTag = $readinessTag | default .Values.preupgrade.tag }}
   {{- else }}
+    {{- $ucpImageName := last (splitList "/" .Values.ucp.image) }}
+    {{- $ucpEmbeddedTag := "" }}
+    {{- if contains ":" $ucpImageName }}
+      {{- $ucpEmbeddedTag = regexReplaceAll "^.*:" $ucpImageName "" }}
+    {{- end }}
     {{- if contains "/" .Values.ucp.image }}
       {{- $readinessImage = regexReplaceAll "/[^/]+$" .Values.ucp.image "/pre-upgrade" }}
     {{- else }}
       {{- $readinessImage = "pre-upgrade" }}
     {{- end }}
-    {{- $readinessTag = $readinessTag | default .Values.ucp.tag }}
+    {{- $readinessTag = $readinessTag | default $ucpEmbeddedTag | default .Values.ucp.tag }}
   {{- end }}
 {{- end }}
 {{- $readinessTag = $readinessTag | default .Values.global.imageTag | default $appversion }}

--- a/deploy/Chart/templates/control-plane-readiness/job.yaml
+++ b/deploy/Chart/templates/control-plane-readiness/job.yaml
@@ -1,4 +1,9 @@
 {{- $appversion := include "radius.versiontag" . }}
+{{- $readiness := .Values.controlPlaneReadiness | default dict }}
+{{- $timeoutSeconds := get $readiness "timeoutSeconds" | default 240 }}
+{{- $pollIntervalSeconds := get $readiness "pollIntervalSeconds" | default 2 }}
+{{- $requestTimeoutSeconds := get $readiness "requestTimeoutSeconds" | default 10 }}
+{{- $ttlSecondsAfterFinished := get $readiness "ttlSecondsAfterFinished" | default 300 }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -15,8 +20,8 @@ metadata:
     "helm.sh/hook-output-log-policy": hook-failed
 spec:
   backoffLimit: 0
-  activeDeadlineSeconds: {{ add .Values.controlPlaneReadiness.timeoutSeconds 30 }}
-  ttlSecondsAfterFinished: {{ .Values.controlPlaneReadiness.ttlSecondsAfterFinished }}
+  activeDeadlineSeconds: {{ add $timeoutSeconds 30 }}
+  ttlSecondsAfterFinished: {{ $ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:
@@ -36,9 +41,9 @@ spec:
           imagePullPolicy: Always
           args:
             - wait-for-control-plane
-            - "--timeout={{ .Values.controlPlaneReadiness.timeoutSeconds }}s"
-            - "--poll-interval={{ .Values.controlPlaneReadiness.pollIntervalSeconds }}s"
-            - "--request-timeout={{ .Values.controlPlaneReadiness.requestTimeoutSeconds }}s"
+            - "--timeout={{ $timeoutSeconds }}s"
+            - "--poll-interval={{ $pollIntervalSeconds }}s"
+            - "--request-timeout={{ $requestTimeoutSeconds }}s"
           terminationMessagePolicy: FallbackToLogsOnError
           resources:
             {{- toYaml .Values.preupgrade.resources | nindent 12 }}

--- a/deploy/Chart/templates/control-plane-readiness/job.yaml
+++ b/deploy/Chart/templates/control-plane-readiness/job.yaml
@@ -4,6 +4,15 @@
 {{- $pollIntervalSeconds := get $readiness "pollIntervalSeconds" | default 2 }}
 {{- $requestTimeoutSeconds := get $readiness "requestTimeoutSeconds" | default 10 }}
 {{- $ttlSecondsAfterFinished := get $readiness "ttlSecondsAfterFinished" | default 300 }}
+{{- $readinessImage := get $readiness "image" | default "" }}
+{{- if not $readinessImage }}
+  {{- if contains "/" .Values.ucp.image }}
+    {{- $readinessImage = regexReplaceAll "/[^/]+$" .Values.ucp.image "/pre-upgrade" }}
+  {{- else }}
+    {{- $readinessImage = "pre-upgrade" }}
+  {{- end }}
+{{- end }}
+{{- $readinessTag := get $readiness "tag" | default .Values.ucp.tag | default .Values.global.imageTag | default $appversion }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -37,7 +46,7 @@ spec:
       {{- end }}
       containers:
         - name: radius-api-readiness
-          image: "{{ include "radius.image" (dict "image" .Values.preupgrade.image "tag" (.Values.preupgrade.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
+          image: "{{ include "radius.image" (dict "image" $readinessImage "tag" $readinessTag "global" .Values.global) }}"
           imagePullPolicy: Always
           args:
             - wait-for-control-plane

--- a/deploy/Chart/templates/control-plane-readiness/serviceaccount.yaml
+++ b/deploy/Chart/templates/control-plane-readiness/serviceaccount.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: radius-api-readiness
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    control-plane: radius-api-readiness
+    app.kubernetes.io/name: radius-api-readiness
+    app.kubernetes.io/part-of: radius
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/deploy/Chart/templates/networkpolicies.yaml
+++ b/deploy/Chart/templates/networkpolicies.yaml
@@ -58,9 +58,9 @@ spec:
 #   - kube-apiserver -> ucp:9443        (APIService aggregation for api.ucp.dev)
 #   - kube-apiserver -> controller:9443 (recipe admission webhook)
 # Both arrive on container port 9443, so the rule is scoped to that port to limit
-# what host-network sources in these CIDRs can reach. (The chart's only kubelet
-# probes are exec probes on dynamic-rp; they run via the container runtime and do
-# not traverse the network, so they need no allowance here.)
+# what host-network sources in these CIDRs can reach. The UCP HTTPS readiness
+# probe also originates from the node on port 9443 and is covered by this rule.
+# The dynamic-rp probes are exec probes and need no network allowance.
 # Without this policy the default-deny above blocks API aggregation and webhooks
 # and breaks the control plane. The CIDRs are cluster-specific (typically the node
 # subnet) and come from networkPolicies.controlPlaneCIDRs.

--- a/deploy/Chart/templates/ucp/deployment.yaml
+++ b/deploy/Chart/templates/ucp/deployment.yaml
@@ -81,6 +81,27 @@ spec:
           name: metrics
           protocol: TCP
         {{- end }}
+        # The kube-apiserver aggregation layer forwards api.ucp.dev requests to this
+        # pod through the ucp Service. Without a readiness gate the pod is added to
+        # the Service endpoints as soon as the container starts, so the aggregator can
+        # route to a backend that is not listening yet and return 503 to callers.
+        #
+        # The probe targets the Kubernetes discovery document, which is the same
+        # endpoint the aggregator polls to decide APIService availability and is
+        # served without authentication. UCP only begins listening after its modules
+        # and default planes are configured, so a successful response here means the
+        # Radius API is genuinely serving. This also makes `helm --wait` and
+        # `rad install kubernetes` return only once the API answers, rather than as
+        # soon as the process starts.
+        readinessProbe:
+          httpGet:
+            path: /apis/api.ucp.dev/v1alpha3
+            port: ucp
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 3
         securityContext:
           allowPrivilegeEscalation: false
         {{- if .Values.ucp.resources }}

--- a/deploy/Chart/tests/control_plane_readiness_test.yaml
+++ b/deploy/Chart/tests/control_plane_readiness_test.yaml
@@ -1,0 +1,110 @@
+suite: test control plane readiness hook
+templates:
+  - control-plane-readiness/serviceaccount.yaml
+  - control-plane-readiness/clusterrole.yaml
+  - control-plane-readiness/clusterrolebinding.yaml
+  - control-plane-readiness/job.yaml
+release:
+  name: radius
+  namespace: radius-system
+tests:
+  - it: always renders the readiness hook when pre-upgrade checks are disabled
+    set:
+      preupgrade.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: control-plane-readiness/job.yaml
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade
+        template: control-plane-readiness/job.yaml
+
+  - it: creates hook prerequisites before the readiness job
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-1"
+        template: control-plane-readiness/serviceaccount.yaml
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-1"
+        template: control-plane-readiness/clusterrole.yaml
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-1"
+        template: control-plane-readiness/clusterrolebinding.yaml
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "0"
+        template: control-plane-readiness/job.yaml
+
+  - it: grants only access to the Radius aggregated API discovery path
+    asserts:
+      - equal:
+          path: rules
+          value:
+            - nonResourceURLs:
+                - /apis/api.ucp.dev/v1alpha3
+              verbs:
+                - get
+        template: control-plane-readiness/clusterrole.yaml
+
+  - it: invokes the readiness subcommand with configured timeouts
+    set:
+      controlPlaneReadiness.timeoutSeconds: 75
+      controlPlaneReadiness.pollIntervalSeconds: 3
+      controlPlaneReadiness.requestTimeoutSeconds: 8
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - wait-for-control-plane
+            - --timeout=75s
+            - --poll-interval=3s
+            - --request-timeout=8s
+        template: control-plane-readiness/job.yaml
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 105
+        template: control-plane-readiness/job.yaml
+
+  - it: retains failed jobs and exposes their logs
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+        template: control-plane-readiness/job.yaml
+      - equal:
+          path: metadata.annotations["helm.sh/hook-output-log-policy"]
+          value: hook-failed
+        template: control-plane-readiness/job.yaml
+
+  - it: uses the build-under-test pre-upgrade image
+    set:
+      global.imageRegistry: test.registry
+      preupgrade.image: custom-readiness
+      preupgrade.tag: test-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: test.registry/custom-readiness:test-tag
+        template: control-plane-readiness/job.yaml
+
+  - it: renders image pull secrets and non-root security settings
+    set:
+      global.imagePullSecrets:
+        - name: registry-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: registry-secret
+        template: control-plane-readiness/job.yaml
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+        template: control-plane-readiness/job.yaml
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+        template: control-plane-readiness/job.yaml

--- a/deploy/Chart/tests/control_plane_readiness_test.yaml
+++ b/deploy/Chart/tests/control_plane_readiness_test.yaml
@@ -111,6 +111,15 @@ tests:
           value: test.registry/pre-upgrade:test-tag
         template: control-plane-readiness/job.yaml
 
+  - it: preserves a tag embedded in a full UCP image path
+    set:
+      ucp.image: custom-registry.io/ucpd:custom-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: custom-registry.io/pre-upgrade:custom-tag
+        template: control-plane-readiness/job.yaml
+
   - it: honors an explicitly configured pre-upgrade image
     set:
       preupgrade.image: local.registry/pre-upgrade

--- a/deploy/Chart/tests/control_plane_readiness_test.yaml
+++ b/deploy/Chart/tests/control_plane_readiness_test.yaml
@@ -69,6 +69,27 @@ tests:
           value: 105
         template: control-plane-readiness/job.yaml
 
+  - it: uses backward-compatible defaults when reused values omit readiness settings
+    set:
+      controlPlaneReadiness: null
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - wait-for-control-plane
+            - --timeout=240s
+            - --poll-interval=2s
+            - --request-timeout=10s
+        template: control-plane-readiness/job.yaml
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 270
+        template: control-plane-readiness/job.yaml
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 300
+        template: control-plane-readiness/job.yaml
+
   - it: retains failed jobs and exposes their logs
     asserts:
       - equal:

--- a/deploy/Chart/tests/control_plane_readiness_test.yaml
+++ b/deploy/Chart/tests/control_plane_readiness_test.yaml
@@ -111,6 +111,16 @@ tests:
           value: test.registry/pre-upgrade:test-tag
         template: control-plane-readiness/job.yaml
 
+  - it: honors an explicitly configured pre-upgrade image
+    set:
+      preupgrade.image: local.registry/pre-upgrade
+      preupgrade.tag: local-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: local.registry/pre-upgrade:local-tag
+        template: control-plane-readiness/job.yaml
+
   - it: supports an explicit readiness image override
     set:
       controlPlaneReadiness.image: custom.registry/readiness

--- a/deploy/Chart/tests/control_plane_readiness_test.yaml
+++ b/deploy/Chart/tests/control_plane_readiness_test.yaml
@@ -101,15 +101,26 @@ tests:
           value: hook-failed
         template: control-plane-readiness/job.yaml
 
-  - it: uses the build-under-test pre-upgrade image
+  - it: derives the build-under-test pre-upgrade image from UCP
     set:
-      global.imageRegistry: test.registry
-      preupgrade.image: custom-readiness
-      preupgrade.tag: test-tag
+      ucp.image: test.registry/ucpd
+      ucp.tag: test-tag
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: test.registry/custom-readiness:test-tag
+          value: test.registry/pre-upgrade:test-tag
+        template: control-plane-readiness/job.yaml
+
+  - it: supports an explicit readiness image override
+    set:
+      controlPlaneReadiness.image: custom.registry/readiness
+      controlPlaneReadiness.tag: custom-tag
+      ucp.image: ignored.registry/ucpd
+      ucp.tag: ignored-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: custom.registry/readiness:custom-tag
         template: control-plane-readiness/job.yaml
 
   - it: renders image pull secrets and non-root security settings

--- a/deploy/Chart/tests/ucp_readiness_test.yaml
+++ b/deploy/Chart/tests/ucp_readiness_test.yaml
@@ -1,0 +1,61 @@
+suite: test UCP readiness probe
+templates:
+  - ucp/deployment.yaml
+  - ucp/configmaps.yaml
+release:
+  name: radius
+  namespace: radius-system
+tests:
+  - it: gates readiness on the aggregated API discovery document
+    # The kube-apiserver aggregation layer routes api.ucp.dev traffic to this pod
+    # through the ucp Service. The probe must target the discovery document over
+    # HTTPS so the pod stays out of the Service endpoints until UCP actually serves,
+    # otherwise the aggregator forwards to a backend that is not listening and
+    # returns 503.
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /apis/api.ucp.dev/v1alpha3
+        template: ucp/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS
+        template: ucp/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: ucp
+        template: ucp/deployment.yaml
+
+  - it: probes the named port the UCP container serves on
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: ucp
+        template: ucp/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 9443
+        template: ucp/deployment.yaml
+
+  - it: keeps the readiness probe path aligned with the configured server path base
+    # UCP serves the discovery document at server.pathBase. If the path base changes
+    # without the probe, readiness would poll a route that returns 404 and the pod
+    # would never become Ready.
+    asserts:
+      - matchRegex:
+          path: data["ucp-config.yaml"]
+          pattern: 'pathBase: /apis/api\.ucp\.dev/v1alpha3'
+        template: ucp/configmaps.yaml
+
+  - it: keeps the readiness probe configured when Prometheus adds a metrics port
+    set:
+      global.prometheus.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: ucp
+        template: ucp/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].name
+          value: metrics
+        template: ucp/deployment.yaml

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -273,9 +273,10 @@ controlPlaneReadiness:
   # Helm post-install/post-upgrade hook settings. The hook waits until the Radius
   # aggregated API is serving through kube-apiserver, so successful Helm completion
   # means clients can use the control plane immediately.
-  # Image override. When unset, the hook uses the pre-upgrade image from the same
-  # registry and tag as UCP. This keeps custom and CI builds aligned without requiring
-  # every installer to set another image value.
+  # Image override. When unset, the hook honors an explicitly configured preupgrade
+  # image; otherwise it uses the pre-upgrade image from the same registry and tag as
+  # UCP. This keeps custom and CI builds aligned without requiring every installer to
+  # set another image value.
   image: ""
   tag: ""
   # This also covers UCP cold-start time when the chart is installed directly

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -273,6 +273,11 @@ controlPlaneReadiness:
   # Helm post-install/post-upgrade hook settings. The hook waits until the Radius
   # aggregated API is serving through kube-apiserver, so successful Helm completion
   # means clients can use the control plane immediately.
+  # Image override. When unset, the hook uses the pre-upgrade image from the same
+  # registry and tag as UCP. This keeps custom and CI builds aligned without requiring
+  # every installer to set another image value.
+  image: ""
+  tag: ""
   # This also covers UCP cold-start time when the chart is installed directly
   # without --wait. Keep it below Helm's operation timeout so hook failure details
   # can be reported before Helm cancels the operation.
@@ -284,8 +289,9 @@ controlPlaneReadiness:
 preupgrade:
   # Enable pre-upgrade preflight checks
   enabled: false
-  # Container image shared by pre-upgrade checks and the mandatory post-install/
-  # post-upgrade control-plane readiness hook.
+  # Container image for pre-upgrade checks. The control-plane readiness hook runs the
+  # same binary but derives its image from UCP unless controlPlaneReadiness.image/tag
+  # override it.
   # Can be overridden with a full registry path (e.g., myregistry.azurecr.io/pre-upgrade)
   # or use just the image name to use global.imageRegistry
   image: pre-upgrade

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -269,10 +269,23 @@ networkPolicies:
   # Example: ["10.0.0.0/16"]
   controlPlaneCIDRs: []
 
+controlPlaneReadiness:
+  # Helm post-install/post-upgrade hook settings. The hook waits until the Radius
+  # aggregated API is serving through kube-apiserver, so successful Helm completion
+  # means clients can use the control plane immediately.
+  # This also covers UCP cold-start time when the chart is installed directly
+  # without --wait. Keep it below Helm's operation timeout so hook failure details
+  # can be reported before Helm cancels the operation.
+  timeoutSeconds: 240
+  pollIntervalSeconds: 2
+  requestTimeoutSeconds: 10
+  ttlSecondsAfterFinished: 300
+
 preupgrade:
   # Enable pre-upgrade preflight checks
   enabled: false
-  # Container image for pre-upgrade checks
+  # Container image shared by pre-upgrade checks and the mandatory post-install/
+  # post-upgrade control-plane readiness hook.
   # Can be overridden with a full registry path (e.g., myregistry.azurecr.io/pre-upgrade)
   # or use just the image name to use global.imageRegistry
   image: pre-upgrade
@@ -305,7 +318,7 @@ preupgrade:
   retryDelaySeconds: 2 # Delay between retry attempts
   # Job configuration
   ttlSecondsAfterFinished: 300
-  # Resource requirements
+  # Resource requirements shared by both hook jobs
   resources:
     requests:
       cpu: "100m"
@@ -313,7 +326,7 @@ preupgrade:
     limits:
       cpu: "200m"
       memory: "128Mi"
-  # Security context for the container
+  # Security context shared by both hook containers
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
@@ -325,7 +338,7 @@ preupgrade:
     runAsGroup: 65532
     seccompProfile:
       type: RuntimeDefault
-  # Pod security context
+  # Pod security context shared by both hook pods
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 65532

--- a/pkg/cli/cmd/install/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes.go
@@ -256,9 +256,9 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	// Helm is configured with Wait=true for the Radius chart (see PopulateDefaultClusterOptions),
-	// so by the time InstallRadius returns the control plane pods are Ready and the UCP API is
-	// reachable. We can therefore call the management client immediately without an extra wait.
+	// The Radius chart's post-install hook waits until the aggregated API responds through
+	// kube-apiserver. A successful InstallRadius call therefore guarantees that the management
+	// client can connect without a second readiness wait here.
 	return r.createDefaultGroupAndEnvironment(ctx)
 }
 


### PR DESCRIPTION
## Summary

Make successful Helm install and upgrade completion the authoritative Radius readiness contract.

- Add an HTTPS UCP pod probe so UCP does not join Service endpoints before it is listening.
- Add a mandatory `post-install,post-upgrade` hook that waits for `/apis/api.ucp.dev/v1alpha3` through kube-apiserver.
- Reuse the Radius `pre-upgrade` binary via a new `wait-for-control-plane` subcommand with least-privilege RBAC, bounded retries, and retained failure diagnostics.

## Reason for change

Helm does not check Kubernetes `APIService` readiness. It can return while UCP is serving but kube-apiserver still reports the recreated Radius APIService as unavailable:

```text
t=+6ms     podReady=1/1  apiserviceAvailable=False  api=503
t=+3182ms  podReady=1/1  apiserviceAvailable=False  api=503
t=+4540ms  podReady=1/1  apiserviceAvailable=True   api=SERVING
```

The pod probe and Helm hook cover different readiness boundaries. The pod probe prevents routing to a process that is not listening; the hook verifies the full client path through kube-apiserver, the aggregation controller, APIService, Service, TLS, and UCP. A pod probe cannot wait on APIService availability because the APIService itself requires a Ready endpoint, which would create a circular dependency.

The hook image follows the current build through this precedence: explicit readiness override, explicit non-default pre-upgrade image, then a `pre-upgrade` image derived from UCP's registry and tag. Template-local defaults preserve direct Helm `--reuse-values` upgrades from older charts.

Related to #11841.

## How to test

Deterministic checks:

```text
go test ./cmd/pre-upgrade/... ./pkg/cli/cmd/install/kubernetes/... -count=1
go vet ./cmd/pre-upgrade/... ./pkg/cli/cmd/install/kubernetes/...
go build ./cmd/pre-upgrade/...
make test-helm
```

Live kind validation with images built from this branch confirmed:

- Fresh install, reinstall, and upgrade all returned with the aggregated endpoint immediately serving.
- Deleting the APIService caused two retryable 404s; the hook succeeded after restoration.
- A forced timeout reported the last error and retained the failed Job.
- Main's existing upgrade test passed 3/3 unmodified with this hook.
- Removing only this hook reproduced the original one-503/idle-timeout failure exactly.

All current CI checks pass, including cloud install legs and `upgrade-noncloud`.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `cmd/pre-upgrade/cmd/root.go` | Preserve preflight behavior while adding subcommand dispatch. |
| `cmd/pre-upgrade/cmd/wait_for_control_plane.go` | Poll the aggregated Radius API with bounded retries and error classification. |
| `cmd/pre-upgrade/cmd/wait_for_control_plane_test.go` | Cover retry, timeout, authorization, request-path, and command behavior. |
| `deploy/Chart/templates/control-plane-readiness/*` | Add the mandatory Helm hook Job, ServiceAccount, and least-privilege RBAC. |
| `deploy/Chart/templates/ucp/deployment.yaml` | Add the direct HTTPS UCP readiness probe. |
| `deploy/Chart/values.yaml` | Configure hook image and timing with backward-compatible defaults. |
| `deploy/Chart/tests/*readiness_test.yaml` | Verify UCP and Helm readiness rendering, RBAC, image precedence, and old-value compatibility. |
| `deploy/Chart/templates/networkpolicies.yaml` | Correct probe/network-policy guidance. |
| `pkg/cli/cmd/install/kubernetes/kubernetes.go` | Document that successful Helm completion guarantees aggregated API readiness. |

PR #12790 is stacked on this PR and contains the upgrade-test cleanup/optimization. After this PR merges, retarget #12790 to `main`.