### PR TITLE
Revert default resource group and environment creation from rad install kubernetes

### DIFF
--- a/.github/extension/actions/restore-state/action.yml
+++ b/.github/extension/actions/restore-state/action.yml
@@ -28,11 +28,10 @@ runs:
             kubectl --kubeconfig "$TARGET_KUBECONFIG" create namespace "$NAMESPACE"
         fi
 
-        # The Radius.Core/environments resource (with its recipe pack and
-        # cloud providers) is created later via Bicep. `rad install kubernetes`
-        # installs only the control plane and does not create a resource group,
-        # so we create the 'default' group explicitly (idempotent), then set up
-        # the local CLI workspace and point it at that group.
+        # The Radius.Core/environments resource (with its recipe pack and cloud
+        # providers) is created later via Bicep, so this pipeline intentionally
+        # does not use `rad init`. `rad install kubernetes` installs the control
+        # plane only.
         rad workspace create kubernetes default
         rad group create default
         rad group switch default

--- a/.github/extension/actions/restore-state/action.yml
+++ b/.github/extension/actions/restore-state/action.yml
@@ -30,9 +30,9 @@ runs:
 
         # The Radius.Core/environments resource (with its recipe pack and
         # cloud providers) is created later via Bicep. `rad install kubernetes`
-        # already creates the 'default' resource group server-side, but we create
-        # it explicitly (idempotent) as a defensive measure against older control
-        # planes, then set up the local CLI workspace and point it at that group.
+        # installs only the control plane and does not create a resource group,
+        # so we create the 'default' group explicitly (idempotent), then set up
+        # the local CLI workspace and point it at that group.
         rad workspace create kubernetes default
         rad group create default
         rad group switch default

--- a/pkg/cli/cmd/install/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes.go
@@ -44,8 +44,9 @@ By default 'rad install kubernetes' will install Radius with the version matchin
 Radius will be installed in the 'radius-system' namespace. For more information visit https://docs.radapp.io/concepts#technical-architecture
 
 This command installs the Radius control plane only. It does not create a resource group,
-an environment, or any recipe packs. Use 'rad init' to install Radius and set up a default
-resource group, environment, and recipe packs for deploying applications.
+an environment, or any recipes. Use 'rad init' to install Radius and set up a default
+resource group, environment, and recipes for deploying applications; 'rad init --preview'
+sets up the default recipe pack.
 
 Overrides can be set by specifying Helm chart values with the '--set' flag. For more information visit https://docs.radapp.io/guides/operations/kubernetes/install/.
 `,
@@ -83,11 +84,11 @@ rad install kubernetes --set 'global.imagePullSecrets[0].name=azure-cred' \
 # Install Radius with the intermediate root CA certificate in the current Kubernetes context
 rad install kubernetes --set-file global.rootCA.cert=/path/to/rootCA.crt
 
-# Install Radius with zipkin server for distributed tracing 
+# Install Radius with zipkin server for distributed tracing
 rad install kubernetes --set global.zipkin.url=http://localhost:9411/api/v2/spans
 
 # Install Radius with central prometheus monitoring service
-rad install kubernetes --set global.prometheus.path=/customdomain.com/metrics,global.prometheus.port=443,global.rootCA.cert=/path/to/rootCA.crt 
+rad install kubernetes --set global.prometheus.path=/customdomain.com/metrics,global.prometheus.port=443,global.rootCA.cert=/path/to/rootCA.crt
 
 # Install Radius using a helmchart from specified file path
 rad install kubernetes --chart /root/radius/deploy/Chart

--- a/pkg/cli/cmd/install/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes.go
@@ -18,35 +18,13 @@ package kubernetes
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"strings"
 
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
-	"github.com/radius-project/radius/pkg/cli/clients"
-	"github.com/radius-project/radius/pkg/cli/clierrors"
-	"github.com/radius-project/radius/pkg/cli/cmd"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
-	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
 	"github.com/radius-project/radius/pkg/cli/helm"
-	cli_kubernetes "github.com/radius-project/radius/pkg/cli/kubernetes"
 	"github.com/radius-project/radius/pkg/cli/output"
-	"github.com/radius-project/radius/pkg/cli/recipepack"
-	"github.com/radius-project/radius/pkg/cli/setup"
-	"github.com/radius-project/radius/pkg/cli/workspaces"
-	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
-	"github.com/radius-project/radius/pkg/to"
 	"github.com/radius-project/radius/pkg/version"
 	"github.com/spf13/cobra"
-)
-
-// Defaults created by `rad install kubernetes` to mirror `rad init` behavior.
-const (
-	defaultResourceGroupName    = "default"
-	defaultEnvironmentName      = "default"
-	defaultEnvironmentNamespace = "default"
-	defaultUCPPlane             = "local"
 )
 
 // NewCommand creates an instance of the `rad install kubernetes` command and runner.
@@ -65,22 +43,14 @@ By default 'rad install kubernetes' will install Radius with the version matchin
 
 Radius will be installed in the 'radius-system' namespace. For more information visit https://docs.radapp.io/concepts#technical-architecture
 
-On install or reinstall, this command also ensures that a default resource group named 'default'
-and a default environment named 'default' (using the 'default' Kubernetes namespace) exist so the
-cluster is immediately ready to deploy applications. If either resource already exists, it is left
-unchanged (GET-first); user customizations are never overwritten, even with '--reinstall'.
-
-By default the environment is created using the 'Applications.Core/environments' resource type.
-Pass '--preview' (or set RADIUS_PREVIEW=true) to create it using the new 'Radius.Core/environments'
-resource type with the default recipe pack instead.
+This command installs the Radius control plane only. It does not create a resource group,
+an environment, or any recipe packs. Use 'rad init' to install Radius and set up a default
+resource group, environment, and recipe packs for deploying applications.
 
 Overrides can be set by specifying Helm chart values with the '--set' flag. For more information visit https://docs.radapp.io/guides/operations/kubernetes/install/.
 `,
 		Example: `# Install Radius with default settings in current Kubernetes context
 rad install kubernetes
-
-# Install Radius and create the default environment using the Radius.Core/environments type
-rad install kubernetes --preview
 
 # Install Radius with default settings in specified Kubernetes context
 rad install kubernetes --kubecontext mycluster
@@ -133,7 +103,6 @@ rad install kubernetes --set global.terraform.loglevel=DEBUG
 	}
 
 	commonflags.AddKubeContextFlagVar(cmd, &runner.KubeContext)
-	cmd.Flags().Bool("preview", false, "Create the default environment using the Radius.Core/environments resource type instead of Applications.Core/environments (can also be set via RADIUS_PREVIEW=true)")
 	cmd.Flags().BoolVar(&runner.Reinstall, "reinstall", false, "Specify to force reinstallation of Radius")
 	cmd.Flags().StringVar(&runner.Chart, "chart", "", "Specify a file path to a helm chart to install Radius from")
 	cmd.Flags().StringArrayVar(&runner.Set, "set", []string{}, "Set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
@@ -149,10 +118,8 @@ rad install kubernetes --set global.terraform.loglevel=DEBUG
 
 // Runner is the Runner implementation for the `rad install kubernetes` command.
 type Runner struct {
-	Helm                helm.Interface
-	Output              output.Interface
-	ConnectionFactory   connections.Factory
-	KubernetesInterface cli_kubernetes.Interface
+	Helm   helm.Interface
+	Output output.Interface
 
 	KubeContext string
 
@@ -168,43 +135,22 @@ type Runner struct {
 	ContourSetFile  []string
 
 	Reinstall bool
-
-	// Preview selects the new Radius.Core/environments resource type (with the default recipe pack)
-	// for the default environment instead of the legacy Applications.Core/environments type.
-	Preview bool
-
-	// RadiusCoreClientFactory is the Radius.Core (v20250801preview) client factory used to create the
-	// default environment and recipe pack when Preview is set. It is initialized lazily from the
-	// workspace when nil; tests inject a fake factory.
-	RadiusCoreClientFactory *corerpv20250801.ClientFactory
 }
 
 // NewRunner creates an instance of the runner for the `rad install kubernetes` command.
 //
 
-// NewRunner creates a new Runner struct with Helm, Output, ConnectionFactory and KubernetesInterface
-// fields initialized from the supplied factory.
+// NewRunner creates a new Runner struct with Helm and Output fields initialized with the HelmInterface and Output
+// objects returned by the Factory's GetHelmInterface and GetOutput methods respectively.
 func NewRunner(factory framework.Factory) *Runner {
 	return &Runner{
-		Helm:                factory.GetHelmInterface(),
-		Output:              factory.GetOutput(),
-		ConnectionFactory:   factory.GetConnectionFactory(),
-		KubernetesInterface: factory.GetKubernetesInterface(),
+		Helm:   factory.GetHelmInterface(),
+		Output: factory.GetOutput(),
 	}
 }
 
 // Validate runs validation for the `rad install kubernetes` command.
 func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
-	preview, err := cmd.Flags().GetBool("preview")
-	if err != nil {
-		return err
-	}
-	// The --preview flag takes precedence; fall back to RADIUS_PREVIEW only when the flag is unset,
-	// mirroring resolveUsePreview used by the other preview-enabled commands.
-	if !cmd.Flags().Changed("preview") {
-		preview = strings.EqualFold(os.Getenv("RADIUS_PREVIEW"), "true")
-	}
-	r.Preview = preview
 	return nil
 }
 
@@ -213,9 +159,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 // Run checks if a Radius installation exists, and if it does, it either skips the installation or reinstalls it
 // depending on the "Reinstall" flag. If no installation is found, it installs the version of Radius corresponding
-// to the cli version. After a successful install or reinstall it ensures the default resource group and
-// environment exist, creating each only when it is missing so existing user customizations are preserved.
-// It returns any errors that occur during these steps.
+// to the cli version. It then returns any errors that occur during the installation.
 func (r *Runner) Run(ctx context.Context) error {
 	cliOptions := helm.CLIClusterOptions{
 		Radius: helm.ChartOptions{
@@ -256,125 +200,5 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	// The Radius chart's post-install hook waits until the aggregated API responds through
-	// kube-apiserver. A successful InstallRadius call therefore guarantees that the management
-	// client can connect without a second readiness wait here.
-	return r.createDefaultGroupAndEnvironment(ctx)
-}
-
-// createDefaultGroupAndEnvironment ensures a resource group named "default" and an environment named
-// "default" exist on the Radius control plane. Each resource is created only when it is missing
-// (GET-first, create on 404); if it already exists it is left untouched so that any user
-// customizations (recipes, cloud providers, namespace, etc.) are preserved across reinstalls.
-func (r *Runner) createDefaultGroupAndEnvironment(ctx context.Context) error {
-	// r.KubeContext may be empty; downstream Kubernetes client config treats an empty string as
-	// "use the active kubeconfig context", matching workspaces.MakeFallbackWorkspace and the Helm
-	// install call above (r.Helm.InstallRadius(..., r.KubeContext)).
-	workspace := workspaces.Workspace{
-		Connection: map[string]any{
-			"context": r.KubeContext,
-			"kind":    workspaces.KindKubernetes,
-		},
-		Scope: fmt.Sprintf("/planes/radius/%s/resourceGroups/%s", defaultUCPPlane, defaultResourceGroupName),
-	}
-
-	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, workspace)
-	if err != nil {
-		return clierrors.MessageWithCause(err, "Failed to connect to the Radius control plane. Radius was installed successfully; you can create the default resource group and environment manually with 'rad group create default' and 'rad env create default'.")
-	}
-
-	if err := r.ensureDefaultResourceGroup(ctx, client); err != nil {
-		return err
-	}
-
-	if r.Preview {
-		return r.ensureDefaultEnvironmentPreview(ctx, &workspace)
-	}
-	return r.ensureDefaultEnvironment(ctx, client)
-}
-
-// ensureDefaultResourceGroup creates the "default" resource group only if it does not already exist.
-func (r *Runner) ensureDefaultResourceGroup(ctx context.Context, client clients.ApplicationsManagementClient) error {
-	_, err := client.GetResourceGroup(ctx, defaultUCPPlane, defaultResourceGroupName)
-	if err == nil {
-		r.Output.LogInfo("Default resource group %q already exists; leaving it unchanged.", defaultResourceGroupName)
-		return nil
-	}
-	if !clients.Is404Error(err) {
-		return clierrors.MessageWithCause(err, "Failed to check for the default resource group. Radius was installed successfully; you can retry with 'rad group create default'.")
-	}
-
-	r.Output.LogInfo("Creating default resource group %q...", defaultResourceGroupName)
-	if err := setup.EnsureResourceGroup(ctx, client, defaultUCPPlane, defaultResourceGroupName); err != nil {
-		return clierrors.MessageWithCause(err, "Failed to create the default resource group. Radius was installed successfully; you can retry with 'rad group create default'.")
-	}
-	return nil
-}
-
-// ensureDefaultEnvironment creates the "default" environment only if it does not already exist.
-func (r *Runner) ensureDefaultEnvironment(ctx context.Context, client clients.ApplicationsManagementClient) error {
-	_, err := client.GetEnvironment(ctx, defaultEnvironmentName)
-	if err == nil {
-		r.Output.LogInfo("Default environment %q already exists; leaving it unchanged.", defaultEnvironmentName)
-		return nil
-	}
-	if !clients.Is404Error(err) {
-		return clierrors.MessageWithCause(err, "Failed to check for the default environment. Radius was installed successfully; you can retry with 'rad env create default'.")
-	}
-
-	r.Output.LogInfo("Creating default environment %q in namespace %q...", defaultEnvironmentName, defaultEnvironmentNamespace)
-	if err := setup.EnsureEnvironment(ctx, client, defaultEnvironmentName, defaultEnvironmentNamespace, nil, nil); err != nil {
-		return clierrors.MessageWithCause(err, "Failed to create the default environment. Radius was installed successfully; you can retry with 'rad env create default'.")
-	}
-	return nil
-}
-
-// ensureDefaultEnvironmentPreview creates the "default" environment using the new
-// Radius.Core/environments resource type only if it does not already exist. It first ensures the
-// Radius-managed default recipe pack exists (in the default resource group) and attaches it to the
-// environment, mirroring `rad env create --preview`. If the environment already exists it is left
-// untouched so user customizations are preserved across reinstalls.
-func (r *Runner) ensureDefaultEnvironmentPreview(ctx context.Context, workspace *workspaces.Workspace) error {
-	if r.RadiusCoreClientFactory == nil {
-		clientFactory, err := cmd.InitializeRadiusCoreClientFactory(ctx, workspace)
-		if err != nil {
-			return clierrors.MessageWithCause(err, "Failed to connect to the Radius control plane. Radius was installed successfully; you can create the default environment manually with 'rad env create default --preview'.")
-		}
-		r.RadiusCoreClientFactory = clientFactory
-	}
-
-	envClient := r.RadiusCoreClientFactory.NewEnvironmentsClient()
-
-	_, err := envClient.Get(ctx, workspace.Scope, defaultEnvironmentName, nil)
-	if err == nil {
-		r.Output.LogInfo("Default environment %q already exists; leaving it unchanged.", defaultEnvironmentName)
-		return nil
-	}
-	if !clients.Is404Error(err) {
-		return clierrors.MessageWithCause(err, "Failed to check for the default environment. Radius was installed successfully; you can retry with 'rad env create default --preview'.")
-	}
-
-	// The default recipe pack always lives in the default resource group scope, regardless of the
-	// current workspace scope. Create it (or reuse the existing one) before referencing it.
-	recipePackID, err := recipepack.GetOrCreateDefaultRecipePack(ctx, r.RadiusCoreClientFactory.NewRecipePacksClient())
-	if err != nil {
-		return clierrors.MessageWithCause(err, "Failed to create the default recipe pack. Radius was installed successfully; you can retry with 'rad env create default --preview'.")
-	}
-
-	r.Output.LogInfo("Creating default environment %q in namespace %q...", defaultEnvironmentName, defaultEnvironmentNamespace)
-	resource := corerpv20250801.EnvironmentResource{
-		Location: to.Ptr(v1.LocationGlobal),
-		Properties: &corerpv20250801.EnvironmentProperties{
-			RecipePacks: []*string{to.Ptr(recipePackID)},
-			Providers: &corerpv20250801.Providers{
-				Kubernetes: &corerpv20250801.ProvidersKubernetes{
-					Namespace: to.Ptr(defaultEnvironmentNamespace),
-				},
-			},
-		},
-	}
-	if _, err := envClient.CreateOrUpdate(ctx, workspace.Scope, defaultEnvironmentName, resource, nil); err != nil {
-		return clierrors.MessageWithCause(err, "Failed to create the default environment. Radius was installed successfully; you can retry with 'rad env create default --preview'.")
-	}
 	return nil
 }

--- a/pkg/cli/cmd/install/kubernetes/kubernetes_test.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes_test.go
@@ -17,30 +17,13 @@ limitations under the License.
 package kubernetes
 
 import (
-	"context"
-	"errors"
-	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
-	"github.com/radius-project/radius/pkg/cli/clients"
-	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/helm"
-	cli_kubernetes "github.com/radius-project/radius/pkg/cli/kubernetes"
 	"github.com/radius-project/radius/pkg/cli/output"
-	"github.com/radius-project/radius/pkg/cli/recipepack"
-	"github.com/radius-project/radius/pkg/cli/test_client_factory"
-	corerp "github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
-	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
-	corerpfake "github.com/radius-project/radius/pkg/corerp/api/v20250801preview/fake"
-	"github.com/radius-project/radius/pkg/to"
-	ucp "github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	"github.com/radius-project/radius/test/radcli"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-
-	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 )
 
 func Test_CommandValidation(t *testing.T) {
@@ -71,88 +54,22 @@ func Test_Validate(t *testing.T) {
 			Input:         []string{"--skip-contour-install"},
 			ExpectedValid: true,
 		},
-		{
-			Name:          "preview",
-			Input:         []string{"--preview"},
-			ExpectedValid: true,
-		},
 	}
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
 }
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// expectDefaultGroupAndEnvCreation sets up the management client mocks needed for the post-install
-	// "create default resource group + environment" step (the GET-returns-404 path) and returns the
-	// trailing log writes the helper appends so tests can assemble the full expected output slice.
-	expectDefaultGroupAndEnvCreation := func(t *testing.T, ctrl *gomock.Controller) (connections.Factory, cli_kubernetes.Interface, []any) {
-		t.Helper()
-		notFound := &azcore.ResponseError{StatusCode: http.StatusNotFound}
-		mgmtMock := clients.NewMockApplicationsManagementClient(ctrl)
-		mgmtMock.EXPECT().
-			GetResourceGroup(gomock.Any(), "local", "default").
-			Return(ucp.ResourceGroupResource{}, notFound).
-			Times(1)
-		mgmtMock.EXPECT().
-			CreateOrUpdateResourceGroup(gomock.Any(), "local", "default", gomock.Any()).
-			DoAndReturn(func(_ context.Context, _, _ string, rg *ucp.ResourceGroupResource) error {
-				require.NotNil(t, rg)
-				require.NotNil(t, rg.Location)
-				require.Equal(t, v1.LocationGlobal, *rg.Location)
-				return nil
-			}).
-			Times(1)
-		mgmtMock.EXPECT().
-			GetEnvironment(gomock.Any(), "default").
-			Return(corerp.EnvironmentResource{}, notFound).
-			Times(1)
-		mgmtMock.EXPECT().
-			CreateOrUpdateEnvironment(gomock.Any(), "default", gomock.Any()).
-			DoAndReturn(func(_ context.Context, _ string, env *corerp.EnvironmentResource) error {
-				require.NotNil(t, env)
-				require.NotNil(t, env.Location)
-				require.Equal(t, v1.LocationGlobal, *env.Location)
-				require.NotNil(t, env.Properties)
-				k8sCompute, ok := env.Properties.Compute.(*corerp.KubernetesCompute)
-				require.True(t, ok, "environment compute must be KubernetesCompute")
-				require.NotNil(t, k8sCompute.Namespace)
-				require.Equal(t, "default", *k8sCompute.Namespace)
-				return nil
-			}).
-			Times(1)
-
-		// The kube context is no longer resolved by the install command itself: the Runner passes
-		// r.KubeContext (possibly empty) straight into the workspace, and the underlying Kubernetes
-		// client config treats "" as "use the active kubeconfig context". So the KubernetesInterface
-		// mock has no expectations.
-		k8sMock := cli_kubernetes.NewMockInterface(ctrl)
-
-		writes := []any{
-			output.LogOutput{
-				Format: "Creating default resource group %q...",
-				Params: []any{"default"},
-			},
-			output.LogOutput{
-				Format: "Creating default environment %q in namespace %q...",
-				Params: []any{"default", "default"},
-			},
-		}
-		return &connections.MockFactory{ApplicationsManagementClient: mgmtMock}, k8sMock, writes
-	}
-
 	t.Run("Success: Install", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		helmMock := helm.NewMockInterface(ctrl)
 		outputMock := &output.MockOutput{}
-		factory, k8sMock, postInstallWrites := expectDefaultGroupAndEnvCreation(t, ctrl)
 
 		ctx := t.Context()
 		runner := &Runner{
-			Helm:                helmMock,
-			Output:              outputMock,
-			ConnectionFactory:   factory,
-			KubernetesInterface: k8sMock,
+			Helm:   helmMock,
+			Output: outputMock,
 
 			KubeContext: "test-context",
 			Chart:       "test-chart",
@@ -176,12 +93,12 @@ func Test_Run(t *testing.T) {
 		err := runner.Run(ctx)
 		require.NoError(t, err)
 
-		expectedWrites := append([]any{
+		expectedWrites := []any{
 			output.LogOutput{
 				Format: "Installing Radius version %s to namespace: %s...",
 				Params: []any{"edge", "radius-system"},
 			},
-		}, postInstallWrites...)
+		}
 		require.Equal(t, expectedWrites, outputMock.Writes)
 	})
 	t.Run("Success: Already Installed", func(t *testing.T) {
@@ -220,27 +137,10 @@ func Test_Run(t *testing.T) {
 		helmMock := helm.NewMockInterface(ctrl)
 		outputMock := &output.MockOutput{}
 
-		// Simulate the typical reinstall scenario: the default resource group and environment
-		// already exist (a previous install created them, possibly with user customizations).
-		// We expect GETs to succeed and no CreateOrUpdate* calls to be issued.
-		mgmtMock := clients.NewMockApplicationsManagementClient(ctrl)
-		mgmtMock.EXPECT().
-			GetResourceGroup(gomock.Any(), "local", "default").
-			Return(ucp.ResourceGroupResource{}, nil).
-			Times(1)
-		mgmtMock.EXPECT().
-			GetEnvironment(gomock.Any(), "default").
-			Return(corerp.EnvironmentResource{}, nil).
-			Times(1)
-		k8sMock := cli_kubernetes.NewMockInterface(ctrl)
-		factory := &connections.MockFactory{ApplicationsManagementClient: mgmtMock}
-
 		ctx := t.Context()
 		runner := &Runner{
-			Helm:                helmMock,
-			Output:              outputMock,
-			ConnectionFactory:   factory,
-			KubernetesInterface: k8sMock,
+			Helm:   helmMock,
+			Output: outputMock,
 
 			KubeContext: "test-context",
 			Chart:       "test-chart",
@@ -271,14 +171,6 @@ func Test_Run(t *testing.T) {
 				Format: "Reinstalling Radius version %s to namespace: %s...",
 				Params: []any{"edge", "radius-system"},
 			},
-			output.LogOutput{
-				Format: "Default resource group %q already exists; leaving it unchanged.",
-				Params: []any{"default"},
-			},
-			output.LogOutput{
-				Format: "Default environment %q already exists; leaving it unchanged.",
-				Params: []any{"default"},
-			},
 		}
 		require.Equal(t, expectedWrites, outputMock.Writes)
 	})
@@ -287,14 +179,11 @@ func Test_Run(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		helmMock := helm.NewMockInterface(ctrl)
 		outputMock := &output.MockOutput{}
-		factory, k8sMock, postInstallWrites := expectDefaultGroupAndEnvCreation(t, ctrl)
 
 		ctx := t.Context()
 		runner := &Runner{
-			Helm:                helmMock,
-			Output:              outputMock,
-			ConnectionFactory:   factory,
-			KubernetesInterface: k8sMock,
+			Helm:   helmMock,
+			Output: outputMock,
 
 			KubeContext: "test-context",
 			Chart:       "test-chart",
@@ -320,12 +209,12 @@ func Test_Run(t *testing.T) {
 		err := runner.Run(ctx)
 		require.NoError(t, err)
 
-		expectedWrites := append([]any{
+		expectedWrites := []any{
 			output.LogOutput{
 				Format: "Installing Radius version %s to namespace: %s...",
 				Params: []any{"edge", "radius-system"},
 			},
-		}, postInstallWrites...)
+		}
 		require.Equal(t, expectedWrites, outputMock.Writes)
 	})
 	t.Run("Success: Install with global.imageTag", func(t *testing.T) {
@@ -333,14 +222,11 @@ func Test_Run(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		helmMock := helm.NewMockInterface(ctrl)
 		outputMock := &output.MockOutput{}
-		factory, k8sMock, postInstallWrites := expectDefaultGroupAndEnvCreation(t, ctrl)
 
 		ctx := t.Context()
 		runner := &Runner{
-			Helm:                helmMock,
-			Output:              outputMock,
-			ConnectionFactory:   factory,
-			KubernetesInterface: k8sMock,
+			Helm:   helmMock,
+			Output: outputMock,
 
 			KubeContext: "test-context",
 			Set:         []string{"global.imageTag=0.48"},
@@ -362,12 +248,12 @@ func Test_Run(t *testing.T) {
 		err := runner.Run(ctx)
 		require.NoError(t, err)
 
-		expectedWrites := append([]any{
+		expectedWrites := []any{
 			output.LogOutput{
 				Format: "Installing Radius version %s to namespace: %s...",
 				Params: []any{"edge", "radius-system"},
 			},
-		}, postInstallWrites...)
+		}
 		require.Equal(t, expectedWrites, outputMock.Writes)
 	})
 	t.Run("Success: Install with both global.imageRegistry and global.imageTag", func(t *testing.T) {
@@ -375,14 +261,11 @@ func Test_Run(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		helmMock := helm.NewMockInterface(ctrl)
 		outputMock := &output.MockOutput{}
-		factory, k8sMock, postInstallWrites := expectDefaultGroupAndEnvCreation(t, ctrl)
 
 		ctx := t.Context()
 		runner := &Runner{
-			Helm:                helmMock,
-			Output:              outputMock,
-			ConnectionFactory:   factory,
-			KubernetesInterface: k8sMock,
+			Helm:   helmMock,
+			Output: outputMock,
 
 			KubeContext: "test-context",
 			Set:         []string{"global.imageRegistry=myregistry.azurecr.io", "global.imageTag=0.48"},
@@ -404,316 +287,10 @@ func Test_Run(t *testing.T) {
 		err := runner.Run(ctx)
 		require.NoError(t, err)
 
-		expectedWrites := append([]any{
-			output.LogOutput{
-				Format: "Installing Radius version %s to namespace: %s...",
-				Params: []any{"edge", "radius-system"},
-			},
-		}, postInstallWrites...)
-		require.Equal(t, expectedWrites, outputMock.Writes)
-	})
-
-	t.Run("Success: Install with no --kubecontext flag passes empty context through", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		helmMock := helm.NewMockInterface(ctrl)
-		outputMock := &output.MockOutput{}
-		factory, k8sMock, postInstallWrites := expectDefaultGroupAndEnvCreation(t, ctrl)
-
-		ctx := t.Context()
-		runner := &Runner{
-			Helm:                helmMock,
-			Output:              outputMock,
-			ConnectionFactory:   factory,
-			KubernetesInterface: k8sMock,
-			Chart:               "test-chart",
-		}
-
-		// An empty kubecontext is correct here and is the established convention across the CLI
-		// (see workspaces.MakeFallbackWorkspace): the underlying kube client config interprets ""
-		// as "use the active kubeconfig context". rad install kubernetes passes r.KubeContext
-		// (possibly empty) straight to Helm and into the post-install workspace.
-		helmMock.EXPECT().CheckRadiusInstall("").
-			Return(helm.InstallState{}, nil).
-			Times(1)
-
-		expectedOptions := helm.PopulateDefaultClusterOptions(helm.CLIClusterOptions{
-			Radius: helm.ChartOptions{
-				ChartPath: "test-chart",
-			},
-		})
-		helmMock.EXPECT().InstallRadius(ctx, expectedOptions, "").
-			Return(nil).
-			Times(1)
-
-		err := runner.Run(ctx)
-		require.NoError(t, err)
-
-		expectedWrites := append([]any{
-			output.LogOutput{
-				Format: "Installing Radius version %s to namespace: %s...",
-				Params: []any{"edge", "radius-system"},
-			},
-		}, postInstallWrites...)
-		require.Equal(t, expectedWrites, outputMock.Writes)
-	})
-
-	t.Run("Failure: default resource group creation fails", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		helmMock := helm.NewMockInterface(ctrl)
-		outputMock := &output.MockOutput{}
-
-		notFound := &azcore.ResponseError{StatusCode: http.StatusNotFound}
-		boom := errors.New("boom")
-		mgmtMock := clients.NewMockApplicationsManagementClient(ctrl)
-		mgmtMock.EXPECT().
-			GetResourceGroup(gomock.Any(), "local", "default").
-			Return(ucp.ResourceGroupResource{}, notFound).
-			Times(1)
-		mgmtMock.EXPECT().
-			CreateOrUpdateResourceGroup(gomock.Any(), "local", "default", gomock.Any()).
-			Return(boom).
-			Times(1)
-		// GetEnvironment / CreateOrUpdateEnvironment must not be called: the runner should bail out
-		// as soon as the resource group create fails.
-
-		ctx := t.Context()
-		runner := &Runner{
-			Helm:                helmMock,
-			Output:              outputMock,
-			ConnectionFactory:   &connections.MockFactory{ApplicationsManagementClient: mgmtMock},
-			KubernetesInterface: cli_kubernetes.NewMockInterface(ctrl),
-
-			KubeContext: "test-context",
-			Chart:       "test-chart",
-		}
-
-		helmMock.EXPECT().CheckRadiusInstall("test-context").
-			Return(helm.InstallState{}, nil).
-			Times(1)
-
-		expectedOptions := helm.PopulateDefaultClusterOptions(helm.CLIClusterOptions{
-			Radius: helm.ChartOptions{ChartPath: "test-chart"},
-		})
-		helmMock.EXPECT().InstallRadius(ctx, expectedOptions, "test-context").
-			Return(nil).
-			Times(1)
-
-		err := runner.Run(ctx)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "Failed to create the default resource group")
-		require.ErrorIs(t, err, boom)
-	})
-
-	t.Run("Failure: default environment creation fails", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		helmMock := helm.NewMockInterface(ctrl)
-		outputMock := &output.MockOutput{}
-
-		notFound := &azcore.ResponseError{StatusCode: http.StatusNotFound}
-		boom := errors.New("boom")
-		mgmtMock := clients.NewMockApplicationsManagementClient(ctrl)
-		mgmtMock.EXPECT().
-			GetResourceGroup(gomock.Any(), "local", "default").
-			Return(ucp.ResourceGroupResource{}, notFound).
-			Times(1)
-		mgmtMock.EXPECT().
-			CreateOrUpdateResourceGroup(gomock.Any(), "local", "default", gomock.Any()).
-			Return(nil).
-			Times(1)
-		mgmtMock.EXPECT().
-			GetEnvironment(gomock.Any(), "default").
-			Return(corerp.EnvironmentResource{}, notFound).
-			Times(1)
-		mgmtMock.EXPECT().
-			CreateOrUpdateEnvironment(gomock.Any(), "default", gomock.Any()).
-			Return(boom).
-			Times(1)
-
-		ctx := t.Context()
-		runner := &Runner{
-			Helm:                helmMock,
-			Output:              outputMock,
-			ConnectionFactory:   &connections.MockFactory{ApplicationsManagementClient: mgmtMock},
-			KubernetesInterface: cli_kubernetes.NewMockInterface(ctrl),
-
-			KubeContext: "test-context",
-			Chart:       "test-chart",
-		}
-
-		helmMock.EXPECT().CheckRadiusInstall("test-context").
-			Return(helm.InstallState{}, nil).
-			Times(1)
-
-		expectedOptions := helm.PopulateDefaultClusterOptions(helm.CLIClusterOptions{
-			Radius: helm.ChartOptions{ChartPath: "test-chart"},
-		})
-		helmMock.EXPECT().InstallRadius(ctx, expectedOptions, "test-context").
-			Return(nil).
-			Times(1)
-
-		err := runner.Run(ctx)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "Failed to create the default environment")
-		require.ErrorIs(t, err, boom)
-	})
-
-	t.Run("Success: Install with --preview creates a Radius.Core environment", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		helmMock := helm.NewMockInterface(ctrl)
-		outputMock := &output.MockOutput{}
-
-		notFound := &azcore.ResponseError{StatusCode: http.StatusNotFound}
-		mgmtMock := clients.NewMockApplicationsManagementClient(ctrl)
-		mgmtMock.EXPECT().
-			GetResourceGroup(gomock.Any(), "local", "default").
-			Return(ucp.ResourceGroupResource{}, notFound).
-			Times(1)
-		mgmtMock.EXPECT().
-			CreateOrUpdateResourceGroup(gomock.Any(), "local", "default", gomock.Any()).
-			Return(nil).
-			Times(1)
-		// The preview path uses the Radius.Core client factory for the environment, so the legacy
-		// management client must not receive any environment calls.
-
-		// Capture the Radius.Core environment that gets created so we can assert its shape.
-		var capturedScope, capturedName string
-		var capturedEnv corerpv20250801.EnvironmentResource
-		envServer := func() corerpfake.EnvironmentsServer {
-			return corerpfake.EnvironmentsServer{
-				Get: func(_ context.Context, _ string, _ string, _ *corerpv20250801.EnvironmentsClientGetOptions) (resp azfake.Responder[corerpv20250801.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
-					errResp.SetResponseError(http.StatusNotFound, "Not Found")
-					return
-				},
-				CreateOrUpdate: func(_ context.Context, rootScope string, environmentName string, resource corerpv20250801.EnvironmentResource, _ *corerpv20250801.EnvironmentsClientCreateOrUpdateOptions) (resp azfake.Responder[corerpv20250801.EnvironmentsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
-					capturedScope = rootScope
-					capturedName = environmentName
-					capturedEnv = resource
-					resp.SetResponse(http.StatusOK, corerpv20250801.EnvironmentsClientCreateOrUpdateResponse{EnvironmentResource: resource}, nil)
-					return
-				},
-			}
-		}
-		radiusCoreFactory, err := test_client_factory.NewRadiusCoreTestClientFactory(
-			"/planes/radius/local/resourceGroups/default",
-			envServer,
-			test_client_factory.WithRecipePackServer404OnGet,
-		)
-		require.NoError(t, err)
-
-		ctx := t.Context()
-		runner := &Runner{
-			Helm:                    helmMock,
-			Output:                  outputMock,
-			ConnectionFactory:       &connections.MockFactory{ApplicationsManagementClient: mgmtMock},
-			KubernetesInterface:     cli_kubernetes.NewMockInterface(ctrl),
-			RadiusCoreClientFactory: radiusCoreFactory,
-
-			KubeContext: "test-context",
-			Chart:       "test-chart",
-			Preview:     true,
-		}
-
-		helmMock.EXPECT().CheckRadiusInstall("test-context").
-			Return(helm.InstallState{}, nil).
-			Times(1)
-		expectedOptions := helm.PopulateDefaultClusterOptions(helm.CLIClusterOptions{
-			Radius: helm.ChartOptions{ChartPath: "test-chart"},
-		})
-		helmMock.EXPECT().InstallRadius(ctx, expectedOptions, "test-context").
-			Return(nil).
-			Times(1)
-
-		err = runner.Run(ctx)
-		require.NoError(t, err)
-
-		require.Equal(t, "planes/radius/local/resourceGroups/default", capturedScope)
-		require.Equal(t, "default", capturedName)
-		require.NotNil(t, capturedEnv.Properties)
-		require.Equal(t, []*string{to.Ptr(recipepack.DefaultRecipePackID())}, capturedEnv.Properties.RecipePacks)
-		require.NotNil(t, capturedEnv.Properties.Providers)
-		require.NotNil(t, capturedEnv.Properties.Providers.Kubernetes)
-		require.Equal(t, "default", *capturedEnv.Properties.Providers.Kubernetes.Namespace)
-
 		expectedWrites := []any{
 			output.LogOutput{
 				Format: "Installing Radius version %s to namespace: %s...",
 				Params: []any{"edge", "radius-system"},
-			},
-			output.LogOutput{
-				Format: "Creating default resource group %q...",
-				Params: []any{"default"},
-			},
-			output.LogOutput{
-				Format: "Creating default environment %q in namespace %q...",
-				Params: []any{"default", "default"},
-			},
-		}
-		require.Equal(t, expectedWrites, outputMock.Writes)
-	})
-
-	t.Run("Success: Reinstall with --preview leaves an existing Radius.Core environment unchanged", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		helmMock := helm.NewMockInterface(ctrl)
-		outputMock := &output.MockOutput{}
-
-		mgmtMock := clients.NewMockApplicationsManagementClient(ctrl)
-		mgmtMock.EXPECT().
-			GetResourceGroup(gomock.Any(), "local", "default").
-			Return(ucp.ResourceGroupResource{}, nil).
-			Times(1)
-
-		// The environment already exists: Get succeeds and no CreateOrUpdate is issued.
-		radiusCoreFactory, err := test_client_factory.NewRadiusCoreTestClientFactory(
-			"/planes/radius/local/resourceGroups/default",
-			test_client_factory.WithEnvironmentServerNoError,
-			nil,
-		)
-		require.NoError(t, err)
-
-		ctx := t.Context()
-		runner := &Runner{
-			Helm:                    helmMock,
-			Output:                  outputMock,
-			ConnectionFactory:       &connections.MockFactory{ApplicationsManagementClient: mgmtMock},
-			KubernetesInterface:     cli_kubernetes.NewMockInterface(ctrl),
-			RadiusCoreClientFactory: radiusCoreFactory,
-
-			KubeContext: "test-context",
-			Chart:       "test-chart",
-			Preview:     true,
-			Reinstall:   true,
-		}
-
-		helmMock.EXPECT().CheckRadiusInstall("test-context").
-			Return(helm.InstallState{RadiusInstalled: true, RadiusVersion: "test-version"}, nil).
-			Times(1)
-		expectedOptions := helm.PopulateDefaultClusterOptions(helm.CLIClusterOptions{
-			Radius: helm.ChartOptions{ChartPath: "test-chart", Reinstall: true},
-		})
-		helmMock.EXPECT().InstallRadius(ctx, expectedOptions, "test-context").
-			Return(nil).
-			Times(1)
-
-		err = runner.Run(ctx)
-		require.NoError(t, err)
-
-		expectedWrites := []any{
-			output.LogOutput{
-				Format: "Reinstalling Radius version %s to namespace: %s...",
-				Params: []any{"edge", "radius-system"},
-			},
-			output.LogOutput{
-				Format: "Default resource group %q already exists; leaving it unchanged.",
-				Params: []any{"default"},
-			},
-			output.LogOutput{
-				Format: "Default environment %q already exists; leaving it unchanged.",
-				Params: []any{"default"},
 			},
 		}
 		require.Equal(t, expectedWrites, outputMock.Writes)


### PR DESCRIPTION
## Summary
Reverts the default resource group and environment creation that `rad install kubernetes` performed,
returning it to a barebones control-plane install. Also removes the `--preview` flag from this command,
since its only effect was selecting the resource type (and default recipe pack) for the default
environment that is no longer created.

After this change:

- `rad install kubernetes` installs the Radius control plane .
- No `default` resource group, no `default` environment, no default recipe pack, and no environment
  targeting the `default` Kubernetes namespace.

This reverts the behavior introduced by #11870 (shipped in v0.59.0) and the `--preview` flag added on
top of it by #12504 (shipped in v0.60.0). Unrelated changes that landed in the same files since then
are preserved: the `t.Context()` test modernization from #12523 and the current `docs.radapp.io`
architecture URL.

## Reason for change

`rad install kubernetes` silently provisioning a default environment and recipe packs is undesirable
for anyone who intends to customize environments, namespaces, or recipe packs — notably the GitHub
Copilot app integration, where a default environment targeting the `default` Kubernetes namespace
conflicts with the intended setup.

Opinionated initialization belongs in `rad init`, where users expect an onboarding flow with defaults
preset. This restores a clean separation of responsibilities:

- `rad install kubernetes` — install the control plane only.
- `rad init` — install and/or initialize Radius with default resources and recipe packs.

Fixes #12827

## How to test
Manual, against a clean cluster:

rad install kubernetes
rad group show default   # expect: not found
rad env show default     # expect: not found

rad init                 # still creates the default group, environment, and recipe pack
rad group show default   # expect: exists
rad env show default     # expect: exists

Also confirm  rad install kubernetes --preview  now reports  unknown flag: --preview , and that the
existing install flags ( --reinstall ,  --chart ,  --set ,  --set-file ,  --kubecontext ,
 --skip-contour-install , and the  --contour-*  flags) are unchanged.


| File | Summary of change |
| ---- | ----------------- |
| `pkg/cli/cmd/install/kubernetes/kubernetes.go` | Removed `createDefaultGroupAndEnvironment`, `ensureDefaultResourceGroup`, `ensureDefaultEnvironment`, and `ensureDefaultEnvironmentPreview`, along with the `--preview` flag and the `ConnectionFactory`, `KubernetesInterface`, `Preview`, and `RadiusCoreClientFactory` runner fields. `Run` now returns after `Helm.InstallRadius`. Added help text stating the command installs the control plane only and pointing to `rad init` for defaults. |
| `pkg/cli/cmd/install/kubernetes/kubernetes_test.go` | Removed mock expectations for default group/environment/recipe-pack creation. Each install test now asserts the full `Output.Writes` sequence exactly, so any reintroduced default-resource logging fails the test. Retains the `t.Context()` usage from #12523. |
| `.github/extension/actions/restore-state/action.yml` | Updated a now-inaccurate comment claiming `rad install kubernetes` creates the `default` resource group. Behavior is unchanged — the action already creates the group explicitly. |

Note for follow-up:
Check for docs update to reflect updated changes.