### PR TITLE
Make control-plane services reachable for paginated deletes

### DIFF
--- a/.github/extension/actions/delete-resource/action.yml
+++ b/.github/extension/actions/delete-resource/action.yml
@@ -25,6 +25,64 @@ inputs:
 runs:
   using: composite
   steps:
+    # `rad` reaches the control plane through the Kubernetes API-server proxy, but a
+    # paginated LIST returns a nextLink built from the serving RP's own address (for
+    # example http://dynamic-rp.radius-system:8082/...). The CLI follows that URL
+    # verbatim, bypassing the proxy, and the in-cluster name does not resolve on the
+    # runner -- so deleting an application with more than one page of resources of a
+    # single type fails while enumerating, before anything is deleted. Alias the
+    # control-plane services onto loopback so the directly dialled nextLink still
+    # reaches them. Runs here rather than in setup-control-plane because the earlier
+    # target-credential refresh restarts these deployments, which would drop the
+    # forwards. The forwards are left running for the delete below; the runner
+    # reclaims them when the job ends.
+    - name: Make control-plane services reachable for paginated listings
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        port_open() {
+          # The subshell closes the descriptor when it exits, so this only probes.
+          (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
+        }
+
+        for service in dynamic-rp applications-rp ucp; do
+          port=$(kubectl get service "${service}" -n radius-system \
+            -o jsonpath='{.spec.ports[0].port}' 2>/dev/null || echo "")
+          if [[ -z "${port}" ]]; then
+            echo "Skipping ${service}: no service port found."
+            continue
+          fi
+
+          # A port already in use would satisfy the readiness probe below and alias
+          # the service to whatever else is listening.
+          if port_open "${port}"; then
+            echo "::warning::Port ${port} is already in use; not aliasing ${service}."
+            continue
+          fi
+
+          kubectl port-forward -n radius-system "service/${service}" \
+            "${port}:${port}" --address 127.0.0.1 >/dev/null 2>&1 &
+
+          ready=""
+          for _ in {1..30}; do
+            if port_open "${port}"; then
+              ready="yes"
+              break
+            fi
+            sleep 1
+          done
+
+          if [[ -z "${ready}" ]]; then
+            echo "::warning::Could not port-forward ${service} on port ${port}; paginated listings naming it may fail."
+            continue
+          fi
+
+          echo "127.0.0.1 ${service}.radius-system ${service}.radius-system.svc ${service}.radius-system.svc.cluster.local" \
+            | sudo tee -a /etc/hosts >/dev/null
+          echo "✅ ${service} reachable on 127.0.0.1:${port}"
+        done
+
     - name: Delete Radius resource
       shell: bash
       env:


### PR DESCRIPTION
## Summary

Adds a step to the shared `delete-resource` composite action that makes the Radius control-plane services reachable from the runner under their in-cluster DNS names, so `rad app delete` can follow a paginated resource listing.

## Reason for change

`rad` reaches the ephemeral control plane through the Kubernetes API-server proxy, but a paginated LIST returns a `nextLink` built from the serving RP's own address:

```text
Error: Get "http://dynamic-rp.radius-system:8082/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containers?api-version=2025-08-01-preview&skipToken=...&top=10": dial tcp: lookup dynamic-rp.radius-system on 127.0.0.53:53: no such host
```

The CLI follows that URL verbatim, bypassing the proxy, and the in-cluster name does not resolve on a GitHub runner. The first page succeeds; the second fails. So deleting an application with more than one page of resources of a single type (`top=10`) fails while **enumerating**, before anything is deleted, leaving the application undeletable from the workflow.

This is a workflow-level mitigation so the delete workflows work today. The underlying leak — `GetURLFromReqWithQueryParameters` using `req.Host` and ignoring the `X-Forwarded-Host` UCP already sends downstream — is tracked in #12837 and fixed separately. Once that lands this step becomes redundant and can be removed.

Reported downstream as radius-project/ai-extensions#441.

## Implementation notes

- Placed in `delete-resource` rather than `setup-control-plane`: the earlier "Refresh external deployment target credentials" step restarts `applications-rp`, `dynamic-rp` and `bicep-de`, which would drop any forwards established earlier.
- Placed in the shared composite action rather than in `delete-azure.yml` / `delete-aws.yml`, so both providers and both the application and environment delete paths get it without duplication.
- Each service is forwarded onto the *same* port it uses in-cluster, so the aliased host:port from the `nextLink` matches.
- A port that is already in use is reported and skipped rather than aliased to whatever else is listening.
- A service with no resolvable port, or a forward that never becomes ready, warns and continues instead of failing the delete.
- The forwards are deliberately left running for the delete step; the runner reclaims them at job end.

## How to test

1. Model an application with more than 10 resources of the same type (e.g. 10+ `Radius.Compute/containers`).
2. Deploy it to an AKS-backed environment via the extension deploy workflow.
3. Run the `Delete with Radius` workflow for that application.
4. The new step logs `✅ dynamic-rp reachable on 127.0.0.1:8082` (and similarly for `applications-rp` / `ucp`), and `rad app delete` pages through the full listing and completes instead of failing DNS resolution.

Validated locally:

- `.github/extension/actions/action-shell-syntax_test.sh` passes (19 run blocks across 10 action.yml files).
- `shellcheck -s bash` is clean on the extracted run block.
- The run block was executed against a stubbed `kubectl`/`sudo`/`tee` harness covering all three branches: a healthy service (forwarded and aliased), a service with no port (skipped), and a port already in use (warned, not aliased). Step exits 0 in every case and writes exactly the expected `/etc/hosts` lines.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `.github/extension/actions/delete-resource/action.yml` | Add a "Make control-plane services reachable for paginated listings" step before the delete that port-forwards `dynamic-rp`, `applications-rp` and `ucp` onto their in-cluster ports on loopback and aliases their in-cluster DNS names in `/etc/hosts`. |
