### PR TITLE
ci: update repo-files-sync action to v0.1.0-rc.18

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -177,7 +177,7 @@ jobs:
       # still generated and uploaded as artifacts above for inspection.
       - name: Sync reference docs to docs repository
         if: env.PUBLISH_DOCS == 'true'
-        uses: raven-actions/repo-files-sync@a4c9248f592fa5c5d19d70f630b7bd0d4772ab67 # v0.1.0-rc.12
+        uses: raven-actions/repo-files-sync@511c602835ac7dd8529673f91afe348db8d08185 # v0.1.0-rc.18
         with:
           # The App installation token authenticates as <app-slug>[bot]. Passing it as
           # GH_TOKEN makes repo-files-sync create verified commits through


### PR DESCRIPTION
<!--
Thank you for contributing to Radius! Please fill out each section below so
reviewers have the context they need. Sections marked optional can be removed
if they do not apply.
-->

## Summary

Update the pinned `raven-actions/repo-files-sync` action used by the reference documentation workflow from v0.1.0-rc.12 to v0.1.0-rc.18.

## Reason for change

The older action could delete the shared sync branch when a closed PR existed, which caused GitHub to close the active documentation PR. The newer pinned release contains the fix for closed-PR handling.

## How to test

- `actionlint .github/workflows/publish-docs.yaml`

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `.github/workflows/publish-docs.yaml` | Pin the documentation sync action to the immutable v0.1.0-rc.18 commit. |