### PR TITLE
chore(release-prep): update versions.yaml and release notes for v0.60.1

### DIFF
--- a/docs/release-notes/v0.60.1.md
+++ b/docs/release-notes/v0.60.1.md
@@ -1,6 +1,6 @@
 ## Radius v0.60.1
 
-This patch release backports fixes for `rad resource list --preview`, live deployment graph support, custom recipe pack reconciliation on repeat deploys, architecture-aware container image builds, Azure OIDC token refresh and RBAC-propagation verification, functional test cleanup ordering, and the Go 1.27.0 toolchain bump. Check out the [changelog](#changelog) for more details of what was addressed in this patch.
+This patch release backports fixes for `rad resource list --preview`, live deployment graph support, custom recipe pack reconciliation on repeat deploys, architecture-aware container image builds, Azure OIDC token refresh and RBAC-propagation verification, control-plane readiness during install and upgrade, functional test cleanup ordering, and the Go 1.27.0 toolchain bump. It also reverts default resource group and environment creation from `rad install kubernetes`. Check out the [changelog](#changelog) for more details of what was addressed in this patch.
 
 ## Changelog
 
@@ -19,6 +19,8 @@ This patch release backports fixes for `rad resource list --preview`, live deplo
 - ci(update-tools): use create-pull-request action by @DariuszPorowski in <https://github.com/radius-project/radius/pull/12786>
 - Fix Azure verification during RBAC propagation by @ryanwaite in <https://github.com/radius-project/radius/pull/12764>
 - build(go): bump to 1.27.0 by @DariuszPorowski in <https://github.com/radius-project/radius/pull/12758>
+- fix(chart): wait for Radius aggregated API readiness by @brooke-hamilton in <https://github.com/radius-project/radius/pull/12785>
 - Fix custom recipe pack reconciliation on repeat deploys by @sk593 in <https://github.com/radius-project/radius/pull/12742>
+- Revert default resource group and environment creation from `rad install kubernetes` by @lakshmimsft in <https://github.com/radius-project/radius/pull/12829>
 
 **Full Changelog**: <https://github.com/radius-project/radius/compare/v0.60.0...v0.60.1>

--- a/docs/release-notes/v0.60.1.md
+++ b/docs/release-notes/v0.60.1.md
@@ -1,0 +1,24 @@
+## Radius v0.60.1
+
+This patch release backports fixes for `rad resource list --preview`, live deployment graph support, custom recipe pack reconciliation on repeat deploys, architecture-aware container image builds, Azure OIDC token refresh and RBAC-propagation verification, functional test cleanup ordering, and the Go 1.27.0 toolchain bump. Check out the [changelog](#changelog) for more details of what was addressed in this patch.
+
+## Changelog
+
+- Architecture-aware container image builds in deploy workflows by @sylvainsf in <https://github.com/radius-project/radius/pull/12640>
+- Fix invalid YAML in deploy workflow templates (arch placeholder quoting) by @sk593 in <https://github.com/radius-project/radius/pull/12721>
+- ci(deps): bump the github-actions group across 1 directory with 4 updates by @dependabot in <https://github.com/radius-project/radius/pull/12733>
+- Add `--preview` support to `rad resource list` for Radius.Core environments and applications types by @lakshmimsft in <https://github.com/radius-project/radius/pull/12728>
+- Delete functional test resources in dependency order to fix LRT by @brooke-hamilton in <https://github.com/radius-project/radius/pull/12702>
+- fix(azure): keep federated assertions valid for the whole run by @DariuszPorowski in <https://github.com/radius-project/radius/pull/12751>
+- Live graph support by @nithyatsu in <https://github.com/radius-project/radius/pull/12727>
+- ci(codeql): stabilize GoSec SARIF category by @brooke-hamilton in <https://github.com/radius-project/radius/pull/12769>
+- fix(test): stop AWS functional test cleanup from failing without waiting by @lakshmimsft in <https://github.com/radius-project/radius/pull/12765>
+- Fix run-rad-commands parse regression and add shell syntax gate for extension actions by @Copilot in <https://github.com/radius-project/radius/pull/12775>
+- Fix deployed graph publisher enrichment by @nithyatsu in <https://github.com/radius-project/radius/pull/12779>
+- fix(graph): link deployment progress to resolved resources by @nithyatsu in <https://github.com/radius-project/radius/pull/12782>
+- ci(update-tools): use create-pull-request action by @DariuszPorowski in <https://github.com/radius-project/radius/pull/12786>
+- Fix Azure verification during RBAC propagation by @ryanwaite in <https://github.com/radius-project/radius/pull/12764>
+- build(go): bump to 1.27.0 by @DariuszPorowski in <https://github.com/radius-project/radius/pull/12758>
+- Fix custom recipe pack reconciliation on repeat deploys by @sk593 in <https://github.com/radius-project/radius/pull/12742>
+
+**Full Changelog**: <https://github.com/radius-project/radius/compare/v0.60.0...v0.60.1>

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.60'
-    version: 'v0.60.0'
+    version: 'v0.60.1'
 deprecated:
   - channel: '0.59'
     version: 'v0.59.0'


### PR DESCRIPTION
Patch release `v0.60.1` for channel `0.60`.

## Backported PRs

Listed in cherry-pick (topological) order. **Gap filler** = not requested for the patch, but included because it touched the same region of a shared file between `release/0.60` and a requested commit. Without it the cherry-pick has no common merge base and conflicts.

| # | Commit | PR | Role |
| --- | --- | --- | --- |
| 1 | `6882b5fdf` | #12640 | Requested |
| 2 | `af0443809` | #12721 | Requested |
| 3 | `7c6de043d` | #12733 | **Gap filler** — `.github/workflows/codeql.yml` |
| 4 | `ca7b5a3e7` | #12728 | Requested |
| 5 | `2eac7c1f1` | #12702 | Requested |
| 6 | `b4ebe2f28` | #12751 | Requested |
| 7 | `e30a2594d` | #12727 | Requested |
| 8 | `3c7dfecd6` | #12769 | **Gap filler** — `.github/workflows/codeql.yml` |
| 9 | `787b6ca1a` | #12765 | **Gap filler** — `build/test.mk` |
| 10 | `f84184955` | #12775 | Requested |
| 11 | `415d5b9c2` | #12779 | Requested |
| 12 | `a1d976013` | #12782 | Requested |
| 13 | `14a21bd0d` | #12786 | **Gap filler** — `build/test.mk` |
| 14 | `a87146c77` | #12764 | **Gap filler** — `build/test.mk` |
| 15 | `073ca3cfa` | #12758 | Requested |
| 16 | `5e1f94c13` | #12785 | **Gap filler** — `pkg/cli/cmd/install/kubernetes/kubernetes.go` |
| 17 | `1fd650af5` | #12742 | Requested |
| 18 | `19376c3f3` | #12829 | Requested |

Five of the six gap fillers are CI/test-only. #12785 is not: it adds a Helm `control-plane-readiness` Job, a `pre-upgrade wait-for-control-plane` command, UCP readiness probes, and a NetworkPolicy change. It is required for #12829 to apply.

## Validation

Full chain dry-run cherry-picked onto `release/0.60` with zero conflicts. `go build ./...` clean; `pkg/cli/cmd/install/kubernetes`, `cmd/pre-upgrade/cmd`, `pkg/cli/...`, `pkg/graph/...`, and `test/validation` all pass.