### PR TITLE
test(upgrade): install once for the preflight container test

### DIFF
--- a/deploy/Chart/templates/ucp/deployment.yaml
+++ b/deploy/Chart/templates/ucp/deployment.yaml
@@ -81,6 +81,27 @@ spec:
           name: metrics
           protocol: TCP
         {{- end }}
+        # The kube-apiserver aggregation layer forwards api.ucp.dev requests to this
+        # pod through the ucp Service. Without a readiness gate the pod is added to
+        # the Service endpoints as soon as the container starts, so the aggregator can
+        # route to a backend that is not listening yet and return 503 to callers.
+        #
+        # The probe targets the Kubernetes discovery document, which is the same
+        # endpoint the aggregator polls to decide APIService availability and is
+        # served without authentication. UCP only begins listening after its modules
+        # and default planes are configured, so a successful response here means the
+        # Radius API is genuinely serving. This also makes `helm --wait` and
+        # `rad install kubernetes` return only once the API answers, rather than as
+        # soon as the process starts.
+        readinessProbe:
+          httpGet:
+            path: /apis/api.ucp.dev/v1alpha3
+            port: ucp
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 3
         securityContext:
           allowPrivilegeEscalation: false
         {{- if .Values.ucp.resources }}

--- a/deploy/Chart/tests/ucp_readiness_test.yaml
+++ b/deploy/Chart/tests/ucp_readiness_test.yaml
@@ -1,0 +1,61 @@
+suite: test UCP readiness probe
+templates:
+  - ucp/deployment.yaml
+  - ucp/configmaps.yaml
+release:
+  name: radius
+  namespace: radius-system
+tests:
+  - it: gates readiness on the aggregated API discovery document
+    # The kube-apiserver aggregation layer routes api.ucp.dev traffic to this pod
+    # through the ucp Service. The probe must target the discovery document over
+    # HTTPS so the pod stays out of the Service endpoints until UCP actually serves,
+    # otherwise the aggregator forwards to a backend that is not listening and
+    # returns 503.
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /apis/api.ucp.dev/v1alpha3
+        template: ucp/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS
+        template: ucp/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: ucp
+        template: ucp/deployment.yaml
+
+  - it: probes the named port the UCP container serves on
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: ucp
+        template: ucp/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 9443
+        template: ucp/deployment.yaml
+
+  - it: keeps the readiness probe path aligned with the configured server path base
+    # UCP serves the discovery document at server.pathBase. If the path base changes
+    # without the probe, readiness would poll a route that returns 404 and the pod
+    # would never become Ready.
+    asserts:
+      - matchRegex:
+          path: data["ucp-config.yaml"]
+          pattern: 'pathBase: /apis/api\.ucp\.dev/v1alpha3'
+        template: ucp/configmaps.yaml
+
+  - it: keeps the readiness probe configured when Prometheus adds a metrics port
+    set:
+      global.prometheus.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: ucp
+        template: ucp/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].name
+          value: metrics
+        template: ucp/deployment.yaml

--- a/test/functional-portable/upgrade/upgrade_test.go
+++ b/test/functional-portable/upgrade/upgrade_test.go
@@ -41,16 +41,29 @@ import (
 
 const (
 	radiusNamespace   = "radius-system"
+	helmReleaseName   = "radius"
 	preUpgradeJobName = "pre-upgrade"
 	helmTimeout       = "5m"
 
 	relativeChartPath = "../../../deploy/Chart"
+
+	// helmStatusDeployed is the Helm release status that means the last operation
+	// succeeded and the release is ready to be upgraded again.
+	helmStatusDeployed = "deployed"
+
+	// preflightJobTTLSeconds is the ttlSecondsAfterFinished the test configures on the
+	// pre-upgrade Job and then asserts was applied.
+	preflightJobTTLSeconds = 60
 
 	// Polling intervals for waiting on Kubernetes state changes.
 	controlPlanePollInterval = 3 * time.Second
 	cleanupPollInterval      = 3 * time.Second
 	jobPollInterval          = 1 * time.Second
 	jobPollAttempts          = 15
+
+	// jobDeletionTimeout is the maximum time to wait for a deleted pre-upgrade Job to
+	// disappear from the API server.
+	jobDeletionTimeout = 60 * time.Second
 
 	// controlPlaneTimeout is the maximum time to wait for the control plane API
 	// to become available after Helm install/upgrade completes. This needs to be
@@ -61,10 +74,6 @@ const (
 	// cleanupTimeout is the maximum time to wait for Radius pods to terminate
 	// after uninstalling the Helm release.
 	cleanupTimeout = 2 * time.Minute
-
-	// cleanupFallbackWait is the fallback sleep duration when unable to create
-	// a Kubernetes client for cleanup polling.
-	cleanupFallbackWait = 10 * time.Second
 
 	// apiServiceDeregistrationTimeout is the maximum time to wait for the
 	// Kubernetes aggregated API service to deregister after Radius pods terminate.
@@ -105,89 +114,100 @@ const (
 	recentEventLimit = 30
 )
 
-// Test_PreflightContainer runs all preflight container upgrade tests as sequential
-// subtests. These tests cannot run in parallel because they share the same Helm
-// release name and Kubernetes namespace. Consolidating into subtests reduces the
-// number of full install/uninstall cycles (from 4 to 2) and eliminates redundant
-// test logic.
+// Test_PreflightContainer exercises the chart's pre-upgrade Helm hook.
+//
+// The hook only runs on helm upgrade, so installing Radius is setup cost rather than the
+// subject of the test. The parent installs once with the hook enabled, waits for the
+// control plane once, and uninstalls once; the subtests then run in sequence against
+// that single release, upgrading first with the hook enabled and then again with it
+// disabled. They share a Helm release name and a Kubernetes namespace and so must not
+// run in parallel.
 func Test_PreflightContainer(t *testing.T) {
-	t.Run("Enabled", testPreflightEnabled)
-	t.Run("Disabled", testPreflightDisabled)
+	ctx := t.Context()
+	image, tag := getPreUpgradeImage()
+
+	k8sClient, err := newKubernetesClient()
+	require.NoError(t, err, "Failed to create Kubernetes client")
+
+	cleanupAndWait(t, ctx, k8sClient)
+
+	t.Log("Installing Radius with preflight enabled and custom configuration")
+	require.NoError(t, helmInstall(ctx, image, tag, preflightEnabledValues()), "Failed to install Radius")
+
+	// t.Context is canceled before cleanup functions run, so the uninstall needs a
+	// context that outlives it.
+	t.Cleanup(func() { helmUninstall(t, context.WithoutCancel(ctx)) })
+
+	release := preflightRelease{options: waitForControlPlane(t, ctx, k8sClient), image: image, tag: tag}
+
+	// The subtests are given the parent's context rather than their own so the shared
+	// release outlives any single subtest.
+	t.Run("Enabled", func(t *testing.T) { testPreflightEnabled(t, ctx, release) })
+	t.Run("Disabled", func(t *testing.T) { testPreflightDisabled(t, ctx, release) })
+}
+
+// preflightRelease is the state the preflight subtests share: the single Helm release
+// they upgrade in sequence and the clients used to observe it.
+type preflightRelease struct {
+	options rp.RPTestOptions
+	image   string
+	tag     string
+}
+
+// preflightEnabledValues returns the Helm values that enable the pre-upgrade hook with
+// the Job configuration the Enabled subtest asserts on.
+func preflightEnabledValues() map[string]string {
+	return map[string]string{
+		"preupgrade.enabled":                 "true",
+		"preupgrade.ttlSecondsAfterFinished": strconv.Itoa(preflightJobTTLSeconds),
+		"preupgrade.checks.version":          "true",
+	}
 }
 
 // testPreflightEnabled verifies that when preflight is enabled:
 //   - The pre-upgrade Helm hook creates a job during upgrade
 //   - Custom job configuration (TTL, version check) is applied correctly
 //   - Job logs and status are accessible
-func testPreflightEnabled(t *testing.T) {
-	ctx := t.Context()
-	image, tag := getPreUpgradeImage()
-
-	cleanupAndWait(t, ctx)
-
-	helmValues := map[string]string{
-		"preupgrade.enabled":                 "true",
-		"preupgrade.ttlSecondsAfterFinished": "60",
-		"preupgrade.checks.version":          "true",
-	}
-
-	t.Log("Installing Radius with preflight enabled and custom configuration")
-	err := helmInstall(ctx, image, tag, helmValues)
-	require.NoError(t, err, "Failed to install Radius")
-
-	options := waitForControlPlane(t, ctx)
-
+func testPreflightEnabled(t *testing.T, ctx context.Context, release preflightRelease) {
 	t.Log("Upgrading to trigger pre-upgrade hook")
-	// Upgrade may fail due to version issues, but should trigger the Helm hook.
-	// The key assertion is that the job gets created.
-	_ = helmUpgrade(ctx, image, tag, helmValues)
+	// The upgrade itself is allowed to fail: the preflight checks may legitimately
+	// reject it. The assertion is that the hook created the job.
+	if err := helmUpgrade(ctx, release.image, release.tag, preflightEnabledValues()); err != nil {
+		t.Logf("Upgrade with preflight enabled failed, which is expected when the preflight checks reject it: %v", err)
+	}
 
 	t.Log("Verifying preflight job was created and configured correctly")
-	job := findPreflightJob(t, ctx, options)
-	if job != nil {
-		logJobDetails(t, ctx, options, job)
+	job := findPreflightJob(t, ctx, release.options)
+	require.NotNil(t, job, "Preflight job not found - upgrade likely failed before hooks triggered")
 
-		// Verify custom configuration was applied
-		require.NotNil(t, job.Spec.TTLSecondsAfterFinished, "TTLSecondsAfterFinished should be set")
-		require.Equal(t, int32(60), *job.Spec.TTLSecondsAfterFinished)
-		t.Log("Job configuration verified")
-	} else {
-		t.Fatal("Preflight job not found - upgrade likely failed before hooks triggered")
-	}
+	logJobDetails(t, ctx, release.options, job)
 
-	helmUninstall(t, ctx)
+	require.NotNil(t, job.Spec.TTLSecondsAfterFinished, "TTLSecondsAfterFinished should be set")
+	require.Equal(t, int32(preflightJobTTLSeconds), *job.Spec.TTLSecondsAfterFinished)
+	t.Log("Job configuration verified")
 }
 
-// testPreflightDisabled verifies that when preflight is disabled, the pre-upgrade
-// Helm hook does not create a job during upgrade.
-func testPreflightDisabled(t *testing.T) {
-	ctx := t.Context()
-	image, tag := getPreUpgradeImage()
-
-	cleanupAndWait(t, ctx)
-
-	helmValues := map[string]string{
-		"preupgrade.enabled": "false",
-	}
-
-	t.Log("Installing Radius with preflight disabled")
-	err := helmInstall(ctx, image, tag, helmValues)
-	require.NoError(t, err, "Failed to install Radius")
-
-	options := waitForControlPlane(t, ctx)
-
-	// Ensure no leftover job exists before upgrade
-	_ = options.K8sClient.BatchV1().Jobs(radiusNamespace).Delete(ctx, preUpgradeJobName, metav1.DeleteOptions{})
+// testPreflightDisabled verifies that upgrading with preflight disabled does not create a
+// pre-upgrade job.
+//
+// It upgrades the release the Enabled subtest left behind, so it first restores that
+// release to a state Helm will upgrade and removes the job from the previous subtest.
+func testPreflightDisabled(t *testing.T, ctx context.Context, release preflightRelease) {
+	requireDeployedRelease(t, ctx)
+	deletePreflightJob(t, ctx, release.options)
 
 	t.Log("Upgrading with preflight disabled")
-	_ = helmUpgrade(ctx, image, tag, helmValues)
+	// With the hook disabled there is no job to reject the upgrade, so it must succeed.
+	// Otherwise the assertion below would pass simply because no upgrade ran.
+	err := helmUpgrade(ctx, release.image, release.tag, map[string]string{"preupgrade.enabled": "false"})
+	require.NoError(t, err, "Upgrade with preflight disabled should succeed")
 
 	t.Log("Verifying no preflight job was created")
 	// Poll several times to confirm no job was created. The helm upgrade --wait
 	// flag ensures the upgrade is fully complete before returning, so if a job
 	// was going to be created it would exist by now. We poll briefly to be safe.
 	for i := range jobPollAttempts {
-		_, err = options.K8sClient.BatchV1().Jobs(radiusNamespace).Get(ctx, preUpgradeJobName, metav1.GetOptions{})
+		_, err := release.options.K8sClient.BatchV1().Jobs(radiusNamespace).Get(ctx, preUpgradeJobName, metav1.GetOptions{})
 		switch {
 		case apierrors.IsNotFound(err):
 			if i < jobPollAttempts-1 {
@@ -195,15 +215,76 @@ func testPreflightDisabled(t *testing.T) {
 			}
 			continue
 		case err == nil:
-			t.Error("Expected preflight job to not exist when disabled, but it was found")
-			return
+			t.Fatal("Expected preflight job to not exist when disabled, but it was found")
 		default:
 			t.Fatalf("Unexpected error checking for preflight job: %v", err)
 		}
 	}
 	t.Log("Preflight job correctly not created when disabled")
+}
 
-	helmUninstall(t, ctx)
+// requireDeployedRelease makes sure the Radius Helm release will accept another upgrade.
+//
+// The Enabled subtest tolerates a failed upgrade because the preflight checks may reject
+// it, which leaves the release in "failed" or, if Helm was interrupted partway, in
+// "pending-upgrade". Helm refuses to start a new operation on a pending release
+// ("another operation (install/upgrade/rollback) is in progress"), so recover by rolling
+// back to the last deployed revision rather than letting the next upgrade fail with that
+// error.
+func requireDeployedRelease(t *testing.T, ctx context.Context) {
+	t.Helper()
+
+	info, err := helmReleaseStatus(ctx)
+	require.NoError(t, err, "Failed to read the status of Helm release %q", helmReleaseName)
+	if info.Status == helmStatusDeployed {
+		return
+	}
+
+	t.Logf("Helm release %q is %q (%s); rolling back to the last deployed revision",
+		helmReleaseName, info.Status, info.Description)
+	err = runCommand(ctx, []string{
+		"helm", "rollback", helmReleaseName,
+		"--namespace", radiusNamespace,
+		"--wait",
+		"--timeout", helmTimeout,
+	})
+	require.NoError(t, err, "Failed to roll back Helm release %q from status %q (%s)",
+		helmReleaseName, info.Status, info.Description)
+
+	info, err = helmReleaseStatus(ctx)
+	require.NoError(t, err, "Failed to read the status of Helm release %q after rollback", helmReleaseName)
+	require.Equal(t, helmStatusDeployed, info.Status,
+		"Helm release %q is still not deployed after rollback: %s", helmReleaseName, info.Description)
+}
+
+// deletePreflightJob removes the pre-upgrade job left behind by the previous subtest and
+// blocks until the API server reports it gone.
+//
+// Helm does not remove the job itself: its helm.sh/hook-delete-policy is
+// before-hook-creation, which only deletes the job when a later upgrade recreates it, and
+// the upgrade with preflight disabled never renders one. Without this the assertion that
+// no job was created would observe the job from the enabled run.
+func deletePreflightJob(t *testing.T, ctx context.Context, options rp.RPTestOptions) {
+	t.Helper()
+	t.Log("Deleting the preflight job left by the previous subtest")
+
+	jobs := options.K8sClient.BatchV1().Jobs(radiusNamespace)
+	propagation := metav1.DeletePropagationForeground
+	err := jobs.Delete(ctx, preUpgradeJobName, metav1.DeleteOptions{PropagationPolicy: &propagation})
+	if !apierrors.IsNotFound(err) {
+		require.NoError(t, err, "Failed to delete job %s/%s", radiusNamespace, preUpgradeJobName)
+	}
+
+	require.Eventually(t, func() bool {
+		_, err := jobs.Get(ctx, preUpgradeJobName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+		if err != nil {
+			t.Logf("Warning: failed to get job %s/%s: %v", radiusNamespace, preUpgradeJobName, err)
+		}
+		return false
+	}, jobDeletionTimeout, jobPollInterval, "Job %s/%s was not deleted within timeout", radiusNamespace, preUpgradeJobName)
 }
 
 // Helper functions
@@ -217,7 +298,7 @@ func getPreUpgradeImage() (image string, tag string) {
 // helmInstall runs helm install with the given image, tag, and additional values.
 func helmInstall(ctx context.Context, image, tag string, values map[string]string) error {
 	args := []string{
-		"helm", "install", "radius", relativeChartPath,
+		"helm", "install", helmReleaseName, relativeChartPath,
 		"--namespace", radiusNamespace,
 		"--create-namespace",
 		"--set", fmt.Sprintf("preupgrade.image=%s", image),
@@ -232,13 +313,19 @@ func helmInstall(ctx context.Context, image, tag string, values map[string]strin
 }
 
 // helmUpgrade runs helm upgrade with the given image, tag, and additional values.
+//
+// --cleanup-on-fail is set because a caller may tolerate a failed upgrade and then
+// upgrade again: it removes resources the failed attempt created rather than leaving
+// them for the next attempt to reconcile. It does not remove the pre-upgrade job, which
+// Helm tracks as a hook rather than as a resource created from the release manifest.
 func helmUpgrade(ctx context.Context, image, tag string, values map[string]string) error {
 	args := []string{
-		"helm", "upgrade", "radius", relativeChartPath,
+		"helm", "upgrade", helmReleaseName, relativeChartPath,
 		"--namespace", radiusNamespace,
 		"--set", fmt.Sprintf("preupgrade.image=%s", image),
 		"--set", fmt.Sprintf("preupgrade.tag=%s", tag),
 		"--wait",
+		"--cleanup-on-fail",
 		"--timeout", helmTimeout,
 	}
 	for k, v := range values {
@@ -251,8 +338,36 @@ func helmUpgrade(ctx context.Context, image, tag string, values map[string]strin
 func helmUninstall(t *testing.T, ctx context.Context) {
 	t.Helper()
 	t.Log("Uninstalling Radius")
-	err := runCommand(ctx, []string{"helm", "uninstall", "radius", "--namespace", radiusNamespace})
+	err := runCommand(ctx, []string{"helm", "uninstall", helmReleaseName, "--namespace", radiusNamespace})
 	require.NoError(t, err, "Failed to uninstall Radius")
+}
+
+// helmReleaseInfo is the subset of "helm status --output json" this test reads.
+type helmReleaseInfo struct {
+	// Status is the Helm release status, for example "deployed", "failed" or
+	// "pending-upgrade".
+	Status string `json:"status"`
+
+	// Description is Helm's summary of the last operation and carries the reason a
+	// release failed.
+	Description string `json:"description"`
+}
+
+// helmReleaseStatus reports the current state of the Radius Helm release.
+func helmReleaseStatus(ctx context.Context) (helmReleaseInfo, error) {
+	output, err := exec.CommandContext(ctx, "helm", "status", helmReleaseName,
+		"--namespace", radiusNamespace, "--output", "json").CombinedOutput()
+	if err != nil {
+		return helmReleaseInfo{}, fmt.Errorf("helm status failed: %w, output: %s", err, string(output))
+	}
+
+	var release struct {
+		Info helmReleaseInfo `json:"info"`
+	}
+	if err := json.Unmarshal(output, &release); err != nil {
+		return helmReleaseInfo{}, fmt.Errorf("failed to decode helm status output %q: %w", string(output), err)
+	}
+	return release.Info, nil
 }
 
 // runCommand executes a shell command and returns an error if it fails.
@@ -281,11 +396,8 @@ func runCommand(ctx context.Context, args []string) error {
 // condition returns a value. The result was a single readiness attempt followed by an
 // idle wait for the full timeout. rp.NewRPTestOptions is therefore called exactly
 // once, on the test goroutine, after readiness has already succeeded.
-func waitForControlPlane(t *testing.T, ctx context.Context) rp.RPTestOptions {
+func waitForControlPlane(t *testing.T, ctx context.Context, k8sClient kubernetes.Interface) rp.RPTestOptions {
 	t.Helper()
-
-	k8sClient, err := newKubernetesClient()
-	require.NoError(t, err, "Failed to create Kubernetes client")
 
 	readyCtx, cancel := context.WithTimeout(ctx, controlPlaneTimeout)
 	defer cancel()
@@ -510,23 +622,16 @@ func optionalBool(value *bool) string {
 // Only Radius-owned pods (labeled app.kubernetes.io/part-of=radius) are monitored.
 // Contour is deployed as a separate Helm release in the same namespace and its pods
 // are expected to remain running.
-func cleanupAndWait(t *testing.T, ctx context.Context) {
+func cleanupAndWait(t *testing.T, ctx context.Context, k8sClient kubernetes.Interface) {
 	t.Helper()
 
 	t.Log("Cleaning up any existing Radius installation")
-	_ = exec.CommandContext(ctx, "helm", "uninstall", "radius",
+	_ = exec.CommandContext(ctx, "helm", "uninstall", helmReleaseName,
 		"--namespace", radiusNamespace, "--ignore-not-found", "--wait").Run()
 
 	// Wait for Radius pods to terminate. The Kubernetes aggregated API service needs
 	// time to deregister after pods are gone, so we must wait for Radius pods to be
 	// fully removed before starting a new install.
-	k8sClient, err := newKubernetesClient()
-	if err != nil {
-		t.Logf("Warning: could not create k8s client for cleanup wait: %v", err)
-		time.Sleep(cleanupFallbackWait)
-		return
-	}
-
 	require.Eventually(t, func() bool {
 		pods, err := k8sClient.CoreV1().Pods(radiusNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: radiusPodSelector,

--- a/test/functional-portable/upgrade/upgrade_test.go
+++ b/test/functional-portable/upgrade/upgrade_test.go
@@ -18,8 +18,12 @@ package upgrade_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -73,6 +78,31 @@ const (
 	// Contour is deployed as a separate Helm release in the same namespace and
 	// must be excluded from cleanup checks — its pods will remain running.
 	radiusPodSelector = "app.kubernetes.io/part-of=radius"
+
+	// ucpServiceName is the Service the kube-apiserver aggregation layer forwards
+	// api.ucp.dev requests to.
+	ucpServiceName = "ucp"
+
+	// ucpPodSelector and ucpContainerName identify the workload behind that Service.
+	ucpPodSelector   = "app.kubernetes.io/name=ucp"
+	ucpContainerName = "ucp"
+
+	// ucpAPIServicePath addresses the aggregated APIService object. It is fetched as
+	// raw JSON because k8s.io/kube-aggregator is not a dependency of this module.
+	ucpAPIServiceName = "v1alpha3.api.ucp.dev"
+	ucpAPIServicePath = "/apis/apiregistration.k8s.io/v1/apiservices/" + ucpAPIServiceName
+
+	// controlPlaneDiagnosticsTimeout bounds the diagnostics dump emitted when
+	// readiness times out, so a wedged API server cannot hang the test run.
+	controlPlaneDiagnosticsTimeout = 30 * time.Second
+
+	// ucpLogTailLines is how many lines of UCP container logs to include in the
+	// readiness failure diagnostics.
+	ucpLogTailLines = 100
+
+	// recentEventLimit is how many of the most recent namespace events to include in
+	// the readiness failure diagnostics.
+	recentEventLimit = 30
 )
 
 // Test_PreflightContainer runs all preflight container upgrade tests as sequential
@@ -235,25 +265,241 @@ func runCommand(ctx context.Context, args []string) error {
 	return nil
 }
 
-// waitForControlPlane polls until the Radius control plane API is reachable.
-// It treats transient errors (including 503 from the aggregated APIService) as
-// retryable and keeps polling until the timeout expires.
+// waitForControlPlane blocks until the Radius aggregated API is serving, then builds
+// the test options.
+//
+// A transient 503 immediately after install is normal and unavoidable: the APIService
+// Available condition is owned by the kube-apiserver aggregator, which re-checks the
+// backend on its own schedule and can keep returning a stale unavailable result for
+// several seconds after the UCP pod is Ready and serving.
+//
+// Readiness is polled with an error-returning probe rather than by calling
+// rp.NewRPTestOptions in a retry callback. NewRPTestOptions asserts with require.*,
+// which calls t.FailNow and therefore runtime.Goexit. Goexit is not a panic, so
+// recover() cannot see it; a condition goroutine that exits that way never reports
+// back to testify's Eventually loop, which only re-arms its retry ticker when the
+// condition returns a value. The result was a single readiness attempt followed by an
+// idle wait for the full timeout. rp.NewRPTestOptions is therefore called exactly
+// once, on the test goroutine, after readiness has already succeeded.
 func waitForControlPlane(t *testing.T, ctx context.Context) rp.RPTestOptions {
 	t.Helper()
-	var options rp.RPTestOptions
-	require.Eventually(t, func() bool {
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					// NewRPTestOptions calls require.NoError internally, catch panics
-					t.Logf("Control plane not ready yet: %v", r)
-				}
-			}()
-			options = rp.NewRPTestOptions(t)
-		}()
-		return options.ManagementClient != nil
-	}, controlPlaneTimeout, controlPlanePollInterval, "Control plane did not become available within timeout")
-	return options
+
+	k8sClient, err := newKubernetesClient()
+	require.NoError(t, err, "Failed to create Kubernetes client")
+
+	readyCtx, cancel := context.WithTimeout(ctx, controlPlaneTimeout)
+	defer cancel()
+
+	if err := testutil.WaitForControlPlaneReady(readyCtx, t, k8sClient.Discovery().RESTClient(), controlPlanePollInterval); err != nil {
+		logControlPlaneDiagnostics(t, ctx, k8sClient)
+		require.NoError(t, err, "Control plane did not become available within timeout")
+	}
+
+	return rp.NewRPTestOptions(t)
+}
+
+// newKubernetesClient builds a Kubernetes client from the ambient kubeconfig.
+func newKubernetesClient() (*kubernetes.Clientset, error) {
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(), nil).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+	return kubernetes.NewForConfig(config)
+}
+
+// logControlPlaneDiagnostics dumps the state of the Radius aggregated API and the UCP
+// workload behind it, so a readiness timeout can be diagnosed from the CI log without
+// a rerun.
+//
+// It runs on a context detached from ctx because the usual reason for calling it is an
+// expired deadline, which would otherwise cancel every diagnostic request.
+func logControlPlaneDiagnostics(t *testing.T, ctx context.Context, k8sClient kubernetes.Interface) {
+	t.Helper()
+	t.Log("Control plane readiness diagnostics")
+
+	diagnosticsCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), controlPlaneDiagnosticsTimeout)
+	defer cancel()
+
+	logAPIServiceConditions(t, diagnosticsCtx, k8sClient)
+	logUCPService(t, diagnosticsCtx, k8sClient)
+	logUCPPods(t, diagnosticsCtx, k8sClient)
+	logRecentEvents(t, diagnosticsCtx, k8sClient)
+}
+
+// logAPIServiceConditions reports the aggregator's own view of the Radius APIService.
+// This distinguishes "the aggregator never contacted UCP" from "UCP answered badly".
+func logAPIServiceConditions(t *testing.T, ctx context.Context, k8sClient kubernetes.Interface) {
+	t.Helper()
+
+	raw, err := k8sClient.Discovery().RESTClient().Get().AbsPath(ucpAPIServicePath).DoRaw(ctx)
+	if err != nil {
+		t.Logf("failed to get APIService %s: %v", ucpAPIServiceName, err)
+		return
+	}
+
+	var apiService struct {
+		Status struct {
+			Conditions []struct {
+				Type    string `json:"type"`
+				Status  string `json:"status"`
+				Reason  string `json:"reason"`
+				Message string `json:"message"`
+			} `json:"conditions"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(raw, &apiService); err != nil {
+		t.Logf("failed to decode APIService %s (raw: %s): %v", ucpAPIServiceName, string(raw), err)
+		return
+	}
+
+	if len(apiService.Status.Conditions) == 0 {
+		t.Logf("APIService %s reports no status conditions", ucpAPIServiceName)
+		return
+	}
+	for _, condition := range apiService.Status.Conditions {
+		t.Logf("APIService %s condition %s=%s reason=%s message=%s",
+			ucpAPIServiceName, condition.Type, condition.Status, condition.Reason, condition.Message)
+	}
+}
+
+// logUCPService reports the Service the aggregator routes through and its
+// EndpointSlices, which show whether a Ready backend was actually registered.
+func logUCPService(t *testing.T, ctx context.Context, k8sClient kubernetes.Interface) {
+	t.Helper()
+
+	service, err := k8sClient.CoreV1().Services(radiusNamespace).Get(ctx, ucpServiceName, metav1.GetOptions{})
+	if err != nil {
+		t.Logf("failed to get Service %s/%s: %v", radiusNamespace, ucpServiceName, err)
+	} else {
+		ports := make([]string, 0, len(service.Spec.Ports))
+		for _, port := range service.Spec.Ports {
+			ports = append(ports, fmt.Sprintf("%s:%d->%s/%s", port.Name, port.Port, port.TargetPort.String(), port.Protocol))
+		}
+		t.Logf("Service %s/%s: clusterIP=%s ports=%s selector=%v",
+			service.Namespace, service.Name, service.Spec.ClusterIP, strings.Join(ports, ","), service.Spec.Selector)
+	}
+
+	endpointSlices, err := k8sClient.DiscoveryV1().EndpointSlices(radiusNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: discoveryv1.LabelServiceName + "=" + ucpServiceName,
+	})
+	if err != nil {
+		t.Logf("failed to list EndpointSlices for Service %s/%s: %v", radiusNamespace, ucpServiceName, err)
+		return
+	}
+	if len(endpointSlices.Items) == 0 {
+		t.Logf("Service %s/%s has no EndpointSlices", radiusNamespace, ucpServiceName)
+		return
+	}
+
+	for _, endpointSlice := range endpointSlices.Items {
+		endpoints := make([]string, 0, len(endpointSlice.Endpoints))
+		for _, endpoint := range endpointSlice.Endpoints {
+			endpoints = append(endpoints, fmt.Sprintf("%s ready=%s serving=%s terminating=%s",
+				strings.Join(endpoint.Addresses, ","),
+				optionalBool(endpoint.Conditions.Ready),
+				optionalBool(endpoint.Conditions.Serving),
+				optionalBool(endpoint.Conditions.Terminating)))
+		}
+		t.Logf("EndpointSlice %s/%s: endpoints=[%s]", endpointSlice.Namespace, endpointSlice.Name, strings.Join(endpoints, "; "))
+	}
+}
+
+// logUCPPods reports pod and container status plus recent UCP logs.
+func logUCPPods(t *testing.T, ctx context.Context, k8sClient kubernetes.Interface) {
+	t.Helper()
+
+	pods, err := k8sClient.CoreV1().Pods(radiusNamespace).List(ctx, metav1.ListOptions{LabelSelector: ucpPodSelector})
+	if err != nil {
+		t.Logf("failed to list pods matching %q in %s: %v", ucpPodSelector, radiusNamespace, err)
+		return
+	}
+	if len(pods.Items) == 0 {
+		t.Logf("no pods matching %q in %s", ucpPodSelector, radiusNamespace)
+		return
+	}
+
+	tailLines := int64(ucpLogTailLines)
+	for _, pod := range pods.Items {
+		t.Logf("Pod %s/%s: phase=%s podIP=%s", pod.Namespace, pod.Name, pod.Status.Phase, pod.Status.PodIP)
+		for _, condition := range pod.Status.Conditions {
+			t.Logf("  condition %s=%s reason=%s message=%s", condition.Type, condition.Status, condition.Reason, condition.Message)
+		}
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			t.Logf("  container %s: ready=%t restarts=%d state=%s",
+				containerStatus.Name, containerStatus.Ready, containerStatus.RestartCount, containerState(containerStatus.State))
+		}
+
+		logs, err := k8sClient.CoreV1().Pods(pod.Namespace).
+			GetLogs(pod.Name, &corev1.PodLogOptions{Container: ucpContainerName, TailLines: &tailLines}).
+			DoRaw(ctx)
+		if err != nil {
+			t.Logf("  failed to get logs for %s/%s: %v", pod.Namespace, pod.Name, err)
+			continue
+		}
+		t.Logf("  last %d log lines for %s/%s:\n%s", ucpLogTailLines, pod.Namespace, pod.Name, string(logs))
+	}
+}
+
+// logRecentEvents reports the most recent events in the Radius namespace.
+func logRecentEvents(t *testing.T, ctx context.Context, k8sClient kubernetes.Interface) {
+	t.Helper()
+
+	events, err := k8sClient.CoreV1().Events(radiusNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Logf("failed to list events in %s: %v", radiusNamespace, err)
+		return
+	}
+	if len(events.Items) == 0 {
+		t.Logf("no events in %s", radiusNamespace)
+		return
+	}
+
+	items := events.Items
+	sort.Slice(items, func(i, j int) bool { return eventTime(items[i]).Before(eventTime(items[j])) })
+	if len(items) > recentEventLimit {
+		items = items[len(items)-recentEventLimit:]
+	}
+
+	for _, event := range items {
+		t.Logf("Event %s %s/%s: type=%s reason=%s message=%s",
+			eventTime(event).Format(time.RFC3339), event.InvolvedObject.Kind, event.InvolvedObject.Name,
+			event.Type, event.Reason, event.Message)
+	}
+}
+
+// eventTime returns the most meaningful timestamp available on an event. Events written
+// through the newer events.k8s.io API leave LastTimestamp empty.
+func eventTime(event corev1.Event) time.Time {
+	switch {
+	case !event.LastTimestamp.IsZero():
+		return event.LastTimestamp.Time
+	case !event.EventTime.IsZero():
+		return event.EventTime.Time
+	default:
+		return event.CreationTimestamp.Time
+	}
+}
+
+func containerState(state corev1.ContainerState) string {
+	switch {
+	case state.Running != nil:
+		return fmt.Sprintf("running since %s", state.Running.StartedAt.Format(time.RFC3339))
+	case state.Waiting != nil:
+		return fmt.Sprintf("waiting reason=%s message=%s", state.Waiting.Reason, state.Waiting.Message)
+	case state.Terminated != nil:
+		return fmt.Sprintf("terminated reason=%s exitCode=%d message=%s",
+			state.Terminated.Reason, state.Terminated.ExitCode, state.Terminated.Message)
+	default:
+		return "unknown"
+	}
+}
+
+func optionalBool(value *bool) string {
+	if value == nil {
+		return "unknown"
+	}
+	return strconv.FormatBool(*value)
 }
 
 // cleanupAndWait uninstalls the Radius Helm release and waits for all Radius pods in
@@ -274,15 +520,7 @@ func cleanupAndWait(t *testing.T, ctx context.Context) {
 	// Wait for Radius pods to terminate. The Kubernetes aggregated API service needs
 	// time to deregister after pods are gone, so we must wait for Radius pods to be
 	// fully removed before starting a new install.
-	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(), nil).ClientConfig()
-	if err != nil {
-		t.Logf("Warning: could not create k8s client for cleanup wait: %v", err)
-		time.Sleep(cleanupFallbackWait)
-		return
-	}
-
-	k8sClient, err := kubernetes.NewForConfig(config)
+	k8sClient, err := newKubernetesClient()
 	if err != nil {
 		t.Logf("Warning: could not create k8s client for cleanup wait: %v", err)
 		time.Sleep(cleanupFallbackWait)

--- a/test/functional-portable/upgrade/upgrade_test.go
+++ b/test/functional-portable/upgrade/upgrade_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package upgrade_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -354,18 +355,28 @@ type helmReleaseInfo struct {
 }
 
 // helmReleaseStatus reports the current state of the Radius Helm release.
+//
+// Only stdout is parsed. Helm writes diagnostics such as the insecure kubeconfig
+// permissions warning to stderr, and mixing those into the JSON would make a successful
+// "helm status --output json" undecodable.
 func helmReleaseStatus(ctx context.Context) (helmReleaseInfo, error) {
-	output, err := exec.CommandContext(ctx, "helm", "status", helmReleaseName,
-		"--namespace", radiusNamespace, "--output", "json").CombinedOutput()
+	cmd := exec.CommandContext(ctx, "helm", "status", helmReleaseName,
+		"--namespace", radiusNamespace, "--output", "json")
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	stdout, err := cmd.Output()
 	if err != nil {
-		return helmReleaseInfo{}, fmt.Errorf("helm status failed: %w, output: %s", err, string(output))
+		return helmReleaseInfo{}, fmt.Errorf("helm status failed: %w, stderr: %s", err, stderr.String())
 	}
 
 	var release struct {
 		Info helmReleaseInfo `json:"info"`
 	}
-	if err := json.Unmarshal(output, &release); err != nil {
-		return helmReleaseInfo{}, fmt.Errorf("failed to decode helm status output %q: %w", string(output), err)
+	if err := json.Unmarshal(stdout, &release); err != nil {
+		return helmReleaseInfo{}, fmt.Errorf("failed to decode helm status output %q (stderr: %s): %w",
+			string(stdout), stderr.String(), err)
 	}
 	return release.Info, nil
 }

--- a/test/step/controlplane.go
+++ b/test/step/controlplane.go
@@ -18,32 +18,16 @@ package step
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
+	"github.com/radius-project/radius/test/testutil"
 	k8s "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
-const (
-	// controlPlaneReadyPollInterval is how long to wait between readiness
-	// probes while the control plane is recovering.
-	controlPlaneReadyPollInterval = 5 * time.Second
-
-	// controlPlaneProbeTimeout bounds a single readiness probe so a hung
-	// kube-apiserver cannot consume the caller's entire retry budget in one
-	// request.
-	controlPlaneProbeTimeout = 10 * time.Second
-
-	// radiusAggregatedAPIPath is the aggregated API discovery path that rad
-	// itself requests when it opens a workspace connection (see
-	// pkg/cli/workspaces.Connection). Probing it exercises the whole chain a
-	// deployment depends on: the kube-apiserver, its aggregation layer, and the
-	// UCP APIService behind it. A healthy response here implies the
-	// kube-apiserver is serving, so no separate /readyz probe is needed.
-	radiusAggregatedAPIPath = "/apis/api.ucp.dev/v1alpha3"
-)
+// controlPlaneReadyPollInterval is how long to wait between readiness probes
+// while the control plane is recovering.
+const controlPlaneReadyPollInterval = 5 * time.Second
 
 // newControlPlaneReadyWaiter returns a function that blocks until the Radius
 // aggregated API is serving again, or until ctx is done.
@@ -67,35 +51,6 @@ func newControlPlaneReadyWaiter(t *testing.T, client k8s.Interface) func(context
 	}
 
 	return func(ctx context.Context) error {
-		return waitForControlPlaneReady(ctx, t, restClient, controlPlaneReadyPollInterval)
+		return testutil.WaitForControlPlaneReady(ctx, t, restClient, controlPlaneReadyPollInterval)
 	}
-}
-
-// waitForControlPlaneReady polls until the control plane is ready or ctx is
-// done. The error returned on timeout includes the last probe failure so the
-// test log records what was still unavailable.
-func waitForControlPlaneReady(ctx context.Context, t *testing.T, client rest.Interface, pollInterval time.Duration) error {
-	for {
-		lastErr := probe(ctx, client, radiusAggregatedAPIPath)
-		if lastErr == nil {
-			return nil
-		}
-
-		t.Logf("waiting for the Radius control plane to become ready: %v", lastErr)
-
-		timer := time.NewTimer(pollInterval)
-		select {
-		case <-timer.C:
-		case <-ctx.Done():
-			timer.Stop()
-			return fmt.Errorf("control plane did not become ready: %w (last probe failure: %v)", ctx.Err(), lastErr)
-		}
-	}
-}
-
-func probe(ctx context.Context, client rest.Interface, path string) error {
-	probeCtx, cancel := context.WithTimeout(ctx, controlPlaneProbeTimeout)
-	defer cancel()
-
-	return client.Get().AbsPath(path).Do(probeCtx).Error()
 }

--- a/test/step/controlplane_test.go
+++ b/test/step/controlplane_test.go
@@ -21,19 +21,23 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/radius-project/radius/test/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
-// newTestRESTClient returns a REST client pointed at a test HTTP server that
-// serves the given handler.
-func newTestRESTClient(t *testing.T, handler http.Handler) rest.Interface {
+// The polling, timeout, and last-failure reporting behavior of the readiness gate is
+// covered by testutil.WaitForControlPlaneReady's own tests. These tests cover the
+// wiring in this package: which client the gate probes and when it is disabled.
+
+// newTestKubernetesClient returns a Kubernetes client pointed at a test HTTP server
+// that serves the given handler.
+func newTestKubernetesClient(t *testing.T, handler http.Handler) kubernetes.Interface {
 	t.Helper()
 
 	server := httptest.NewServer(handler)
@@ -42,60 +46,51 @@ func newTestRESTClient(t *testing.T, handler http.Handler) rest.Interface {
 	client, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
 	require.NoError(t, err)
 
-	return client.Discovery().RESTClient()
+	return client
 }
 
-func Test_WaitForControlPlaneReady_ReturnsWhenAggregatedAPIServes(t *testing.T) {
+func Test_NewControlPlaneReadyWaiter_ProbesAggregatedAPI(t *testing.T) {
 	t.Parallel()
 	var mu sync.Mutex
 	var paths []string
-	client := newTestRESTClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := newTestKubernetesClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		paths = append(paths, r.URL.Path)
 		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	require.NoError(t, waitForControlPlaneReady(t.Context(), t, client, time.Millisecond))
+	waiter := newControlPlaneReadyWaiter(t, client)
+	require.NotNil(t, waiter)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	require.NoError(t, waiter(ctx))
 
 	// A single probe of the aggregated path is enough: it cannot succeed unless
 	// the kube-apiserver and its aggregation layer are both serving.
 	mu.Lock()
 	defer mu.Unlock()
-	assert.Equal(t, []string{radiusAggregatedAPIPath}, paths)
+	assert.Equal(t, []string{testutil.RadiusAggregatedAPIPath}, paths)
 }
 
-func Test_WaitForControlPlaneReady_PollsUntilHealthy(t *testing.T) {
+func Test_NewControlPlaneReadyWaiter_ReturnsErrorWhenAggregatedAPIStaysUnavailable(t *testing.T) {
 	t.Parallel()
-	var requests atomic.Int32
-	// The kube-apiserver can be up while the UCP APIService behind the
-	// aggregation layer is still unavailable, which surfaces as a 503. The gate
-	// must keep polling rather than let a retry proceed in that window.
-	client := newTestRESTClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if requests.Add(1) < 3 {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
+	// The kube-apiserver can be up while the UCP APIService behind the aggregation
+	// layer is still unavailable, which surfaces as a 503. The gate must report that
+	// as an error rather than let a retry proceed.
+	client := newTestKubernetesClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
-
-	require.NoError(t, waitForControlPlaneReady(ctx, t, client, time.Millisecond))
-	assert.Equal(t, int32(3), requests.Load())
-}
-
-func Test_WaitForControlPlaneReady_ReportsLastProbeFailureOnTimeout(t *testing.T) {
-	t.Parallel()
-	client := newTestRESTClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
+	waiter := newControlPlaneReadyWaiter(t, client)
+	require.NotNil(t, waiter)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
 	defer cancel()
 
-	err := waitForControlPlaneReady(ctx, t, client, time.Millisecond)
+	err := waiter(ctx)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.Contains(t, err.Error(), "last probe failure")

--- a/test/testutil/controlplane.go
+++ b/test/testutil/controlplane.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/rest"
+)
+
+const (
+	// RadiusAggregatedAPIPath is the aggregated API discovery path that rad itself
+	// requests when it opens a workspace connection (see pkg/cli/workspaces.Connection).
+	// Probing it exercises the whole chain a deployment depends on: the kube-apiserver,
+	// its aggregation layer, and the UCP APIService behind it. A healthy response here
+	// implies the kube-apiserver is serving, so no separate /readyz probe is needed.
+	RadiusAggregatedAPIPath = "/apis/api.ucp.dev/v1alpha3"
+
+	// ControlPlaneProbeTimeout bounds a single readiness probe so a hung kube-apiserver
+	// cannot consume the caller's entire retry budget in one request.
+	ControlPlaneProbeTimeout = 10 * time.Second
+)
+
+// WaitForControlPlaneReady polls until the Radius aggregated API is serving, or until
+// ctx is done. The error returned on timeout includes the last probe failure so the
+// test log records what was still unavailable.
+//
+// A transient 503 right after install is normal: the APIService Available condition is
+// owned by the kube-apiserver aggregator, which re-checks the backend on its own
+// schedule and can keep reporting a stale unavailable result for several seconds after
+// UCP is Ready and serving. Callers must treat that window as retryable.
+//
+// This reports readiness by returning an error rather than by asserting, so it is safe
+// to call from any goroutine. Do not reintroduce require.* assertions here or in a
+// caller's polling callback: require.* calls t.FailNow, which calls runtime.Goexit.
+// Goexit is not a panic, so recover() cannot observe it, and a goroutine that exits
+// that way never reports back to testify's Eventually loop — which then re-arms its
+// ticker never, makes exactly one attempt, and blocks until its timeout expires.
+func WaitForControlPlaneReady(ctx context.Context, t *testing.T, client rest.Interface, pollInterval time.Duration) error {
+	for {
+		lastErr := ProbeControlPlane(ctx, client)
+		if lastErr == nil {
+			return nil
+		}
+
+		t.Logf("waiting for the Radius control plane to become ready: %v", lastErr)
+
+		timer := time.NewTimer(pollInterval)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("control plane did not become ready: %w (last probe failure: %v)", ctx.Err(), lastErr)
+		}
+	}
+}
+
+// ProbeControlPlane issues a single bounded request against the Radius aggregated API
+// discovery path and reports whether it is serving.
+func ProbeControlPlane(ctx context.Context, client rest.Interface) error {
+	probeCtx, cancel := context.WithTimeout(ctx, ControlPlaneProbeTimeout)
+	defer cancel()
+
+	return client.Get().AbsPath(RadiusAggregatedAPIPath).Do(probeCtx).Error()
+}

--- a/test/testutil/controlplane_test.go
+++ b/test/testutil/controlplane_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// newTestRESTClient returns a REST client pointed at a test HTTP server that
+// serves the given handler.
+func newTestRESTClient(t *testing.T, handler http.Handler) rest.Interface {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	require.NoError(t, err)
+
+	return client.Discovery().RESTClient()
+}
+
+func Test_WaitForControlPlaneReady_ReturnsWhenAggregatedAPIServes(t *testing.T) {
+	t.Parallel()
+	var mu sync.Mutex
+	var paths []string
+	client := newTestRESTClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	require.NoError(t, WaitForControlPlaneReady(t.Context(), t, client, time.Millisecond))
+
+	// A single probe of the aggregated path is enough: it cannot succeed unless
+	// the kube-apiserver and its aggregation layer are both serving.
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{RadiusAggregatedAPIPath}, paths)
+}
+
+func Test_WaitForControlPlaneReady_PollsUntilHealthy(t *testing.T) {
+	t.Parallel()
+	var requests atomic.Int32
+	// The kube-apiserver can be up while the UCP APIService behind the
+	// aggregation layer is still unavailable, which surfaces as a 503. The gate
+	// must keep polling rather than let a caller proceed in that window.
+	client := newTestRESTClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	require.NoError(t, WaitForControlPlaneReady(ctx, t, client, time.Millisecond))
+	assert.Equal(t, int32(3), requests.Load())
+}
+
+func Test_WaitForControlPlaneReady_ReportsLastProbeFailureOnTimeout(t *testing.T) {
+	t.Parallel()
+	client := newTestRESTClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	err := WaitForControlPlaneReady(ctx, t, client, time.Millisecond)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Contains(t, err.Error(), "last probe failure")
+}
+
+// Test_WaitForControlPlaneReady_DoesNotGoexit guards the property that makes this
+// helper safe to call from a polling goroutine: it must report failure by returning
+// an error, never by calling t.FailNow (directly or through require.*). A helper that
+// exits via runtime.Goexit silently kills its caller's goroutine, which is what broke
+// the upgrade test's readiness retry loop.
+func Test_WaitForControlPlaneReady_DoesNotGoexit(t *testing.T) {
+	t.Parallel()
+	client := newTestRESTClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+
+	returned := make(chan error, 1)
+	go func() {
+		// A Goexit would skip this send and leave the channel empty forever.
+		defer close(returned)
+		err := WaitForControlPlaneReady(ctx, t, client, time.Millisecond)
+		returned <- err
+	}()
+
+	select {
+	case err, ok := <-returned:
+		require.True(t, ok, "helper exited via runtime.Goexit instead of returning")
+		require.Error(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("helper never returned")
+	}
+}


### PR DESCRIPTION
# Description

Third and final PR of the stack fixing the flaky `upgrade-noncloud` functional test ([#11841](https://github.com/radius-project/radius/issues/11841)). PR 1 added a readiness probe to the UCP deployment; PR 2 made the test's control-plane readiness check actually retry. This PR removes the remaining cost and state hazards in `Test_PreflightContainer`.

`Test_PreflightContainer` ran two subtests, `Enabled` and `Disabled`, and each performed a full `helm uninstall` + `helm install` + `helm upgrade` + `helm uninstall` cycle. The pre-upgrade Helm hook only runs on `helm upgrade`, so the second install was pure setup cost for a test whose subject is the hook.

The parent now installs Radius once with preflight enabled, waits for the control plane once, shares the image, tag, and `rp.RPTestOptions` with the two sequential subtests, and uninstalls once from `t.Cleanup`. The subtests remain sequential and non-parallel because they share a Helm release and a namespace.

Chaining two upgrades against one release means the state between them has to be handled explicitly rather than assumed:

- **Release status.** `helm upgrade` now passes `--cleanup-on-fail`, and the disabled subtest checks `helm status radius -n radius-system -o json` before upgrading. The enabled scenario deliberately tolerates a failed upgrade because the preflight checks may reject it, which leaves the release `failed` or, if Helm was interrupted partway, `pending-upgrade`. Recovery is a rollback to the last deployed revision followed by a re-check, instead of letting the next `helm upgrade` fail with an opaque "another operation (install/upgrade/rollback) is in progress".
- **Job cleanup.** The `pre-upgrade` Job from the enabled run is deleted before the disabled upgrade, tolerating `NotFound`, surfacing any other error, and polling until a `Get` returns `NotFound`. Helm does not remove the Job itself: its `helm.sh/hook-delete-policy` is `before-hook-creation`, which only deletes it when a later upgrade recreates one, and the disabled upgrade never renders it. I confirmed on a live cluster that the Job survives both the failed upgrade (`--cleanup-on-fail` does not touch it, because Helm tracks hooks separately from resources created off the release manifest) and the rollback.
- **The disabled upgrade must now succeed.** It was previously discarded with `_ = helmUpgrade(...)`, so "no Job was created" passed vacuously whenever the upgrade never ran. With preflight disabled there is no hook to reject the upgrade, so it is now required to succeed, and `runCommand` already carries the Helm output into the failure message.

`cleanupFallbackWait` is removed. `cleanupAndWait` and `waitForControlPlane` now take the Kubernetes client the parent already builds, so there is no longer a path where the client is unavailable and the code has to fall back to a fixed sleep. The diagnostics and readiness helpers added in PR 2 are unchanged.

## Coverage change

This changes what `Disabled` verifies: previously "fresh install with the hook disabled, then upgrade", now "upgrade from enabled to disabled". That is a better test, because it exercises the supported transition of the `preupgrade.enabled` value rather than a value that was never anything else, but it is a real change in what is covered and worth calling out.

Reinstall coverage is not lost repo-wide. `test/functional-portable/statestore/noncloud/statestore_lifecycle_test.go` exists specifically to exercise install, uninstall with `--purge`, and reinstall, and runs as its own CI leg (`statestore-noncloud`, which the shared "Install Radius" step deliberately skips).

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (#11841).

Fixes: part of #11841

## Validation

`gofmt`, `go vet ./test/functional-portable/upgrade/...`, and `go build ./test/...` are clean.

`Test_PreflightContainer` was run against a local kind cluster primed the same way CI primes it: Radius installed by a preceding `helm install`, a `rad workspace` pointed at the cluster, and the default public `ghcr.io/radius-project` images. The "before" row is the same test on this PR's base branch, on the same cluster, so the difference reflects the restructure alone rather than a faster machine or a warmer image cache. The three "after" rows are repeats of the same test, included to show the result is stable rather than one lucky run.

| Run | Total | `Enabled` | `Disabled` |
| --- | --- | --- | --- |
| Before (base branch) | 136.18s | 35.42s | 100.76s |
| After, run 1 | 60.75s | 10.68s | 24.22s |
| After, run 2 | 61.82s | 10.62s | 24.22s |
| After, run 3 | 52.10s | 9.60s | 23.35s |

The roughly 75 seconds saved is the second install and its control-plane wait. `Disabled` drops the most because it no longer uninstalls, reinstalls, and waits for the aggregated API to come back before it can upgrade.

Both subtests passed on all three runs. In every run the preflight version check rejected the upgrade (`invalid current version format` against the `edge` app version), so the release genuinely reached `failed` and the rollback recovery path ran each time rather than being untested code.