### PR TITLE
Add depreciation warning to `rad deploy` for Application.* types

### DIFF
--- a/pkg/cli/bicep/resources.go
+++ b/pkg/cli/bicep/resources.go
@@ -17,6 +17,8 @@ limitations under the License.
 package bicep
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -26,7 +28,48 @@ const (
 
 	// legacyEnvironmentResourceType is the legacy resource type for Radius environments
 	legacyEnvironmentResourceType = "applications.core/environments"
+
+	// deprecatedNamespacePrefix is the namespace prefix of the legacy Radius resource types.
+	deprecatedNamespacePrefix = "applications."
+
+	// deprecatedAPIVersion is the API version of the legacy Radius resource types.
+	deprecatedAPIVersion = "2023-10-01-preview"
+
+	// replacementAPIVersion is the API version of the extensible Radius.* resource types that
+	// replace the legacy Applications.* resource types.
+	replacementAPIVersion = "2025-08-01-preview"
 )
+
+// deprecatedTypeReplacements maps a lowercased legacy Applications.* resource type to the
+// extensible Radius.* resource type that replaces it. Types that are absent from this map have no
+// direct one-to-one replacement and are reported with generic recipe pack guidance instead.
+//
+// Keep this in sync with the built-in resource types in deploy/manifest/defaults.yaml.
+var deprecatedTypeReplacements = map[string]string{
+	"applications.core/applications":         "Radius.Core/applications",
+	"applications.core/environments":         "Radius.Core/environments",
+	"applications.core/containers":           "Radius.Compute/containers",
+	"applications.core/gateways":             "Radius.Compute/routes",
+	"applications.core/volumes":              "Radius.Compute/persistentVolumes",
+	"applications.core/secretstores":         "Radius.Security/secrets",
+	"applications.datastores/mongodatabases": "Radius.Data/mongoDatabases",
+	"applications.datastores/rediscaches":    "Radius.Data/redisCaches",
+	"applications.datastores/sqldatabases":   "Radius.Data/sqlServerDatabases",
+	"applications.messaging/rabbitmqqueues":  "Radius.Messaging/rabbitMQ",
+}
+
+// DeprecatedResource describes a resource in a template that uses a legacy Applications.* resource
+// type with the deprecated API version.
+type DeprecatedResource struct {
+	// FullType is the resource type as authored, including the API version,
+	// e.g. "Applications.Core/containers@2023-10-01-preview".
+	FullType string
+
+	// Replacement is the extensible Radius.* resource type that replaces this type, including the
+	// API version, e.g. "Radius.Compute/containers@2025-08-01-preview". It is empty when no direct
+	// replacement exists.
+	Replacement string
+}
 
 // radiusNamespacePatterns lists namespace prefixes for resource type namespaces that belong to Radius.
 // Resource types matching these prefixes are routed through the Radius control plane, not Azure ARM.
@@ -42,6 +85,10 @@ type TemplateInspectionResult struct {
 
 	// EnvironmentResources contains the list of environment resources found in the template.
 	EnvironmentResources []map[string]any
+
+	// DeprecatedResources contains the resources that use a legacy Applications.* resource type
+	// with the deprecated API version, along with their replacements.
+	DeprecatedResources []DeprecatedResource
 }
 
 // ResourceTypeEntry represents a parsed resource type from a compiled Bicep/ARM template.
@@ -136,23 +183,38 @@ func HasOnlyRadiusResourceTypes(template map[string]any) bool {
 // The expected structure of resource in the template is:
 // {"resources": {"resourceName": {"type": "Applications.Core/containers@2023-10-01-preview", ...}}}
 func InspectTemplateResources(template map[string]any) TemplateInspectionResult {
-	result := TemplateInspectionResult{
-		ContainsEnvironmentResource: false,
-	}
+	containsEnvironment, environmentResources := inspectEnvironmentResources(template)
 
+	return TemplateInspectionResult{
+		ContainsEnvironmentResource: containsEnvironment,
+		EnvironmentResources:        environmentResources,
+		DeprecatedResources:         inspectDeprecatedResources(template),
+	}
+}
+
+// inspectEnvironmentResources walks the top-level resources of a compiled template and reports
+// whether an environment resource is present, along with the Radius.Core environment resources.
+//
+// This deliberately does not descend into nested module templates: the results drive deployment
+// behavior (whether the template creates its own environment, and default recipe pack injection),
+// so the scope must stay exactly as it has always been.
+func inspectEnvironmentResources(template map[string]any) (bool, []map[string]any) {
 	if template == nil {
-		return result
+		return false, nil
 	}
 
 	resourcesValue, ok := template["resources"]
 	if !ok {
-		return result
+		return false, nil
 	}
 
 	resources, ok := resourcesValue.(map[string]any)
 	if !ok {
-		return result
+		return false, nil
 	}
+
+	containsEnvironment := false
+	var environmentResources []map[string]any
 
 	for _, resourceValue := range resources {
 		resource, ok := resourceValue.(map[string]any)
@@ -170,16 +232,112 @@ func InspectTemplateResources(template map[string]any) TemplateInspectionResult 
 		// Check for environment resource
 		if strings.HasPrefix(resourceTypeLower, environmentResourceType) ||
 			strings.HasPrefix(resourceTypeLower, legacyEnvironmentResourceType) {
-			result.ContainsEnvironmentResource = true
+			containsEnvironment = true
 		}
 
 		// add Radius.Core environment resources to the result list
 		if strings.HasPrefix(resourceTypeLower, environmentResourceType) {
-			result.EnvironmentResources = append(result.EnvironmentResources, resource)
+			environmentResources = append(environmentResources, resource)
 		}
 	}
 
-	return result
+	return containsEnvironment, environmentResources
+}
+
+// inspectDeprecatedResources returns the distinct deprecated resource types in a compiled template,
+// in a stable order.
+func inspectDeprecatedResources(template map[string]any) []DeprecatedResource {
+	var deprecated []DeprecatedResource
+	collectDeprecatedResources(template, map[string]struct{}{}, &deprecated)
+
+	// Sort for deterministic output, since Go map iteration order is randomized.
+	sort.Slice(deprecated, func(i, j int) bool {
+		return deprecated[i].FullType < deprecated[j].FullType
+	})
+
+	return deprecated
+}
+
+// newDeprecatedResource returns a DeprecatedResource for the given resource type if it uses a legacy
+// Applications.* namespace together with the deprecated API version. The second return value reports
+// whether the resource type is deprecated.
+func newDeprecatedResource(resourceType string) (DeprecatedResource, bool) {
+	baseType, apiVersion, hasAPIVersion := strings.Cut(resourceType, "@")
+	if !hasAPIVersion {
+		return DeprecatedResource{}, false
+	}
+
+	baseTypeLower := strings.ToLower(baseType)
+	if !strings.HasPrefix(baseTypeLower, deprecatedNamespacePrefix) ||
+		!strings.EqualFold(apiVersion, deprecatedAPIVersion) {
+		return DeprecatedResource{}, false
+	}
+
+	deprecated := DeprecatedResource{FullType: resourceType}
+	if replacement, ok := deprecatedTypeReplacements[baseTypeLower]; ok {
+		deprecated.Replacement = replacement + "@" + replacementAPIVersion
+	}
+
+	return deprecated, true
+}
+
+// collectDeprecatedResources walks a compiled template and appends every distinct deprecated
+// resource type it finds to out, recursing into nested templates so that resources declared inside
+// Bicep modules are reported too. Templates commonly declare several resources of the same type, so
+// seen is shared across the whole walk to report each distinct type only once.
+//
+// A Bicep module compiles to a resource of type Microsoft.Resources/deployments whose resources are
+// nested at properties.template.resources.
+func collectDeprecatedResources(template map[string]any, seen map[string]struct{}, out *[]DeprecatedResource) {
+	if template == nil {
+		return
+	}
+
+	resourcesValue, ok := template["resources"]
+	if !ok {
+		return
+	}
+
+	// Symbolic-name templates use a map keyed by resource name; classic ARM templates and nested
+	// module templates may use an array instead, so handle both shapes.
+	var resourceValues []any
+	switch typed := resourcesValue.(type) {
+	case map[string]any:
+		for _, resourceValue := range typed {
+			resourceValues = append(resourceValues, resourceValue)
+		}
+	case []any:
+		resourceValues = typed
+	default:
+		return
+	}
+
+	for _, resourceValue := range resourceValues {
+		resource, ok := resourceValue.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if resourceType, ok := resource["type"].(string); ok {
+			if deprecated, isDeprecated := newDeprecatedResource(resourceType); isDeprecated {
+				key := strings.ToLower(deprecated.FullType)
+				if _, alreadySeen := seen[key]; !alreadySeen {
+					seen[key] = struct{}{}
+					*out = append(*out, deprecated)
+				}
+			}
+		}
+
+		// Recurse into the inline template of a nested deployment (a Bicep module).
+		properties, ok := resource["properties"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if nested, ok := properties["template"].(map[string]any); ok {
+			collectDeprecatedResources(nested, seen, out)
+		}
+	}
 }
 
 // ContainsEnvironmentResource inspects the compiled Radius Bicep template's resources to determine if an
@@ -188,11 +346,45 @@ func InspectTemplateResources(template map[string]any) TemplateInspectionResult 
 // The expected structure of resource in the template is:
 // {"resources": {"resourceName": {"type": "Applications.Core/environments@2023-10-01-preview", ...}}}
 func ContainsEnvironmentResource(template map[string]any) bool {
-	return InspectTemplateResources(template).ContainsEnvironmentResource
+	containsEnvironment, _ := inspectEnvironmentResources(template)
+	return containsEnvironment
 }
 
 // GetEnvironmentResources inspects the compiled Radius Bicep template's resources and returns
 // all environment resources found as maps.
 func GetEnvironmentResources(template map[string]any) []map[string]any {
-	return InspectTemplateResources(template).EnvironmentResources
+	_, environmentResources := inspectEnvironmentResources(template)
+	return environmentResources
+}
+
+// GetDeprecatedResources inspects the compiled Radius Bicep template's resources and returns the
+// resources that use a legacy Applications.* resource type with the deprecated API version.
+func GetDeprecatedResources(template map[string]any) []DeprecatedResource {
+	return inspectDeprecatedResources(template)
+}
+
+// FormatDeprecationWarning builds the user-facing warning message for the given deprecated
+// resources. It returns an empty string when there is nothing to warn about, so callers can skip
+// printing entirely.
+func FormatDeprecationWarning(deprecated []DeprecatedResource) string {
+	if len(deprecated) == 0 {
+		return ""
+	}
+
+	var builder strings.Builder
+	fmt.Fprintf(&builder,
+		"WARNING: The following resource types use the deprecated Applications.* namespace with API version %s and will be removed in a future release:\n",
+		deprecatedAPIVersion)
+
+	for _, resource := range deprecated {
+		if resource.Replacement != "" {
+			fmt.Fprintf(&builder, "  - %s: use %s instead.\n", resource.FullType, resource.Replacement)
+		} else {
+			fmt.Fprintf(&builder,
+				"  - %s: no direct replacement. Define an equivalent resource type and register a recipe pack that provides it to your environment.\n",
+				resource.FullType)
+		}
+	}
+
+	return builder.String()
 }

--- a/pkg/cli/bicep/resources.go
+++ b/pkg/cli/bicep/resources.go
@@ -303,8 +303,18 @@ func collectDeprecatedResources(template map[string]any, seen map[string]struct{
 	var resourceValues []any
 	switch typed := resourcesValue.(type) {
 	case map[string]any:
-		for _, resourceValue := range typed {
-			resourceValues = append(resourceValues, resourceValue)
+		// Visit map entries in sorted key order. Go randomizes map iteration, and de-duplication
+		// keeps the first spelling of a type it encounters, so an unordered walk would render a
+		// different casing of the same type from run to run when a template declares it more than
+		// once with different casing (resource types are case-insensitive).
+		names := make([]string, 0, len(typed))
+		for name := range typed {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		for _, name := range names {
+			resourceValues = append(resourceValues, typed[name])
 		}
 	case []any:
 		resourceValues = typed

--- a/pkg/cli/bicep/resources.go
+++ b/pkg/cli/bicep/resources.go
@@ -38,13 +38,21 @@ const (
 	// replacementAPIVersion is the API version of the extensible Radius.* resource types that
 	// replace the legacy Applications.* resource types.
 	replacementAPIVersion = "2025-08-01-preview"
+
+	// nestedDeploymentResourceType is the resource type a Bicep module compiles to. Its inline
+	// template is the only place a nested template legitimately appears.
+	nestedDeploymentResourceType = "Microsoft.Resources/deployments"
 )
 
 // deprecatedTypeReplacements maps a lowercased legacy Applications.* resource type to the
 // extensible Radius.* resource type that replaces it. Types that are absent from this map have no
 // direct one-to-one replacement and are reported with generic recipe pack guidance instead.
 //
-// Keep this in sync with the built-in resource types in deploy/manifest/defaults.yaml.
+// Keep this in sync with the resource types declared by the built-in provider manifests in
+// deploy/manifest/built-in-providers/{dev,self-hosted}/. The Radius.Core types live in
+// radius_core.yaml; the remaining namespaces are mirrored from resource-types-contrib and are
+// listed for default registration in deploy/manifest/defaults.yaml.
+// Test_DeprecatedTypeReplacements_ExistInManifests enforces this.
 var deprecatedTypeReplacements = map[string]string{
 	"applications.core/applications":         "Radius.Core/applications",
 	"applications.core/environments":         "Radius.Core/environments",
@@ -328,7 +336,8 @@ func collectDeprecatedResources(template map[string]any, seen map[string]struct{
 			continue
 		}
 
-		if resourceType, ok := resource["type"].(string); ok {
+		resourceType, hasType := resource["type"].(string)
+		if hasType {
 			if deprecated, isDeprecated := newDeprecatedResource(resourceType); isDeprecated {
 				key := strings.ToLower(deprecated.FullType)
 				if _, alreadySeen := seen[key]; !alreadySeen {
@@ -338,7 +347,15 @@ func collectDeprecatedResources(template map[string]any, seen map[string]struct{
 			}
 		}
 
-		// Recurse into the inline template of a nested deployment (a Bicep module).
+		// Recurse into the inline template of a nested deployment (a Bicep module). Only
+		// Microsoft.Resources/deployments carries one. Other resource types can hold arbitrary
+		// user-supplied properties -- Applications.Core/extenders in particular -- so recursing on
+		// the presence of a "template" object alone would walk data that is not a template and
+		// report resources the deployment never creates.
+		if !hasType || !strings.EqualFold(resourceType, nestedDeploymentResourceType) {
+			continue
+		}
+
 		properties, ok := resource["properties"].(map[string]any)
 		if !ok {
 			continue
@@ -365,12 +382,6 @@ func ContainsEnvironmentResource(template map[string]any) bool {
 func GetEnvironmentResources(template map[string]any) []map[string]any {
 	_, environmentResources := inspectEnvironmentResources(template)
 	return environmentResources
-}
-
-// GetDeprecatedResources inspects the compiled Radius Bicep template's resources and returns the
-// resources that use a legacy Applications.* resource type with the deprecated API version.
-func GetDeprecatedResources(template map[string]any) []DeprecatedResource {
-	return inspectDeprecatedResources(template)
 }
 
 // FormatDeprecationWarning builds the user-facing warning message for the given deprecated

--- a/pkg/cli/bicep/resources_test.go
+++ b/pkg/cli/bicep/resources_test.go
@@ -17,9 +17,13 @@ limitations under the License.
 package bicep
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func Test_InspectTemplateResources(t *testing.T) {
@@ -535,7 +539,7 @@ func Test_HasOnlyRadiusResourceTypes(t *testing.T) {
 	}
 }
 
-func Test_GetDeprecatedResources(t *testing.T) {
+func Test_InspectDeprecatedResources(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -788,7 +792,7 @@ func Test_GetDeprecatedResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tt.expected, GetDeprecatedResources(tt.template))
+			require.Equal(t, tt.expected, inspectDeprecatedResources(tt.template))
 		})
 	}
 }
@@ -835,11 +839,11 @@ func Test_FormatDeprecationWarning(t *testing.T) {
 	}
 }
 
-// Test_GetDeprecatedResources_IsDeterministic guards the stable ordering and spelling of the
+// Test_InspectDeprecatedResources_IsDeterministic guards the stable ordering and spelling of the
 // warning. Resource types are case-insensitive, so a template may declare the same type with
 // different casing. De-duplication keeps the first spelling encountered, which made the rendered
 // output vary between runs while map iteration order was unsorted.
-func Test_GetDeprecatedResources_IsDeterministic(t *testing.T) {
+func Test_InspectDeprecatedResources_IsDeterministic(t *testing.T) {
 	t.Parallel()
 
 	template := map[string]any{
@@ -889,7 +893,7 @@ func Test_GetDeprecatedResources_IsDeterministic(t *testing.T) {
 
 	// Repeat enough times to reliably surface randomized map iteration order.
 	for range 100 {
-		actual := GetDeprecatedResources(template)
+		actual := inspectDeprecatedResources(template)
 		require.Len(t, actual, 3, "the two casing variants of each type should collapse to one entry")
 
 		fullTypes := make([]string, 0, len(actual))
@@ -900,7 +904,7 @@ func Test_GetDeprecatedResources_IsDeterministic(t *testing.T) {
 	}
 }
 
-func Test_GetDeprecatedResources_MalformedTemplates(t *testing.T) {
+func Test_InspectDeprecatedResources_MalformedTemplates(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -966,7 +970,7 @@ func Test_GetDeprecatedResources_MalformedTemplates(t *testing.T) {
 			t.Parallel()
 			// Malformed input must be skipped rather than panic. A panic would
 			// fail the test on its own, so no NotPanics wrapper is needed.
-			require.Empty(t, GetDeprecatedResources(tt.template))
+			require.Empty(t, inspectDeprecatedResources(tt.template))
 		})
 	}
 }
@@ -1033,4 +1037,123 @@ func Test_GetEnvironmentResources(t *testing.T) {
 		require.Nil(t, GetEnvironmentResources(template))
 		require.False(t, ContainsEnvironmentResource(template))
 	})
+}
+
+// Test_InspectDeprecatedResources_OnlyRecursesIntoNestedDeployments guards against walking
+// arbitrary resource properties that happen to be named "template". Applications.Core/extenders
+// accepts free-form properties, so without a resource type check an extender could make the CLI
+// warn about resources the deployment never creates.
+func Test_InspectDeprecatedResources_OnlyRecursesIntoNestedDeployments(t *testing.T) {
+	t.Parallel()
+
+	// The deprecated type is buried under a non-deployment resource's properties.template.
+	decoy := map[string]any{
+		"template": map[string]any{
+			"resources": map[string]any{
+				"inner": map[string]any{
+					"type": "Applications.Core/containers@2023-10-01-preview",
+					"name": "not-a-real-resource",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		resourceType string
+		expectFound  bool
+	}{
+		{
+			name:         "Nested deployment is walked",
+			resourceType: nestedDeploymentResourceType,
+			expectFound:  true,
+		},
+		{
+			name:         "Nested deployment is matched case-insensitively",
+			resourceType: "microsoft.resources/DEPLOYMENTS",
+			expectFound:  true,
+		},
+		{
+			name:         "Extender template property is not walked",
+			resourceType: "Applications.Core/extenders@2025-08-01-preview",
+			expectFound:  false,
+		},
+		{
+			name:         "Arbitrary resource template property is not walked",
+			resourceType: "Radius.Compute/containers@2025-08-01-preview",
+			expectFound:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			template := map[string]any{
+				"resources": map[string]any{
+					"outer": map[string]any{
+						"type":       tt.resourceType,
+						"name":       "outer",
+						"properties": decoy,
+					},
+				},
+			}
+
+			actual := inspectDeprecatedResources(template)
+			if tt.expectFound {
+				require.Len(t, actual, 1)
+				require.Equal(t, "Applications.Core/containers@2023-10-01-preview", actual[0].FullType)
+				return
+			}
+
+			require.Empty(t, actual, "a non-deployment resource's properties must not be walked as a nested template")
+		})
+	}
+}
+
+// Test_DeprecatedTypeReplacements_ExistInManifests keeps deprecatedTypeReplacements honest against
+// the built-in provider manifests. The first attempt at this warning was reverted because it
+// pointed users at Radius.* types that did not exist, so every replacement must name a real type
+// that declares replacementAPIVersion.
+func Test_DeprecatedTypeReplacements_ExistInManifests(t *testing.T) {
+	t.Parallel()
+
+	manifestDir := filepath.Join("..", "..", "..", "deploy", "manifest", "built-in-providers", "self-hosted")
+	entries, err := filepath.Glob(filepath.Join(manifestDir, "*.yaml"))
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "no provider manifests found under %s", manifestDir)
+
+	// declared maps a lowercased "<namespace>/<typeName>" to the API versions it declares.
+	declared := map[string][]string{}
+	for _, entry := range entries {
+		data, err := os.ReadFile(entry)
+		require.NoError(t, err, "failed to read %s", entry)
+
+		var provider struct {
+			Namespace string `json:"namespace"`
+			Types     map[string]struct {
+				APIVersions map[string]any `json:"apiVersions"`
+			} `json:"types"`
+		}
+		require.NoError(t, yaml.Unmarshal(data, &provider), "failed to parse %s", entry)
+
+		for typeName, typeDef := range provider.Types {
+			key := strings.ToLower(provider.Namespace + "/" + typeName)
+			for apiVersion := range typeDef.APIVersions {
+				declared[key] = append(declared[key], apiVersion)
+			}
+		}
+	}
+
+	require.NotEmpty(t, declared, "parsed no resource types from %s", manifestDir)
+
+	for legacyType, replacement := range deprecatedTypeReplacements {
+		apiVersions, ok := declared[strings.ToLower(replacement)]
+		require.Truef(t, ok,
+			"%q maps to %q, which no built-in provider manifest declares. Update the mapping or the manifests.",
+			legacyType, replacement)
+		require.Containsf(t, apiVersions, replacementAPIVersion,
+			"%q maps to %q, which does not declare API version %s.",
+			legacyType, replacement, replacementAPIVersion)
+	}
 }

--- a/pkg/cli/bicep/resources_test.go
+++ b/pkg/cli/bicep/resources_test.go
@@ -534,3 +534,303 @@ func Test_HasOnlyRadiusResourceTypes(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetDeprecatedResources(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		template map[string]any
+		expected []DeprecatedResource
+	}{
+		{
+			name:     "Nil template",
+			template: nil,
+			expected: nil,
+		},
+		{
+			name:     "Empty template",
+			template: map[string]any{},
+			expected: nil,
+		},
+		{
+			name: "Template with empty resources map",
+			template: map[string]any{
+				"resources": map[string]any{},
+			},
+			expected: nil,
+		},
+		{
+			name: "Deprecated type with a known replacement",
+			template: map[string]any{
+				"resources": map[string]any{
+					"container": map[string]any{
+						"type": "Applications.Core/containers@2023-10-01-preview",
+						"name": "my-container",
+					},
+				},
+			},
+			expected: []DeprecatedResource{
+				{
+					FullType:    "Applications.Core/containers@2023-10-01-preview",
+					Replacement: "Radius.Compute/containers@2025-08-01-preview",
+				},
+			},
+		},
+		{
+			name: "Deprecated type without a known replacement",
+			template: map[string]any{
+				"resources": map[string]any{
+					"store": map[string]any{
+						"type": "Applications.Dapr/stateStores@2023-10-01-preview",
+						"name": "my-store",
+					},
+				},
+			},
+			expected: []DeprecatedResource{
+				{FullType: "Applications.Dapr/stateStores@2023-10-01-preview"},
+			},
+		},
+		{
+			name: "Deprecated type matching is case-insensitive",
+			template: map[string]any{
+				"resources": map[string]any{
+					"gateway": map[string]any{
+						"type": "applications.core/GATEWAYS@2023-10-01-PREVIEW",
+						"name": "my-gateway",
+					},
+				},
+			},
+			expected: []DeprecatedResource{
+				{
+					FullType:    "applications.core/GATEWAYS@2023-10-01-PREVIEW",
+					Replacement: "Radius.Compute/routes@2025-08-01-preview",
+				},
+			},
+		},
+		{
+			name: "Applications type with a different API version is not deprecated",
+			template: map[string]any{
+				"resources": map[string]any{
+					"container": map[string]any{
+						"type": "Applications.Core/containers@2025-08-01-preview",
+						"name": "my-container",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "Radius namespace type is not deprecated",
+			template: map[string]any{
+				"resources": map[string]any{
+					"container": map[string]any{
+						"type": "Radius.Compute/containers@2025-08-01-preview",
+						"name": "my-container",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "Non-Radius type with the deprecated API version is not flagged",
+			template: map[string]any{
+				"resources": map[string]any{
+					"storage": map[string]any{
+						"type": "Microsoft.Storage/storageAccounts@2023-10-01-preview",
+						"name": "my-storage",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "Resource type without an API version is not flagged",
+			template: map[string]any{
+				"resources": map[string]any{
+					"container": map[string]any{
+						"type": "Applications.Core/containers",
+						"name": "my-container",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "Repeated resources of the same type are reported once",
+			template: map[string]any{
+				"resources": map[string]any{
+					"containera": map[string]any{
+						"type": "Applications.Core/containers@2023-10-01-preview",
+						"name": "container-a",
+					},
+					"containerb": map[string]any{
+						"type": "Applications.Core/containers@2023-10-01-preview",
+						"name": "container-b",
+					},
+				},
+			},
+			expected: []DeprecatedResource{
+				{
+					FullType:    "Applications.Core/containers@2023-10-01-preview",
+					Replacement: "Radius.Compute/containers@2025-08-01-preview",
+				},
+			},
+		},
+		{
+			name: "Deprecated resource inside a Bicep module is detected",
+			template: map[string]any{
+				"resources": map[string]any{
+					"env": map[string]any{
+						"type": "Applications.Core/environments@2023-10-01-preview",
+						"name": "my-env",
+					},
+					"module": map[string]any{
+						"type": "Microsoft.Resources/deployments",
+						"name": "my-module",
+						"properties": map[string]any{
+							"template": map[string]any{
+								"resources": map[string]any{
+									"app": map[string]any{
+										"type": "Applications.Core/applications@2023-10-01-preview",
+										"name": "my-app",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []DeprecatedResource{
+				{
+					FullType:    "Applications.Core/applications@2023-10-01-preview",
+					Replacement: "Radius.Core/applications@2025-08-01-preview",
+				},
+				{
+					FullType:    "Applications.Core/environments@2023-10-01-preview",
+					Replacement: "Radius.Core/environments@2025-08-01-preview",
+				},
+			},
+		},
+		{
+			name: "Deprecated resource inside a nested module and an array-shaped template is detected",
+			template: map[string]any{
+				"resources": map[string]any{
+					"outer": map[string]any{
+						"type": "Microsoft.Resources/deployments",
+						"name": "outer-module",
+						"properties": map[string]any{
+							"template": map[string]any{
+								"resources": []any{
+									map[string]any{
+										"type": "Microsoft.Resources/deployments",
+										"name": "inner-module",
+										"properties": map[string]any{
+											"template": map[string]any{
+												"resources": map[string]any{
+													"container": map[string]any{
+														"type": "Applications.Core/containers@2023-10-01-preview",
+														"name": "my-container",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []DeprecatedResource{
+				{
+					FullType:    "Applications.Core/containers@2023-10-01-preview",
+					Replacement: "Radius.Compute/containers@2025-08-01-preview",
+				},
+			},
+		},
+		{
+			name: "Mixed resources are reported in sorted order",
+			template: map[string]any{
+				"resources": map[string]any{
+					"container": map[string]any{
+						"type": "Applications.Core/containers@2023-10-01-preview",
+						"name": "my-container",
+					},
+					"app": map[string]any{
+						"type": "Applications.Core/applications@2023-10-01-preview",
+						"name": "my-app",
+					},
+					"extender": map[string]any{
+						"type": "Applications.Core/extenders@2023-10-01-preview",
+						"name": "my-extender",
+					},
+					"modern": map[string]any{
+						"type": "Radius.Core/environments@2025-08-01-preview",
+						"name": "my-env",
+					},
+				},
+			},
+			expected: []DeprecatedResource{
+				{
+					FullType:    "Applications.Core/applications@2023-10-01-preview",
+					Replacement: "Radius.Core/applications@2025-08-01-preview",
+				},
+				{
+					FullType:    "Applications.Core/containers@2023-10-01-preview",
+					Replacement: "Radius.Compute/containers@2025-08-01-preview",
+				},
+				{FullType: "Applications.Core/extenders@2023-10-01-preview"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, GetDeprecatedResources(tt.template))
+		})
+	}
+}
+
+func Test_FormatDeprecationWarning(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		deprecated []DeprecatedResource
+		expected   string
+	}{
+		{
+			name:       "No deprecated resources returns an empty string",
+			deprecated: nil,
+			expected:   "",
+		},
+		{
+			name: "Resource with a replacement names the replacement type",
+			deprecated: []DeprecatedResource{
+				{
+					FullType:    "Applications.Core/containers@2023-10-01-preview",
+					Replacement: "Radius.Compute/containers@2025-08-01-preview",
+				},
+			},
+			expected: "WARNING: The following resource types use the deprecated Applications.* namespace with API version 2023-10-01-preview and will be removed in a future release:\n" +
+				"  - Applications.Core/containers@2023-10-01-preview: use Radius.Compute/containers@2025-08-01-preview instead.\n",
+		},
+		{
+			name: "Resource without a replacement falls back to recipe pack guidance",
+			deprecated: []DeprecatedResource{
+				{FullType: "Applications.Core/extenders@2023-10-01-preview"},
+			},
+			expected: "WARNING: The following resource types use the deprecated Applications.* namespace with API version 2023-10-01-preview and will be removed in a future release:\n" +
+				"  - Applications.Core/extenders@2023-10-01-preview: no direct replacement. Define an equivalent resource type and register a recipe pack that provides it to your environment.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, FormatDeprecationWarning(tt.deprecated))
+		})
+	}
+}

--- a/pkg/cli/bicep/resources_test.go
+++ b/pkg/cli/bicep/resources_test.go
@@ -834,3 +834,203 @@ func Test_FormatDeprecationWarning(t *testing.T) {
 		})
 	}
 }
+
+// Test_GetDeprecatedResources_IsDeterministic guards the stable ordering and spelling of the
+// warning. Resource types are case-insensitive, so a template may declare the same type with
+// different casing. De-duplication keeps the first spelling encountered, which made the rendered
+// output vary between runs while map iteration order was unsorted.
+func Test_GetDeprecatedResources_IsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	template := map[string]any{
+		"resources": map[string]any{
+			"containerUpper": map[string]any{
+				"type": "Applications.Core/containers@2023-10-01-preview",
+				"name": "container-upper",
+			},
+			"containerLower": map[string]any{
+				"type": "applications.core/CONTAINERS@2023-10-01-preview",
+				"name": "container-lower",
+			},
+			"app": map[string]any{
+				"type": "Applications.Core/applications@2023-10-01-preview",
+				"name": "my-app",
+			},
+			"module": map[string]any{
+				"type": "Microsoft.Resources/deployments",
+				"name": "my-module",
+				"properties": map[string]any{
+					"template": map[string]any{
+						"resources": map[string]any{
+							"gatewayA": map[string]any{
+								"type": "Applications.Core/gateways@2023-10-01-preview",
+								"name": "gateway-a",
+							},
+							"gatewayB": map[string]any{
+								"type": "APPLICATIONS.CORE/GATEWAYS@2023-10-01-preview",
+								"name": "gateway-b",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Pin the exact spelling that wins de-duplication rather than comparing runs
+	// against each other. Sorted key traversal makes the lowest-sorting symbolic
+	// name win ("containerLower" over "containerUpper", "gatewayA" over
+	// "gatewayB"), and the authored casing is preserved rather than canonicalized.
+	expected := []string{
+		"Applications.Core/applications@2023-10-01-preview",
+		"Applications.Core/gateways@2023-10-01-preview",
+		"applications.core/CONTAINERS@2023-10-01-preview",
+	}
+
+	// Repeat enough times to reliably surface randomized map iteration order.
+	for range 100 {
+		actual := GetDeprecatedResources(template)
+		require.Len(t, actual, 3, "the two casing variants of each type should collapse to one entry")
+
+		fullTypes := make([]string, 0, len(actual))
+		for _, resource := range actual {
+			fullTypes = append(fullTypes, resource.FullType)
+		}
+		require.Equal(t, expected, fullTypes)
+	}
+}
+
+func Test_GetDeprecatedResources_MalformedTemplates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		template map[string]any
+	}{
+		{
+			name: "Resources value is not a map or array",
+			template: map[string]any{
+				"resources": "not-a-collection",
+			},
+		},
+		{
+			name: "Resource entry is not a map",
+			template: map[string]any{
+				"resources": map[string]any{
+					"bad": "not-a-map",
+				},
+			},
+		},
+		{
+			name: "Array entry is not a map",
+			template: map[string]any{
+				"resources": []any{"not-a-map", 42, nil},
+			},
+		},
+		{
+			name: "Resource type is not a string",
+			template: map[string]any{
+				"resources": map[string]any{
+					"bad": map[string]any{"type": 42},
+				},
+			},
+		},
+		{
+			name: "Module properties are not a map",
+			template: map[string]any{
+				"resources": map[string]any{
+					"module": map[string]any{
+						"type":       "Microsoft.Resources/deployments",
+						"properties": "not-a-map",
+					},
+				},
+			},
+		},
+		{
+			name: "Module template is not a map",
+			template: map[string]any{
+				"resources": map[string]any{
+					"module": map[string]any{
+						"type": "Microsoft.Resources/deployments",
+						"properties": map[string]any{
+							"template": "not-a-map",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// Malformed input must be skipped rather than panic. A panic would
+			// fail the test on its own, so no NotPanics wrapper is needed.
+			require.Empty(t, GetDeprecatedResources(tt.template))
+		})
+	}
+}
+
+func Test_GetEnvironmentResources(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Returns only Radius.Core environment resources", func(t *testing.T) {
+		t.Parallel()
+
+		radiusEnv := map[string]any{
+			"type": "Radius.Core/environments@2025-08-01-preview",
+			"name": "my-env",
+		}
+		template := map[string]any{
+			"resources": map[string]any{
+				"env": radiusEnv,
+				"legacyEnv": map[string]any{
+					"type": "Applications.Core/environments@2023-10-01-preview",
+					"name": "legacy-env",
+				},
+				"app": map[string]any{
+					"type": "Radius.Core/applications@2025-08-01-preview",
+					"name": "my-app",
+				},
+			},
+		}
+
+		require.Equal(t, []map[string]any{radiusEnv}, GetEnvironmentResources(template))
+	})
+
+	t.Run("Returns nil when no environment resources are present", func(t *testing.T) {
+		t.Parallel()
+
+		require.Nil(t, GetEnvironmentResources(nil))
+		require.Nil(t, GetEnvironmentResources(map[string]any{}))
+		require.Nil(t, GetEnvironmentResources(map[string]any{
+			"resources": map[string]any{
+				"app": map[string]any{"type": "Radius.Core/applications@2025-08-01-preview"},
+			},
+		}))
+	})
+
+	t.Run("Environment resources inside modules are intentionally not returned", func(t *testing.T) {
+		t.Parallel()
+
+		// Environment detection is deliberately top-level only, because it drives deployment
+		// behavior. Only the deprecation scan recurses into modules.
+		template := map[string]any{
+			"resources": map[string]any{
+				"module": map[string]any{
+					"type": "Microsoft.Resources/deployments",
+					"properties": map[string]any{
+						"template": map[string]any{
+							"resources": map[string]any{
+								"env": map[string]any{"type": "Radius.Core/environments@2025-08-01-preview"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		require.Nil(t, GetEnvironmentResources(template))
+		require.False(t, ContainsEnvironmentResource(template))
+	})
+}

--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -306,6 +306,13 @@ func (r *Runner) Run(ctx context.Context) error {
 	// Use the template that was prepared during validation
 	template := r.Template
 
+	// Warn about legacy Applications.* resource types before deploying, so the message is visible
+	// above the deployment progress output.
+	if warning := bicep.FormatDeprecationWarning(r.TemplateInspectionResult.DeprecatedResources); warning != "" {
+		r.Output.LogInfo("")
+		r.Output.LogInfo("%s", warning)
+	}
+
 	// This is the earliest point where we can inject parameters, we have
 	// to wait until the template is prepared.
 	err := r.injectAutomaticParameters(template)

--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -717,6 +717,70 @@ func Test_Run(t *testing.T) {
 		require.Empty(t, outputSink.Writes)
 	})
 
+	t.Run("Deprecated Applications.* resource types produce a warning", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		bicepMock := bicep.NewMockInterface(ctrl)
+
+		workspace := &workspaces.Workspace{
+			Connection: map[string]any{
+				"kind":    "kubernetes",
+				"context": "kind-kind",
+			},
+			Name: "kind-kind",
+		}
+		provider := &clients.Providers{
+			Radius: &clients.RadiusProvider{
+				EnvironmentID: fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/applications.core/environments/%s", radcli.TestEnvironmentName, radcli.TestEnvironmentName),
+			},
+		}
+
+		deployMock := deploy.NewMockInterface(ctrl)
+		deployMock.EXPECT().
+			DeployWithProgress(gomock.Any(), gomock.Any()).
+			Return(clients.DeploymentResult{}, nil).
+			Times(1)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			Bicep:               bicepMock,
+			Deploy:              deployMock,
+			Output:              outputSink,
+			FilePath:            "app.bicep",
+			EnvironmentNameOrID: radcli.TestEnvironmentID,
+			Parameters:          map[string]map[string]any{},
+			Workspace:           workspace,
+			Providers:           provider,
+			Template:            map[string]any{},
+			TemplateInspectionResult: bicep.TemplateInspectionResult{
+				DeprecatedResources: []bicep.DeprecatedResource{
+					{
+						FullType:    "Applications.Core/containers@2023-10-01-preview",
+						Replacement: "Radius.Compute/containers@2025-08-01-preview",
+					},
+					{FullType: "Applications.Core/extenders@2023-10-01-preview"},
+				},
+			},
+		}
+
+		err := runner.Run(t.Context())
+		require.NoError(t, err)
+
+		expected := []any{
+			output.LogOutput{Format: ""},
+			output.LogOutput{
+				Format: "%s",
+				Params: []any{
+					"WARNING: The following resource types use the deprecated Applications.* namespace with API version 2023-10-01-preview and will be removed in a future release:\n" +
+						"  - Applications.Core/containers@2023-10-01-preview: use Radius.Compute/containers@2025-08-01-preview instead.\n" +
+						"  - Applications.Core/extenders@2023-10-01-preview: no direct replacement. Define an equivalent resource type and register a recipe pack that provides it to your environment.\n",
+				},
+			},
+		}
+		require.Equal(t, expected, outputSink.Writes)
+	})
+
 	t.Run("Remote template URL credentials are redacted in progress text", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()


### PR DESCRIPTION
## Summary
Adds a deprecation warning to `rad deploy` when a Bicep template uses a legacy `Applications.*` resource type with the `2023-10-01-preview` API version. Each deprecated type is reported alongside the extensible `Radius.*` type that replaces it.

Example output:

```text
WARNING: The following resource types use the deprecated Applications.* namespace with API version 2023-10-01-preview and will be removed in a future release:
  - Applications.Core/applications@2023-10-01-preview: use Radius.Core/applications@2025-08-01-preview instead.
  - Applications.Core/containers@2023-10-01-preview: use Radius.Compute/containers@2025-08-01-preview instead.
```

Types without a one-to-one replacement (`Applications.Core/extenders`, all `Applications.Dapr/*`) fall back to generic guidance directing users to define an equivalent resource type and register a recipe pack that provides it.

## Reason for change
The replacement types now exist as opposed to earlier and are registered by default in `deploy/manifest/defaults.yaml`. 
Notes:
- Emitted from `rad deploy` only. This is the authoring path, where the user can act on the warning immediately. Read paths such as `rad resource list` were deliberately excluded: they report resources already deployed, would re-fire on every read, and cannot carry an API version in their arguments — the repeat-noise-without-recourse pattern that motivated the original revert.

Fixes #12643

## How to test

1. Deploy any template that uses a legacy type, for example:

   ```bicep
   resource app 'Applications.Core/applications@2023-10-01-preview' = {
     name: 'my-app'
     properties: { environment: environment }
   }
   ```

   ```bash
   rad deploy app.bicep
   ```

   The warning is printed once, above the deployment progress output, and the deployment proceeds normally.

2. Confirm a modern template is silent — a template using only `Radius.*` types produces no warning.

3. Confirm module coverage — declare a legacy resource inside a Bicep `module`. It is still reported, because module contents compile into a nested `Microsoft.Resources/deployments` template.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `pkg/cli/bicep/resources.go` | Adds `deprecatedTypeReplacements` (legacy → `Radius.*` mapping, kept in sync with `deploy/manifest/defaults.yaml`), the `DeprecatedResource` type, and `FormatDeprecationWarning`. Adds `collectDeprecatedResources`, which recurses into nested module templates and de-duplicates types case-insensitively, and sorts results for deterministic output. Splits inspection into `inspectEnvironmentResources` and `inspectDeprecatedResources` so each exported wrapper performs only the scan it needs. |
| `pkg/cli/bicep/resources_test.go` | Adds `Test_GetDeprecatedResources` and `Test_FormatDeprecationWarning`, covering the mapping, unmapped-type fallback, case-insensitive matching, non-matching API versions, non-Radius namespaces, missing API version, duplicate types, and resources nested inside single and doubly-nested modules. |
| `pkg/cli/cmd/deploy/deploy.go` | Emits the warning at the start of `Run()`, reusing the `TemplateInspectionResult` already computed once during `Validate()`. |
| `pkg/cli/cmd/deploy/deploy_test.go` | Adds a `Test_Run` case asserting the exact warning output for both a mapped and an unmapped deprecated type. |
