### PR TITLE
Fix empty environment list in deploy status control-plane diagnostic

### DIFF
--- a/.github/extension/actions/publish-deploy-status/action.yml
+++ b/.github/extension/actions/publish-deploy-status/action.yml
@@ -187,8 +187,11 @@ runs:
           echo "# rad version"
           rad version 2>&1 || true
           echo ""
-          echo "# rad env list"
-          rad env list -o json 2>&1 || true
+          # --preview reads Radius.Core/environments, which is what this pipeline
+          # creates. Without it `rad env list` dispatches to the legacy
+          # Applications.Core surface and always reports an empty list.
+          echo "# rad env list --preview"
+          rad env list --preview -o json 2>&1 || true
         } > "$STATUS_DIR/deploy-controlplane.log" 2>&1 || true
 
         printf 'state=%s\nexitCode=%s\napplication=%s\nenvironment=%s\nupdatedAt=%s\nsha=%s\n' \

--- a/.github/extension/actions/publish-deploy-status/publish-deploy-status_test.sh
+++ b/.github/extension/actions/publish-deploy-status/publish-deploy-status_test.sh
@@ -265,6 +265,10 @@ case "${1:-} ${2:-}" in
         echo "RELEASE VERSION 0.99.0-test"
         ;;
     "env list")
+        if [[ " $* " != *" --preview "* ]]; then
+            echo "rad: env list must use --preview" >&2
+            exit 64
+        fi
         printf '%s\n' '[{"name":"aks-dev"}]'
         ;;
     *)
@@ -561,7 +565,8 @@ progress_jq 'any(.resources[]; .name == "queue"
 
 assert_status_file_contains "deploy-activity.log" '"outcome":"success"'
 assert_status_file_contains "deploy-controlplane.log" "# rad version"
-assert_status_file_contains "deploy-controlplane.log" "# rad env list"
+assert_status_file_contains "deploy-controlplane.log" "# rad env list --preview"
+assert_status_file_contains "deploy-controlplane.log" "aks-dev"
 assert_status_file_contains "deploy-state.txt" "state=success"
 assert_status_file_contains "deploy-state.txt" "application=todolist"
 assert_status_file_contains "deploy-state.txt" "sha=deadbeefcafe"


### PR DESCRIPTION
## Summary

`publish-deploy-status` runs `rad env list -o json` to capture control-plane health
into the `deploy-controlplane.log` status artifact. `rad env list` without `--preview`
dispatches to the legacy `Applications.Core/environments` surface, but this pipeline
creates its environment as a `Radius.Core/environments` resource. The diagnostic
therefore always logged an empty list.

This adds `--preview` to that call so the log reports the environments the pipeline
actually created, and adds a test guard so the flag cannot be dropped again.

## Reason for change

The extension consistently uses the Radius.Core preview surface: the environment is
created as `Radius.Core/environments` via Bicep (`run-rad-commands-azure.yml`,
`run-rad-commands-aws.yml`), and every other read-side command already passes
`--preview`.

 The result could be a diagnostic artifact that silently reports no
environments on every run — most misleading exactly when someone is using it to debug a
failed deploy, since an empty list reads as "the control plane has no environments"
rather than "this command looked in the wrong place".

The existing test asserted only that the `# rad env list` *header* was present, so it
guarded the `echo` rather than the command, and stayed green with the bug in place.

## How to test

Unit tests:

```bash
bash .github/extension/actions/publish-deploy-status/publish-deploy-status_test.sh
bash .github/extension/actions/action-shell-syntax_test.sh
```

To confirm the new assertions actually reach the changed code, revert `action.yml` and
re-run — the test must fail with `rad: env list must use --preview`:

```bash
git stash push -- .github/extension/actions/publish-deploy-status/action.yml
bash .github/extension/actions/publish-deploy-status/publish-deploy-status_test.sh   # expected: FAIL
git stash pop
```

End to end: run a deploy workflow and download the
`radius-deploy-status-<environment>-<app>` artifact. `deploy-controlplane.log` should
now list the environment the run created under `# rad env list --preview`, where it
previously showed an empty array.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `.github/extension/actions/publish-deploy-status/action.yml` | Pass `--preview` to `rad env list` so the control-plane diagnostic reads `Radius.Core/environments`; update the log header to match and add a comment explaining why the flag is required. |
| `.github/extension/actions/publish-deploy-status/publish-deploy-status_test.sh` | Make the `rad` stub reject `env list` without `--preview` (mirroring the existing `resource list` guard), and assert the environment name reaches `deploy-controlplane.log` rather than only the header. |
