### PR TITLE
Serialize pnpm-based lint checks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -95,10 +95,11 @@ jobs:
         run: make install-shellcheck
 
       # Run the independent, read-only linters concurrently. Each parallel step is
-      # self-contained; the TypeSpec and Prettier checks share a pnpm/corepack
-      # toolchain, so they are grouped into one step to avoid racing on that
-      # shared install. The group has an implicit wait that aggregates results:
-      # every linter runs and any failure fails this job (a single status check).
+      # self-contained; the TypeSpec, Prettier, and deploy progress uploader
+      # checks share a pnpm/corepack toolchain, so they are grouped into one step
+      # to avoid racing on that shared install. The group has an implicit wait
+      # that aggregates results: every linter runs and any failure fails this job
+      # (a single status check).
       - parallel:
           - name: Go lint
             run: make lint-go
@@ -108,13 +109,11 @@ jobs:
               helm lint "${HELM_CHARTS_DIR}"
               make test-helm
 
-          - name: TypeSpec and Prettier format checks
+          - name: pnpm-based checks
             run: |
               make tsp-format-check
               make format-check || { echo "Format check failed. Run 'make format-write' to fix the formatting issues."; exit 1; }
-
-          - name: Deploy progress artifact uploader
-            run: make test-deploy-progress-uploader
+              make test-deploy-progress-uploader
 
           - name: Shell lint
             run: make lint-shell

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -95,10 +95,11 @@ jobs:
         run: make install-shellcheck
 
       # Run the independent, read-only linters concurrently. Each parallel step is
-      # self-contained. The pnpm-based checks run as separate goals in one Make
-      # process so their shared corepack setup runs once before the checks execute
-      # concurrently. The group has an implicit wait that aggregates results:
-      # every linter runs and any failure fails this job (a single status check).
+      # self-contained; the TypeSpec, Prettier, and deploy progress uploader
+      # checks share a pnpm/corepack toolchain, so they are grouped into one step
+      # to avoid racing on that shared install. The group has an implicit wait
+      # that aggregates results: every linter runs and any failure fails this job
+      # (a single status check).
       - parallel:
           - name: Go lint
             run: make lint-go
@@ -109,7 +110,10 @@ jobs:
               make test-helm
 
           - name: pnpm-based checks
-            run: make --keep-going --jobs=3 tsp-format-check format-check test-deploy-progress-uploader
+            run: |
+              make tsp-format-check
+              make format-check || { echo "Format check failed. Run 'make format-write' to fix the formatting issues."; exit 1; }
+              make test-deploy-progress-uploader
 
           - name: Shell lint
             run: make lint-shell

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -95,11 +95,10 @@ jobs:
         run: make install-shellcheck
 
       # Run the independent, read-only linters concurrently. Each parallel step is
-      # self-contained; the TypeSpec, Prettier, and deploy progress uploader
-      # checks share a pnpm/corepack toolchain, so they are grouped into one step
-      # to avoid racing on that shared install. The group has an implicit wait
-      # that aggregates results: every linter runs and any failure fails this job
-      # (a single status check).
+      # self-contained. The pnpm-based checks run as separate goals in one Make
+      # process so their shared corepack setup runs once before the checks execute
+      # concurrently. The group has an implicit wait that aggregates results:
+      # every linter runs and any failure fails this job (a single status check).
       - parallel:
           - name: Go lint
             run: make lint-go
@@ -110,10 +109,7 @@ jobs:
               make test-helm
 
           - name: pnpm-based checks
-            run: |
-              make tsp-format-check
-              make format-check || { echo "Format check failed. Run 'make format-write' to fix the formatting issues."; exit 1; }
-              make test-deploy-progress-uploader
+            run: make --keep-going --jobs=3 tsp-format-check format-check test-deploy-progress-uploader
 
           - name: Shell lint
             run: make lint-shell


### PR DESCRIPTION
## Summary

Serialize the pnpm-based checks inside the Lint workflow so TypeSpec formatting, repository Prettier checks, and the deploy progress artifact uploader test run as three individual Make commands in one branch of the existing parallel group.

## Root cause

The Lint workflow launches `TypeSpec and Prettier format checks` and `Deploy progress artifact uploader` as separate parallel steps. Their Make targets all reach the phony `generate-pnpm-installed` target: `tsp-format-check` through `generate-tsp-installed`, and `format-check` and `test-deploy-progress-uploader` directly.

Because the workflow previously used separate parallel steps, each step independently executed `corepack enable pnpm` and `corepack install`. Those commands mutate the same Corepack/pnpm installation state on the shared runner concurrently. The uploader branch can therefore lose the race and fail at `build/generate.mk:41` before its own pnpm install, tests, or build execute. This is a workflow orchestration race, not a failure in the artifact uploader tests.

Example failures:

- [Lint run 32976217643, job 98201717880](https://github.com/radius-project/radius/actions/runs/32976217643/job/98201717880)
- [Lint run 32975538165, job 98199398811](https://github.com/radius-project/radius/actions/runs/32975538165/job/98199398811)

## Fix

Run `make tsp-format-check`, `make format-check`, and `make test-deploy-progress-uploader` serially in one `pnpm-based checks` workflow step. This prevents concurrent Corepack mutation while keeping each check as an explicit Make invocation.

Only the commands that share Corepack/pnpm installation state are serialized. Go lint, Helm lint/tests, and ShellCheck remain independent parallel branches, preserving the useful concurrency of the aggregate Lint job.

## Validation

- `pnpm exec prettier --config ./.github/linters/.prettierrc.yml --check .github/workflows/lint.yaml` passed.
- `git diff --check HEAD^ HEAD` passed.
- Confirmed the workflow contains the three individual Make targets in this order: `tsp-format-check`, `format-check`, and `test-deploy-progress-uploader`.
- Confirmed the identical serial workflow structure passed on Linux in [Lint run 32978487623, job 98209271225](https://github.com/radius-project/radius/actions/runs/32978487623/job/98209271225).

## File change summary

| File | Change |
| ---- | ------ |
| `.github/workflows/lint.yaml` | Run the three pnpm-based checks serially in one parallel branch so they cannot race while mutating shared Corepack state. |