### PR TITLE
Update test `Test_RabbitMQ` for flakiness

### DIFF
--- a/test/functional-portable/corerp/noncloud/resources/rabbitmq_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/rabbitmq_test.go
@@ -20,12 +20,15 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/radius-project/radius/pkg/kubernetes"
 	"github.com/radius-project/radius/test/rp"
 	"github.com/radius-project/radius/test/step"
 	"github.com/radius-project/radius/test/validation"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -63,14 +66,31 @@ func Test_RabbitMQ(t *testing.T) {
 			},
 			PostStepVerify: func(ctx context.Context, t *testing.T, test rp.RPTest) {
 				labelset := kubernetes.MakeSelectorLabels(name, resourceName)
-				deployments, err := test.Options.K8sClient.AppsV1().Deployments(appNamespace).List(ctx, metav1.ListOptions{
+				listOptions := metav1.ListOptions{
 					LabelSelector: labels.SelectorFromSet(labelset).String(),
-				})
-				require.NoError(t, err)
-				require.Len(t, deployments.Items, 1, "expected one RabbitMQ Deployment")
+				}
 
-				deployment := deployments.Items[0]
-				require.Equal(t, int32(1), deployment.Status.AvailableReplicas, "RabbitMQ Deployment should have one available replica")
+				// The test framework only waits for the Pod to become Ready. The Deployment's
+				// status is written separately by the deployment controller, so it can still
+				// report zero available replicas at this point. Poll instead of asserting on a
+				// single point-in-time read.
+				var deployment appsv1.Deployment
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					deployments, err := test.Options.K8sClient.AppsV1().Deployments(appNamespace).List(ctx, listOptions)
+					if !assert.NoError(c, err) {
+						return
+					}
+					if !assert.Len(c, deployments.Items, 1, "expected one RabbitMQ Deployment") {
+						return
+					}
+
+					if !assert.Equal(c, int32(1), deployments.Items[0].Status.AvailableReplicas, "RabbitMQ Deployment should have one available replica") {
+						return
+					}
+
+					deployment = deployments.Items[0]
+				}, time.Minute*2, time.Second*2)
+
 				require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
 				require.Equal(t, "rabbitmq", deployment.Spec.Template.Spec.Containers[0].Name)
 				require.Len(t, deployment.Spec.Template.Spec.Containers[0].Ports, 1)


### PR DESCRIPTION


## Summary

Fixes a race in `Test_RabbitMQ` that makes the `corerp-noncloud` functional test job fail intermittently.

The test's `PostStepVerify` did a single, non-retrying read of the RabbitMQ `Deployment`'s `status.availableReplicas` and asserted it equalled `1`. That read can happen before the value has been written, so the test fails with `expected: 1, actual: 0` even though the deployment succeeded and the pod is healthy.

The assertion is now wrapped in `require.EventuallyWithT` (2 minute timeout, 2 second poll interval), matching the polling idiom already used elsewhere in `test/`.

## Reason for change
The test framework and the assertion wait on two different things:

- `validation.NewK8sPodForResource` waits for the **Pod**. In `test/validation/k8s.go`, readiness checks only run when `resourceGVR.Resource == "pods"`, and `PodMonitor.ValidateRunning` waits for `ContainersReady=True`. It never inspects Deployment status.
- The assertion read the **Deployment**'s `status.availableReplicas`, which is written separately and asynchronously by the Kubernetes deployment controller.

`test/rp/rptest.go` runs the pod validation before `PostStepVerify`, so a Ready pod can be observed while the Deployment status still reports `0`.

This is what happened in the failing run. Deploy completed successfully and both resources were created; the pod's `rabbitmq` container reached Running and the pod reported Ready at `17:30:30`, and the assertion failed at that same instant:

```
=== FAIL: test/functional-portable/corerp/noncloud/resources Test_RabbitMQ/deploy_testdata/corerp-resources-rabbitmq.bicep (45.82s)
    rabbitmq_test.go:73:
        Error: Not equal:
               expected: 1
               actual  : 0
        Messages: RabbitMQ Deployment should have one available replica
```

The window being bridged is well under a second in the observed failure, but it widens on a loaded CI runner.

Related to #12752



## How to test

The functional test requires a live Kubernetes cluster with Radius installed, so it cannot be run locally without that setup. CI coverage on this PR exercises it.

Static checks:

```bash
go vet ./test/functional-portable/corerp/noncloud/resources/...
go test -c -o /dev/null ./test/functional-portable/corerp/noncloud/resources/
gofmt -l test/functional-portable/corerp/noncloud/resources/
```

The polling behaviour was verified separately against a fake clientset whose `Deployment` reports `availableReplicas: 0` for the first few `List` calls and `1` thereafter, confirming that:

1. A single point-in-time read observes `0` and fails, reproducing the CI failure.
2. The polling version converges once the status catches up.
3. The polling version **still fails** when the deployment never becomes available, so a genuinely broken deployment is not masked.
4. Capturing the Deployment inside the polling closure is clean under `-race`.

Note on the timeout: 2 minutes matches existing timeouts in this package (`container_test.go` uses `2*time.Minute` and `5*time.Minute`) and fits comfortably within the job's `FUNCTIONALTEST_TIMEOUT: 15m`. The 2 second interval costs nothing in the common case, since `EventuallyWithT` evaluates the condition once before its first tick.


## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `test/functional-portable/corerp/noncloud/resources/rabbitmq_test.go` | Wrapped the `availableReplicas` assertion in `require.EventuallyWithT` (2m/2s) instead of a single read, capturing the satisfied `Deployment` for the subsequent container and port assertions. Added `time`, `assert`, and `appsv1` imports. |