### PR TITLE
Return a relative paginated nextLink so clients can reach the next page

### DIFF
--- a/pkg/armrpc/frontend/controller/util.go
+++ b/pkg/armrpc/frontend/controller/util.go
@@ -131,7 +131,19 @@ func GetURLFromReqWithQueryParameters(req *http.Request, qps url.Values) *url.UR
 	return &url
 }
 
-// GetNextLinkUrl function returns the URL string by building a URL from the request and the pagination token.
+// GetNextLinkURL returns the link to the next page of a paginated list response, or an empty
+// string when the current page is the last one.
+//
+// The link is deliberately a relative reference (path and query only) rather than an absolute URL.
+// A server has no reliable way to know the address the client actually dialed: the request may have
+// been proxied by UCP and, in Kubernetes, the API server aggregator replaces the original host with
+// the address of the service it forwards to (kubernetes/kubernetes#107435). Building the link from
+// the inbound host therefore leaks a cluster-internal address such as
+// http://dynamic-rp.radius-system:8082/... that no out-of-cluster client can reach.
+//
+// Emitting a relative reference lets the client resolve the link against the endpoint it already
+// reached, which is by definition routable for it. Clients generated against azcore do this
+// automatically in runtime.NewRequestForNextLink.
 func GetNextLinkURL(ctx context.Context, req *http.Request, paginationToken string) string {
 	if paginationToken == "" {
 		return ""
@@ -144,5 +156,14 @@ func GetNextLinkURL(ctx context.Context, req *http.Request, paginationToken stri
 	qps.Add("skipToken", paginationToken)
 	qps.Add("top", strconv.Itoa(serviceCtx.Top))
 
-	return GetURLFromReqWithQueryParameters(req, qps).String()
+	// Strip whatever the caller's routable base path is so the client can supply its own. UCP serves
+	// its own lists under a path base (/apis/api.ucp.dev/v1alpha3) which is already part of every
+	// client's endpoint, while a proxied resource provider sees a path that begins at /planes/ and
+	// so has nothing to trim.
+	relative := url.URL{
+		Path:     strings.TrimPrefix(req.URL.Path, v1.ParsePathBase(req.URL.Path)),
+		RawQuery: qps.Encode(),
+	}
+
+	return relative.String()
 }

--- a/pkg/armrpc/frontend/controller/util_test.go
+++ b/pkg/armrpc/frontend/controller/util_test.go
@@ -18,8 +18,10 @@ package controller
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/google/uuid"
@@ -182,4 +184,133 @@ func TestValidateEtag_IfNoneMatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func nextLinkContext(t *testing.T) context.Context {
+	t.Helper()
+
+	return v1.WithARMRequestContext(t.Context(), &v1.ARMRequestContext{
+		APIVersion: "2025-08-01-preview",
+		Top:        10,
+	})
+}
+
+// nextLinkRequest models a request as the server receives it. inboundHost is the host the server
+// saw, which behind the Kubernetes API server aggregator is the server's own in-cluster address
+// rather than anything the client dialed.
+func nextLinkRequest(t *testing.T, inboundHost string, path string) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, "http://"+inboundHost+path+"?api-version=2025-08-01-preview&top=10", nil)
+	require.NoError(t, err)
+	return req
+}
+
+func TestGetNextLinkURL_IsRelativeSoTheClientSuppliesTheAddress(t *testing.T) {
+	cases := []struct {
+		name        string
+		inboundHost string
+		path        string
+		expected    string
+	}{
+		{
+			// A proxied resource provider: UCP has already trimmed its path base, so the path starts
+			// at /planes/ and there is nothing left to strip.
+			name:        "resource provider behind the UCP proxy",
+			inboundHost: "dynamic-rp.radius-system:8082",
+			path:        "/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containers",
+			expected:    "/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containers?api-version=2025-08-01-preview&skipToken=page2&top=10",
+		},
+		{
+			// UCP serving its own list: it mounts routes under its path base, which is already part
+			// of every client's endpoint and so must not be repeated in the link.
+			name:        "UCP serving its own list under a path base",
+			inboundHost: "ucp.radius-system:9000",
+			path:        "/apis/api.ucp.dev/v1alpha3/planes/radius/local/providers/System.Resources/resourceproviders",
+			expected:    "/planes/radius/local/providers/System.Resources/resourceproviders?api-version=2025-08-01-preview&skipToken=page2&top=10",
+		},
+		{
+			name:        "UCP serving an azure plane list under a path base",
+			inboundHost: "ucp.radius-system:9000",
+			path:        "/apis/api.ucp.dev/v1alpha3/subscriptions/s1/resourcegroups/rg/providers/Applications.Core/containers",
+			expected:    "/subscriptions/s1/resourcegroups/rg/providers/Applications.Core/containers?api-version=2025-08-01-preview&skipToken=page2&top=10",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			req := nextLinkRequest(t, tt.inboundHost, tt.path)
+
+			link := GetNextLinkURL(nextLinkContext(t), req, "page2")
+
+			require.Equal(t, tt.expected, link)
+
+			// The inbound host is not routable for the client, so it must never appear in the link.
+			require.NotContains(t, link, tt.inboundHost)
+
+			parsed, err := url.Parse(link)
+			require.NoError(t, err)
+			require.Empty(t, parsed.Scheme, "link must not be absolute")
+			require.Empty(t, parsed.Host, "link must not carry an authority")
+		})
+	}
+}
+
+func TestGetNextLinkURL_ResolvesAgainstTheEndpointTheClientDialed(t *testing.T) {
+	// The endpoint a Kubernetes connection builds, whose path is exactly UCP's configured path base.
+	const endpoint = "https://kubernetes.example.com/apis/api.ucp.dev/v1alpha3"
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "link produced by a proxied resource provider",
+			path: "/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containers",
+		},
+		{
+			name: "link produced by UCP itself",
+			path: "/apis/api.ucp.dev/v1alpha3/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containers",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			link := GetNextLinkURL(nextLinkContext(t), nextLinkRequest(t, "dynamic-rp.radius-system:8082", tt.path), "page2")
+
+			// This mirrors how a generated client resolves the link: azcore joins a relative
+			// nextLink onto the endpoint it was configured with.
+			base, err := url.Parse(endpoint)
+			require.NoError(t, err)
+			resolved, err := url.Parse(link)
+			require.NoError(t, err)
+			resolved = base.ResolveReference(resolved)
+
+			// Whichever server produced the link, the client ends up at the same reachable URL.
+			require.Equal(t,
+				"https://kubernetes.example.com/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containers?api-version=2025-08-01-preview&skipToken=page2&top=10",
+				resolved.String())
+		})
+	}
+}
+
+func TestGetNextLinkURL_CarriesThePaginationState(t *testing.T) {
+	req := nextLinkRequest(t, "dynamic-rp.radius-system:8082", "/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containers")
+
+	link := GetNextLinkURL(nextLinkContext(t), req, "opaque token/with+reserved=chars")
+
+	parsed, err := url.Parse(link)
+	require.NoError(t, err)
+	query := parsed.Query()
+
+	require.Equal(t, "2025-08-01-preview", query.Get("api-version"))
+	require.Equal(t, "10", query.Get("top"))
+	// The token round trips through the encoding untouched.
+	require.Equal(t, "opaque token/with+reserved=chars", query.Get("skipToken"))
+}
+
+func TestGetNextLinkURL_IsEmptyOnTheLastPage(t *testing.T) {
+	req := nextLinkRequest(t, "dynamic-rp.radius-system:8082", "/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containers")
+
+	require.Empty(t, GetNextLinkURL(nextLinkContext(t), req, ""))
 }

--- a/pkg/armrpc/frontend/controller/util_test.go
+++ b/pkg/armrpc/frontend/controller/util_test.go
@@ -22,8 +22,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/google/uuid"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/stretchr/testify/require"
@@ -252,6 +254,10 @@ func TestGetNextLinkURL_IsRelativeSoTheClientSuppliesTheAddress(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, parsed.Scheme, "link must not be absolute")
 			require.Empty(t, parsed.Host, "link must not carry an authority")
+
+			// The link must be an absolute-path reference. azcore concatenates it onto the endpoint,
+			// so a relative-path reference would silently produce a URL missing a separator.
+			require.True(t, strings.HasPrefix(link, "/"), "link must start at the root")
 		})
 	}
 }
@@ -278,18 +284,18 @@ func TestGetNextLinkURL_ResolvesAgainstTheEndpointTheClientDialed(t *testing.T) 
 		t.Run(tt.name, func(t *testing.T) {
 			link := GetNextLinkURL(nextLinkContext(t), nextLinkRequest(t, "dynamic-rp.radius-system:8082", tt.path), "page2")
 
-			// This mirrors how a generated client resolves the link: azcore joins a relative
-			// nextLink onto the endpoint it was configured with.
-			base, err := url.Parse(endpoint)
+			// Resolve the link exactly as a generated client does, rather than modelling it. azcore
+			// concatenates a scheme-less link onto the endpoint, which is not the same as RFC 3986
+			// reference resolution: the latter would treat the link as replacing the endpoint's path
+			// and drop the path base, producing a URL the API server does not route.
+			req, err := runtime.NewRequestForNextLink(t.Context(), http.MethodGet, endpoint, link)
 			require.NoError(t, err)
-			resolved, err := url.Parse(link)
-			require.NoError(t, err)
-			resolved = base.ResolveReference(resolved)
 
-			// Whichever server produced the link, the client ends up at the same reachable URL.
+			// Whichever server produced the link, the client ends up at the same URL, and it is the
+			// one UCP is served on through the aggregated APIService.
 			require.Equal(t,
-				"https://kubernetes.example.com/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containers?api-version=2025-08-01-preview&skipToken=page2&top=10",
-				resolved.String())
+				"https://kubernetes.example.com/apis/api.ucp.dev/v1alpha3/planes/radius/local/resourcegroups/default/providers/Radius.Compute/containers?api-version=2025-08-01-preview&skipToken=page2&top=10",
+				req.Raw().URL.String())
 		})
 	}
 }


### PR DESCRIPTION
# Description

`GetNextLinkURL` built the paginated `nextLink` from the inbound request host:

```go
url := url.URL{
    Host:   req.Host,        // ← the host *this server* was reached on
    Scheme: req.URL.Scheme,
    Path:   req.URL.Path,
    ...
}
```

A server has no reliable way to know the address the client actually dialed. The request may have been proxied by UCP, and in Kubernetes the API server aggregator explicitly replaces the original host with the address of the service it forwards to:

```go
// k8s.io/apiserver/pkg/util/proxy/proxy.go
newReq.Host = location.Host
```

(see kubernetes/kubernetes#107435 — the same limitation already documented in `pkg/sdk/connection_location.go`).

So the link came back as `http://dynamic-rp.radius-system:8082/planes/...`, a cluster-internal address no out-of-cluster client can reach. Any client that follows it fails. That is why `rad app delete` aborts partway through enumerating resources and leaves the application undeletable, as reported in radius-project/ai-extensions#441.

## Reason for change

Fixes #12837.

The bug only appears once a listing paginates, so it stays invisible until an application has more resources than one page holds — and then the application cannot be deleted at all.

## Approach

The server cannot know the client's address, so it should stop trying to guess it. This change emits a **relative** reference (path and query only) and lets the client resolve it against the endpoint it already reached — which is routable for that client by definition.

This requires no client change. Every generated client already funnels the link through azcore, which resolves a relative `nextLink` against its configured endpoint:

```go
// azcore/internal/exported/request.go — NewRequestForNextLink
if !hasScheme(nextLink) {
    nextLink = JoinPaths(endpoint, nextLink)
}
```

The path base is trimmed so the client supplies its own, which keeps both producers of `nextLink` consistent:

| Producer | Path the server sees | Emitted link |
|---|---|---|
| Resource provider behind the UCP proxy | `/planes/...` (UCP already trimmed its path base in `proxy.go`) | `/planes/...` |
| UCP serving its own list | `/apis/api.ucp.dev/v1alpha3/planes/...` (routes are mounted *under* the path base) | `/planes/...` |

UCP's configured path base (`/apis/api.ucp.dev/v1alpha3`) is exactly the path portion of the endpoint a Kubernetes connection builds, so repeating it would double-prefix the URL. Trimming it means both producers resolve to the same reachable URL. `v1.ParsePathBase` already implements this, so no configuration has to be plumbed through.

## Alternatives considered

Rewriting the link on the way out — either in the UCP proxy or in the SDK round tripper, mirroring how `Location` and `Azure-AsyncOperation` are handled — was implemented first and discarded. Both stages depend on the `Referer` header, whose host is *also* the address UCP itself was reached on and therefore wrong behind the aggregator. Rewriting also means parsing and re-serializing every paginated response body in the proxy. Not embedding an unknowable host in the first place is smaller and removes the failure mode rather than compensating for it.

## Auto-generated summary

<!-- GENERATED BY COPILOT -->

| File | Change |
|---|---|
| `pkg/armrpc/frontend/controller/util.go` | `GetNextLinkURL` returns a relative reference, dropping the scheme and authority the server cannot know, and trims the path base so the client supplies its own. |
| `pkg/armrpc/frontend/controller/util_test.go` | Adds value-level coverage for `GetNextLinkURL`. |

## Testing

`GetNextLinkURL` had **no value-level coverage** before this change. The existing tests only asserted that a link was non-empty (`require.NotNil(t, actualOutput.NextLink)`), which is precisely why the leaked host went unnoticed. The new tests assert the link itself:

- the link is relative and never contains the inbound host, for a proxied RP, a UCP-served list, and an Azure-plane list;
- resolving it against the endpoint a Kubernetes connection builds yields the same reachable URL whether it came from the RP or from UCP;
- `api-version`, `top` and an opaque `skipToken` containing reserved characters survive the round trip;
- the last page yields an empty link.

All six subtests fail against the previous implementation and pass with this change. `./pkg/armrpc/...`, `./pkg/ucp/...`, `./pkg/dynamicrp/...`, `./pkg/sdk/...` and `./pkg/corerp/frontend/...` pass, and `golangci-lint` reports no issues.

### Manual verification

With a resource group holding more than one page of resources:

```console
kubectl get --raw "/apis/api.ucp.dev/v1alpha3/planes/radius/local/resourcegroups/<rg>/providers/Radius.Compute/containers?api-version=2025-08-01-preview&top=5" | jq -r .nextLink
```

Before: `http://dynamic-rp.radius-system:8082/planes/...`
After: `/planes/...`

Then confirm `rad app delete` completes against that resource group.

## Contributor checklist

- [x] Considered malicious use cases and addressed them.
- [x] Considered UX impact.
- [x] Considered security implications.
- [x] Added relevant tests.
- [ ] Documentation updated (no user-facing documentation describes the shape of `nextLink`).