### PR TITLE
fix: improve Radius CLI installer error output

### DIFF
--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -140,10 +140,12 @@ jobs:
           persist-credentials: false
 
       - name: Install Radius CLI from official release
+        # bash runs with -eo pipefail, so a failure fetching the installer
+        # fails the step instead of being masked by the pipe.
+        shell: bash
         run: |
           # Install the latest Radius CLI, including release candidates if available.
           # INSTALL_DIR places rad directly into the workspace bin directory — no copy needed.
-          set -o pipefail
           mkdir -p "$GITHUB_WORKSPACE/bin"
           wget --no-verbose "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" -O - | INSTALL_DIR="$GITHUB_WORKSPACE/bin" INCLUDE_RC=true /bin/bash
 

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -140,11 +140,12 @@ jobs:
           persist-credentials: false
 
       - name: Install Radius CLI from official release
+        shell: bash
         run: |
           # Install the latest Radius CLI, including release candidates if available.
           # INSTALL_DIR places rad directly into the workspace bin directory — no copy needed.
           mkdir -p "$GITHUB_WORKSPACE/bin"
-          wget -q "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" -O - | INSTALL_DIR="$GITHUB_WORKSPACE/bin" INCLUDE_RC=true /bin/bash
+          wget --no-verbose "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" -O - | INSTALL_DIR="$GITHUB_WORKSPACE/bin" INCLUDE_RC=true /bin/bash
 
       - name: Verify CLI installation
         run: |

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -143,8 +143,9 @@ jobs:
         run: |
           # Install the latest Radius CLI, including release candidates if available.
           # INSTALL_DIR places rad directly into the workspace bin directory — no copy needed.
+          set -o pipefail
           mkdir -p "$GITHUB_WORKSPACE/bin"
-          wget -q "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" -O - | INSTALL_DIR="$GITHUB_WORKSPACE/bin" INCLUDE_RC=true /bin/bash
+          wget --no-verbose "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" -O - | INSTALL_DIR="$GITHUB_WORKSPACE/bin" INCLUDE_RC=true /bin/bash
 
       - name: Verify CLI installation
         run: |

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -140,14 +140,11 @@ jobs:
           persist-credentials: false
 
       - name: Install Radius CLI from official release
-        # bash runs with -eo pipefail, so a failure fetching the installer
-        # fails the step instead of being masked by the pipe.
-        shell: bash
         run: |
           # Install the latest Radius CLI, including release candidates if available.
           # INSTALL_DIR places rad directly into the workspace bin directory — no copy needed.
           mkdir -p "$GITHUB_WORKSPACE/bin"
-          wget --no-verbose "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" -O - | INSTALL_DIR="$GITHUB_WORKSPACE/bin" INCLUDE_RC=true /bin/bash
+          wget -q "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" -O - | INSTALL_DIR="$GITHUB_WORKSPACE/bin" INCLUDE_RC=true /bin/bash
 
       - name: Verify CLI installation
         run: |

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -256,69 +256,35 @@ warnExistingRadiusElsewhere() {
     echo "============================================================================"
 }
 
-# Fetch the releases payload and write it to stdout. On failure the HTTP status
-# and response body are reported, because the body carries the actionable
-# message for conditions such as API rate limiting.
-fetchReleases() {
-    local url="$1"
-
-    if [[ "${RADIUS_HTTP_REQUEST_CLI}" != "curl" ]]; then
-        # wget discards the error body, but writes its diagnostics to stderr,
-        # which the caller's command substitution does not capture.
-        local wget_body=""
-        if ! wget_body=$(wget --no-verbose \
-            --header="Accept: application/json" -O - "${url}"); then
-            echo "Error: request to ${url} failed" >&2
-            return 1
-        fi
-        printf '%s\n' "${wget_body}"
-        return 0
-    fi
-
-    # --write-out appends the status code so the body is preserved for
-    # diagnostics, which --fail would discard.
-    local response=""
-    if ! response=$(curl --show-error --silent --location \
-        --write-out '\n%{http_code}' "${url}"); then
-        echo "Error: request to ${url} failed" >&2
-        return 1
-    fi
-
-    local http_code="${response##*$'\n'}"
-    local body="${response%$'\n'*}"
-
-    if [[ "${http_code}" != 2* ]]; then
-        echo "Error: ${url} returned HTTP ${http_code}" >&2
-        echo "${body}" >&2
-        return 1
-    fi
-
-    printf '%s\n' "${body}"
-}
-
 getLatestRelease() {
     local radReleaseUrl="https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases"
-    local releases=""
+    local response=""
     local latest_release=""
 
-    if ! releases=$(fetchReleases "${radReleaseUrl}"); then
-        exit 1
+    if [[ "${RADIUS_HTTP_REQUEST_CLI}" == "curl" ]]; then
+        # -S preserves curl's error output while -s hides the progress meter.
+        if ! response=$(curl -sS "${radReleaseUrl}"); then
+            exit 1
+        fi
+    else
+        if ! response=$(wget --no-verbose \
+            --header="Accept: application/json" -O - "${radReleaseUrl}"); then
+            exit 1
+        fi
     fi
 
-    # Tolerate a payload without matches so the diagnostic below is reachable;
-    # otherwise pipefail aborts the script before it can report anything.
     if [[ "${INCLUDE_RC}" == "true" ]]; then
-        latest_release=$(printf '%s\n' "${releases}" | grep \"tag_name\" |
+        latest_release=$(printf '%s\n' "${response}" | grep \"tag_name\" |
             awk 'NR==1{print $2}' | sed -n 's/\"\(.*\)\",/\1/p') || true
     else
-        latest_release=$(printf '%s\n' "${releases}" | grep \"tag_name\" |
+        latest_release=$(printf '%s\n' "${response}" | grep \"tag_name\" |
             grep -v rc | awk 'NR==1{print $2}' |
             sed -n 's/\"\(.*\)\",/\1/p') || true
     fi
 
     if [[ -z "${latest_release}" ]]; then
-        echo "Error: could not determine latest release from ${radReleaseUrl}" >&2
-        echo "Response: ${releases:0:500}" >&2
+        echo "Error: could not determine latest release" >&2
+        echo "Response: ${response:0:500}" >&2
         exit 1
     fi
 
@@ -356,10 +322,9 @@ downloadFile() {
 
         echo "Downloading ${download_url}..."
         if [[ "${RADIUS_HTTP_REQUEST_CLI}" == "curl" ]]; then
-            curl --fail --show-error --silent --location "${download_url}" \
-                -o "${artifact_tmp_file}"
+            curl -SsL "${download_url}" -o "${artifact_tmp_file}"
         else
-            wget --no-verbose -O "${artifact_tmp_file}" "${download_url}"
+            wget -q -O "${artifact_tmp_file}" "${download_url}"
         fi
     fi
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -262,15 +262,25 @@ getLatestRelease() {
 
     if [[ "${INCLUDE_RC}" == "true" ]]; then
         if [[ "${RADIUS_HTTP_REQUEST_CLI}" == "curl" ]]; then
-            latest_release=$(curl -s "${radReleaseUrl}" | grep \"tag_name\" | awk 'NR==1{print $2}' | sed -n 's/\"\(.*\)\",/\1/p')
+            latest_release=$(curl --fail --show-error --silent --location \
+                "${radReleaseUrl}" | grep \"tag_name\" | awk 'NR==1{print $2}' |
+                sed -n 's/\"\(.*\)\",/\1/p')
         else
-            latest_release=$(wget -q --header="Accept: application/json" -O - "${radReleaseUrl}" | grep \"tag_name\" | awk 'NR==1{print $2}' | sed -n 's/\"\(.*\)\",/\1/p')
+            latest_release=$(wget --no-verbose \
+                --header="Accept: application/json" -O - "${radReleaseUrl}" |
+                grep \"tag_name\" | awk 'NR==1{print $2}' |
+                sed -n 's/\"\(.*\)\",/\1/p')
         fi
     else
         if [[ "${RADIUS_HTTP_REQUEST_CLI}" == "curl" ]]; then
-            latest_release=$(curl -s "${radReleaseUrl}" | grep \"tag_name\" | grep -v rc | awk 'NR==1{print $2}' | sed -n 's/\"\(.*\)\",/\1/p')
+            latest_release=$(curl --fail --show-error --silent --location \
+                "${radReleaseUrl}" | grep \"tag_name\" | grep -v rc |
+                awk 'NR==1{print $2}' | sed -n 's/\"\(.*\)\",/\1/p')
         else
-            latest_release=$(wget -q --header="Accept: application/json" -O - "${radReleaseUrl}" | grep \"tag_name\" | grep -v rc | awk 'NR==1{print $2}' | sed -n 's/\"\(.*\)\",/\1/p')
+            latest_release=$(wget --no-verbose \
+                --header="Accept: application/json" -O - "${radReleaseUrl}" |
+                grep \"tag_name\" | grep -v rc | awk 'NR==1{print $2}' |
+                sed -n 's/\"\(.*\)\",/\1/p')
         fi
     fi
 
@@ -313,9 +323,10 @@ downloadFile() {
 
         echo "Downloading ${download_url}..."
         if [[ "${RADIUS_HTTP_REQUEST_CLI}" == "curl" ]]; then
-            curl -SsL "${download_url}" -o "${artifact_tmp_file}"
+            curl --fail --show-error --silent --location "${download_url}" \
+                -o "${artifact_tmp_file}"
         else
-            wget -q -O "${artifact_tmp_file}" "${download_url}"
+            wget --no-verbose -O "${artifact_tmp_file}" "${download_url}"
         fi
     fi
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -322,9 +322,10 @@ downloadFile() {
 
         echo "Downloading ${download_url}..."
         if [[ "${RADIUS_HTTP_REQUEST_CLI}" == "curl" ]]; then
-            curl -SsL "${download_url}" -o "${artifact_tmp_file}"
+            curl --fail --show-error --silent --location "${download_url}" \
+                -o "${artifact_tmp_file}"
         else
-            wget -q -O "${artifact_tmp_file}" "${download_url}"
+            wget --no-verbose -O "${artifact_tmp_file}" "${download_url}"
         fi
     fi
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -256,36 +256,69 @@ warnExistingRadiusElsewhere() {
     echo "============================================================================"
 }
 
+# Fetch the releases payload and write it to stdout. On failure the HTTP status
+# and response body are reported, because the body carries the actionable
+# message for conditions such as API rate limiting.
+fetchReleases() {
+    local url="$1"
+
+    if [[ "${RADIUS_HTTP_REQUEST_CLI}" != "curl" ]]; then
+        # wget discards the error body, but writes its diagnostics to stderr,
+        # which the caller's command substitution does not capture.
+        local wget_body=""
+        if ! wget_body=$(wget --no-verbose \
+            --header="Accept: application/json" -O - "${url}"); then
+            echo "Error: request to ${url} failed" >&2
+            return 1
+        fi
+        printf '%s\n' "${wget_body}"
+        return 0
+    fi
+
+    # --write-out appends the status code so the body is preserved for
+    # diagnostics, which --fail would discard.
+    local response=""
+    if ! response=$(curl --show-error --silent --location \
+        --write-out '\n%{http_code}' "${url}"); then
+        echo "Error: request to ${url} failed" >&2
+        return 1
+    fi
+
+    local http_code="${response##*$'\n'}"
+    local body="${response%$'\n'*}"
+
+    if [[ "${http_code}" != 2* ]]; then
+        echo "Error: ${url} returned HTTP ${http_code}" >&2
+        echo "${body}" >&2
+        return 1
+    fi
+
+    printf '%s\n' "${body}"
+}
+
 getLatestRelease() {
     local radReleaseUrl="https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases"
+    local releases=""
     local latest_release=""
 
+    if ! releases=$(fetchReleases "${radReleaseUrl}"); then
+        exit 1
+    fi
+
+    # Tolerate a payload without matches so the diagnostic below is reachable;
+    # otherwise pipefail aborts the script before it can report anything.
     if [[ "${INCLUDE_RC}" == "true" ]]; then
-        if [[ "${RADIUS_HTTP_REQUEST_CLI}" == "curl" ]]; then
-            latest_release=$(curl --fail --show-error --silent --location \
-                "${radReleaseUrl}" | grep \"tag_name\" | awk 'NR==1{print $2}' |
-                sed -n 's/\"\(.*\)\",/\1/p')
-        else
-            latest_release=$(wget --no-verbose \
-                --header="Accept: application/json" -O - "${radReleaseUrl}" |
-                grep \"tag_name\" | awk 'NR==1{print $2}' |
-                sed -n 's/\"\(.*\)\",/\1/p')
-        fi
+        latest_release=$(printf '%s\n' "${releases}" | grep \"tag_name\" |
+            awk 'NR==1{print $2}' | sed -n 's/\"\(.*\)\",/\1/p') || true
     else
-        if [[ "${RADIUS_HTTP_REQUEST_CLI}" == "curl" ]]; then
-            latest_release=$(curl --fail --show-error --silent --location \
-                "${radReleaseUrl}" | grep \"tag_name\" | grep -v rc |
-                awk 'NR==1{print $2}' | sed -n 's/\"\(.*\)\",/\1/p')
-        else
-            latest_release=$(wget --no-verbose \
-                --header="Accept: application/json" -O - "${radReleaseUrl}" |
-                grep \"tag_name\" | grep -v rc | awk 'NR==1{print $2}' |
-                sed -n 's/\"\(.*\)\",/\1/p')
-        fi
+        latest_release=$(printf '%s\n' "${releases}" | grep \"tag_name\" |
+            grep -v rc | awk 'NR==1{print $2}' |
+            sed -n 's/\"\(.*\)\",/\1/p') || true
     fi
 
     if [[ -z "${latest_release}" ]]; then
-        echo "Error: could not determine latest release"
+        echo "Error: could not determine latest release from ${radReleaseUrl}" >&2
+        echo "Response: ${releases:0:500}" >&2
         exit 1
     fi
 

--- a/deploy/test-install.sh
+++ b/deploy/test-install.sh
@@ -357,6 +357,39 @@ test_edge_version_with_oras() {
     assert_rad_installed "${dir}"
 }
 
+test_latest_release_curl_error_visible() {
+    local dir
+    dir=$(make_test_dir "latest-release-curl-error")
+    local bin_dir
+    bin_dir=$(make_test_dir "latest-release-curl-error-bin")
+    local tool tool_path
+    for tool in bash uname tr grep awk sed; do
+        tool_path=$(command -v "${tool}" 2>/dev/null) || continue
+        ln -sf "${tool_path}" "${bin_dir}/"
+    done
+
+    cat > "${bin_dir}/curl" << 'EOF'
+#!/bin/bash
+for argument in "$@"; do
+    if [[ "${argument}" == "--show-error" ]]; then
+        echo "curl: (22) simulated HTTP error" >&2
+        break
+    fi
+done
+exit 22
+EOF
+    chmod +x "${bin_dir}/curl"
+
+    echo "  CMD: PATH=<failing-curl> ${INSTALLER} --install-dir ${dir}"
+    if LAST_OUTPUT=$(PATH="${bin_dir}" "${INSTALLER}" \
+        --install-dir "${dir}" 2>&1); then
+        echo "  ASSERT FAILED: expected non-zero exit for HTTP error"
+        return 1
+    fi
+    echo "${LAST_OUTPUT}"
+    assert_contains "${LAST_OUTPUT}" "curl: (22) simulated HTTP error"
+}
+
 test_flag_overrides_install_dir_env() {
     local env_dir flag_dir
     env_dir=$(make_test_dir "env-dir-ignored")
@@ -499,6 +532,7 @@ run_test "PATH hint shown for non-PATH dir" test_path_hint_shown
 run_test "version with v prefix" test_version_with_v_prefix
 run_test "edge version without oras fails" test_edge_version_without_oras
 run_test "edge version with oras succeeds" test_edge_version_with_oras
+run_test "latest release curl error is visible" test_latest_release_curl_error_visible
 run_test "--install-dir flag overrides INSTALL_DIR env" test_flag_overrides_install_dir_env
 run_test "INSTALL_DIR env overrides RADIUS_INSTALL_DIR" test_install_dir_env_overrides_radius_install_dir
 run_test "warning for existing rad elsewhere in PATH" test_warn_existing_rad_elsewhere

--- a/deploy/test-install.sh
+++ b/deploy/test-install.sh
@@ -113,7 +113,7 @@ make_stub_curl_bin() {
     bin_dir=$(make_test_dir "${name}")
 
     local tool tool_path
-    for tool in bash uname tr grep awk sed; do
+    for tool in bash mktemp uname tr grep awk sed; do
         tool_path=$(command -v "${tool}" 2>/dev/null) || continue
         ln -sf "${tool_path}" "${bin_dir}/"
     done
@@ -410,6 +410,23 @@ exit 0')
     assert_contains "${LAST_OUTPUT}" "API rate limit exceeded"
 }
 
+test_artifact_download_error_visible() {
+    local dir bin_dir
+    dir=$(make_test_dir "artifact-download-error")
+    bin_dir=$(make_stub_curl_bin "artifact-download-error-bin" '#!/bin/bash
+echo "curl: (22) The requested URL returned error: 404" >&2
+exit 22')
+
+    echo "  CMD: PATH=<failing-curl> ${INSTALLER} --version ${PINNED_VERSION} --install-dir ${dir}"
+    if LAST_OUTPUT=$(PATH="${bin_dir}" "${INSTALLER}" \
+        --version "${PINNED_VERSION}" --install-dir "${dir}" 2>&1); then
+        echo "  ASSERT FAILED: expected non-zero exit for download error"
+        return 1
+    fi
+    echo "${LAST_OUTPUT}"
+    assert_contains "${LAST_OUTPUT}" "curl: (22)"
+}
+
 test_flag_overrides_install_dir_env() {
     local env_dir flag_dir
     env_dir=$(make_test_dir "env-dir-ignored")
@@ -554,6 +571,7 @@ run_test "edge version without oras fails" test_edge_version_without_oras
 run_test "edge version with oras succeeds" test_edge_version_with_oras
 run_test "latest release transport error is visible" test_transport_error_visible
 run_test "latest release API error body is visible" test_api_error_body_visible
+run_test "artifact download error is visible" test_artifact_download_error_visible
 run_test "--install-dir flag overrides INSTALL_DIR env" test_flag_overrides_install_dir_env
 run_test "INSTALL_DIR env overrides RADIUS_INSTALL_DIR" test_install_dir_env_overrides_radius_install_dir
 run_test "warning for existing rad elsewhere in PATH" test_warn_existing_rad_elsewhere

--- a/deploy/test-install.sh
+++ b/deploy/test-install.sh
@@ -113,7 +113,7 @@ make_stub_curl_bin() {
     bin_dir=$(make_test_dir "${name}")
 
     local tool tool_path
-    for tool in bash mktemp uname tr grep awk sed; do
+    for tool in bash mktemp rm uname tr grep awk sed; do
         tool_path=$(command -v "${tool}" 2>/dev/null) || continue
         ln -sf "${tool_path}" "${bin_dir}/"
     done

--- a/deploy/test-install.sh
+++ b/deploy/test-install.sh
@@ -398,17 +398,15 @@ test_api_error_body_visible() {
     dir=$(make_test_dir "api-error-body")
     bin_dir=$(make_stub_curl_bin "api-error-body-bin" '#!/bin/bash
 printf "%s" "{\"message\":\"API rate limit exceeded for 203.0.113.5.\"}"
-printf "\n403"
 exit 0')
 
     echo "  CMD: PATH=<rate-limited-curl> ${INSTALLER} --install-dir ${dir}"
     if LAST_OUTPUT=$(PATH="${bin_dir}" "${INSTALLER}" \
         --install-dir "${dir}" 2>&1); then
-        echo "  ASSERT FAILED: expected non-zero exit for HTTP 403"
+        echo "  ASSERT FAILED: expected non-zero exit for API error response"
         return 1
     fi
     echo "${LAST_OUTPUT}"
-    assert_contains "${LAST_OUTPUT}" "HTTP 403"
     assert_contains "${LAST_OUTPUT}" "API rate limit exceeded"
 }
 

--- a/deploy/test-install.sh
+++ b/deploy/test-install.sh
@@ -104,6 +104,25 @@ make_test_dir() {
     echo "${dir}"
 }
 
+# Create a bin directory holding the tools install.sh needs plus a stub curl,
+# so HTTP failures can be simulated without network access.
+make_stub_curl_bin() {
+    local name="$1"
+    local script="$2"
+    local bin_dir
+    bin_dir=$(make_test_dir "${name}")
+
+    local tool tool_path
+    for tool in bash uname tr grep awk sed; do
+        tool_path=$(command -v "${tool}" 2>/dev/null) || continue
+        ln -sf "${tool_path}" "${bin_dir}/"
+    done
+
+    printf '%s\n' "${script}" > "${bin_dir}/curl"
+    chmod +x "${bin_dir}/curl"
+    echo "${bin_dir}"
+}
+
 # Assert rad binary exists, is executable, and can report its version.
 assert_rad_installed() {
     local dir="$1"
@@ -357,37 +376,40 @@ test_edge_version_with_oras() {
     assert_rad_installed "${dir}"
 }
 
-test_latest_release_curl_error_visible() {
-    local dir
-    dir=$(make_test_dir "latest-release-curl-error")
-    local bin_dir
-    bin_dir=$(make_test_dir "latest-release-curl-error-bin")
-    local tool tool_path
-    for tool in bash uname tr grep awk sed; do
-        tool_path=$(command -v "${tool}" 2>/dev/null) || continue
-        ln -sf "${tool_path}" "${bin_dir}/"
-    done
-
-    cat > "${bin_dir}/curl" << 'EOF'
-#!/bin/bash
-for argument in "$@"; do
-    if [[ "${argument}" == "--show-error" ]]; then
-        echo "curl: (22) simulated HTTP error" >&2
-        break
-    fi
-done
-exit 22
-EOF
-    chmod +x "${bin_dir}/curl"
+test_transport_error_visible() {
+    local dir bin_dir
+    dir=$(make_test_dir "transport-error")
+    bin_dir=$(make_stub_curl_bin "transport-error-bin" '#!/bin/bash
+echo "curl: (7) Failed to connect to api.github.com port 443" >&2
+exit 7')
 
     echo "  CMD: PATH=<failing-curl> ${INSTALLER} --install-dir ${dir}"
     if LAST_OUTPUT=$(PATH="${bin_dir}" "${INSTALLER}" \
         --install-dir "${dir}" 2>&1); then
-        echo "  ASSERT FAILED: expected non-zero exit for HTTP error"
+        echo "  ASSERT FAILED: expected non-zero exit for transport error"
         return 1
     fi
     echo "${LAST_OUTPUT}"
-    assert_contains "${LAST_OUTPUT}" "curl: (22) simulated HTTP error"
+    assert_contains "${LAST_OUTPUT}" "curl: (7) Failed to connect"
+}
+
+test_api_error_body_visible() {
+    local dir bin_dir
+    dir=$(make_test_dir "api-error-body")
+    bin_dir=$(make_stub_curl_bin "api-error-body-bin" '#!/bin/bash
+printf "%s" "{\"message\":\"API rate limit exceeded for 203.0.113.5.\"}"
+printf "\n403"
+exit 0')
+
+    echo "  CMD: PATH=<rate-limited-curl> ${INSTALLER} --install-dir ${dir}"
+    if LAST_OUTPUT=$(PATH="${bin_dir}" "${INSTALLER}" \
+        --install-dir "${dir}" 2>&1); then
+        echo "  ASSERT FAILED: expected non-zero exit for HTTP 403"
+        return 1
+    fi
+    echo "${LAST_OUTPUT}"
+    assert_contains "${LAST_OUTPUT}" "HTTP 403"
+    assert_contains "${LAST_OUTPUT}" "API rate limit exceeded"
 }
 
 test_flag_overrides_install_dir_env() {
@@ -532,7 +554,8 @@ run_test "PATH hint shown for non-PATH dir" test_path_hint_shown
 run_test "version with v prefix" test_version_with_v_prefix
 run_test "edge version without oras fails" test_edge_version_without_oras
 run_test "edge version with oras succeeds" test_edge_version_with_oras
-run_test "latest release curl error is visible" test_latest_release_curl_error_visible
+run_test "latest release transport error is visible" test_transport_error_visible
+run_test "latest release API error body is visible" test_api_error_body_visible
 run_test "--install-dir flag overrides INSTALL_DIR env" test_flag_overrides_install_dir_env
 run_test "INSTALL_DIR env overrides RADIUS_INSTALL_DIR" test_install_dir_env_overrides_radius_install_dir
 run_test "warning for existing rad elsewhere in PATH" test_warn_existing_rad_elsewhere


### PR DESCRIPTION
## Summary

Preserves the underlying error output when Radius CLI installation fails, both in the long-running workflow and when users run `deploy/install.sh` locally.

## Reason for change

The failed workflow only logged `Failed to install Radius CLI` because network diagnostics were suppressed or discarded. The installation path now keeps errors visible while fetching the installer, resolving the latest release, and downloading the CLI artifact. Other installation commands already write their errors to stderr.

Fixes #12794

## How to test

- Run `deploy/test-install.sh` (25 tests, including transport, API-response, and artifact-download error coverage).
- Run `shellcheck deploy/install.sh deploy/test-install.sh`.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `.github/workflows/long-running-azure.yaml` | Uses Bash pipeline failure handling and preserves `wget` errors while fetching the installer. |
| `deploy/install.sh` | Preserves HTTP client diagnostics, logs unexpected GitHub API responses, and reports artifact download failures. |
| `deploy/test-install.sh` | Verifies that transport errors, API error responses, and artifact download errors appear in installer output. |