### PR TITLE
Build paginated nextLink from the caller-visible host

### DIFF
--- a/pkg/armrpc/frontend/controller/util.go
+++ b/pkg/armrpc/frontend/controller/util.go
@@ -115,13 +115,38 @@ func checkIfNoneMatchHeader(ifNoneMatchETag string, etag string) error {
 	return nil
 }
 
-// GetURLFromReqWithQueryParameters function builds a URL from the request and query parameters
+// forwardedHeaderValue returns the first entry of a possibly comma-separated
+// X-Forwarded-* header, or an empty string when the header is absent.
+func forwardedHeaderValue(req *http.Request, header string) string {
+	value := req.Header.Get(header)
+	if value == "" {
+		return ""
+	}
+
+	first, _, _ := strings.Cut(value, ",")
+	return strings.TrimSpace(first)
+}
+
+// GetURLFromReqWithQueryParameters function builds a URL from the request and query parameters.
+//
+// When a request reaches a resource provider through UCP's proxy, req.Host is the
+// provider's own cluster-internal address (for example dynamic-rp.radius-system:8082),
+// which the original caller cannot resolve. The proxy forwards the caller-visible host
+// and scheme as X-Forwarded-Host and X-Forwarded-Proto, so prefer those when present.
 func GetURLFromReqWithQueryParameters(req *http.Request, qps url.Values) *url.URL {
 	url := url.URL{
 		Host:     req.Host,
 		Scheme:   req.URL.Scheme,
 		Path:     req.URL.Path,
 		RawQuery: qps.Encode(),
+	}
+
+	if host := forwardedHeaderValue(req, "X-Forwarded-Host"); host != "" {
+		url.Host = host
+	}
+
+	if scheme := forwardedHeaderValue(req, "X-Forwarded-Proto"); scheme != "" {
+		url.Scheme = scheme
 	}
 
 	if url.Scheme == "" {

--- a/pkg/armrpc/frontend/controller/util_test.go
+++ b/pkg/armrpc/frontend/controller/util_test.go
@@ -18,8 +18,10 @@ package controller
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/google/uuid"
@@ -182,4 +184,148 @@ func TestValidateEtag_IfNoneMatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetURLFromReqWithQueryParameters(t *testing.T) {
+	urlTests := []struct {
+		name     string
+		host     string
+		scheme   string
+		headers  map[string]string
+		expected string
+	}{
+		{
+			name:     "uses the request host when the request was not proxied",
+			host:     "ucp.example.com",
+			scheme:   "https",
+			expected: "https://ucp.example.com/planes/radius/local?top=10",
+		},
+		{
+			name:     "defaults the scheme when the request URL has none",
+			host:     "ucp.example.com",
+			expected: "http://ucp.example.com/planes/radius/local?top=10",
+		},
+		{
+			name:   "prefers the forwarded host over the internal request host",
+			host:   "dynamic-rp.radius-system:8082",
+			scheme: "http",
+			headers: map[string]string{
+				"X-Forwarded-Host": "ucp.example.com",
+			},
+			expected: "http://ucp.example.com/planes/radius/local?top=10",
+		},
+		{
+			name:   "prefers the forwarded scheme over the request scheme",
+			host:   "ucp.example.com",
+			scheme: "http",
+			headers: map[string]string{
+				"X-Forwarded-Proto": "https",
+			},
+			expected: "https://ucp.example.com/planes/radius/local?top=10",
+		},
+		{
+			name:   "applies the forwarded host and scheme together",
+			host:   "dynamic-rp.radius-system:8082",
+			scheme: "http",
+			headers: map[string]string{
+				"X-Forwarded-Host":  "ucp.example.com",
+				"X-Forwarded-Proto": "https",
+			},
+			expected: "https://ucp.example.com/planes/radius/local?top=10",
+		},
+		{
+			name:   "uses the first entry of a forwarded header set by a proxy chain",
+			host:   "dynamic-rp.radius-system:8082",
+			scheme: "http",
+			headers: map[string]string{
+				"X-Forwarded-Host":  "ucp.example.com, inner.example.com",
+				"X-Forwarded-Proto": "https, http",
+			},
+			expected: "https://ucp.example.com/planes/radius/local?top=10",
+		},
+		{
+			name:   "falls back to the request values when the forwarded headers are empty",
+			host:   "ucp.example.com",
+			scheme: "https",
+			headers: map[string]string{
+				"X-Forwarded-Host":  "",
+				"X-Forwarded-Proto": "",
+			},
+			expected: "https://ucp.example.com/planes/radius/local?top=10",
+		},
+	}
+
+	for _, tc := range urlTests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "/planes/radius/local", nil)
+			require.NoError(t, err)
+			req.Host = tc.host
+			req.URL.Scheme = tc.scheme
+			for key, value := range tc.headers {
+				req.Header.Set(key, value)
+			}
+
+			qps := url.Values{}
+			qps.Add("top", "10")
+
+			require.Equal(t, tc.expected, GetURLFromReqWithQueryParameters(req, qps).String())
+		})
+	}
+}
+
+func TestGetNextLinkURL(t *testing.T) {
+	newRequest := func(t *testing.T) *http.Request {
+		t.Helper()
+		// A LIST that UCP proxied downstream: the provider sees its own
+		// cluster-internal address as the host, and the caller-visible one only in
+		// X-Forwarded-Host.
+		req, err := http.NewRequest(http.MethodGet, "/planes/radius/local/resourceGroups/default/providers/Radius.Compute/containers", nil)
+		require.NoError(t, err)
+		req.Host = "dynamic-rp.radius-system:8082"
+		req.URL.Scheme = "http"
+		return req
+	}
+
+	ctx := v1.WithARMRequestContext(context.Background(), &v1.ARMRequestContext{
+		APIVersion: "2025-08-01-preview",
+		Top:        10,
+	})
+
+	t.Run("returns an empty link when there are no further pages", func(t *testing.T) {
+		require.Empty(t, GetNextLinkURL(ctx, newRequest(t), ""))
+	})
+
+	t.Run("returns a link the original caller can reach", func(t *testing.T) {
+		req := newRequest(t)
+		req.Header.Set("X-Forwarded-Host", "ucp.example.com")
+		req.Header.Set("X-Forwarded-Proto", "https")
+
+		nextLink, err := url.Parse(GetNextLinkURL(ctx, req, "skip-token"))
+		require.NoError(t, err)
+
+		require.Equal(t, "https", nextLink.Scheme)
+		require.Equal(t, "ucp.example.com", nextLink.Host)
+		require.Equal(t, "/planes/radius/local/resourceGroups/default/providers/Radius.Compute/containers", nextLink.Path)
+		require.Equal(t, "2025-08-01-preview", nextLink.Query().Get("api-version"))
+		require.Equal(t, "skip-token", nextLink.Query().Get("skipToken"))
+		require.Equal(t, "10", nextLink.Query().Get("top"))
+	})
+
+	t.Run("does not leak the provider's cluster-internal address", func(t *testing.T) {
+		req := newRequest(t)
+		req.Header.Set("X-Forwarded-Host", "ucp.example.com")
+
+		require.NotContains(t, GetNextLinkURL(ctx, req, "skip-token"), "dynamic-rp.radius-system")
+	})
+
+	t.Run("uses the request host when the request was not proxied", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/planes/radius/local/providers/Radius.Compute/containers", nil)
+		require.NoError(t, err)
+		req.Host = "localhost:8080"
+		req.URL.Scheme = "http"
+
+		nextLink, err := url.Parse(GetNextLinkURL(ctx, req, "skip-token"))
+		require.NoError(t, err)
+		require.Equal(t, "localhost:8080", nextLink.Host)
+	})
 }

--- a/pkg/armrpc/frontend/controller/util_test.go
+++ b/pkg/armrpc/frontend/controller/util_test.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -286,7 +285,7 @@ func TestGetNextLinkURL(t *testing.T) {
 		return req
 	}
 
-	ctx := v1.WithARMRequestContext(context.Background(), &v1.ARMRequestContext{
+	ctx := v1.WithARMRequestContext(t.Context(), &v1.ARMRequestContext{
 		APIVersion: "2025-08-01-preview",
 		Top:        10,
 	})


### PR DESCRIPTION
## Summary

Builds a paginated `nextLink` from the caller-visible host (`X-Forwarded-Host` / `X-Forwarded-Proto`) instead of the serving provider's own `req.Host`.

## Reason for change

`GetURLFromReqWithQueryParameters` took the host straight from `req.Host`. When UCP proxies a LIST downstream to a resource provider, `req.Host` as seen by that provider is its cluster-internal service address, so the `nextLink` it emits is only usable from inside the cluster:

```text
Error: Get "http://dynamic-rp.radius-system:8082/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containers?api-version=2025-08-01-preview&skipToken=...&top=10": dial tcp: lookup dynamic-rp.radius-system on 127.0.0.53:53: no such host
```

Any client that is not in-cluster gets the first page fine and then fails on the second. The user-visible symptom is `rad app delete` failing during **resource enumeration**, before anything is deleted, for an application with more than one page of resources of a single type (`top=10` by default) — leaving the application undeletable. It is not delete-specific: it affects every paginated LIST for every out-of-cluster caller.

UCP's proxy already forwards the caller-visible host and scheme downstream as `X-Forwarded-Host` and `X-Forwarded-Proto` (see `pkg/ucp/proxy/testdata/arm/basic-roundtrip/downstream-request.json`); the helper just ignored them.

Fixes #12837. Reported downstream as radius-project/ai-extensions#441.

## Implementation notes

- Fixing the shared helper covers both `GetNextLinkURL` callers (`pkg/armrpc/frontend/defaultoperation/listresources.go` and `pkg/dynamicrp/frontend/listresources.go`) and every RP that goes through them, with no CLI change.
- Falls back to `req.Host` / `req.URL.Scheme` / `DefaultSheme` exactly as before when the headers are absent or empty, so a direct (unproxied) request is unchanged.
- Takes the first entry of a comma-separated value, as set by a proxy chain.
- `X-Forwarded-Proto` handling follows the existing precedent in `pkg/armrpc/rest/results.go`.

Follow-up worth considering separately: `results.go` builds `Location` / `Azure-AsyncOperation` headers from `req.Host` in the same way and applies `X-Forwarded-Proto` but not `X-Forwarded-Host`, so async operation URLs likely have the same leak. Left out of scope here.

## How to test

`go test ./pkg/armrpc/frontend/controller/ -run 'TestGetURLFromReqWithQueryParameters|TestGetNextLinkURL' -v`

Validated locally:

- 11 new subtests pass, covering: unproxied request, missing scheme defaulting, forwarded host only, forwarded scheme only, both together, comma-separated proxy chain, empty forwarded headers, empty pagination token, and a full proxied `nextLink` round-trip asserting scheme/host/path/`api-version`/`skipToken`/`top`.
- Confirmed the new tests **fail without the production change** (6 subtests fail, including an explicit assertion that the link does not contain `dynamic-rp.radius-system`), so they are real regression tests rather than vacuous ones.
- `go build`, `go vet`, and `gofmt -l` clean.
- Full `./pkg/armrpc/...` and `./pkg/dynamicrp/frontend/...` suites pass with no failures.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `pkg/armrpc/frontend/controller/util.go` | Prefer `X-Forwarded-Host` / `X-Forwarded-Proto` over `req.Host` / `req.URL.Scheme` when building the URL, via a new `forwardedHeaderValue` helper that takes the first entry of a comma-separated value. |
| `pkg/armrpc/frontend/controller/util_test.go` | Add `TestGetURLFromReqWithQueryParameters` and `TestGetNextLinkURL` covering proxied and unproxied requests, proxy chains, empty headers, scheme defaulting, and the no-further-pages case. |
