### PR TITLE
Pin RADIUS_INSTALL_REF to install.sh sudo fix commit

### DIFF
--- a/.github/extension/actions/setup-control-plane/action.yml
+++ b/.github/extension/actions/setup-control-plane/action.yml
@@ -44,11 +44,13 @@ runs:
     - name: Install Radius CLI
       shell: bash
       env:
-        # Pin the Radius install script to a released tag and verify its checksum
+        # Pin the Radius install script to an immutable ref and verify its checksum
         # before running it, rather than piping from main. The CLI channel stays
         # `edge` so the workflow still exercises the latest control-plane build.
-        RADIUS_INSTALL_REF: v0.59.0
-        RADIUS_INSTALL_SHA256: cf96794af522b266f56985f195e9c2bdd4f7e8d9e5267ae0595b9d37cb225e7b
+        # Pinned to the commit carrying the install.sh sudo fix so consumers pick it
+        # up without waiting for a patch release.
+        RADIUS_INSTALL_REF: 3fd9e2a5514fcc8e8048300eadfb0d3e2ae7aac1
+        RADIUS_INSTALL_SHA256: 6a00f7b8793337deda816759422bd1d9441b80a7ef15c7d76be1aec4d0a51b14
       run: |
         curl -sSL "https://raw.githubusercontent.com/radius-project/radius/${RADIUS_INSTALL_REF}/deploy/install.sh" -o install-rad.sh
         echo "${RADIUS_INSTALL_SHA256}  install-rad.sh" | sha256sum -c -

--- a/.github/extension/actions/setup-control-plane/action.yml
+++ b/.github/extension/actions/setup-control-plane/action.yml
@@ -47,11 +47,11 @@ runs:
         # Pin the Radius install script to an immutable ref and verify its checksum
         # before running it, rather than piping from main. The CLI channel stays
         # `edge` so the workflow still exercises the latest control-plane build.
-        # Pinned to the commit carrying the install.sh sudo fix so consumers pick it
-        # up without waiting for a patch release. Use an unambiguous abbreviated ref;
-        # the checksum below verifies the exact script contents.
-        RADIUS_INSTALL_REF: 3fd9e2a5514f
-        RADIUS_INSTALL_SHA256: 6a00f7b8793337deda816759422bd1d9441b80a7ef15c7d76be1aec4d0a51b14
+        # Pinned to the main commit carrying the install.sh sudo fix so consumers
+        # pick it up without waiting for a patch release. Use an unambiguous
+        # abbreviated ref; the checksum below verifies the exact script contents.
+        RADIUS_INSTALL_REF: f4b44130e6cc
+        RADIUS_INSTALL_SHA256: d12f6e1101dea7911c491de14a0f0aef57518aaf573d46e225b29d6f103c2e86
       run: |
         curl -sSL "https://raw.githubusercontent.com/radius-project/radius/${RADIUS_INSTALL_REF}/deploy/install.sh" -o install-rad.sh
         echo "${RADIUS_INSTALL_SHA256}  install-rad.sh" | sha256sum -c -

--- a/.github/extension/actions/setup-control-plane/action.yml
+++ b/.github/extension/actions/setup-control-plane/action.yml
@@ -48,8 +48,9 @@ runs:
         # before running it, rather than piping from main. The CLI channel stays
         # `edge` so the workflow still exercises the latest control-plane build.
         # Pinned to the commit carrying the install.sh sudo fix so consumers pick it
-        # up without waiting for a patch release.
-        RADIUS_INSTALL_REF: 3fd9e2a5514fcc8e8048300eadfb0d3e2ae7aac1
+        # up without waiting for a patch release. Use an unambiguous abbreviated ref;
+        # the checksum below verifies the exact script contents.
+        RADIUS_INSTALL_REF: 3fd9e2a5514f
         RADIUS_INSTALL_SHA256: 6a00f7b8793337deda816759422bd1d9441b80a7ef15c7d76be1aec4d0a51b14
       run: |
         curl -sSL "https://raw.githubusercontent.com/radius-project/radius/${RADIUS_INSTALL_REF}/deploy/install.sh" -o install-rad.sh


### PR DESCRIPTION
## Purpose

Unblock the extensions workflows on the `install.sh` sudo fix (#12836) **without waiting for a patch release**.

`setup-control-plane` fetches `install.sh` from a pinned Radius ref and checksum-verifies it. This repoints that pin from the released tag to the **immutable commit** that carries the sudo fix, so consumers get the fixed script immediately. A full commit SHA is immutable and the script is still checksum-verified, so the existing security posture is preserved.

- `RADIUS_INSTALL_REF`: `f4b44130e6cc`
- `RADIUS_INSTALL_SHA256`: `d12f6e1101dea7911c491de14a0f0aef57518aaf573d46e225b29d6f103c2e86`

Verified locally that the workflow's fetch + `sha256sum -c` succeeds against this ref.

## Before merging

- [ ] Merge #12836 first.
- [ ] Repoint `RADIUS_INSTALL_REF` to the **squash-merge commit of #12836 on `main`** (the fixed `install.sh` content is unchanged, so `RADIUS_INSTALL_SHA256` stays `6a00f7b8…`). This avoids depending on a PR-branch commit that could be GC'd after the branch is deleted.

## Notes

Depends on #12836.