### PR TITLE
fix(testhost): remove panic from Eventually polling condition

### DIFF
--- a/pkg/components/testhost/host.go
+++ b/pkg/components/testhost/host.go
@@ -58,10 +58,14 @@ func StartHost(t *testing.T, host *hosting.Host, baseURL string) *TestHost {
 	}
 	t.Cleanup(th.Close)
 
-	// Parse the URL before polling. The polling condition runs in a goroutine that testify does not
-	// recover panics from, so any failure must be reported on the test goroutine instead.
+	// Resolve the address to dial before polling. The polling condition runs in a goroutine that
+	// testify does not recover panics from, so any failure must be reported on the test goroutine
+	// instead. url.Parse accepts URLs that cannot be dialed, so the host and port are validated too;
+	// otherwise the poll would spin until its timeout and report a misleading failure.
 	u, err := url.Parse(baseURL)
 	require.NoErrorf(t, err, "invalid URL: %q", baseURL)
+	require.NotEmptyf(t, u.Hostname(), "URL is missing a host: %q", baseURL)
+	require.NotEmptyf(t, u.Port(), "URL is missing a port: %q", baseURL)
 
 	address := net.JoinHostPort(u.Hostname(), u.Port())
 

--- a/pkg/components/testhost/host.go
+++ b/pkg/components/testhost/host.go
@@ -58,14 +58,16 @@ func StartHost(t *testing.T, host *hosting.Host, baseURL string) *TestHost {
 	}
 	t.Cleanup(th.Close)
 
+	// Parse the URL before polling. The polling condition runs in a goroutine that testify does not
+	// recover panics from, so any failure must be reported on the test goroutine instead.
+	u, err := url.Parse(baseURL)
+	require.NoErrorf(t, err, "invalid URL: %q", baseURL)
+
+	address := net.JoinHostPort(u.Hostname(), u.Port())
+
 	// Wait for the server to start listening on the port.
 	require.Eventuallyf(t, func() bool {
-		u, err := url.Parse(baseURL)
-		if err != nil {
-			panic("Invalid URL: " + baseURL)
-		}
-
-		conn, err := net.Dial("tcp", net.JoinHostPort(u.Hostname(), u.Port()))
+		conn, err := net.Dial("tcp", address)
 		if err != nil {
 			t.Logf("Waiting for server to start listening on port: %v", err)
 			return false


### PR DESCRIPTION
# Description

`StartHost` in `pkg/components/testhost/host.go` waits for the test host to start listening using `require.Eventuallyf`. The polling condition parsed `baseURL` on every attempt and called a bare `panic` if the parse failed.

testify runs an `Eventually` condition in its own goroutine (`go func() { ch <- condition() }()`) and does not recover panics raised inside it. An unrecovered panic in that goroutine terminates the entire test process, so every other test in the binary is reported as failed or not run, and the real cause is buried in a goroutine stack trace instead of being attributed to the test that caused it.

This change resolves the dial address once before entering the polling loop. The URL does not change between attempts, so re-parsing it every 20ms was wasted work as well. `url.Parse` also accepts URLs that cannot be dialed — one with no port yields `net.JoinHostPort("localhost", "")` → `"localhost:"`, which fails every attempt and spins for the full 5s before reporting a misleading "server did not start listening on port" — so the host and port are validated alongside the parse. A malformed `baseURL` now fails immediately on the test goroutine with an accurate message, and the polling condition contains no `panic`, no `require.*`, no `t.Fatal*`, and no `t.FailNow` — only `t.Logf` and a bool return.

This is a latent fix rather than an active bug fix. Both callers build `baseURL` from `Server.Address()`, so neither the `url.Parse` error path nor the missing host/port paths are reachable today. It is worth fixing because it belongs to the same defect class as the flake fixed in #11841 — terminating abnormally from inside a polling goroutine — which stayed invisible for months.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (#12787).

Fixes: #12787

## Contributor checklist

- [x] Existing Tests Pass
- [x] Code is well-documented

## Validation

- `go build ./pkg/components/...`
- `go vet ./pkg/components/testhost/...`
- `gofmt -l pkg/components/testhost/` (clean)
- `go test ./pkg/ucp/integrationtests/... ./pkg/dynamicrp/integrationtest/... -count=1` — all packages that exercise `StartHost` pass.
