### PR TITLE
refactor(go): apply Go 1.27 go fix simplifications

### DIFF
--- a/pkg/armrpc/api/v1/types_test.go
+++ b/pkg/armrpc/api/v1/types_test.go
@@ -75,12 +75,10 @@ func TestOperationType_ParseOperationType(t *testing.T) {
 
 func TestBaseResource_UpdateMetadata(t *testing.T) {
 	oldResource := BaseResource{
-		TrackedResource: TrackedResource{
-			ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-RG/providers/Applications.Core/environments/EnVironMent0",
-			Name:     "EnVironMent0",
-			Type:     "Applications.Core/environment",
-			Location: "global",
-		},
+		ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-RG/providers/Applications.Core/environments/EnVironMent0",
+		Name:     "EnVironMent0",
+		Type:     "Applications.Core/environment",
+		Location: "global",
 	}
 
 	newResourceID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/environment0"

--- a/pkg/armrpc/asyncoperation/statusmanager/statusmanager.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/statusmanager.go
@@ -93,12 +93,10 @@ func (aom *statusManager) QueueAsyncOperation(ctx context.Context, sCtx *v1.ARMR
 
 	opID := aom.operationStatusResourceID(sCtx.ResourceID, sCtx.OperationID)
 	aos := &Status{
-		AsyncOperationStatus: v1.AsyncOperationStatus{
-			ID:        opID,
-			Name:      sCtx.OperationID.String(),
-			Status:    v1.ProvisioningStateAccepted,
-			StartTime: time.Now().UTC(),
-		},
+		ID:               opID,
+		Name:             sCtx.OperationID.String(),
+		Status:           v1.ProvisioningStateAccepted,
+		StartTime:        time.Now().UTC(),
 		LinkedResourceID: sCtx.ResourceID.String(),
 		Location:         aom.location,
 		RetryAfter:       options.RetryAfter,
@@ -107,8 +105,8 @@ func (aom *statusManager) QueueAsyncOperation(ctx context.Context, sCtx *v1.ARMR
 	}
 
 	err := aom.databaseClient.Save(ctx, &database.Object{
-		Metadata: database.Metadata{ID: opID},
-		Data:     aos,
+		ID:   opID,
+		Data: aos,
 	})
 
 	if err != nil {

--- a/pkg/armrpc/asyncoperation/statusmanager/statusmanager_test.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/statusmanager_test.go
@@ -70,12 +70,10 @@ var reqCtx = &v1.ARMRequestContext{
 var opID = uuid.New()
 
 var testAos = &Status{
-	AsyncOperationStatus: v1.AsyncOperationStatus{
-		ID:        opID.String(),
-		Name:      opID.String(),
-		Status:    v1.ProvisioningStateUpdating,
-		StartTime: time.Now().UTC(),
-	},
+	ID:               opID.String(),
+	Name:             opID.String(),
+	Status:           v1.ProvisioningStateUpdating,
+	StartTime:        time.Now().UTC(),
 	LinkedResourceID: uuid.New().String(),
 	Location:         "test-location",
 	RetryAfter:       opererationRetryAfterDuration,
@@ -231,8 +229,8 @@ func TestGetAsyncOperationStatus(t *testing.T) {
 			Desc:   "get_success",
 			GetErr: nil,
 			Obj: &database.Object{
-				Metadata: database.Metadata{ID: opID.String(), ETag: "etag"},
-				Data:     testAos,
+				ID: opID.String(), ETag: "etag",
+				Data: testAos,
 			},
 		},
 		{
@@ -281,8 +279,8 @@ func TestUpdateAsyncOperationStatus(t *testing.T) {
 			Desc:   "update_success",
 			GetErr: nil,
 			Obj: &database.Object{
-				Metadata: database.Metadata{ID: opID.String(), ETag: "etag"},
-				Data:     testAos,
+				ID: opID.String(), ETag: "etag",
+				Data: testAos,
 			},
 			SaveErr: nil,
 		},

--- a/pkg/armrpc/asyncoperation/worker/worker_runoperation_test.go
+++ b/pkg/armrpc/asyncoperation/worker/worker_runoperation_test.go
@@ -47,12 +47,10 @@ const (
 var (
 	testResourceType    = "Applications.Core/environments"
 	testOperationStatus = &manager.Status{
-		AsyncOperationStatus: v1.AsyncOperationStatus{
-			ID:        uuid.NewString(),
-			Name:      "operation-status",
-			Status:    v1.ProvisioningStateUpdating,
-			StartTime: time.Now().UTC(),
-		},
+		ID:               uuid.NewString(),
+		Name:             "operation-status",
+		Status:           v1.ProvisioningStateUpdating,
+		StartTime:        time.Now().UTC(),
 		LinkedResourceID: uuid.New().String(),
 		Location:         "test-location",
 		HomeTenantID:     "test-home-tenant-id",
@@ -209,7 +207,7 @@ func TestStart_MaxDequeueCount(t *testing.T) {
 	// The operation is not yet terminal, so the max-retry path completes it with the generic message.
 	tCtx.mockSM.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&manager.Status{
-			AsyncOperationStatus: v1.AsyncOperationStatus{Status: v1.ProvisioningStateUpdating},
+			Status: v1.ProvisioningStateUpdating,
 		}, nil).AnyTimes()
 	tCtx.mockSM.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(v1.ProvisioningStateFailed), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
@@ -275,7 +273,7 @@ func TestStart_MaxDequeueCount_AlreadyTerminal(t *testing.T) {
 	// The operation is already terminal (Failed) from a prior attempt.
 	tCtx.mockSM.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&manager.Status{
-			AsyncOperationStatus: v1.AsyncOperationStatus{Status: v1.ProvisioningStateFailed},
+			Status: v1.ProvisioningStateFailed,
 		}, nil).AnyTimes()
 	// No Update must happen: the recorded terminal status must not be overwritten.
 	tCtx.mockSM.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)

--- a/pkg/armrpc/asyncoperation/worker/worker_test.go
+++ b/pkg/armrpc/asyncoperation/worker/worker_test.go
@@ -177,8 +177,8 @@ func TestIsDuplicated(t *testing.T) {
 
 	t.Run("updating status refreshed recently is duplicated", func(t *testing.T) {
 		sm.EXPECT().Get(gomock.Any(), rID, opID).Return(&manager.Status{
-			AsyncOperationStatus: v1.AsyncOperationStatus{Status: v1.ProvisioningStateUpdating},
-			LastUpdatedTime:      time.Now().UTC().Add(-5 * time.Second),
+			Status:          v1.ProvisioningStateUpdating,
+			LastUpdatedTime: time.Now().UTC().Add(-5 * time.Second),
 		}, nil)
 
 		dup, err := worker.isDuplicated(t.Context(), resourceID, opID)
@@ -188,8 +188,8 @@ func TestIsDuplicated(t *testing.T) {
 
 	t.Run("updating status older than dedup window is not duplicated", func(t *testing.T) {
 		sm.EXPECT().Get(gomock.Any(), rID, opID).Return(&manager.Status{
-			AsyncOperationStatus: v1.AsyncOperationStatus{Status: v1.ProvisioningStateUpdating},
-			LastUpdatedTime:      time.Now().UTC().Add(-2 * time.Minute),
+			Status:          v1.ProvisioningStateUpdating,
+			LastUpdatedTime: time.Now().UTC().Add(-2 * time.Minute),
 		}, nil)
 
 		dup, err := worker.isDuplicated(t.Context(), resourceID, opID)
@@ -199,8 +199,8 @@ func TestIsDuplicated(t *testing.T) {
 
 	t.Run("terminal status is duplicated", func(t *testing.T) {
 		sm.EXPECT().Get(gomock.Any(), rID, opID).Return(&manager.Status{
-			AsyncOperationStatus: v1.AsyncOperationStatus{Status: v1.ProvisioningStateFailed},
-			LastUpdatedTime:      time.Now().UTC().Add(-10 * time.Minute),
+			Status:          v1.ProvisioningStateFailed,
+			LastUpdatedTime: time.Now().UTC().Add(-10 * time.Minute),
 		}, nil)
 
 		dup, err := worker.isDuplicated(t.Context(), resourceID, opID)

--- a/pkg/armrpc/builder/namespace.go
+++ b/pkg/armrpc/builder/namespace.go
@@ -33,11 +33,9 @@ type Namespace struct {
 // NewNamespace creates a new namespace.
 func NewNamespace(namespace string) *Namespace {
 	return &Namespace{
-		ResourceNode: ResourceNode{
-			Kind:     NamespaceResourceKind,
-			Name:     namespace,
-			children: make(map[string]*ResourceNode),
-		},
+		Kind:     NamespaceResourceKind,
+		Name:     namespace,
+		children: make(map[string]*ResourceNode),
 	}
 }
 

--- a/pkg/armrpc/frontend/controller/controller.go
+++ b/pkg/armrpc/frontend/controller/controller.go
@@ -177,9 +177,7 @@ func (c *BaseController) GetResource(ctx context.Context, id string, out any) (e
 // SaveResource saves a resource to the data store with an ETag and returns a store object or an error if the save fails.
 func (c *BaseController) SaveResource(ctx context.Context, id string, in any, etag string) (*database.Object, error) {
 	nr := &database.Object{
-		Metadata: database.Metadata{
-			ID: id,
-		},
+		ID:   id,
 		Data: in,
 	}
 	err := c.DatabaseClient().Save(ctx, nr, database.WithETag(etag))

--- a/pkg/armrpc/frontend/controller/operation.go
+++ b/pkg/armrpc/frontend/controller/operation.go
@@ -111,9 +111,7 @@ func (c *Operation[P, T]) GetResource(ctx context.Context, id resources.ID) (out
 // SaveResource is the helper to save the resource via database client.
 func (c *Operation[P, T]) SaveResource(ctx context.Context, id string, in *T, etag string) (string, error) {
 	nr := &database.Object{
-		Metadata: database.Metadata{
-			ID: id,
-		},
+		ID:   id,
 		Data: in,
 	}
 	err := c.DatabaseClient().Save(ctx, nr, database.WithETag(etag))

--- a/pkg/armrpc/frontend/defaultoperation/defaultasyncdelete_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/defaultasyncdelete_test.go
@@ -87,8 +87,8 @@ func TestDefaultAsyncDelete(t *testing.T) {
 			mds.EXPECT().
 				Get(gomock.Any(), gomock.Any()).
 				Return(&database.Object{
-					Metadata: database.Metadata{ID: appDataModel.ID},
-					Data:     appDataModel,
+					ID:   appDataModel.ID,
+					Data: appDataModel,
 				}, tt.getErr).
 				Times(1)
 

--- a/pkg/armrpc/frontend/defaultoperation/defaultasyncput_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/defaultasyncput_test.go
@@ -265,8 +265,8 @@ func TestDefaultAsyncPut_Update(t *testing.T) {
 			sCtx := v1.ARMRequestContextFromContext(ctx)
 
 			so := &database.Object{
-				Metadata: database.Metadata{ID: sCtx.ResourceID.String()},
-				Data:     reqDataModel,
+				ID:   sCtx.ResourceID.String(),
+				Data: reqDataModel,
 			}
 
 			mds.EXPECT().Get(gomock.Any(), gomock.Any()).

--- a/pkg/armrpc/frontend/defaultoperation/defaultsyncdelete_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/defaultsyncdelete_test.go
@@ -64,8 +64,8 @@ func TestDefaultSyncDelete(t *testing.T) {
 			mds.EXPECT().
 				Get(gomock.Any(), gomock.Any()).
 				Return(&database.Object{
-					Metadata: database.Metadata{ID: appDataModel.ID},
-					Data:     appDataModel,
+					ID:   appDataModel.ID,
+					Data: appDataModel,
 				}, tt.getErr).
 				Times(1)
 

--- a/pkg/armrpc/frontend/defaultoperation/defaultsyncput_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/defaultsyncput_test.go
@@ -192,8 +192,8 @@ func TestDefaultSyncPut_Update(t *testing.T) {
 			sCtx := v1.ARMRequestContextFromContext(ctx)
 
 			so := &database.Object{
-				Metadata: database.Metadata{ID: sCtx.ResourceID.String()},
-				Data:     reqDataModel,
+				ID:   sCtx.ResourceID.String(),
+				Data: reqDataModel,
 			}
 
 			mds.EXPECT().Get(gomock.Any(), gomock.Any()).

--- a/pkg/armrpc/frontend/defaultoperation/getoperationresult_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/getoperationresult_test.go
@@ -130,8 +130,8 @@ func TestGetOperationResultRun(t *testing.T) {
 				Get(gomock.Any(), gomock.Any()).
 				DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 					return &database.Object{
-						Metadata: database.Metadata{ID: id},
-						Data:     osDataModel,
+						ID:   id,
+						Data: osDataModel,
 					}, nil
 				})
 

--- a/pkg/armrpc/frontend/defaultoperation/getoperationstatus_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/getoperationstatus_test.go
@@ -84,8 +84,8 @@ func TestGetOperationStatusRun(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id},
-					Data:     osDataModel,
+					ID:   id,
+					Data: osDataModel,
 				}, nil
 			})
 

--- a/pkg/armrpc/frontend/defaultoperation/getresource_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/getresource_test.go
@@ -141,8 +141,8 @@ func TestGetResourceRun(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id},
-					Data:     testResourceDataModel,
+					ID:   id,
+					Data: testResourceDataModel,
 				}, nil
 			})
 

--- a/pkg/armrpc/frontend/defaultoperation/listresources_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/listresources_test.go
@@ -126,9 +126,7 @@ func TestListResourcesRun(t *testing.T) {
 			items := []database.Object{}
 			for i := 0; i < tt.batchCount; i++ {
 				item := database.Object{
-					Metadata: database.Metadata{
-						ID: uuid.New().String(),
-					},
+					ID:   uuid.New().String(),
 					Data: testResourceDataModel,
 				}
 				items = append(items, item)

--- a/pkg/armrpc/frontend/defaultoperation/resource_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/resource_test.go
@@ -85,19 +85,13 @@ type TestResourceProperties struct {
 // ConvertTo converts a version specific TestResource into a version-agnostic resource, TestResourceDataModel.
 func (src *TestResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &TestResourceDataModel{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      testAPIVersion,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		UpdatedAPIVersion:      testAPIVersion,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 		Properties: &TestResourceDataModelProperties{
 			Application: to.String(src.Properties.Application),
 			Environment: to.String(src.Properties.Environment),

--- a/pkg/armrpc/rpctest/testdatamodel.go
+++ b/pkg/armrpc/rpctest/testdatamodel.go
@@ -73,19 +73,13 @@ type TestResourceProperties struct {
 // ConvertTo converts a version specific TestResource into a version-agnostic resource, TestResourceDataModel.
 func (src *TestResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &TestResourceDataModel{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      TestAPIVersion,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		UpdatedAPIVersion:      TestAPIVersion,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 		Properties: &TestResourceDataModelProperties{
 			Application: to.String(src.Properties.Application),
 			Environment: to.String(src.Properties.Environment),

--- a/pkg/azure/clientv2/clients.go
+++ b/pkg/azure/clientv2/clients.go
@@ -32,10 +32,8 @@ import (
 )
 
 var defaultClientOptions = &arm.ClientOptions{
-	ClientOptions: azcore.ClientOptions{
-		Retry: policy.RetryOptions{
-			MaxRetries: 10,
-		},
+	Retry: policy.RetryOptions{
+		MaxRetries: 10,
 	},
 }
 

--- a/pkg/azure/clientv2/errors.go
+++ b/pkg/azure/clientv2/errors.go
@@ -44,8 +44,7 @@ func ExtractResponseError(err error) (*azcore.ResponseError, bool) {
 		return nil, false
 	}
 
-	var respErr *azcore.ResponseError
-	if errors.As(err, &respErr) {
+	if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
 		return respErr, true
 	}
 

--- a/pkg/cli/bicep/types.go
+++ b/pkg/cli/bicep/types.go
@@ -220,8 +220,7 @@ func urlFileName(urlPath string) string {
 // embeds (which may contain credentials). It applies to both url.Parse failures and http.Client
 // transport failures, since both return *url.Error.
 func urlParseReason(err error) error {
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
+	if urlErr, ok := errors.AsType[*url.Error](err); ok {
 		return urlErr.Err
 	}
 	return err

--- a/pkg/cli/clients/management.go
+++ b/pkg/cli/clients/management.go
@@ -1501,7 +1501,7 @@ func (amc *UCPApplicationsManagementClient) captureResponse(ctx context.Context,
 
 // getApiVersionsForResourceType retrieves the API versions for a given resource type in the configured scope.
 func (amc *UCPApplicationsManagementClient) getApiVersionsForResourceType(ctx context.Context, resourceType string) ([]string, error) {
-	provider := strings.Split(resourceType, "/")[0]
+	provider, _, _ := strings.Cut(resourceType, "/")
 	summary, err := amc.GetResourceProviderSummary(ctx, "local", provider)
 	if err != nil {
 		if clientv2.Is404Error(err) {

--- a/pkg/cli/clients/management_test.go
+++ b/pkg/cli/clients/management_test.go
@@ -49,88 +49,84 @@ const (
 var (
 	resourceProviderSummaryPages = []ucp.ResourceProvidersClientListProviderSummariesResponse{
 		{
-			PagedResourceProviderSummary: ucp.PagedResourceProviderSummary{
-				Value: []*ucp.ResourceProviderSummary{
-					{
-						Name: new("Applications.Test1"),
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"resourceType1": {
-								APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-									version: {},
-								},
-								DefaultAPIVersion: new(version),
+			Value: []*ucp.ResourceProviderSummary{
+				{
+					Name: new("Applications.Test1"),
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"resourceType1": {
+							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+								version: {},
 							},
-						},
-						Locations: map[string]*ucp.ResourceProviderSummaryLocation{
-							"east": {},
+							DefaultAPIVersion: new(version),
 						},
 					},
-					{
-						Name: new("Applications.Test2"),
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"resourceType2": {
-								APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-									version: {},
-								},
-								DefaultAPIVersion: new(version),
-							},
-						},
-						Locations: map[string]*ucp.ResourceProviderSummaryLocation{
-							"east": {},
-						},
+					Locations: map[string]*ucp.ResourceProviderSummaryLocation{
+						"east": {},
 					},
 				},
-				NextLink: new("0"),
+				{
+					Name: new("Applications.Test2"),
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"resourceType2": {
+							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+								version: {},
+							},
+							DefaultAPIVersion: new(version),
+						},
+					},
+					Locations: map[string]*ucp.ResourceProviderSummaryLocation{
+						"east": {},
+					},
+				},
 			},
+			NextLink: new("0"),
 		},
 		{
-			PagedResourceProviderSummary: ucp.PagedResourceProviderSummary{
-				Value: []*ucp.ResourceProviderSummary{
-					{
-						Name: new("Applications.Test3"),
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"resourceType3": {
-								APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-									version: {},
-								},
-								DefaultAPIVersion: new(version),
+			Value: []*ucp.ResourceProviderSummary{
+				{
+					Name: new("Applications.Test3"),
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"resourceType3": {
+							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+								version: {},
 							},
-						},
-						Locations: map[string]*ucp.ResourceProviderSummaryLocation{
-							"east": {},
+							DefaultAPIVersion: new(version),
 						},
 					},
-					{
-						Name: new("Applications.Core"),
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"environments": {
-								APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-									version: {},
-								},
-								DefaultAPIVersion: new(version),
-							},
-						},
-						Locations: map[string]*ucp.ResourceProviderSummaryLocation{
-							"east": {},
-						},
-					},
-					{
-						Name: new("Radius.Core"),
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"environments": {
-								APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-									"2025-08-01-preview": {},
-								},
-								DefaultAPIVersion: new("2025-08-01-preview"),
-							},
-						},
-						Locations: map[string]*ucp.ResourceProviderSummaryLocation{
-							"east": {},
-						},
+					Locations: map[string]*ucp.ResourceProviderSummaryLocation{
+						"east": {},
 					},
 				},
-				NextLink: new("1"),
+				{
+					Name: new("Applications.Core"),
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"environments": {
+							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+								version: {},
+							},
+							DefaultAPIVersion: new(version),
+						},
+					},
+					Locations: map[string]*ucp.ResourceProviderSummaryLocation{
+						"east": {},
+					},
+				},
+				{
+					Name: new("Radius.Core"),
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"environments": {
+							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+								"2025-08-01-preview": {},
+							},
+							DefaultAPIVersion: new("2025-08-01-preview"),
+						},
+					},
+					Locations: map[string]*ucp.ResourceProviderSummaryLocation{
+						"east": {},
+					},
+				},
 			},
+			NextLink: new("1"),
 		},
 	}
 )
@@ -142,9 +138,7 @@ func mockResourceGroupExists(mock *MockresourceGroupClient, planeName, rgName st
 	mock.EXPECT().
 		Get(gomock.Any(), planeName, rgName, gomock.Any()).
 		Return(ucp.ResourceGroupsClientGetResponse{
-			ResourceGroupResource: ucp.ResourceGroupResource{
-				Name: new(rgName),
-			},
+			Name: new(rgName),
 		}, nil).Times(times)
 }
 
@@ -185,13 +179,11 @@ func mockProviderSummaryForDeletion(mock *MockresourceProviderClient, planeName,
 			mock.EXPECT().
 				GetProviderSummary(gomock.Any(), planeName, providerName, gomock.Any()).
 				Return(ucp.ResourceProvidersClientGetProviderSummaryResponse{
-					ResourceProviderSummary: ucp.ResourceProviderSummary{
-						Name: new("Applications.Core"),
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"environments": {
-								APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-									version: {},
-								},
+					Name: new("Applications.Core"),
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"environments": {
+							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+								version: {},
 							},
 						},
 					},
@@ -265,10 +257,8 @@ func createResource(name, resourceType string) *generated.GenericResource {
 func createResourceList(resources ...*generated.GenericResource) []generated.GenericResourcesClientListByRootScopeResponse {
 	return []generated.GenericResourcesClientListByRootScopeResponse{
 		{
-			GenericResourcesList: generated.GenericResourcesList{
-				Value:    resources,
-				NextLink: new("0"),
-			},
+			Value:    resources,
+			NextLink: new("0"),
 		},
 	}
 }
@@ -327,56 +317,52 @@ func Test_Resource(t *testing.T) {
 
 	listPages := []generated.GenericResourcesClientListByRootScopeResponse{
 		{
-			GenericResourcesList: generated.GenericResourcesList{
-				Value: []*generated.GenericResource{
-					{
-						ID:       new(testScope + "/providers/" + testResourceType + "/" + "test1"),
-						Name:     new("test1"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-						Properties: map[string]any{
-							"application": testScope + "/providers/Applications.Core/applications/test-application",
-							"environment": testScope + "/providers/Applications.Core/environments/test-environment",
-						},
-					},
-					{
-						ID:       new(testScope + "/providers/" + testResourceType + "/" + "test2"),
-						Name:     new("test2"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-						Properties: map[string]any{
-							"environment": testScope + "/providers/Applications.Core/environments/test-environment",
-						},
+			Value: []*generated.GenericResource{
+				{
+					ID:       new(testScope + "/providers/" + testResourceType + "/" + "test1"),
+					Name:     new("test1"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
+					Properties: map[string]any{
+						"application": testScope + "/providers/Applications.Core/applications/test-application",
+						"environment": testScope + "/providers/Applications.Core/environments/test-environment",
 					},
 				},
-				NextLink: new("0"),
+				{
+					ID:       new(testScope + "/providers/" + testResourceType + "/" + "test2"),
+					Name:     new("test2"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
+					Properties: map[string]any{
+						"environment": testScope + "/providers/Applications.Core/environments/test-environment",
+					},
+				},
 			},
+			NextLink: new("0"),
 		},
 		{
-			GenericResourcesList: generated.GenericResourcesList{
-				Value: []*generated.GenericResource{
-					{
-						ID:       new(testScope + "/providers/" + testResourceType + "/" + "test3"),
-						Name:     new("test3"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-						Properties: map[string]any{
-							"application": anotherScope + "/providers/Applications.Core/applications/test-application",
-							"environment": anotherScope + "/providers/Applications.Core/environments/test-environment",
-						},
-					},
-					{
-						ID:       new(testScope + "/providers/" + testResourceType + "/" + "test4"),
-						Name:     new("test4"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-						Properties: map[string]any{
-							"environment": anotherScope + "/providers/Applications.Core/environments/test-environment",
-						},
+			Value: []*generated.GenericResource{
+				{
+					ID:       new(testScope + "/providers/" + testResourceType + "/" + "test3"),
+					Name:     new("test3"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
+					Properties: map[string]any{
+						"application": anotherScope + "/providers/Applications.Core/applications/test-application",
+						"environment": anotherScope + "/providers/Applications.Core/environments/test-environment",
 					},
 				},
-				NextLink: new("1"),
+				{
+					ID:       new(testScope + "/providers/" + testResourceType + "/" + "test4"),
+					Name:     new("test4"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
+					Properties: map[string]any{
+						"environment": anotherScope + "/providers/Applications.Core/environments/test-environment",
+					},
+				},
 			},
+			NextLink: new("1"),
 		},
 	}
 
@@ -529,13 +515,11 @@ func Test_Resource(t *testing.T) {
 
 				// Fallback for providers not in test data
 				return ucp.ResourceProvidersClientGetProviderSummaryResponse{
-					ResourceProviderSummary: ucp.ResourceProviderSummary{
-						Name: &providerName,
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"resourceType" + string(providerName[len(providerName)-1]): {
-								APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-									version: {},
-								},
+					Name: &providerName,
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"resourceType" + string(providerName[len(providerName)-1]): {
+							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+								version: {},
 							},
 						},
 					},
@@ -571,13 +555,11 @@ func Test_Resource(t *testing.T) {
 
 				// Fallback for providers not in test data
 				return ucp.ResourceProvidersClientGetProviderSummaryResponse{
-					ResourceProviderSummary: ucp.ResourceProviderSummary{
-						Name: &providerName,
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"resourceType" + string(providerName[len(providerName)-1]): {
-								APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-									version: {},
-								},
+					Name: &providerName,
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"resourceType" + string(providerName[len(providerName)-1]): {
+							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+								version: {},
 							},
 						},
 					},
@@ -617,13 +599,11 @@ func Test_Resource(t *testing.T) {
 
 				// Fallback for providers not in test data
 				return ucp.ResourceProvidersClientGetProviderSummaryResponse{
-					ResourceProviderSummary: ucp.ResourceProviderSummary{
-						Name: &providerName,
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"resourceType" + string(providerName[len(providerName)-1]): {
-								APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-									version: {},
-								},
+					Name: &providerName,
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"resourceType" + string(providerName[len(providerName)-1]): {
+							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+								version: {},
 							},
 						},
 					},
@@ -766,14 +746,12 @@ func Test_Resource(t *testing.T) {
 		resourceProviderMock.EXPECT().
 			GetProviderSummary(gomock.Any(), "local", "Radius.Core", gomock.Any()).
 			Return(ucp.ResourceProvidersClientGetProviderSummaryResponse{
-				ResourceProviderSummary: ucp.ResourceProviderSummary{
-					Name: new("Radius.Core"),
-					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-						"environments": {
-							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-								"2025-08-01-preview": {},
-								"other-version":      {},
-							},
+				Name: new("Radius.Core"),
+				ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+					"environments": {
+						APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+							"2025-08-01-preview": {},
+							"other-version":      {},
 						},
 					},
 				},
@@ -783,11 +761,9 @@ func Test_Resource(t *testing.T) {
 		mock.EXPECT().
 			Get(gomock.Any(), "test-env", gomock.Any()).
 			Return(generated.GenericResourcesClientGetResponse{
-				GenericResource: generated.GenericResource{
-					ID:   new("/test/id"),
-					Name: new("test-env"),
-					Type: new("Radius.Core/environments"),
-				},
+				ID:   new("/test/id"),
+				Name: new("test-env"),
+				Type: new("Radius.Core/environments"),
 			}, nil)
 
 		// Test via GetResource which calls getGenericClient internally
@@ -897,13 +873,11 @@ func Test_DeleteResource_ForceQueryParameter(t *testing.T) {
 			rpClient.EXPECT().
 				GetProviderSummary(gomock.Any(), "local", "Applications.Test", gomock.Any()).
 				Return(ucp.ResourceProvidersClientGetProviderSummaryResponse{
-					ResourceProviderSummary: ucp.ResourceProviderSummary{
-						Name: new("Applications.Test"),
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"testResource": {
-								APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-									version: {},
-								},
+					Name: new("Applications.Test"),
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"testResource": {
+							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+								version: {},
 							},
 						},
 					},
@@ -912,9 +886,7 @@ func Test_DeleteResource_ForceQueryParameter(t *testing.T) {
 			client := &UCPApplicationsManagementClient{
 				RootScope: testScope,
 				ClientOptions: &arm.ClientOptions{
-					ClientOptions: policy.ClientOptions{
-						Transport: transport,
-					},
+					Transport: transport,
 				},
 				resourceProviderClientFactory: func() (resourceProviderClient, error) {
 					return rpClient, nil
@@ -993,10 +965,8 @@ func Test_DeleteApplication_ForceQueryParameter(t *testing.T) {
 				NewListProviderSummariesPager("local", gomock.Any()).
 				Return(pager([]ucp.ResourceProvidersClientListProviderSummariesResponse{
 					{
-						PagedResourceProviderSummary: ucp.PagedResourceProviderSummary{
-							Value:    []*ucp.ResourceProviderSummary{},
-							NextLink: new("0"),
-						},
+						Value:    []*ucp.ResourceProviderSummary{},
+						NextLink: new("0"),
 					},
 				}))
 
@@ -1005,9 +975,7 @@ func Test_DeleteApplication_ForceQueryParameter(t *testing.T) {
 			client := &UCPApplicationsManagementClient{
 				RootScope: testScope,
 				ClientOptions: &arm.ClientOptions{
-					ClientOptions: policy.ClientOptions{
-						Transport: transport,
-					},
+					Transport: transport,
 				},
 				genericResourceClientFactory: func(scope string, resourceType string) (genericResourceClient, error) {
 					return genericMock, nil
@@ -1071,54 +1039,50 @@ func Test_Application(t *testing.T) {
 
 	listPages := []corerp.ApplicationsClientListByScopeResponse{
 		{
-			ApplicationResourceListResult: corerp.ApplicationResourceListResult{
-				Value: []*corerp.ApplicationResource{
-					{
-						ID:       new(testScope + "/providers/" + testResourceType + "/" + "test1"),
-						Name:     new("test1"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-						Properties: &corerp.ApplicationProperties{
-							Environment: new(testScope + "/providers/Applications.Core/environments/test-environment"),
-						},
-					},
-					{
-						ID:       new(testScope + "/providers/" + testResourceType + "/" + "test2"),
-						Name:     new("test2"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-						Properties: &corerp.ApplicationProperties{
-							Environment: new(testScope + "/providers/Applications.Core/environments/test-environment"),
-						},
+			Value: []*corerp.ApplicationResource{
+				{
+					ID:       new(testScope + "/providers/" + testResourceType + "/" + "test1"),
+					Name:     new("test1"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
+					Properties: &corerp.ApplicationProperties{
+						Environment: new(testScope + "/providers/Applications.Core/environments/test-environment"),
 					},
 				},
-				NextLink: new("0"),
+				{
+					ID:       new(testScope + "/providers/" + testResourceType + "/" + "test2"),
+					Name:     new("test2"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
+					Properties: &corerp.ApplicationProperties{
+						Environment: new(testScope + "/providers/Applications.Core/environments/test-environment"),
+					},
+				},
 			},
+			NextLink: new("0"),
 		},
 		{
-			ApplicationResourceListResult: corerp.ApplicationResourceListResult{
-				Value: []*corerp.ApplicationResource{
-					{
-						ID:       new(testScope + "/providers/" + testResourceType + "/" + "test3"),
-						Name:     new("test3"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-						Properties: &corerp.ApplicationProperties{
-							Environment: new(anotherScope + "/providers/Applications.Core/environments/test-environment"),
-						},
-					},
-					{
-						ID:       new(testScope + "/providers/" + testResourceType + "/" + "test4"),
-						Name:     new("test4"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-						Properties: &corerp.ApplicationProperties{
-							Environment: new(anotherScope + "/providers/Applications.Core/environments/test-environment"),
-						},
+			Value: []*corerp.ApplicationResource{
+				{
+					ID:       new(testScope + "/providers/" + testResourceType + "/" + "test3"),
+					Name:     new("test3"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
+					Properties: &corerp.ApplicationProperties{
+						Environment: new(anotherScope + "/providers/Applications.Core/environments/test-environment"),
 					},
 				},
-				NextLink: new("1"),
+				{
+					ID:       new(testScope + "/providers/" + testResourceType + "/" + "test4"),
+					Name:     new("test4"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
+					Properties: &corerp.ApplicationProperties{
+						Environment: new(anotherScope + "/providers/Applications.Core/environments/test-environment"),
+					},
+				},
 			},
+			NextLink: new("1"),
 		},
 	}
 
@@ -1228,30 +1192,28 @@ func Test_Application(t *testing.T) {
 		}
 		resourceListPages := []generated.GenericResourcesClientListByRootScopeResponse{
 			{
-				GenericResourcesList: generated.GenericResourcesList{
-					Value: []*generated.GenericResource{
-						{
-							ID:       new(testScope + "/providers/Applications.Test/testResources/test1"),
-							Name:     new("test1"),
-							Type:     new("Applications.Test1/resourceType1"),
-							Location: to.Ptr(v1.LocationGlobal),
-							Properties: map[string]any{
-								"application": testScope + "/providers/Applications.Core/applications/test-application",
-								"environment": testScope + "/providers/Applications.Core/environments/test-environment",
-							},
-						},
-						{
-							ID:       new(testScope + "/providers/Applications.Test/testResources/test2"),
-							Name:     new("test2"),
-							Type:     new("Applications.Test1/resourceType1"),
-							Location: to.Ptr(v1.LocationGlobal),
-							Properties: map[string]any{
-								"environment": testScope + "/providers/Applications.Core/environments/test-environment",
-							},
+				Value: []*generated.GenericResource{
+					{
+						ID:       new(testScope + "/providers/Applications.Test/testResources/test1"),
+						Name:     new("test1"),
+						Type:     new("Applications.Test1/resourceType1"),
+						Location: to.Ptr(v1.LocationGlobal),
+						Properties: map[string]any{
+							"application": testScope + "/providers/Applications.Core/applications/test-application",
+							"environment": testScope + "/providers/Applications.Core/environments/test-environment",
 						},
 					},
-					NextLink: new("0"),
+					{
+						ID:       new(testScope + "/providers/Applications.Test/testResources/test2"),
+						Name:     new("test2"),
+						Type:     new("Applications.Test1/resourceType1"),
+						Location: to.Ptr(v1.LocationGlobal),
+						Properties: map[string]any{
+							"environment": testScope + "/providers/Applications.Core/environments/test-environment",
+						},
+					},
 				},
+				NextLink: new("0"),
 			},
 		}
 
@@ -1267,13 +1229,11 @@ func Test_Application(t *testing.T) {
 
 				// Fallback for providers not in test data
 				return ucp.ResourceProvidersClientGetProviderSummaryResponse{
-					ResourceProviderSummary: ucp.ResourceProviderSummary{
-						Name: &providerName,
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"resourceType" + string(providerName[len(providerName)-1]): {
-								APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-									version: {},
-								},
+					Name: &providerName,
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"resourceType" + string(providerName[len(providerName)-1]): {
+							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+								version: {},
 							},
 						},
 					},
@@ -1334,13 +1294,11 @@ func Test_Application(t *testing.T) {
 
 				// Fallback for providers not in test data
 				return ucp.ResourceProvidersClientGetProviderSummaryResponse{
-					ResourceProviderSummary: ucp.ResourceProviderSummary{
-						Name: &providerName,
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"resourceType1": {
-								APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-									version: {},
-								},
+					Name: &providerName,
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"resourceType1": {
+							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+								version: {},
 							},
 						},
 					},
@@ -1448,42 +1406,38 @@ func Test_Environment(t *testing.T) {
 
 	listPages := []corerp.EnvironmentsClientListByScopeResponse{
 		{
-			EnvironmentResourceListResult: corerp.EnvironmentResourceListResult{
-				Value: []*corerp.EnvironmentResource{
-					{
-						ID:       new(testScope + "/providers/" + testResourceType + "/" + "test1"),
-						Name:     new("test1"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-					},
-					{
-						ID:       new(testScope + "/providers/" + testResourceType + "/" + "test2"),
-						Name:     new("test2"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-					},
+			Value: []*corerp.EnvironmentResource{
+				{
+					ID:       new(testScope + "/providers/" + testResourceType + "/" + "test1"),
+					Name:     new("test1"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
 				},
-				NextLink: new("0"),
+				{
+					ID:       new(testScope + "/providers/" + testResourceType + "/" + "test2"),
+					Name:     new("test2"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
+				},
 			},
+			NextLink: new("0"),
 		},
 		{
-			EnvironmentResourceListResult: corerp.EnvironmentResourceListResult{
-				Value: []*corerp.EnvironmentResource{
-					{
-						ID:       new(testScope + "/providers/" + testResourceType + "/" + "test3"),
-						Name:     new("test3"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-					},
-					{
-						ID:       new(testScope + "/providers/" + testResourceType + "/" + "test4"),
-						Name:     new("test4"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-					},
+			Value: []*corerp.EnvironmentResource{
+				{
+					ID:       new(testScope + "/providers/" + testResourceType + "/" + "test3"),
+					Name:     new("test3"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
 				},
-				NextLink: new("1"),
+				{
+					ID:       new(testScope + "/providers/" + testResourceType + "/" + "test4"),
+					Name:     new("test4"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
+				},
 			},
+			NextLink: new("1"),
 		},
 	}
 
@@ -1548,10 +1502,8 @@ func Test_Environment(t *testing.T) {
 		mock.EXPECT().
 			GetMetadata(gomock.Any(), testResourceName, expectedMetadata, gomock.Any()).
 			Return(corerp.EnvironmentsClientGetMetadataResponse{
-				RecipeGetMetadataResponse: corerp.RecipeGetMetadataResponse{
-					Parameters: map[string]any{
-						"a": "a-value",
-					},
+				Parameters: map[string]any{
+					"a": "a-value",
 				},
 			}, nil)
 
@@ -1591,21 +1543,19 @@ func Test_Environment(t *testing.T) {
 
 		resourceListPages := []generated.GenericResourcesClientListByRootScopeResponse{
 			{
-				GenericResourcesList: generated.GenericResourcesList{
-					Value: []*generated.GenericResource{
-						{
-							ID:       new(testScope + "/providers/Applications.Test/testResources/test1"),
-							Name:     new("test1"),
-							Type:     new("Applications.Test1/resourceType1"),
-							Location: to.Ptr(v1.LocationGlobal),
-							Properties: map[string]any{
-								"application": testScope + "/providers/Applications.Core/applications/test-application",
-								"environment": testScope + "/providers/Applications.Core/environments/test-environment",
-							},
+				Value: []*generated.GenericResource{
+					{
+						ID:       new(testScope + "/providers/Applications.Test/testResources/test1"),
+						Name:     new("test1"),
+						Type:     new("Applications.Test1/resourceType1"),
+						Location: to.Ptr(v1.LocationGlobal),
+						Properties: map[string]any{
+							"application": testScope + "/providers/Applications.Core/applications/test-application",
+							"environment": testScope + "/providers/Applications.Core/environments/test-environment",
 						},
 					},
-					NextLink: new("0"),
 				},
+				NextLink: new("0"),
 			},
 		}
 
@@ -1621,13 +1571,11 @@ func Test_Environment(t *testing.T) {
 
 				// Fallback for providers not in test data
 				return ucp.ResourceProvidersClientGetProviderSummaryResponse{
-					ResourceProviderSummary: ucp.ResourceProviderSummary{
-						Name: &providerName,
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"resourceType" + string(providerName[len(providerName)-1]): {
-								APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-									version: {},
-								},
+					Name: &providerName,
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"resourceType" + string(providerName[len(providerName)-1]): {
+							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+								version: {},
 							},
 						},
 					},
@@ -1646,20 +1594,18 @@ func Test_Environment(t *testing.T) {
 		// Setup deletion of applications in the environment.
 		applicationListPages := []corerp.ApplicationsClientListByScopeResponse{
 			{
-				ApplicationResourceListResult: corerp.ApplicationResourceListResult{
-					Value: []*corerp.ApplicationResource{
-						{
-							ID:       new(testScope + "/providers/Applications.Core/applications/test-application"),
-							Name:     new("test-application"),
-							Type:     new("Applications.Core/applications"),
-							Location: to.Ptr(v1.LocationGlobal),
-							Properties: &corerp.ApplicationProperties{
-								Environment: new(testScope + "/providers/Applications.Core/environments/test-environment"),
-							},
+				Value: []*corerp.ApplicationResource{
+					{
+						ID:       new(testScope + "/providers/Applications.Core/applications/test-application"),
+						Name:     new("test-application"),
+						Type:     new("Applications.Core/applications"),
+						Location: to.Ptr(v1.LocationGlobal),
+						Properties: &corerp.ApplicationProperties{
+							Environment: new(testScope + "/providers/Applications.Core/environments/test-environment"),
 						},
 					},
-					NextLink: new("0"),
 				},
+				NextLink: new("0"),
 			},
 		}
 		resourceProviderMock.EXPECT().
@@ -1706,36 +1652,32 @@ func Test_RadiusCoreEnvironment(t *testing.T) {
 
 	listPages := []corerpv20250801.EnvironmentsClientListByScopeResponse{
 		{
-			EnvironmentResourceListResult: corerpv20250801.EnvironmentResourceListResult{
-				Value: []*corerpv20250801.EnvironmentResource{
-					{
-						ID:       to.Ptr(testScope + "/providers/" + testResourceType + "/" + "test1"),
-						Name:     to.Ptr("test1"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-					},
-					{
-						ID:       to.Ptr(testScope + "/providers/" + testResourceType + "/" + "test2"),
-						Name:     to.Ptr("test2"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-					},
+			Value: []*corerpv20250801.EnvironmentResource{
+				{
+					ID:       to.Ptr(testScope + "/providers/" + testResourceType + "/" + "test1"),
+					Name:     to.Ptr("test1"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
 				},
-				NextLink: to.Ptr("0"),
+				{
+					ID:       to.Ptr(testScope + "/providers/" + testResourceType + "/" + "test2"),
+					Name:     to.Ptr("test2"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
+				},
 			},
+			NextLink: to.Ptr("0"),
 		},
 		{
-			EnvironmentResourceListResult: corerpv20250801.EnvironmentResourceListResult{
-				Value: []*corerpv20250801.EnvironmentResource{
-					{
-						ID:       to.Ptr(testScope + "/providers/" + testResourceType + "/" + "test3"),
-						Name:     to.Ptr("test3"),
-						Type:     &testResourceType,
-						Location: to.Ptr(v1.LocationGlobal),
-					},
+			Value: []*corerpv20250801.EnvironmentResource{
+				{
+					ID:       to.Ptr(testScope + "/providers/" + testResourceType + "/" + "test3"),
+					Name:     to.Ptr("test3"),
+					Type:     &testResourceType,
+					Location: to.Ptr(v1.LocationGlobal),
 				},
-				NextLink: to.Ptr("1"),
 			},
+			NextLink: to.Ptr("1"),
 		},
 	}
 
@@ -1786,42 +1728,38 @@ func Test_ResourceGroup(t *testing.T) {
 
 		resourceGroupPages := []ucp.ResourceGroupsClientListResponse{
 			{
-				ResourceGroupResourceListResult: ucp.ResourceGroupResourceListResult{
-					Value: []*ucp.ResourceGroupResource{
-						{
-							ID:       new("/planes/radius/local/resourcegroups/test1"),
-							Name:     new("test1"),
-							Type:     new("System.Resources/resourceGroups"),
-							Location: to.Ptr(v1.LocationGlobal),
-						},
-						{
-							ID:       new("/planes/radius/local/resourcegroups/test2"),
-							Name:     new("test2"),
-							Type:     new("System.Resources/resourceGroups"),
-							Location: to.Ptr(v1.LocationGlobal),
-						},
+				Value: []*ucp.ResourceGroupResource{
+					{
+						ID:       new("/planes/radius/local/resourcegroups/test1"),
+						Name:     new("test1"),
+						Type:     new("System.Resources/resourceGroups"),
+						Location: to.Ptr(v1.LocationGlobal),
 					},
-					NextLink: new("0"),
+					{
+						ID:       new("/planes/radius/local/resourcegroups/test2"),
+						Name:     new("test2"),
+						Type:     new("System.Resources/resourceGroups"),
+						Location: to.Ptr(v1.LocationGlobal),
+					},
 				},
+				NextLink: new("0"),
 			},
 			{
-				ResourceGroupResourceListResult: ucp.ResourceGroupResourceListResult{
-					Value: []*ucp.ResourceGroupResource{
-						{
-							ID:       new("/planes/radius/local/resourcegroups/test3"),
-							Name:     new("test3"),
-							Type:     new("System.Resources/resourceGroups"),
-							Location: to.Ptr(v1.LocationGlobal),
-						},
-						{
-							ID:       new("/planes/radius/local/resourcegroups/test4"),
-							Name:     new("test4"),
-							Type:     new("System.Resources/resourceGroups"),
-							Location: to.Ptr(v1.LocationGlobal),
-						},
+				Value: []*ucp.ResourceGroupResource{
+					{
+						ID:       new("/planes/radius/local/resourcegroups/test3"),
+						Name:     new("test3"),
+						Type:     new("System.Resources/resourceGroups"),
+						Location: to.Ptr(v1.LocationGlobal),
 					},
-					NextLink: new("1"),
+					{
+						ID:       new("/planes/radius/local/resourcegroups/test4"),
+						Name:     new("test4"),
+						Type:     new("System.Resources/resourceGroups"),
+						Location: to.Ptr(v1.LocationGlobal),
+					},
 				},
+				NextLink: new("1"),
 			},
 		}
 
@@ -1893,10 +1831,8 @@ func Test_ResourceGroup(t *testing.T) {
 		// Expect listing resources for each type (empty results)
 		emptyResources := []generated.GenericResourcesClientListByRootScopeResponse{
 			{
-				GenericResourcesList: generated.GenericResourcesList{
-					Value:    []*generated.GenericResource{},
-					NextLink: new("0"),
-				},
+				Value:    []*generated.GenericResource{},
+				NextLink: new("0"),
 			},
 		}
 		mockGenericClient.EXPECT().
@@ -2061,23 +1997,21 @@ func Test_ListResourcesInResourceGroup(t *testing.T) {
 
 		// Provider summaries with partial API versions
 		summariesWithErrors := []ucp.ResourceProvidersClientListProviderSummariesResponse{{
-			PagedResourceProviderSummary: ucp.PagedResourceProviderSummary{
-				Value: []*ucp.ResourceProviderSummary{
-					{
-						Name: new("Applications.Test"),
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"resources": {APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{version: {}}},
-						},
-					},
-					{
-						Name: new("Applications.TestNoVersion"),
-						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-							"resources": {}, // Empty API versions
-						},
+			Value: []*ucp.ResourceProviderSummary{
+				{
+					Name: new("Applications.Test"),
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"resources": {APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{version: {}}},
 					},
 				},
-				NextLink: new("0"),
+				{
+					Name: new("Applications.TestNoVersion"),
+					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+						"resources": {}, // Empty API versions
+					},
+				},
 			},
+			NextLink: new("0"),
 		}}
 
 		mockResourceGroupExists(mockRG, "local", "test-group", 1)
@@ -2347,42 +2281,38 @@ func Test_ResourceProvider(t *testing.T) {
 
 		resourceProviderPages := []ucp.ResourceProvidersClientListResponse{
 			{
-				ResourceProviderResourceListResult: ucp.ResourceProviderResourceListResult{
-					Value: []*ucp.ResourceProviderResource{
-						{
-							ID:       new("/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test1"),
-							Name:     new("Applications.Test1"),
-							Type:     new("System.Resources/resourceProviders"),
-							Location: to.Ptr(v1.LocationGlobal),
-						},
-						{
-							ID:       new("/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test2"),
-							Name:     new("Applications.Test2"),
-							Type:     new("System.Resources/resourceProviders"),
-							Location: to.Ptr(v1.LocationGlobal),
-						},
+				Value: []*ucp.ResourceProviderResource{
+					{
+						ID:       new("/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test1"),
+						Name:     new("Applications.Test1"),
+						Type:     new("System.Resources/resourceProviders"),
+						Location: to.Ptr(v1.LocationGlobal),
 					},
-					NextLink: new("0"),
+					{
+						ID:       new("/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test2"),
+						Name:     new("Applications.Test2"),
+						Type:     new("System.Resources/resourceProviders"),
+						Location: to.Ptr(v1.LocationGlobal),
+					},
 				},
+				NextLink: new("0"),
 			},
 			{
-				ResourceProviderResourceListResult: ucp.ResourceProviderResourceListResult{
-					Value: []*ucp.ResourceProviderResource{
-						{
-							ID:       new("/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test3"),
-							Name:     new("Applications.Test3"),
-							Type:     new("System.Resources/resourceProviders"),
-							Location: to.Ptr(v1.LocationGlobal),
-						},
-						{
-							ID:       new("/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test4"),
-							Name:     new("Applications.Test4"),
-							Type:     new("System.Resources/resourceProviders"),
-							Location: to.Ptr(v1.LocationGlobal),
-						},
+				Value: []*ucp.ResourceProviderResource{
+					{
+						ID:       new("/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test3"),
+						Name:     new("Applications.Test3"),
+						Type:     new("System.Resources/resourceProviders"),
+						Location: to.Ptr(v1.LocationGlobal),
 					},
-					NextLink: new("1"),
+					{
+						ID:       new("/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test4"),
+						Name:     new("Applications.Test4"),
+						Type:     new("System.Resources/resourceProviders"),
+						Location: to.Ptr(v1.LocationGlobal),
+					},
 				},
+				NextLink: new("1"),
 			},
 		}
 

--- a/pkg/cli/cmd/app/graph/preview/graph_test.go
+++ b/pkg/cli/cmd/app/graph/preview/graph_test.go
@@ -141,15 +141,13 @@ func Test_Run(t *testing.T) {
 				containerType := "Applications.Core/containers"
 
 				resp.SetResponse(http.StatusOK, corerpv20250801.ApplicationsClientGetGraphResponse{
-					ApplicationGraphResponse: corerpv20250801.ApplicationGraphResponse{
-						Resources: []*corerpv20250801.ApplicationGraphResource{
-							{
-								ID:              &containerID,
-								Name:            &containerName,
-								Type:            &containerType,
-								Connections:     []*corerpv20250801.ApplicationGraphConnection{},
-								OutputResources: []*corerpv20250801.ApplicationGraphOutputResource{},
-							},
+					Resources: []*corerpv20250801.ApplicationGraphResource{
+						{
+							ID:              &containerID,
+							Name:            &containerName,
+							Type:            &containerType,
+							Connections:     []*corerpv20250801.ApplicationGraphConnection{},
+							OutputResources: []*corerpv20250801.ApplicationGraphOutputResource{},
 						},
 					},
 				}, nil)

--- a/pkg/cli/cmd/app/list/preview/list_test.go
+++ b/pkg/cli/cmd/app/list/preview/list_test.go
@@ -110,9 +110,7 @@ func Test_Run(t *testing.T) {
 				return fake.ApplicationsServer{
 					NewListByScopePager: func(rootScope string, _ *corerpv20250801.ApplicationsClientListByScopeOptions) (resp azfake.PagerResponder[corerpv20250801.ApplicationsClientListByScopeResponse]) {
 						resp.AddPage(http.StatusOK, corerpv20250801.ApplicationsClientListByScopeResponse{
-							ApplicationResourceListResult: corerpv20250801.ApplicationResourceListResult{
-								Value: []*corerpv20250801.ApplicationResource{},
-							},
+							Value: []*corerpv20250801.ApplicationResource{},
 						}, nil)
 						return
 					},
@@ -132,14 +130,10 @@ func Test_Run(t *testing.T) {
 				return fake.ApplicationsServer{
 					NewListByScopePager: func(rootScope string, _ *corerpv20250801.ApplicationsClientListByScopeOptions) (resp azfake.PagerResponder[corerpv20250801.ApplicationsClientListByScopeResponse]) {
 						resp.AddPage(http.StatusOK, corerpv20250801.ApplicationsClientListByScopeResponse{
-							ApplicationResourceListResult: corerpv20250801.ApplicationResourceListResult{
-								Value: []*corerpv20250801.ApplicationResource{{Name: new("page1-a")}, {Name: new("page1-b")}},
-							},
+							Value: []*corerpv20250801.ApplicationResource{{Name: new("page1-a")}, {Name: new("page1-b")}},
 						}, nil)
 						resp.AddPage(http.StatusOK, corerpv20250801.ApplicationsClientListByScopeResponse{
-							ApplicationResourceListResult: corerpv20250801.ApplicationResourceListResult{
-								Value: []*corerpv20250801.ApplicationResource{{Name: new("page2-a")}},
-							},
+							Value: []*corerpv20250801.ApplicationResource{{Name: new("page2-a")}},
 						}, nil)
 						return
 					},

--- a/pkg/cli/cmd/bicep/publish/publish.go
+++ b/pkg/cli/cmd/bicep/publish/publish.go
@@ -32,7 +32,6 @@ import (
 	"github.com/radius-project/radius/pkg/cli/output"
 
 	"github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
@@ -174,8 +173,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	r.Destination = dest
 
 	digest, err := r.publish(ctx)
-	var httpErr *errcode.ErrorResponse
-	if errors.As(err, &httpErr) {
+	if httpErr, ok := errors.AsType[*errcode.ErrorResponse](err); ok {
 		message := fmt.Sprintf("Failed to publish Bicep file %q to %q", displayFile, r.Target)
 		return handleErrorResponse(httpErr, message)
 	} else if err != nil {
@@ -361,9 +359,9 @@ func pushBlob(ctx context.Context, mediaType string, blob []byte, target oras.Ta
 // generateManifestContent generates a manifest content based on the config and layers descriptors
 func generateManifestContent(config ocispec.Descriptor, layers ...ocispec.Descriptor) ([]byte, error) {
 	content := ocispec.Manifest{
-		Config:    config,
-		Layers:    layers,
-		Versioned: specs.Versioned{SchemaVersion: 2},
+		Config:        config,
+		Layers:        layers,
+		SchemaVersion: 2,
 	}
 	return json.Marshal(content)
 }
@@ -371,6 +369,6 @@ func generateManifestContent(config ocispec.Descriptor, layers ...ocispec.Descri
 // computeImmutableRecipeUrl builds an OCI URL using the registry/repo portion of the
 // target (no leading "br:" and without the tag) and replaces the tag with the digest.
 func computeImmutableRecipeUrl(target, hash string) string {
-	host := strings.Split(target, ":")[0]
+	host, _, _ := strings.Cut(target, ":")
 	return fmt.Sprintf("%s@%s", host, hash)
 }

--- a/pkg/cli/cmd/credential/list/objectformats_test.go
+++ b/pkg/cli/cmd/credential/list/objectformats_test.go
@@ -27,10 +27,8 @@ import (
 
 func Test_credentialFormat(t *testing.T) {
 	obj := credential.ProviderCredentialConfiguration{
-		CloudProviderStatus: credential.CloudProviderStatus{
-			Name:    "test",
-			Enabled: true,
-		},
+		Name:    "test",
+		Enabled: true,
 	}
 
 	buffer := &bytes.Buffer{}

--- a/pkg/cli/cmd/credential/show/objectformats_test.go
+++ b/pkg/cli/cmd/credential/show/objectformats_test.go
@@ -27,10 +27,8 @@ import (
 
 func Test_credentialFormatAzureServicePrincipal(t *testing.T) {
 	obj := credential.ProviderCredentialConfiguration{
-		CloudProviderStatus: credential.CloudProviderStatus{
-			Name:    "test",
-			Enabled: true,
-		},
+		Name:    "test",
+		Enabled: true,
 		AzureCredentials: &credential.AzureCredentialProperties{
 			Kind: new("ServicePrincipal"),
 			ServicePrincipal: &credential.AzureServicePrincipalCredentialProperties{
@@ -52,10 +50,8 @@ func Test_credentialFormatAzureServicePrincipal(t *testing.T) {
 
 func Test_credentialFormat_Azure_WorkloadIdentity(t *testing.T) {
 	obj := credential.ProviderCredentialConfiguration{
-		CloudProviderStatus: credential.CloudProviderStatus{
-			Name:    "test",
-			Enabled: true,
-		},
+		Name:    "test",
+		Enabled: true,
 		AzureCredentials: &credential.AzureCredentialProperties{
 			Kind: new("WorkloadIdentity"),
 			WorkloadIdentity: &credential.AzureWorkloadIdentityCredentialProperties{
@@ -77,10 +73,8 @@ func Test_credentialFormat_Azure_WorkloadIdentity(t *testing.T) {
 
 func Test_credentialFormatAWSAccessKey(t *testing.T) {
 	obj := credential.ProviderCredentialConfiguration{
-		CloudProviderStatus: credential.CloudProviderStatus{
-			Name:    "test",
-			Enabled: true,
-		},
+		Name:    "test",
+		Enabled: true,
 		AWSCredentials: &credential.AWSCredentialProperties{
 			Kind: new("AccessKey"),
 			AccessKey: &credential.AWSAccessKeyCredentialProperties{
@@ -102,10 +96,8 @@ func Test_credentialFormatAWSAccessKey(t *testing.T) {
 
 func Test_credentialFormatAWSIRSA(t *testing.T) {
 	obj := credential.ProviderCredentialConfiguration{
-		CloudProviderStatus: credential.CloudProviderStatus{
-			Name:    "test",
-			Enabled: true,
-		},
+		Name:    "test",
+		Enabled: true,
 		AWSCredentials: &credential.AWSCredentialProperties{
 			Kind: new("IRSA"),
 			IRSA: &credential.AWSIRSACredentialProperties{

--- a/pkg/cli/cmd/credential/show/show_test.go
+++ b/pkg/cli/cmd/credential/show/show_test.go
@@ -106,10 +106,8 @@ func Test_Run(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			provider := cli_credential.ProviderCredentialConfiguration{
-				CloudProviderStatus: cli_credential.CloudProviderStatus{
-					Name:    "azure",
-					Enabled: true,
-				},
+				Name:    "azure",
+				Enabled: true,
 				AzureCredentials: &cli_credential.AzureCredentialProperties{
 					Kind: new("ServicePrincipal"),
 				},
@@ -154,10 +152,8 @@ func Test_Run(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			provider := cli_credential.ProviderCredentialConfiguration{
-				CloudProviderStatus: cli_credential.CloudProviderStatus{
-					Name:    "azure",
-					Enabled: true,
-				},
+				Name:    "azure",
+				Enabled: true,
 				AzureCredentials: &cli_credential.AzureCredentialProperties{
 					Kind: new("WorkloadIdentity"),
 				},
@@ -227,10 +223,8 @@ func Test_Run(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			provider := cli_credential.ProviderCredentialConfiguration{
-				CloudProviderStatus: cli_credential.CloudProviderStatus{
-					Name:    "aws",
-					Enabled: true,
-				},
+				Name:    "aws",
+				Enabled: true,
 				AWSCredentials: &cli_credential.AWSCredentialProperties{
 					Kind: new("AccessKey"),
 				},
@@ -273,10 +267,8 @@ func Test_Run(t *testing.T) {
 		t.Run("Not Found", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			provider := cli_credential.ProviderCredentialConfiguration{
-				CloudProviderStatus: cli_credential.CloudProviderStatus{
-					Name:    "aws",
-					Enabled: false,
-				},
+				Name:    "aws",
+				Enabled: false,
 			}
 			client := cli_credential.NewMockCredentialManagementClient(ctrl)
 			client.EXPECT().

--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -943,8 +943,7 @@ func isProviderNotConfiguredError(message string) bool {
 }
 
 func extractDeploymentEngineErrorDetails(err error) (*v1.ErrorDetails, bool) {
-	var clientErr *v1.ErrClientRP
-	if errors.As(err, &clientErr) {
+	if clientErr, ok := errors.AsType[*v1.ErrClientRP](err); ok {
 		return &v1.ErrorDetails{Code: clientErr.Code, Message: clientErr.Message}, true
 	}
 

--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -560,14 +560,12 @@ func Test_ValidateRadiusCoreEnvProvider(t *testing.T) {
 				_ *v20250801preview.EnvironmentsClientGetOptions,
 			) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 				resp.SetResponse(200, v20250801preview.EnvironmentsClientGetResponse{
-					EnvironmentResource: v20250801preview.EnvironmentResource{
-						ID: new("/planes/radius/local/resourceGroups/test-resource-group/providers/Radius.Core/environments/conflictenv"),
-						Properties: &v20250801preview.EnvironmentProperties{
-							Providers: &v20250801preview.Providers{
-								Azure: &v20250801preview.ProvidersAzure{
-									SubscriptionID:    new("test-sub-id"),
-									ResourceGroupName: new("test-rg-name"),
-								},
+					ID: new("/planes/radius/local/resourceGroups/test-resource-group/providers/Radius.Core/environments/conflictenv"),
+					Properties: &v20250801preview.EnvironmentProperties{
+						Providers: &v20250801preview.Providers{
+							Azure: &v20250801preview.ProvidersAzure{
+								SubscriptionID:    new("test-sub-id"),
+								ResourceGroupName: new("test-rg-name"),
 							},
 						},
 					},
@@ -1003,7 +1001,7 @@ func Test_Run(t *testing.T) {
 					capturedAppName = applicationName
 					capturedResource = resource
 					resp.SetResponse(http.StatusOK, v20250801preview.ApplicationsClientCreateOrUpdateResponse{
-						ApplicationResource: v20250801preview.ApplicationResource{Name: to.Ptr(applicationName)},
+						Name: to.Ptr(applicationName),
 					}, nil)
 					return
 				},
@@ -1105,7 +1103,7 @@ func Test_Run(t *testing.T) {
 					createdRadiusCoreApp = true
 					capturedResource = resource
 					resp.SetResponse(http.StatusOK, v20250801preview.ApplicationsClientCreateOrUpdateResponse{
-						ApplicationResource: v20250801preview.ApplicationResource{Name: to.Ptr(applicationName)},
+						Name: to.Ptr(applicationName),
 					}, nil)
 					return
 				},
@@ -2061,10 +2059,8 @@ func Test_FetchEnvironment_RadiusCoreEnvironmentUsesOwnGroup(t *testing.T) {
 				return
 			}
 			resp.SetResponse(200, v20250801preview.EnvironmentsClientGetResponse{
-				EnvironmentResource: v20250801preview.EnvironmentResource{
-					Name: to.Ptr(environmentName),
-					ID:   to.Ptr(envID),
-				},
+				Name: to.Ptr(environmentName),
+				ID:   to.Ptr(envID),
 			}, nil)
 			return
 		},

--- a/pkg/cli/cmd/env/delete/preview/cascade_test.go
+++ b/pkg/cli/cmd/env/delete/preview/cascade_test.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -81,9 +80,7 @@ func applicationsServerWithEnvironment(applications []*corerpv20250801.Applicati
 				resp.AddPage(
 					http.StatusOK,
 					corerpv20250801.ApplicationsClientListByScopeResponse{
-						ApplicationResourceListResult: corerpv20250801.ApplicationResourceListResult{
-							Value: applications,
-						},
+						Value: applications,
 					},
 					nil,
 				)
@@ -113,10 +110,10 @@ func applicationsServerWithEnvironment(applications []*corerpv20250801.Applicati
 // application builds a Radius.Core application resource in the test scope pointing at environmentID.
 func application(name string, environmentID string) *corerpv20250801.ApplicationResource {
 	return &corerpv20250801.ApplicationResource{
-		Name: to.Ptr(name),
-		ID:   to.Ptr(testScope + "/providers/Radius.Core/applications/" + name),
+		Name: new(name),
+		ID:   new(testScope + "/providers/Radius.Core/applications/" + name),
 		Properties: &corerpv20250801.ApplicationProperties{
-			Environment: to.Ptr(environmentID),
+			Environment: new(environmentID),
 		},
 	}
 }
@@ -124,8 +121,8 @@ func application(name string, environmentID string) *corerpv20250801.Application
 // resource builds a generic resource with the given name.
 func resource(name string) generated.GenericResource {
 	return generated.GenericResource{
-		ID:   to.Ptr(testScope + "/providers/" + testResourceType + "/" + name),
-		Type: to.Ptr(testResourceType),
+		ID:   new(testScope + "/providers/" + testResourceType + "/" + name),
+		Type: new(testResourceType),
 	}
 }
 
@@ -561,9 +558,9 @@ func Test_Run_Cascade(t *testing.T) {
 		// An application that reports no name cannot be addressed, so the cascade cannot delete
 		// it. It must say so rather than deleting the environment and orphaning it in silence.
 		unnamed := &corerpv20250801.ApplicationResource{
-			ID: to.Ptr(testScope + "/providers/Radius.Core/applications/unnamed"),
+			ID: new(testScope + "/providers/Radius.Core/applications/unnamed"),
 			Properties: &corerpv20250801.ApplicationProperties{
-				Environment: to.Ptr(testEnvironmentID),
+				Environment: new(testEnvironmentID),
 			},
 		}
 

--- a/pkg/cli/cmd/env/show/preview/show_test.go
+++ b/pkg/cli/cmd/env/show/preview/show_test.go
@@ -220,13 +220,11 @@ func Test_Run_RecipeSortOrder(t *testing.T) {
 				options *corerpv20250801.EnvironmentsClientGetOptions,
 			) (resp azfake.Responder[corerpv20250801.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 				result := corerpv20250801.EnvironmentsClientGetResponse{
-					EnvironmentResource: corerpv20250801.EnvironmentResource{
-						Name: new(environmentName),
-						Properties: &corerpv20250801.EnvironmentProperties{
-							RecipePacks: []*string{
-								new("/planes/radius/local/resourceGroups/test-group/providers/Radius.Core/recipePacks/pack-b"),
-								new("/planes/radius/local/resourceGroups/test-group/providers/Radius.Core/recipePacks/pack-a"),
-							},
+					Name: new(environmentName),
+					Properties: &corerpv20250801.EnvironmentProperties{
+						RecipePacks: []*string{
+							new("/planes/radius/local/resourceGroups/test-group/providers/Radius.Core/recipePacks/pack-b"),
+							new("/planes/radius/local/resourceGroups/test-group/providers/Radius.Core/recipePacks/pack-a"),
 						},
 					},
 				}
@@ -265,11 +263,9 @@ func Test_Run_RecipeSortOrder(t *testing.T) {
 					}
 				}
 				result := corerpv20250801.RecipePacksClientGetResponse{
-					RecipePackResource: corerpv20250801.RecipePackResource{
-						Name: new(recipePackName),
-						Properties: &corerpv20250801.RecipePackProperties{
-							Recipes: recipes,
-						},
+					Name: new(recipePackName),
+					Properties: &corerpv20250801.RecipePackProperties{
+						Recipes: recipes,
 					},
 				}
 				resp.SetResponse(http.StatusOK, result, nil)

--- a/pkg/cli/cmd/env/update/preview/update_test.go
+++ b/pkg/cli/cmd/env/update/preview/update_test.go
@@ -226,26 +226,24 @@ func Test_Run(t *testing.T) {
 				options *v20250801preview.EnvironmentsClientGetOptions,
 			) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 				result := v20250801preview.EnvironmentsClientGetResponse{
-					EnvironmentResource: v20250801preview.EnvironmentResource{
-						ID:   to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
-						Name: to.Ptr(environmentName),
-						Properties: &v20250801preview.EnvironmentProperties{
-							Providers: &v20250801preview.Providers{
-								Azure: &v20250801preview.ProvidersAzure{
-									SubscriptionID:    to.Ptr("test-subscription-id"),
-									ResourceGroupName: to.Ptr("test-resource-group"),
-								},
-								Aws: &v20250801preview.ProvidersAws{
-									AccountID: to.Ptr("test-account-id"),
-									Region:    to.Ptr("test-region"),
-								},
-								Kubernetes: &v20250801preview.ProvidersKubernetes{
-									Namespace: to.Ptr("test-namespace"),
-								},
+					ID:   to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
+					Name: to.Ptr(environmentName),
+					Properties: &v20250801preview.EnvironmentProperties{
+						Providers: &v20250801preview.Providers{
+							Azure: &v20250801preview.ProvidersAzure{
+								SubscriptionID:    to.Ptr("test-subscription-id"),
+								ResourceGroupName: to.Ptr("test-resource-group"),
 							},
-							RecipePacks: []*string{
-								to.Ptr(workspace.Scope + "/providers/Radius.Core/recipePacks/old-pack"),
+							Aws: &v20250801preview.ProvidersAws{
+								AccountID: to.Ptr("test-account-id"),
+								Region:    to.Ptr("test-region"),
 							},
+							Kubernetes: &v20250801preview.ProvidersKubernetes{
+								Namespace: to.Ptr("test-namespace"),
+							},
+						},
+						RecipePacks: []*string{
+							to.Ptr(workspace.Scope + "/providers/Radius.Core/recipePacks/old-pack"),
 						},
 					},
 				}
@@ -343,12 +341,10 @@ func Test_Run_RecipePacksReplaced(t *testing.T) {
 				_ *v20250801preview.EnvironmentsClientGetOptions,
 			) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 				result := v20250801preview.EnvironmentsClientGetResponse{
-					EnvironmentResource: v20250801preview.EnvironmentResource{
-						ID:   to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
-						Name: to.Ptr(environmentName),
-						Properties: &v20250801preview.EnvironmentProperties{
-							RecipePacks: []*string{to.Ptr(existingPackID)},
-						},
+					ID:   to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
+					Name: to.Ptr(environmentName),
+					Properties: &v20250801preview.EnvironmentProperties{
+						RecipePacks: []*string{to.Ptr(existingPackID)},
 					},
 				}
 				resp.SetResponse(http.StatusOK, result, nil)
@@ -428,12 +424,10 @@ func Test_Run_RecipePackNotFound(t *testing.T) {
 				_ *v20250801preview.EnvironmentsClientGetOptions,
 			) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 				result := v20250801preview.EnvironmentsClientGetResponse{
-					EnvironmentResource: v20250801preview.EnvironmentResource{
-						ID:   to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
-						Name: to.Ptr(environmentName),
-						Properties: &v20250801preview.EnvironmentProperties{
-							RecipePacks: []*string{to.Ptr(existingPackID)},
-						},
+					ID:   to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
+					Name: to.Ptr(environmentName),
+					Properties: &v20250801preview.EnvironmentProperties{
+						RecipePacks: []*string{to.Ptr(existingPackID)},
 					},
 				}
 				resp.SetResponse(http.StatusOK, result, nil)
@@ -513,12 +507,10 @@ func Test_Run_RecipePacksWithGroup(t *testing.T) {
 				_ *v20250801preview.EnvironmentsClientGetOptions,
 			) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 				result := v20250801preview.EnvironmentsClientGetResponse{
-					EnvironmentResource: v20250801preview.EnvironmentResource{
-						ID:   to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
-						Name: to.Ptr(environmentName),
-						Properties: &v20250801preview.EnvironmentProperties{
-							RecipePacks: []*string{to.Ptr(expectedPackID)},
-						},
+					ID:   to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
+					Name: to.Ptr(environmentName),
+					Properties: &v20250801preview.EnvironmentProperties{
+						RecipePacks: []*string{to.Ptr(expectedPackID)},
 					},
 				}
 				resp.SetResponse(http.StatusOK, result, nil)
@@ -587,11 +579,9 @@ func Test_Run_RecipePackFullResourceID(t *testing.T) {
 				_ *v20250801preview.EnvironmentsClientGetOptions,
 			) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 				result := v20250801preview.EnvironmentsClientGetResponse{
-					EnvironmentResource: v20250801preview.EnvironmentResource{
-						ID:         to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
-						Name:       to.Ptr(environmentName),
-						Properties: &v20250801preview.EnvironmentProperties{},
-					},
+					ID:         to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
+					Name:       to.Ptr(environmentName),
+					Properties: &v20250801preview.EnvironmentProperties{},
 				}
 				resp.SetResponse(http.StatusOK, result, nil)
 				return
@@ -670,11 +660,9 @@ func Test_Run_DefaultsKubernetesNamespace(t *testing.T) {
 						props.Providers = existingProviders
 					}
 					result := v20250801preview.EnvironmentsClientGetResponse{
-						EnvironmentResource: v20250801preview.EnvironmentResource{
-							ID:         to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
-							Name:       to.Ptr(environmentName),
-							Properties: props,
-						},
+						ID:         to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
+						Name:       to.Ptr(environmentName),
+						Properties: props,
 					}
 					resp.SetResponse(http.StatusOK, result, nil)
 					return
@@ -956,12 +944,10 @@ func Test_syncRecipePackReferences(t *testing.T) {
 				) (resp azfake.Responder[v20250801preview.RecipePacksClientGetResponse], errResp azfake.ErrorResponder) {
 					// Pack has both this env and another env in referencedBy.
 					result := v20250801preview.RecipePacksClientGetResponse{
-						RecipePackResource: v20250801preview.RecipePackResource{
-							Name: to.Ptr(name),
-							Properties: &v20250801preview.RecipePackProperties{
-								Recipes:      map[string]*v20250801preview.RecipeDefinition{},
-								ReferencedBy: []*string{to.Ptr("some-other-env"), to.Ptr(envID)},
-							},
+						Name: to.Ptr(name),
+						Properties: &v20250801preview.RecipePackProperties{
+							Recipes:      map[string]*v20250801preview.RecipeDefinition{},
+							ReferencedBy: []*string{to.Ptr("some-other-env"), to.Ptr(envID)},
 						},
 					}
 					resp.SetResponse(http.StatusOK, result, nil)
@@ -999,12 +985,10 @@ func Test_syncRecipePackReferences(t *testing.T) {
 					_ *v20250801preview.RecipePacksClientGetOptions,
 				) (resp azfake.Responder[v20250801preview.RecipePacksClientGetResponse], errResp azfake.ErrorResponder) {
 					result := v20250801preview.RecipePacksClientGetResponse{
-						RecipePackResource: v20250801preview.RecipePackResource{
-							Name: to.Ptr(name),
-							Properties: &v20250801preview.RecipePackProperties{
-								Recipes:      map[string]*v20250801preview.RecipeDefinition{},
-								ReferencedBy: []*string{to.Ptr(envID)},
-							},
+						Name: to.Ptr(name),
+						Properties: &v20250801preview.RecipePackProperties{
+							Recipes:      map[string]*v20250801preview.RecipeDefinition{},
+							ReferencedBy: []*string{to.Ptr(envID)},
 						},
 					}
 					resp.SetResponse(http.StatusOK, result, nil)

--- a/pkg/cli/cmd/previewdelete_test.go
+++ b/pkg/cli/cmd/previewdelete_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -38,8 +37,8 @@ const (
 
 func testResource(name string) generated.GenericResource {
 	return generated.GenericResource{
-		ID:   to.Ptr(testScope + "/providers/" + testResourceType + "/" + name),
-		Type: to.Ptr(testResourceType),
+		ID:   new(testScope + "/providers/" + testResourceType + "/" + name),
+		Type: new(testResourceType),
 	}
 }
 
@@ -71,8 +70,8 @@ func Test_DeleteResourcesInParallel(t *testing.T) {
 		defer ctrl.Finish()
 
 		valid := testResource("a")
-		noID := generated.GenericResource{Type: to.Ptr(testResourceType)}
-		noType := generated.GenericResource{ID: to.Ptr(testScope + "/providers/" + testResourceType + "/c")}
+		noID := generated.GenericResource{Type: new(testResourceType)}
+		noType := generated.GenericResource{ID: new(testScope + "/providers/" + testResourceType + "/c")}
 
 		mock := clients.NewMockApplicationsManagementClient(ctrl)
 		mock.EXPECT().DeleteResource(gomock.Any(), testResourceType, *valid.ID, false).Return(true, nil).Times(1)
@@ -95,7 +94,7 @@ func Test_DeleteResourcesInParallel(t *testing.T) {
 		defer ctrl.Finish()
 
 		mock := clients.NewMockApplicationsManagementClient(ctrl)
-		named := generated.GenericResource{Name: to.Ptr("my-resource")}
+		named := generated.GenericResource{Name: new("my-resource")}
 
 		sink := &output.MockOutput{}
 		err := DeleteResourcesInParallel(t.Context(), mock, sink, []generated.GenericResource{named}, false)

--- a/pkg/cli/cmd/radinit/preview/init_test.go
+++ b/pkg/cli/cmd/radinit/preview/init_test.go
@@ -897,11 +897,9 @@ func Test_Run_WithApplicationScaffold(t *testing.T) {
 					assert.Equal(t, v1.LocationGlobal, *resource.Location)
 					assert.Equal(t, "/planes/radius/local/resourceGroups/default/providers/Radius.Core/environments/default", *resource.Properties.Environment)
 					result := corerpv20250801.ApplicationsClientCreateOrUpdateResponse{
-						ApplicationResource: corerpv20250801.ApplicationResource{
-							Name:       to.Ptr(applicationName),
-							Location:   resource.Location,
-							Properties: resource.Properties,
-						},
+						Name:       to.Ptr(applicationName),
+						Location:   resource.Location,
+						Properties: resource.Properties,
 					}
 					resp.SetResponse(http.StatusOK, result, nil)
 					return
@@ -935,9 +933,7 @@ func Test_Run_WithApplicationScaffold(t *testing.T) {
 				) (resp azfake.Responder[corerpv20250801.ApplicationsClientGetResponse], errResp azfake.ErrorResponder) {
 					getCalled++
 					result := corerpv20250801.ApplicationsClientGetResponse{
-						ApplicationResource: corerpv20250801.ApplicationResource{
-							Name: to.Ptr(applicationName),
-						},
+						Name: to.Ptr(applicationName),
 					}
 					resp.SetResponse(http.StatusOK, result, nil)
 					return

--- a/pkg/cli/cmd/recipepack/delete/delete_test.go
+++ b/pkg/cli/cmd/recipepack/delete/delete_test.go
@@ -124,11 +124,9 @@ func Test_Run(t *testing.T) {
 					_ *v20250801preview.EnvironmentsClientGetOptions,
 				) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 					resp.SetResponse(http.StatusOK, v20250801preview.EnvironmentsClientGetResponse{
-						EnvironmentResource: v20250801preview.EnvironmentResource{
-							Name: to.Ptr(environmentName),
-							Properties: &v20250801preview.EnvironmentProperties{
-								RecipePacks: []*string{to.Ptr(packFullID)},
-							},
+						Name: to.Ptr(environmentName),
+						Properties: &v20250801preview.EnvironmentProperties{
+							RecipePacks: []*string{to.Ptr(packFullID)},
 						},
 					}, nil)
 					return
@@ -389,11 +387,9 @@ func Test_Run(t *testing.T) {
 					_ *v20250801preview.EnvironmentsClientGetOptions,
 				) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 					resp.SetResponse(http.StatusOK, v20250801preview.EnvironmentsClientGetResponse{
-						EnvironmentResource: v20250801preview.EnvironmentResource{
-							Name: to.Ptr(environmentName),
-							Properties: &v20250801preview.EnvironmentProperties{
-								RecipePacks: []*string{to.Ptr(packFullID)},
-							},
+						Name: to.Ptr(environmentName),
+						Properties: &v20250801preview.EnvironmentProperties{
+							RecipePacks: []*string{to.Ptr(packFullID)},
 						},
 					}, nil)
 					return
@@ -490,11 +486,9 @@ func Test_Run(t *testing.T) {
 					_ *v20250801preview.EnvironmentsClientGetOptions,
 				) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 					resp.SetResponse(http.StatusOK, v20250801preview.EnvironmentsClientGetResponse{
-						EnvironmentResource: v20250801preview.EnvironmentResource{
-							Name: to.Ptr(environmentName),
-							Properties: &v20250801preview.EnvironmentProperties{
-								RecipePacks: []*string{to.Ptr(packFullID)},
-							},
+						Name: to.Ptr(environmentName),
+						Properties: &v20250801preview.EnvironmentProperties{
+							RecipePacks: []*string{to.Ptr(packFullID)},
 						},
 					}, nil)
 					return
@@ -568,13 +562,11 @@ func Test_Run(t *testing.T) {
 					_ *v20250801preview.EnvironmentsClientGetOptions,
 				) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 					resp.SetResponse(http.StatusOK, v20250801preview.EnvironmentsClientGetResponse{
-						EnvironmentResource: v20250801preview.EnvironmentResource{
-							Name: to.Ptr(environmentName),
-							Properties: &v20250801preview.EnvironmentProperties{
-								RecipePacks: []*string{
-									to.Ptr(mixedCasePackID),  // should be removed (case-insensitive match)
-									to.Ptr(otherScopePackID), // must NOT be removed
-								},
+						Name: to.Ptr(environmentName),
+						Properties: &v20250801preview.EnvironmentProperties{
+							RecipePacks: []*string{
+								to.Ptr(mixedCasePackID),  // should be removed (case-insensitive match)
+								to.Ptr(otherScopePackID), // must NOT be removed
 							},
 						},
 					}, nil)

--- a/pkg/cli/cmd/resourcetype/list/list_test.go
+++ b/pkg/cli/cmd/resourcetype/list/list_test.go
@@ -89,28 +89,22 @@ func Test_Run(t *testing.T) {
 
 		resourceTypes := []common.ResourceTypeListOutputFormat{
 			{
-				ResourceType: common.ResourceType{
-					Name:                      "Applications.Test1/exampleResources1",
-					ResourceProviderNamespace: "Applications.Test1",
-					APIVersions:               map[string]*common.APIVersionProperties{"2023-10-01-preview": {}},
-				},
-				APIVersionList: []string{"2023-10-01-preview"},
+				Name:                      "Applications.Test1/exampleResources1",
+				ResourceProviderNamespace: "Applications.Test1",
+				APIVersions:               map[string]*common.APIVersionProperties{"2023-10-01-preview": {}},
+				APIVersionList:            []string{"2023-10-01-preview"},
 			},
 			{
-				ResourceType: common.ResourceType{
-					Name:                      "Applications.Test2/exampleResources2",
-					ResourceProviderNamespace: "Applications.Test2",
-					APIVersions:               map[string]*common.APIVersionProperties{"2023-10-01-preview": {}},
-				},
-				APIVersionList: []string{"2023-10-01-preview"},
+				Name:                      "Applications.Test2/exampleResources2",
+				ResourceProviderNamespace: "Applications.Test2",
+				APIVersions:               map[string]*common.APIVersionProperties{"2023-10-01-preview": {}},
+				APIVersionList:            []string{"2023-10-01-preview"},
 			},
 			{
-				ResourceType: common.ResourceType{
-					Name:                      "Applications.Test2/exampleResources3",
-					ResourceProviderNamespace: "Applications.Test2",
-					APIVersions:               map[string]*common.APIVersionProperties{"2023-10-01-preview": {}},
-				},
-				APIVersionList: []string{"2023-10-01-preview"},
+				Name:                      "Applications.Test2/exampleResources3",
+				ResourceProviderNamespace: "Applications.Test2",
+				APIVersions:               map[string]*common.APIVersionProperties{"2023-10-01-preview": {}},
+				APIVersionList:            []string{"2023-10-01-preview"},
 			},
 		}
 

--- a/pkg/cli/cmd/run/run_test.go
+++ b/pkg/cli/cmd/run/run_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/radius-project/radius/pkg/to"
 	"github.com/radius-project/radius/test/radcli"
 	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -529,24 +528,22 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	runner := &Runner{
-		Runner: deploycmd.Runner{
-			Deploy: deployMock,
-			Output: outputSink,
-			ConnectionFactory: &connections.MockFactory{
-				ApplicationsManagementClient: clientMock,
-			},
-
-			FilePath:            "app.bicep",
-			ApplicationName:     "test-application",
-			EnvironmentNameOrID: radcli.TestEnvironmentName,
-			Parameters:          map[string]map[string]any{},
-			Template:            map[string]any{}, // Template is prepared in Validate
-			Workspace:           workspace,
-			Providers:           providers,
+		Deploy: deployMock,
+		Output: outputSink,
+		ConnectionFactory: &connections.MockFactory{
+			ApplicationsManagementClient: clientMock,
 		},
-		Logstream:        logstreamMock,
-		Portforward:      portforwardMock,
-		kubernetesClient: fakeKubernetesClient,
+
+		FilePath:            "app.bicep",
+		ApplicationName:     "test-application",
+		EnvironmentNameOrID: radcli.TestEnvironmentName,
+		Parameters:          map[string]map[string]any{},
+		Template:            map[string]any{}, // Template is prepared in Validate
+		Workspace:           workspace,
+		Providers:           providers,
+		Logstream:           logstreamMock,
+		Portforward:         portforwardMock,
+		kubernetesClient:    fakeKubernetesClient,
 	}
 
 	// We'll run the actual command in the background, and do cancellation and verification in
@@ -695,24 +692,22 @@ func Test_Run_NoDashboard(t *testing.T) {
 		},
 	}
 	runner := &Runner{
-		Runner: deploycmd.Runner{
-			Deploy: deployMock,
-			Output: outputSink,
-			ConnectionFactory: &connections.MockFactory{
-				ApplicationsManagementClient: clientMock,
-			},
-
-			FilePath:            "app.bicep",
-			ApplicationName:     "test-application",
-			EnvironmentNameOrID: radcli.TestEnvironmentName,
-			Parameters:          map[string]map[string]any{},
-			Template:            map[string]any{}, // Template is prepared in Validate
-			Workspace:           workspace,
-			Providers:           providers,
+		Deploy: deployMock,
+		Output: outputSink,
+		ConnectionFactory: &connections.MockFactory{
+			ApplicationsManagementClient: clientMock,
 		},
-		Logstream:        logstreamMock,
-		Portforward:      portforwardMock,
-		kubernetesClient: fakeKubernetesClient,
+
+		FilePath:            "app.bicep",
+		ApplicationName:     "test-application",
+		EnvironmentNameOrID: radcli.TestEnvironmentName,
+		Parameters:          map[string]map[string]any{},
+		Template:            map[string]any{}, // Template is prepared in Validate
+		Workspace:           workspace,
+		Providers:           providers,
+		Logstream:           logstreamMock,
+		Portforward:         portforwardMock,
+		kubernetesClient:    fakeKubernetesClient,
 	}
 
 	// We'll run the actual command in the background, and do cancellation and verification in
@@ -810,19 +805,17 @@ func Test_Run_ExtensibleEnvironment(t *testing.T) {
 	}
 
 	runner := &Runner{
-		Runner: deploycmd.Runner{
-			Deploy:                   deployMock,
-			Output:                   outputSink,
-			FilePath:                 "app.bicep",
-			ApplicationName:          "test-application",
-			Parameters:               map[string]map[string]any{},
-			Template:                 template,
-			Workspace:                workspace,
-			Providers:                providers,
-			TemplateInspectionResult: bicep.InspectTemplateResources(template),
-		},
-		Logstream:   logstreamMock,
-		Portforward: portforwardMock,
+		Deploy:                   deployMock,
+		Output:                   outputSink,
+		FilePath:                 "app.bicep",
+		ApplicationName:          "test-application",
+		Parameters:               map[string]map[string]any{},
+		Template:                 template,
+		Workspace:                workspace,
+		Providers:                providers,
+		TemplateInspectionResult: bicep.InspectTemplateResources(template),
+		Logstream:                logstreamMock,
+		Portforward:              portforwardMock,
 	}
 
 	ctx := t.Context()
@@ -870,22 +863,20 @@ func Test_Run_ExtensibleEnvironment_PreExisting(t *testing.T) {
 		Radius: &clients.RadiusProvider{},
 	}
 	runner := &Runner{
-		Runner: deploycmd.Runner{
-			Deploy:          deployMock,
-			Output:          outputSink,
-			FilePath:        "app.bicep",
-			ApplicationName: "test-application",
-			Parameters:      map[string]map[string]any{},
-			Template:        map[string]any{},
-			Workspace:       workspace,
-			Providers:       providers,
-			// A pre-existing environment was resolved during validation and is backed by the
-			// extensible Radius.Core/environments resource type.
-			EnvResult: &deploycmd.EnvironmentCheckResult{
-				UseApplicationsCore: false,
-				RadiusCoreEnv: &v20250801preview.EnvironmentResource{
-					ID: to.Ptr("/planes/radius/local/resourceGroups/default/providers/Radius.Core/environments/test-env"),
-				},
+		Deploy:          deployMock,
+		Output:          outputSink,
+		FilePath:        "app.bicep",
+		ApplicationName: "test-application",
+		Parameters:      map[string]map[string]any{},
+		Template:        map[string]any{},
+		Workspace:       workspace,
+		Providers:       providers,
+		// A pre-existing environment was resolved during validation and is backed by the
+		// extensible Radius.Core/environments resource type.
+		EnvResult: &deploycmd.EnvironmentCheckResult{
+			UseApplicationsCore: false,
+			RadiusCoreEnv: &v20250801preview.EnvironmentResource{
+				ID: to.Ptr("/planes/radius/local/resourceGroups/default/providers/Radius.Core/environments/test-env"),
 			},
 		},
 		Logstream:   logstreamMock,
@@ -926,13 +917,11 @@ func (p PortForwardOptionsMatcher) String() string {
 
 func createDashboardDeploymentObject() *appsv1.Deployment {
 	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dashboard",
-			Namespace: "radius-system",
-			Labels: map[string]string{
-				"app.kubernetes.io/name":    "dashboard",
-				"app.kubernetes.io/part-of": "radius",
-			},
+		Name:      "dashboard",
+		Namespace: "radius-system",
+		Labels: map[string]string{
+			"app.kubernetes.io/name":    "dashboard",
+			"app.kubernetes.io/part-of": "radius",
 		},
 	}
 }

--- a/pkg/cli/controlplane/controlplane_test.go
+++ b/pkg/cli/controlplane/controlplane_test.go
@@ -35,8 +35,8 @@ const testNamespace = "radius-system"
 
 func deployment(name string, replicas int32) *appsv1.Deployment {
 	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
-		Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+		Name: name, Namespace: testNamespace,
+		Spec: appsv1.DeploymentSpec{Replicas: &replicas},
 		// The fake clientset does not run controllers, so seed status to match spec so the
 		// scale-down/up waits converge immediately.
 		Status: appsv1.DeploymentStatus{Replicas: replicas, AvailableReplicas: replicas},

--- a/pkg/cli/credential/aws_credential_management.go
+++ b/pkg/cli/credential/aws_credential_management.go
@@ -113,10 +113,8 @@ func (cpm *AWSCredentialManagementClient) Get(ctx context.Context, credentialNam
 		}
 
 		providerCredentialConfiguration := ProviderCredentialConfiguration{
-			CloudProviderStatus: CloudProviderStatus{
-				Name:    AWSCredential,
-				Enabled: true,
-			},
+			Name:    AWSCredential,
+			Enabled: true,
 			AWSCredentials: &AWSCredentialProperties{
 				Kind: (*string)(awsAccessKeyCredentials.Kind),
 				AccessKey: &AWSAccessKeyCredentialProperties{
@@ -132,10 +130,8 @@ func (cpm *AWSCredentialManagementClient) Get(ctx context.Context, credentialNam
 		}
 
 		providerCredentialConfiguration := ProviderCredentialConfiguration{
-			CloudProviderStatus: CloudProviderStatus{
-				Name:    AWSCredential,
-				Enabled: true,
-			},
+			Name:    AWSCredential,
+			Enabled: true,
 			AWSCredentials: &AWSCredentialProperties{
 				Kind: (*string)(awsIRSACredentials.Kind),
 				IRSA: &AWSIRSACredentialProperties{

--- a/pkg/cli/credential/azure_credential_management.go
+++ b/pkg/cli/credential/azure_credential_management.go
@@ -133,10 +133,8 @@ func (cpm *AzureCredentialManagementClient) Get(ctx context.Context, credentialN
 		}
 
 		providerCredentialConfiguration := ProviderCredentialConfiguration{
-			CloudProviderStatus: CloudProviderStatus{
-				Name:    AzureCredential,
-				Enabled: true,
-			},
+			Name:    AzureCredential,
+			Enabled: true,
 			AzureCredentials: &AzureCredentialProperties{
 				Kind: (*string)(azureServicePrincipal.Kind),
 				ServicePrincipal: &AzureServicePrincipalCredentialProperties{
@@ -155,10 +153,8 @@ func (cpm *AzureCredentialManagementClient) Get(ctx context.Context, credentialN
 		}
 
 		providerCredentialConfiguration := ProviderCredentialConfiguration{
-			CloudProviderStatus: CloudProviderStatus{
-				Name:    AzureCredential,
-				Enabled: true,
-			},
+			Name:    AzureCredential,
+			Enabled: true,
 			AzureCredentials: &AzureCredentialProperties{
 				Kind: (*string)(azureWorkloadIdentity.Kind),
 				WorkloadIdentity: &AzureWorkloadIdentityCredentialProperties{

--- a/pkg/cli/credential/credential_management.go
+++ b/pkg/cli/credential/credential_management.go
@@ -119,10 +119,8 @@ func (cpm *UCPCredentialManagementClient) Get(ctx context.Context, providerName 
 	// We get 404 when credential for the provider plane is not registered.
 	if clients.Is404Error(err) {
 		return ProviderCredentialConfiguration{
-			CloudProviderStatus: CloudProviderStatus{
-				Name:    providerName,
-				Enabled: false,
-			},
+			Name:    providerName,
+			Enabled: false,
 		}, nil
 	} else if err != nil {
 		return ProviderCredentialConfiguration{}, err

--- a/pkg/cli/credential/credential_management_test.go
+++ b/pkg/cli/credential/credential_management_test.go
@@ -320,10 +320,8 @@ func Test_Credential_Azure_Show(t *testing.T) {
 	azMockCredentialClient := NewMockAzureCredentialManagementClientInterface(mockCtrl)
 
 	expectedAzProvider := ProviderCredentialConfiguration{
-		CloudProviderStatus: CloudProviderStatus{
-			Name:    azureProviderName,
-			Enabled: true,
-		},
+		Name:    azureProviderName,
+		Enabled: true,
 	}
 
 	azMockCredentialClient.EXPECT().Get(gomock.Any(), gomock.Any()).Return(expectedAzProvider, nil).Times(1)
@@ -345,10 +343,8 @@ func Test_Credential_AWS_Show(t *testing.T) {
 	AWSMockCredentialClient := NewMockAWSCredentialManagementClientInterface(mockCtrl)
 
 	expectedAWSProvider := ProviderCredentialConfiguration{
-		CloudProviderStatus: CloudProviderStatus{
-			Name:    awsProviderName,
-			Enabled: true,
-		},
+		Name:    awsProviderName,
+		Enabled: true,
 	}
 
 	AWSMockCredentialClient.EXPECT().Get(gomock.Any(), gomock.Any()).Return(expectedAWSProvider, nil).Times(1)
@@ -463,10 +459,8 @@ func setupSuccessPutAWSMocks(mockAzure MockAzureCredentialManagementClientInterf
 
 func setupSuccessGetAzureMocks(mockAzure MockAzureCredentialManagementClientInterface, mockAWS MockAWSCredentialManagementClientInterface, planeType string, planeName string) {
 	credential := ProviderCredentialConfiguration{
-		CloudProviderStatus: CloudProviderStatus{
-			Name:    azureProviderName,
-			Enabled: true,
-		},
+		Name:    azureProviderName,
+		Enabled: true,
 	}
 	mockAzure.EXPECT().
 		Get(gomock.Any(), gomock.Any()).
@@ -475,10 +469,8 @@ func setupSuccessGetAzureMocks(mockAzure MockAzureCredentialManagementClientInte
 
 func setupSuccessGetAWSMocks(mockAzure MockAzureCredentialManagementClientInterface, mockAWS MockAWSCredentialManagementClientInterface, planeType string, planeName string) {
 	credential := ProviderCredentialConfiguration{
-		CloudProviderStatus: CloudProviderStatus{
-			Name:    awsProviderName,
-			Enabled: true,
-		},
+		Name:    awsProviderName,
+		Enabled: true,
 	}
 	mockAWS.EXPECT().
 		Get(gomock.Any(), gomock.Any()).

--- a/pkg/cli/helm/cluster.go
+++ b/pkg/cli/helm/cluster.go
@@ -20,6 +20,7 @@ import (
 	context "context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"helm.sh/helm/v4/pkg/storage/driver"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -497,11 +498,11 @@ func (i *Impl) RollbackRadius(ctx context.Context, kubeContext string) error {
 	var currentChartVersion string
 
 	// Find the current deployed revision
-	for i := len(history) - 1; i >= 0; i-- {
-		if history[i].Info.Status == "deployed" {
-			currentRevision = history[i].Version
-			if history[i].Chart != nil && history[i].Chart.Metadata != nil {
-				currentChartVersion = history[i].Chart.Metadata.Version
+	for _, h := range slices.Backward(history) {
+		if h.Info.Status == "deployed" {
+			currentRevision = h.Version
+			if h.Chart != nil && h.Chart.Metadata != nil {
+				currentChartVersion = h.Chart.Metadata.Version
 			}
 			break
 		}

--- a/pkg/cli/helm/contour_test.go
+++ b/pkg/cli/helm/contour_test.go
@@ -73,10 +73,8 @@ func Test_prepareContourChart_LoadChartError(t *testing.T) {
 	helmAction := NewHelmAction(mockHelmClient)
 
 	options := ContourChartOptions{
-		ChartOptions: ChartOptions{
-			Namespace: "radius-system",
-			ChartPath: "bad-contour-chart",
-		},
+		Namespace: "radius-system",
+		ChartPath: "bad-contour-chart",
 	}
 
 	_, _, _, err := prepareContourChart(helmAction, options, "")
@@ -100,10 +98,8 @@ func Test_prepareContourChart_DoesNotMutateChartValues(t *testing.T) {
 	helmAction := NewHelmAction(mockHelmClient)
 
 	options := ContourChartOptions{
-		ChartOptions: ChartOptions{
-			Namespace: "radius-system",
-			ChartPath: "test-contour-chart",
-		},
+		Namespace:   "radius-system",
+		ChartPath:   "test-contour-chart",
 		HostNetwork: true,
 	}
 

--- a/pkg/cli/helm/helmaction.go
+++ b/pkg/cli/helm/helmaction.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/radius-project/radius/pkg/cli/clierrors"
@@ -263,8 +264,8 @@ func (helmAction *HelmActionImpl) GetPreviousReleaseVersion(kubeContext, release
 
 	// Find the most recent deployed or superseded release
 	// We iterate from the end (newest) to find the last stable release
-	for i := len(releases) - 1; i >= 0; i-- {
-		rel := releases[i]
+	for _, rel := range slices.Backward(releases) {
+
 		if rel.Info != nil && (rel.Info.Status == releasecommon.StatusDeployed || rel.Info.Status == releasecommon.StatusSuperseded) {
 			if rel.Chart != nil && rel.Chart.Metadata != nil {
 				version := rel.Chart.Metadata.AppVersion
@@ -329,8 +330,7 @@ func locateChartFile(dirPath string) (string, error) {
 // Helm v4 performs OCI registry operations via oras-go, which surfaces HTTP failures as
 // *errcode.ErrorResponse.
 func isHelmGHCR403Error(err error) bool {
-	var respErr *errcode.ErrorResponse
-	if errors.As(err, &respErr) {
+	if respErr, ok := errors.AsType[*errcode.ErrorResponse](err); ok {
 		if respErr.StatusCode == http.StatusForbidden && respErr.URL != nil && strings.Contains(respErr.URL.Host, "ghcr.io") {
 			return true
 		}

--- a/pkg/cli/helm/helmaction_test.go
+++ b/pkg/cli/helm/helmaction_test.go
@@ -65,10 +65,8 @@ func Test_isHelmGHCR403Error(t *testing.T) {
 
 func Test_parseUserValuesFromCLI(t *testing.T) {
 	options := &RadiusChartOptions{
-		ChartOptions: ChartOptions{
-			SetArgs:     []string{"global.zipkin.url=url,global.prometheus.path=path"},
-			SetFileArgs: []string{"global.rootCA.cert=./testdata/fake-ca-cert.crt"},
-		},
+		SetArgs:     []string{"global.zipkin.url=url,global.prometheus.path=path"},
+		SetFileArgs: []string{"global.rootCA.cert=./testdata/fake-ca-cert.crt"},
 	}
 
 	values, err := parseUserValuesFromCLI(options)
@@ -112,11 +110,9 @@ func Test_prepareRadiusChart_DoesNotMutateChartValues(t *testing.T) {
 	helmAction := NewHelmAction(mockHelmClient)
 
 	options := &RadiusChartOptions{
-		ChartOptions: ChartOptions{
-			Namespace: "radius-system",
-			ChartPath: "test-chart",
-			SetArgs:   []string{"global.zipkin.url=url"},
-		},
+		Namespace: "radius-system",
+		ChartPath: "test-chart",
+		SetArgs:   []string{"global.zipkin.url=url"},
 	}
 
 	_, _, values, err := prepareRadiusChart(helmAction, *options, "")
@@ -137,9 +133,7 @@ func Test_prepareRadiusChart_DoesNotMutateChartValues(t *testing.T) {
 
 func Test_parseUserValuesFromCLI_InvalidSetArg(t *testing.T) {
 	options := &RadiusChartOptions{
-		ChartOptions: ChartOptions{
-			SetArgs: []string{"invalid_no_equals"},
-		},
+		SetArgs: []string{"invalid_no_equals"},
 	}
 
 	_, err := parseUserValuesFromCLI(options)
@@ -148,9 +142,7 @@ func Test_parseUserValuesFromCLI_InvalidSetArg(t *testing.T) {
 
 func Test_parseUserValuesFromCLI_InvalidSetFileArg(t *testing.T) {
 	options := &RadiusChartOptions{
-		ChartOptions: ChartOptions{
-			SetFileArgs: []string{"key=./testdata/nonexistent-file.txt"},
-		},
+		SetFileArgs: []string{"key=./testdata/nonexistent-file.txt"},
 	}
 
 	_, err := parseUserValuesFromCLI(options)
@@ -176,10 +168,8 @@ func Test_prepareRadiusChart_LoadChartError(t *testing.T) {
 	helmAction := NewHelmAction(mockHelmClient)
 
 	options := &RadiusChartOptions{
-		ChartOptions: ChartOptions{
-			Namespace: "radius-system",
-			ChartPath: "bad-chart",
-		},
+		Namespace: "radius-system",
+		ChartPath: "bad-chart",
 	}
 
 	_, _, _, err := prepareRadiusChart(helmAction, *options, "")
@@ -196,11 +186,9 @@ func Test_prepareRadiusChart_ParseValuesError(t *testing.T) {
 	helmAction := NewHelmAction(mockHelmClient)
 
 	options := &RadiusChartOptions{
-		ChartOptions: ChartOptions{
-			Namespace: "radius-system",
-			ChartPath: "test-chart",
-			SetArgs:   []string{"invalid_no_equals"},
-		},
+		Namespace: "radius-system",
+		ChartPath: "test-chart",
+		SetArgs:   []string{"invalid_no_equals"},
 	}
 
 	_, _, _, err := prepareRadiusChart(helmAction, *options, "")
@@ -210,9 +198,7 @@ func Test_prepareRadiusChart_ParseValuesError(t *testing.T) {
 
 func Test_AddRadiusValuesOverrideWithSet(t *testing.T) {
 	options := &RadiusChartOptions{
-		ChartOptions: ChartOptions{
-			SetArgs: []string{"rp.image=ghcr.io/radius-project/applications-rp,rp.tag=latest", "global.zipkin.url=url,global.prometheus.path=path"},
-		},
+		SetArgs: []string{"rp.image=ghcr.io/radius-project/applications-rp,rp.tag=latest", "global.zipkin.url=url,global.prometheus.path=path"},
 	}
 
 	values, err := parseUserValuesFromCLI(options)

--- a/pkg/cli/kubernetes/kubernetes_test.go
+++ b/pkg/cli/kubernetes/kubernetes_test.go
@@ -32,13 +32,11 @@ import (
 )
 
 func TestEnsureNamespace(t *testing.T) {
-	f := k8sfake.NewClientset(&v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "radius-test"}})
+	f := k8sfake.NewClientset(&v1.Namespace{Name: "radius-test"})
 
 	k8sutil.PrependPatchReactor(f, "namespaces", func(pa clienttesting.PatchAction) runtime.Object {
 		return &v1.Namespace{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name: pa.GetName(),
-			},
+			Name: pa.GetName(),
 		}
 	})
 
@@ -51,7 +49,7 @@ func TestEnsureNamespace(t *testing.T) {
 
 func TestDeleteNamespace(t *testing.T) {
 	namespace := "radius-test"
-	f := k8sfake.NewClientset(&v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: namespace}})
+	f := k8sfake.NewClientset(&v1.Namespace{Name: namespace})
 
 	ctx := t.Context()
 	_, err := f.CoreV1().Namespaces().Get(ctx, namespace, meta_v1.GetOptions{})

--- a/pkg/cli/kubernetes/portforward/application_watcher_test.go
+++ b/pkg/cli/kubernetes/portforward/application_watcher_test.go
@@ -158,11 +158,9 @@ func stopDeploymentWatchers(aw *applicationWatcher) {
 
 func createDeployment(name, value, revision string) *appsv1.Deployment {
 	return &appsv1.Deployment{
-		ObjectMeta: v1.ObjectMeta{
-			Name: name,
-			Annotations: map[string]string{
-				"deployment.kubernetes.io/revision": revision,
-			},
+		Name: name,
+		Annotations: map[string]string{
+			"deployment.kubernetes.io/revision": revision,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &v1.LabelSelector{

--- a/pkg/cli/kubernetes/portforward/deployment_watcher_test.go
+++ b/pkg/cli/kubernetes/portforward/deployment_watcher_test.go
@@ -390,14 +390,12 @@ func stopPodWatchers(dw *deploymentWatcher) {
 
 func createPod(name string, replicaSetName string) *corev1.Pod {
 	return &corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{
-			Name: name,
-			OwnerReferences: []v1.OwnerReference{
-				{
-					APIVersion: "v1",
-					Kind:       "ReplicaSet",
-					Name:       replicaSetName,
-				},
+		Name: name,
+		OwnerReferences: []v1.OwnerReference{
+			{
+				APIVersion: "v1",
+				Kind:       "ReplicaSet",
+				Name:       replicaSetName,
 			},
 		},
 	}

--- a/pkg/cli/kubernetes/portforward/pod_watcher_test.go
+++ b/pkg/cli/kubernetes/portforward/pod_watcher_test.go
@@ -23,18 +23,15 @@ import (
 	"github.com/radius-project/radius/pkg/kubernetes"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_podWatcher_CanShutdownGracefully(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
 	pod := &corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "test-app-test-container-abcd-efghij",
-			Labels: map[string]string{
-				kubernetes.LabelRadiusResource: "test-container",
-			},
+		Name: "test-app-test-container-abcd-efghij",
+		Labels: map[string]string{
+			kubernetes.LabelRadiusResource: "test-container",
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
@@ -90,11 +87,9 @@ func Test_podWatcher_CanStartWhenPodIsReady(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
 	pod := &corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "test-app-test-container-abcd-efghij",
-			Labels: map[string]string{
-				kubernetes.LabelRadiusResource: "test-container",
-			},
+		Name: "test-app-test-container-abcd-efghij",
+		Labels: map[string]string{
+			kubernetes.LabelRadiusResource: "test-container",
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodUnknown,

--- a/pkg/cli/kubernetes/portforward/util_test.go
+++ b/pkg/cli/kubernetes/portforward/util_test.go
@@ -32,138 +32,124 @@ func Test_findStaleReplicaSets(t *testing.T) {
 
 		// Owned by d1
 		&appsv1.ReplicaSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "rs1a",
-				Namespace: "default",
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: "apps/v1",
-						Kind:       "Deployment",
-						Name:       "d1",
-					},
+			Name:      "rs1a",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "d1",
 				},
-				Labels: map[string]string{
-					kubernetes.LabelRadiusApplication: "test-app",
-				},
-				Annotations: map[string]string{
-					"deployment.kubernetes.io/revision": "1",
-				},
+			},
+			Labels: map[string]string{
+				kubernetes.LabelRadiusApplication: "test-app",
+			},
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "1",
 			},
 		},
 
 		// Also owned by d1, but newer revision
 		&appsv1.ReplicaSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "rs1b",
-				Namespace: "default",
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: "apps/v1",
-						Kind:       "Deployment",
-						Name:       "d1",
-					},
+			Name:      "rs1b",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "d1",
 				},
-				Labels: map[string]string{
-					kubernetes.LabelRadiusApplication: "test-app",
-				},
-				Annotations: map[string]string{
-					"deployment.kubernetes.io/revision": "3",
-				},
+			},
+			Labels: map[string]string{
+				kubernetes.LabelRadiusApplication: "test-app",
+			},
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "3",
 			},
 		},
 
 		// Also owned by d1, but newer revision (not newest, though)
 		&appsv1.ReplicaSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "rs1c",
-				Namespace: "default",
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: "apps/v1",
-						Kind:       "Deployment",
-						Name:       "d1",
-					},
+			Name:      "rs1c",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "d1",
 				},
-				Labels: map[string]string{
-					kubernetes.LabelRadiusApplication: "test-app",
-				},
-				Annotations: map[string]string{
-					"deployment.kubernetes.io/revision": "2",
-				},
+			},
+			Labels: map[string]string{
+				kubernetes.LabelRadiusApplication: "test-app",
+			},
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "2",
 			},
 		},
 
 		// Owned by d2 - only one replicaset is here, so it can't be stale
 		&appsv1.ReplicaSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "rs2a",
-				Namespace: "default",
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: "apps/v1",
-						Kind:       "Deployment",
-						Name:       "d2",
-					},
+			Name:      "rs2a",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "d2",
 				},
-				Labels: map[string]string{
-					kubernetes.LabelRadiusApplication: "test-app",
-				},
-				Annotations: map[string]string{
-					"deployment.kubernetes.io/revision": "3",
-				},
+			},
+			Labels: map[string]string{
+				kubernetes.LabelRadiusApplication: "test-app",
+			},
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "3",
 			},
 		},
 
 		// No owner, ignored
 		&appsv1.ReplicaSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "rs3a",
-				Namespace: "default",
-				Labels: map[string]string{
-					kubernetes.LabelRadiusApplication: "test-app",
-				},
-				Annotations: map[string]string{
-					"deployment.kubernetes.io/revision": "3",
-				},
+			Name:      "rs3a",
+			Namespace: "default",
+			Labels: map[string]string{
+				kubernetes.LabelRadiusApplication: "test-app",
+			},
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "3",
 			},
 		},
 
 		// Not part of application, ignored
 		&appsv1.ReplicaSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "rs4a",
-				Namespace: "default",
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: "apps/v1",
-						Kind:       "Deployment",
-						Name:       "d4",
-					},
+			Name:      "rs4a",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "d4",
 				},
-				Annotations: map[string]string{
-					"deployment.kubernetes.io/revision": "3",
-				},
+			},
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "3",
 			},
 		},
 
 		// Part of other application, ignored
 		&appsv1.ReplicaSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "rs5a",
-				Namespace: "default",
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: "apps/v1",
-						Kind:       "Deployment",
-						Name:       "d5",
-					},
+			Name:      "rs5a",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "d5",
 				},
-				Labels: map[string]string{
-					kubernetes.LabelRadiusApplication: "another-test-app",
-				},
-				Annotations: map[string]string{
-					"deployment.kubernetes.io/revision": "3",
-				},
+			},
+			Labels: map[string]string{
+				kubernetes.LabelRadiusApplication: "another-test-app",
+			},
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "3",
 			},
 		},
 	}

--- a/pkg/cli/manifest/parser.go
+++ b/pkg/cli/manifest/parser.go
@@ -117,7 +117,7 @@ func createValidator() yaml.StructValidator {
 
 	// Use the `yaml` tag for field names
 	v.RegisterTagNameFunc(func(fld reflect.StructField) string {
-		name := strings.SplitN(fld.Tag.Get("yaml"), ",", 2)[0]
+		name, _, _ := strings.Cut(fld.Tag.Get("yaml"), ",")
 		if name == "-" {
 			return fld.Name
 		}

--- a/pkg/cli/manifest/registermanifest_test.go
+++ b/pkg/cli/manifest/registermanifest_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	ucpfake "github.com/radius-project/radius/pkg/ucp/api/v20231001preview/fake"
 	"github.com/radius-project/radius/pkg/ucp/datamodel"
@@ -1266,9 +1265,7 @@ func createErrorResourceProviderClientFactory() (*v20231001preview.ClientFactory
 	serverFactoryTransport := ucpfake.NewServerFactoryTransport(&serverFactory)
 
 	clientOptions := &armpolicy.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: serverFactoryTransport,
-		},
+		Transport: serverFactoryTransport,
 	}
 
 	return v20231001preview.NewClientFactory(&azfake.TokenCredential{}, clientOptions)
@@ -1300,9 +1297,7 @@ func createErrorLocationClientFactory() (*v20231001preview.ClientFactory, error)
 	serverFactoryTransport := ucpfake.NewServerFactoryTransport(&serverFactory)
 
 	clientOptions := &armpolicy.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: serverFactoryTransport,
-		},
+		Transport: serverFactoryTransport,
 	}
 
 	return v20231001preview.NewClientFactory(&azfake.TokenCredential{}, clientOptions)
@@ -1319,13 +1314,11 @@ func createLocationClientFactoryWithAddress() (*v20231001preview.ClientFactory, 
 			options *v20231001preview.LocationsClientGetOptions,
 		) (resp azfake.Responder[v20231001preview.LocationsClientGetResponse], errResp azfake.ErrorResponder) {
 			response := v20231001preview.LocationsClientGetResponse{
-				LocationResource: v20231001preview.LocationResource{
-					Name: new(locationName),
-					ID:   new("id"),
-					Properties: &v20231001preview.LocationProperties{
-						Address:       new("http://localhost:8080"),
-						ResourceTypes: map[string]*v20231001preview.LocationResourceType{},
-					},
+				Name: new(locationName),
+				ID:   new("id"),
+				Properties: &v20231001preview.LocationProperties{
+					Address:       new("http://localhost:8080"),
+					ResourceTypes: map[string]*v20231001preview.LocationResourceType{},
 				},
 			}
 			resp.SetResponse(http.StatusOK, response, nil)
@@ -1343,9 +1336,7 @@ func createLocationClientFactoryWithAddress() (*v20231001preview.ClientFactory, 
 	serverFactoryTransport := ucpfake.NewServerFactoryTransport(&serverFactory)
 
 	clientOptions := &armpolicy.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: serverFactoryTransport,
-		},
+		Transport: serverFactoryTransport,
 	}
 
 	return v20231001preview.NewClientFactory(&azfake.TokenCredential{}, clientOptions)
@@ -1362,21 +1353,19 @@ func createLocationClientFactoryWithResourceTypes() (*v20231001preview.ClientFac
 			options *v20231001preview.LocationsClientGetOptions,
 		) (resp azfake.Responder[v20231001preview.LocationsClientGetResponse], errResp azfake.ErrorResponder) {
 			response := v20231001preview.LocationsClientGetResponse{
-				LocationResource: v20231001preview.LocationResource{
-					Name: new(locationName),
-					ID:   new("id"),
-					Properties: &v20231001preview.LocationProperties{
-						ResourceTypes: map[string]*v20231001preview.LocationResourceType{
-							"testResource": {
-								APIVersions: map[string]*v20231001preview.LocationResourceTypeAPIVersion{
-									"2023-01-01": {},
-								},
+				Name: new(locationName),
+				ID:   new("id"),
+				Properties: &v20231001preview.LocationProperties{
+					ResourceTypes: map[string]*v20231001preview.LocationResourceType{
+						"testResource": {
+							APIVersions: map[string]*v20231001preview.LocationResourceTypeAPIVersion{
+								"2023-01-01": {},
 							},
-							"anotherResource": {
-								APIVersions: map[string]*v20231001preview.LocationResourceTypeAPIVersion{
-									"2023-01-01": {},
-									"2023-06-01": {},
-								},
+						},
+						"anotherResource": {
+							APIVersions: map[string]*v20231001preview.LocationResourceTypeAPIVersion{
+								"2023-01-01": {},
+								"2023-06-01": {},
 							},
 						},
 					},
@@ -1397,9 +1386,7 @@ func createLocationClientFactoryWithResourceTypes() (*v20231001preview.ClientFac
 	serverFactoryTransport := ucpfake.NewServerFactoryTransport(&serverFactory)
 
 	clientOptions := &armpolicy.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: serverFactoryTransport,
-		},
+		Transport: serverFactoryTransport,
 	}
 
 	return v20231001preview.NewClientFactory(&azfake.TokenCredential{}, clientOptions)

--- a/pkg/cli/manifest/testclientfactory.go
+++ b/pkg/cli/manifest/testclientfactory.go
@@ -23,7 +23,6 @@ import (
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	ucpfake "github.com/radius-project/radius/pkg/ucp/api/v20231001preview/fake"
 )
@@ -40,9 +39,7 @@ func NewTestClientFactory(resourceProvidersServer func() ucpfake.ResourceProvide
 	serverFactoryTransport := ucpfake.NewServerFactoryTransport(&serverFactory)
 
 	clientOptions := &armpolicy.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: serverFactoryTransport,
-		},
+		Transport: serverFactoryTransport,
 	}
 
 	clientFactory, err := v20231001preview.NewClientFactory(&azfake.TokenCredential{}, clientOptions)
@@ -78,9 +75,7 @@ func WithResourceProviderServerNoError() ucpfake.ResourceProvidersServer {
 			options *v20231001preview.ResourceProvidersClientGetOptions, // Add this parameter
 		) (resp azfake.Responder[v20231001preview.ResourceProvidersClientGetResponse], errResp azfake.ErrorResponder) {
 			response := v20231001preview.ResourceProvidersClientGetResponse{
-				ResourceProviderResource: v20231001preview.ResourceProviderResource{
-					Name: new(resourceProviderName),
-				},
+				Name: new(resourceProviderName),
 			}
 			resp.SetResponse(http.StatusOK, response, nil)
 			return
@@ -92,32 +87,30 @@ func WithResourceProviderServerNoError() ucpfake.ResourceProvidersServer {
 			options *v20231001preview.ResourceProvidersClientGetProviderSummaryOptions,
 		) (resp azfake.Responder[v20231001preview.ResourceProvidersClientGetProviderSummaryResponse], errResp azfake.ErrorResponder) {
 			response := v20231001preview.ResourceProvidersClientGetProviderSummaryResponse{
-				ResourceProviderSummary: v20231001preview.ResourceProviderSummary{
-					Name: new(resourceProviderName),
-					ResourceTypes: map[string]*v20231001preview.ResourceProviderSummaryResourceType{
-						"testResources": {
-							Description: new("Resource type description"),
-							APIVersions: map[string]*v20231001preview.ResourceTypeSummaryResultAPIVersion{
-								"2023-10-01-preview": {
-									Schema: map[string]any{
-										"properties": map[string]any{
-											"application": map[string]any{
-												"type":        "string",
-												"description": "The name of the application.",
-											},
-											"environment": map[string]any{
-												"type":        "string",
-												"description": "The name of the environment.",
-											},
-											"database": map[string]any{
-												"type":        "string",
-												"description": "The name of the database.",
-												"readOnly":    true,
-											},
+				Name: new(resourceProviderName),
+				ResourceTypes: map[string]*v20231001preview.ResourceProviderSummaryResourceType{
+					"testResources": {
+						Description: new("Resource type description"),
+						APIVersions: map[string]*v20231001preview.ResourceTypeSummaryResultAPIVersion{
+							"2023-10-01-preview": {
+								Schema: map[string]any{
+									"properties": map[string]any{
+										"application": map[string]any{
+											"type":        "string",
+											"description": "The name of the application.",
 										},
-										"required": []any{
-											"environment",
+										"environment": map[string]any{
+											"type":        "string",
+											"description": "The name of the environment.",
 										},
+										"database": map[string]any{
+											"type":        "string",
+											"description": "The name of the database.",
+											"readOnly":    true,
+										},
+									},
+									"required": []any{
+										"environment",
 									},
 								},
 							},
@@ -159,9 +152,7 @@ func WithResourceTypeServerNoError() ucpfake.ResourceTypesServer {
 			options *v20231001preview.ResourceTypesClientGetOptions,
 		) (resp azfake.Responder[v20231001preview.ResourceTypesClientGetResponse], errResp azfake.ErrorResponder) {
 			response := v20231001preview.ResourceTypesClientGetResponse{
-				ResourceTypeResource: v20231001preview.ResourceTypeResource{
-					Name: new(resourceTypeName),
-				},
+				Name: new(resourceTypeName),
 			}
 			resp.SetResponse(http.StatusOK, response, nil)
 			return
@@ -220,12 +211,10 @@ func WithLocationServerNoError() ucpfake.LocationsServer {
 			options *v20231001preview.LocationsClientGetOptions,
 		) (resp azfake.Responder[v20231001preview.LocationsClientGetResponse], errResp azfake.ErrorResponder) {
 			response := v20231001preview.LocationsClientGetResponse{
-				LocationResource: v20231001preview.LocationResource{
-					Name: new(locationName),
-					ID:   new("id"),
-					Properties: &v20231001preview.LocationProperties{
-						ResourceTypes: map[string]*v20231001preview.LocationResourceType{},
-					},
+				Name: new(locationName),
+				ID:   new("id"),
+				Properties: &v20231001preview.LocationProperties{
+					ResourceTypes: map[string]*v20231001preview.LocationResourceType{},
 				},
 			}
 			resp.SetResponse(http.StatusOK, response, nil)
@@ -260,9 +249,7 @@ func WithResourceProviderServerNotFoundError() ucpfake.ResourceProvidersServer {
 			options *v20231001preview.ResourceProvidersClientGetOptions, // Add this parameter
 		) (resp azfake.Responder[v20231001preview.ResourceProvidersClientGetResponse], errResp azfake.ErrorResponder) {
 			response := v20231001preview.ResourceProvidersClientGetResponse{
-				ResourceProviderResource: v20231001preview.ResourceProviderResource{
-					Name: new(resourceProviderName),
-				},
+				Name: new(resourceProviderName),
 			}
 			resp.SetResponse(http.StatusNotFound, response, nil)
 			return
@@ -305,9 +292,7 @@ func WithResourceProviderServerInternalError() ucpfake.ResourceProvidersServer {
 			options *v20231001preview.ResourceProvidersClientGetOptions, // Add this parameter
 		) (resp azfake.Responder[v20231001preview.ResourceProvidersClientGetResponse], errResp azfake.ErrorResponder) {
 			response := v20231001preview.ResourceProvidersClientGetResponse{
-				ResourceProviderResource: v20231001preview.ResourceProviderResource{
-					Name: new(resourceProviderName),
-				},
+				Name: new(resourceProviderName),
 			}
 			resp.SetResponse(http.StatusInternalServerError, response, nil)
 			return

--- a/pkg/cli/test_client_factory/radius_core.go
+++ b/pkg/cli/test_client_factory/radius_core.go
@@ -23,7 +23,6 @@ import (
 
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
 	corerpfake "github.com/radius-project/radius/pkg/corerp/api/v20250801preview/fake"
 	"github.com/radius-project/radius/pkg/to"
@@ -54,9 +53,7 @@ func NewRadiusCoreTestClientFactory(rootScope string, envServer func() corerpfak
 	serverFactoryTransport := corerpfake.NewServerFactoryTransport(&serverFactory)
 
 	clientOptions := &armpolicy.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: serverFactoryTransport,
-		},
+		Transport: serverFactoryTransport,
 	}
 
 	clientFactory, err := v20250801preview.NewClientFactory(&azfake.TokenCredential{}, clientOptions)
@@ -71,18 +68,16 @@ func WithRecipePackServerNoError() corerpfake.RecipePacksServer {
 	return corerpfake.RecipePacksServer{
 		Get: func(ctx context.Context, rootScope string, recipePackName string, options *v20250801preview.RecipePacksClientGetOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientGetResponse], errResp azfake.ErrorResponder) {
 			result := v20250801preview.RecipePacksClientGetResponse{
-				RecipePackResource: v20250801preview.RecipePackResource{
-					Name: new(recipePackName),
-					Properties: &v20250801preview.RecipePackProperties{
-						Recipes: map[string]*v20250801preview.RecipeDefinition{
-							"test-recipe1": {
-								Source: new("https://example.com/recipe1?ref=v0.1"),
-								Kind:   to.Ptr(v20250801preview.RecipeKindTerraform),
-							},
-							"test-recipe2": {
-								Source: new("https://example.com/recipe2?ref=v0.1"),
-								Kind:   to.Ptr(v20250801preview.RecipeKindTerraform),
-							},
+				Name: new(recipePackName),
+				Properties: &v20250801preview.RecipePackProperties{
+					Recipes: map[string]*v20250801preview.RecipeDefinition{
+						"test-recipe1": {
+							Source: new("https://example.com/recipe1?ref=v0.1"),
+							Kind:   to.Ptr(v20250801preview.RecipeKindTerraform),
+						},
+						"test-recipe2": {
+							Source: new("https://example.com/recipe2?ref=v0.1"),
+							Kind:   to.Ptr(v20250801preview.RecipeKindTerraform),
 						},
 					},
 				},
@@ -92,10 +87,8 @@ func WithRecipePackServerNoError() corerpfake.RecipePacksServer {
 		},
 		CreateOrUpdate: func(ctx context.Context, rootScope string, recipePackName string, resource v20250801preview.RecipePackResource, options *v20250801preview.RecipePacksClientCreateOrUpdateOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
 			result := v20250801preview.RecipePacksClientCreateOrUpdateResponse{
-				RecipePackResource: v20250801preview.RecipePackResource{
-					Name:       to.Ptr(recipePackName),
-					Properties: resource.Properties,
-				},
+				Name:       to.Ptr(recipePackName),
+				Properties: resource.Properties,
 			}
 			resp.SetResponse(http.StatusOK, result, nil)
 			return
@@ -125,25 +118,23 @@ func WithEnvironmentServerNoError() corerpfake.EnvironmentsServer {
 			options *v20250801preview.EnvironmentsClientGetOptions,
 		) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 			result := v20250801preview.EnvironmentsClientGetResponse{
-				EnvironmentResource: v20250801preview.EnvironmentResource{
-					Name: new(environmentName),
-					Properties: &v20250801preview.EnvironmentProperties{
-						Providers: &v20250801preview.Providers{
-							Azure: &v20250801preview.ProvidersAzure{
-								SubscriptionID:    new("test-subscription-id"),
-								ResourceGroupName: new("test-resource-group"),
-							},
-							Aws: &v20250801preview.ProvidersAws{
-								AccountID: new("test-account-id"),
-								Region:    new("test-region"),
-							},
-							Kubernetes: &v20250801preview.ProvidersKubernetes{
-								Namespace: new("test-namespace"),
-							},
+				Name: new(environmentName),
+				Properties: &v20250801preview.EnvironmentProperties{
+					Providers: &v20250801preview.Providers{
+						Azure: &v20250801preview.ProvidersAzure{
+							SubscriptionID:    new("test-subscription-id"),
+							ResourceGroupName: new("test-resource-group"),
 						},
-						RecipePacks: []*string{
-							new("/planes/radius/local/resourceGroups/test-group/providers/Radius.Core/recipePacks/test-recipe-pack"),
+						Aws: &v20250801preview.ProvidersAws{
+							AccountID: new("test-account-id"),
+							Region:    new("test-region"),
 						},
+						Kubernetes: &v20250801preview.ProvidersKubernetes{
+							Namespace: new("test-namespace"),
+						},
+					},
+					RecipePacks: []*string{
+						new("/planes/radius/local/resourceGroups/test-group/providers/Radius.Core/recipePacks/test-recipe-pack"),
 					},
 				},
 			}
@@ -154,14 +145,12 @@ func WithEnvironmentServerNoError() corerpfake.EnvironmentsServer {
 			resp.AddPage(
 				http.StatusOK,
 				v20250801preview.EnvironmentsClientListByScopeResponse{
-					EnvironmentResourceListResult: v20250801preview.EnvironmentResourceListResult{
-						Value: []*v20250801preview.EnvironmentResource{
-							{
-								Name: new("test-env-1"),
-							},
-							{
-								Name: new("test-env-2"),
-							},
+					Value: []*v20250801preview.EnvironmentResource{
+						{
+							Name: new("test-env-1"),
+						},
+						{
+							Name: new("test-env-2"),
 						},
 					},
 				},
@@ -192,11 +181,9 @@ func WithApplicationsServerNoError() corerpfake.ApplicationsServer {
 			options *v20250801preview.ApplicationsClientCreateOrUpdateOptions,
 		) (resp azfake.Responder[v20250801preview.ApplicationsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
 			result := v20250801preview.ApplicationsClientCreateOrUpdateResponse{
-				ApplicationResource: v20250801preview.ApplicationResource{
-					Name:       to.Ptr(applicationName),
-					Location:   resource.Location,
-					Properties: resource.Properties,
-				},
+				Name:       to.Ptr(applicationName),
+				Location:   resource.Location,
+				Properties: resource.Properties,
 			}
 			resp.SetResponse(http.StatusOK, result, nil)
 			return
@@ -208,9 +195,7 @@ func WithApplicationsServerNoError() corerpfake.ApplicationsServer {
 			options *v20250801preview.ApplicationsClientGetOptions,
 		) (resp azfake.Responder[v20250801preview.ApplicationsClientGetResponse], errResp azfake.ErrorResponder) {
 			result := v20250801preview.ApplicationsClientGetResponse{
-				ApplicationResource: v20250801preview.ApplicationResource{
-					Name: new(applicationName),
-				},
+				Name: new(applicationName),
 			}
 			resp.SetResponse(http.StatusOK, result, nil)
 			return
@@ -228,14 +213,12 @@ func WithApplicationsServerNoError() corerpfake.ApplicationsServer {
 			resp.AddPage(
 				http.StatusOK,
 				v20250801preview.ApplicationsClientListByScopeResponse{
-					ApplicationResourceListResult: v20250801preview.ApplicationResourceListResult{
-						Value: []*v20250801preview.ApplicationResource{
-							{
-								Name: new("test-app-1"),
-							},
-							{
-								Name: new("test-app-2"),
-							},
+					Value: []*v20250801preview.ApplicationResource{
+						{
+							Name: new("test-app-1"),
+						},
+						{
+							Name: new("test-app-2"),
 						},
 					},
 				},
@@ -251,9 +234,7 @@ func WithApplicationsServerNoError() corerpfake.ApplicationsServer {
 			options *v20250801preview.ApplicationsClientGetGraphOptions,
 		) (resp azfake.Responder[v20250801preview.ApplicationsClientGetGraphResponse], errResp azfake.ErrorResponder) {
 			resp.SetResponse(http.StatusOK, v20250801preview.ApplicationsClientGetGraphResponse{
-				ApplicationGraphResponse: v20250801preview.ApplicationGraphResponse{
-					Resources: []*v20250801preview.ApplicationGraphResource{},
-				},
+				Resources: []*v20250801preview.ApplicationGraphResource{},
 			}, nil)
 			return
 		},
@@ -318,12 +299,10 @@ func WithEnvironmentServerNoRecipePacks() corerpfake.EnvironmentsServer {
 			options *v20250801preview.EnvironmentsClientGetOptions,
 		) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 			result := v20250801preview.EnvironmentsClientGetResponse{
-				EnvironmentResource: v20250801preview.EnvironmentResource{
-					Name:     to.Ptr(environmentName),
-					Location: to.Ptr("global"),
-					Properties: &v20250801preview.EnvironmentProperties{
-						RecipePacks: []*string{},
-					},
+				Name:     to.Ptr(environmentName),
+				Location: to.Ptr("global"),
+				Properties: &v20250801preview.EnvironmentProperties{
+					RecipePacks: []*string{},
 				},
 			}
 			resp.SetResponse(http.StatusOK, result, nil)
@@ -357,12 +336,10 @@ func WithEnvironmentServerCustomRecipePacks(recipePacks []*string) func() corerp
 				options *v20250801preview.EnvironmentsClientGetOptions,
 			) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 				result := v20250801preview.EnvironmentsClientGetResponse{
-					EnvironmentResource: v20250801preview.EnvironmentResource{
-						Name:     to.Ptr(environmentName),
-						Location: to.Ptr("global"),
-						Properties: &v20250801preview.EnvironmentProperties{
-							RecipePacks: recipePacks,
-						},
+					Name:     to.Ptr(environmentName),
+					Location: to.Ptr("global"),
+					Properties: &v20250801preview.EnvironmentProperties{
+						RecipePacks: recipePacks,
 					},
 				}
 				resp.SetResponse(http.StatusOK, result, nil)
@@ -407,14 +384,12 @@ func WithRecipePackServerCoreTypes() corerpfake.RecipePacksServer {
 			}
 			bicepKind := v20250801preview.RecipeKindBicep
 			result := v20250801preview.RecipePacksClientGetResponse{
-				RecipePackResource: v20250801preview.RecipePackResource{
-					Name: to.Ptr(recipePackName),
-					Properties: &v20250801preview.RecipePackProperties{
-						Recipes: map[string]*v20250801preview.RecipeDefinition{
-							resourceType: {
-								Source: to.Ptr("ghcr.io/test/" + recipePackName + ":latest"),
-								Kind:   &bicepKind,
-							},
+				Name: to.Ptr(recipePackName),
+				Properties: &v20250801preview.RecipePackProperties{
+					Recipes: map[string]*v20250801preview.RecipeDefinition{
+						resourceType: {
+							Source: to.Ptr("ghcr.io/test/" + recipePackName + ":latest"),
+							Kind:   &bicepKind,
 						},
 					},
 				},
@@ -424,10 +399,8 @@ func WithRecipePackServerCoreTypes() corerpfake.RecipePacksServer {
 		},
 		CreateOrUpdate: func(ctx context.Context, rootScope string, recipePackName string, resource v20250801preview.RecipePackResource, options *v20250801preview.RecipePacksClientCreateOrUpdateOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
 			result := v20250801preview.RecipePacksClientCreateOrUpdateResponse{
-				RecipePackResource: v20250801preview.RecipePackResource{
-					Name:       to.Ptr(recipePackName),
-					Properties: resource.Properties,
-				},
+				Name:       to.Ptr(recipePackName),
+				Properties: resource.Properties,
 			}
 			resp.SetResponse(http.StatusOK, result, nil)
 			return
@@ -442,14 +415,12 @@ func WithRecipePackServerUniqueTypes() corerpfake.RecipePacksServer {
 		Get: func(ctx context.Context, rootScope string, recipePackName string, options *v20250801preview.RecipePacksClientGetOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientGetResponse], errResp azfake.ErrorResponder) {
 			bicepKind := v20250801preview.RecipeKindBicep
 			result := v20250801preview.RecipePacksClientGetResponse{
-				RecipePackResource: v20250801preview.RecipePackResource{
-					Name: to.Ptr(recipePackName),
-					Properties: &v20250801preview.RecipePackProperties{
-						Recipes: map[string]*v20250801preview.RecipeDefinition{
-							"Test.Resource/" + recipePackName: {
-								Source: to.Ptr("ghcr.io/test/" + recipePackName + ":latest"),
-								Kind:   &bicepKind,
-							},
+				Name: to.Ptr(recipePackName),
+				Properties: &v20250801preview.RecipePackProperties{
+					Recipes: map[string]*v20250801preview.RecipeDefinition{
+						"Test.Resource/" + recipePackName: {
+							Source: to.Ptr("ghcr.io/test/" + recipePackName + ":latest"),
+							Kind:   &bicepKind,
 						},
 					},
 				},
@@ -459,10 +430,8 @@ func WithRecipePackServerUniqueTypes() corerpfake.RecipePacksServer {
 		},
 		CreateOrUpdate: func(ctx context.Context, rootScope string, recipePackName string, resource v20250801preview.RecipePackResource, options *v20250801preview.RecipePacksClientCreateOrUpdateOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
 			result := v20250801preview.RecipePacksClientCreateOrUpdateResponse{
-				RecipePackResource: v20250801preview.RecipePackResource{
-					Name:       to.Ptr(recipePackName),
-					Properties: resource.Properties,
-				},
+				Name:       to.Ptr(recipePackName),
+				Properties: resource.Properties,
 			}
 			resp.SetResponse(http.StatusOK, result, nil)
 			return
@@ -482,10 +451,8 @@ func WithRecipePackServer404OnGet() corerpfake.RecipePacksServer {
 		},
 		CreateOrUpdate: func(ctx context.Context, rootScope string, recipePackName string, resource v20250801preview.RecipePackResource, options *v20250801preview.RecipePacksClientCreateOrUpdateOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
 			result := v20250801preview.RecipePacksClientCreateOrUpdateResponse{
-				RecipePackResource: v20250801preview.RecipePackResource{
-					Name:       to.Ptr(recipePackName),
-					Properties: resource.Properties,
-				},
+				Name:       to.Ptr(recipePackName),
+				Properties: resource.Properties,
 			}
 			resp.SetResponse(http.StatusOK, result, nil)
 			return
@@ -500,14 +467,12 @@ func WithRecipePackServerConflictingTypes() corerpfake.RecipePacksServer {
 		Get: func(ctx context.Context, rootScope string, recipePackName string, options *v20250801preview.RecipePacksClientGetOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientGetResponse], errResp azfake.ErrorResponder) {
 			bicepKind := v20250801preview.RecipeKindBicep
 			result := v20250801preview.RecipePacksClientGetResponse{
-				RecipePackResource: v20250801preview.RecipePackResource{
-					Name: to.Ptr(recipePackName),
-					Properties: &v20250801preview.RecipePackProperties{
-						Recipes: map[string]*v20250801preview.RecipeDefinition{
-							"Radius.Compute/containers": {
-								Source: to.Ptr("ghcr.io/test/" + recipePackName + ":latest"),
-								Kind:   &bicepKind,
-							},
+				Name: to.Ptr(recipePackName),
+				Properties: &v20250801preview.RecipePackProperties{
+					Recipes: map[string]*v20250801preview.RecipeDefinition{
+						"Radius.Compute/containers": {
+							Source: to.Ptr("ghcr.io/test/" + recipePackName + ":latest"),
+							Kind:   &bicepKind,
 						},
 					},
 				},
@@ -517,10 +482,8 @@ func WithRecipePackServerConflictingTypes() corerpfake.RecipePacksServer {
 		},
 		CreateOrUpdate: func(ctx context.Context, rootScope string, recipePackName string, resource v20250801preview.RecipePackResource, options *v20250801preview.RecipePacksClientCreateOrUpdateOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
 			result := v20250801preview.RecipePacksClientCreateOrUpdateResponse{
-				RecipePackResource: v20250801preview.RecipePackResource{
-					Name:       to.Ptr(recipePackName),
-					Properties: resource.Properties,
-				},
+				Name:       to.Ptr(recipePackName),
+				Properties: resource.Properties,
 			}
 			resp.SetResponse(http.StatusOK, result, nil)
 			return

--- a/pkg/cli/tfstate/tfstate_test.go
+++ b/pkg/cli/tfstate/tfstate_test.go
@@ -29,14 +29,12 @@ import (
 
 func tfstateSecret(name string, data map[string][]byte) *corev1.Secret {
 	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            name,
-			Namespace:       DefaultNamespace,
-			Labels:          map[string]string{"tfstate": "true"},
-			ResourceVersion: "12345",
-			UID:             "abcde-uid",
-		},
-		Data: data,
+		Name:            name,
+		Namespace:       DefaultNamespace,
+		Labels:          map[string]string{"tfstate": "true"},
+		ResourceVersion: "12345",
+		UID:             "abcde-uid",
+		Data:            data,
 	}
 }
 
@@ -46,8 +44,8 @@ func Test_Backup_WritesLabelledSecretsOnly(t *testing.T) {
 		tfstateSecret("tfstate-default-bbb", map[string][]byte{"tfstate": []byte("state-b")}),
 		// A secret without the tfstate label must be ignored.
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "database-secret", Namespace: DefaultNamespace},
-			Data:       map[string][]byte{"POSTGRES_PASSWORD": []byte("nope")},
+			Name: "database-secret", Namespace: DefaultNamespace,
+			Data: map[string][]byte{"POSTGRES_PASSWORD": []byte("nope")},
 		},
 	)
 

--- a/pkg/components/database/apiserverstore/apiserverclient.go
+++ b/pkg/components/database/apiserverstore/apiserverclient.go
@@ -583,10 +583,8 @@ func readEntry(entry *ucpv1alpha1.ResourceEntry) (*database.Object, error) {
 	}
 
 	obj := database.Object{
-		Metadata: database.Metadata{
-			ID:   entry.ID,
-			ETag: entry.ETag,
-		},
+		ID:   entry.ID,
+		ETag: entry.ETag,
 		Data: data,
 	}
 

--- a/pkg/components/database/apiserverstore/apiserverclient_test.go
+++ b/pkg/components/database/apiserverstore/apiserverclient_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -138,9 +137,7 @@ func Test_APIServer_Client(t *testing.T) {
 		clear(t)
 
 		obj1 := database.Object{
-			Metadata: database.Metadata{
-				ID: shared.Resource1ID.String(),
-			},
+			ID:   shared.Resource1ID.String(),
 			Data: shared.Data1,
 		}
 		err := client.Save(ctx, &obj1)
@@ -171,10 +168,8 @@ func Test_APIServer_Client(t *testing.T) {
 		// delete it without orphaning the existing data.
 		legacyName := legacyResourceName(shared.Resource1ID)
 		legacyObject := ucpv1alpha1.Resource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      legacyName,
-				Namespace: ns,
-			},
+			Name:      legacyName,
+			Namespace: ns,
 			Entries: []ucpv1alpha1.ResourceEntry{
 				{
 					ID:   shared.Resource1ID.String(),
@@ -194,8 +189,8 @@ func Test_APIServer_Client(t *testing.T) {
 		// Save must update the existing legacy object in place rather than creating a new object under
 		// the current (SHA-256) name.
 		obj := database.Object{
-			Metadata: database.Metadata{ID: shared.Resource1ID.String()},
-			Data:     shared.Data2,
+			ID:   shared.Resource1ID.String(),
+			Data: shared.Data2,
 		}
 		err = client.Save(ctx, &obj)
 		require.NoError(t, err)
@@ -223,9 +218,7 @@ func Test_APIServer_Client(t *testing.T) {
 		clear(t)
 
 		obj1 := database.Object{
-			Metadata: database.Metadata{
-				ID: shared.Resource3ID.String(),
-			},
+			ID:   shared.Resource3ID.String(),
 			Data: shared.Data1,
 		}
 		err := client.Save(ctx, &obj1)
@@ -252,9 +245,7 @@ func Test_APIServer_Client(t *testing.T) {
 		clear(t)
 
 		obj1 := database.Object{
-			Metadata: database.Metadata{
-				ID: shared.ResourceGroup1ID.String(),
-			},
+			ID:   shared.ResourceGroup1ID.String(),
 			Data: shared.ResourceGroup1Data,
 		}
 		err := client.Save(ctx, &obj1)
@@ -284,10 +275,8 @@ func Test_APIServer_Client(t *testing.T) {
 		// Let's PRETEND that shared.BasicResource2ID and shared.BasicResource3ID result in the same
 		// resource name. That's obviously not the case, but it's good enough for tests.
 		resource := ucpv1alpha1.Resource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      resourceName(shared.Resource2ID),
-				Namespace: ns,
-			},
+			Name:      resourceName(shared.Resource2ID),
+			Namespace: ns,
 			Entries: []ucpv1alpha1.ResourceEntry{
 				{
 					ID:   shared.Resource3ID.String(),
@@ -300,9 +289,7 @@ func Test_APIServer_Client(t *testing.T) {
 		require.NoError(t, err)
 
 		obj2 := database.Object{
-			Metadata: database.Metadata{
-				ID: shared.Resource2ID.String(),
-			},
+			ID:   shared.Resource2ID.String(),
 			Data: shared.Data2,
 		}
 		err = client.Save(ctx, &obj2)
@@ -349,10 +336,8 @@ func Test_APIServer_Client(t *testing.T) {
 		expected := []database.Object{
 			*obj,
 			{
-				Metadata: database.Metadata{
-					ID:   shared.Resource3ID.String(),
-					ETag: etag.New(shared.MarshalOrPanic(shared.Data3)),
-				},
+				ID:   shared.Resource3ID.String(),
+				ETag: etag.New(shared.MarshalOrPanic(shared.Data3)),
 				Data: shared.Data3,
 			},
 		}
@@ -379,9 +364,7 @@ func Test_APIServer_Client(t *testing.T) {
 		// Start an operation to "save" resource 1
 		go func() {
 			obj1 := database.Object{
-				Metadata: database.Metadata{
-					ID: shared.Resource1ID.String(),
-				},
+				ID:   shared.Resource1ID.String(),
 				Data: shared.Data1,
 			}
 			err = client.Save(ctx, &obj1)
@@ -393,10 +376,8 @@ func Test_APIServer_Client(t *testing.T) {
 		<-readyChan
 
 		resource := ucpv1alpha1.Resource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      resourceName(shared.Resource1ID),
-				Namespace: ns,
-			},
+			Name:      resourceName(shared.Resource1ID),
+			Namespace: ns,
 			Entries: []ucpv1alpha1.ResourceEntry{
 				{
 					ID:   shared.Resource2ID.String(),
@@ -466,10 +447,8 @@ func Test_APIServer_Client(t *testing.T) {
 
 		// First we create the resource
 		resource := ucpv1alpha1.Resource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      resourceName(shared.Resource1ID),
-				Namespace: ns,
-			},
+			Name:      resourceName(shared.Resource1ID),
+			Namespace: ns,
 			Entries: []ucpv1alpha1.ResourceEntry{
 				{
 					ID:   shared.Resource2ID.String(),
@@ -484,9 +463,7 @@ func Test_APIServer_Client(t *testing.T) {
 		// Start an operation to "save" resource 1
 		go func() {
 			obj1 := database.Object{
-				Metadata: database.Metadata{
-					ID: shared.Resource1ID.String(),
-				},
+				ID:   shared.Resource1ID.String(),
 				Data: shared.Data1,
 			}
 			err = client.Save(ctx, &obj1)
@@ -560,10 +537,8 @@ func Test_APIServer_Client(t *testing.T) {
 
 		// First we create the resource
 		resource := ucpv1alpha1.Resource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      resourceName(shared.Resource1ID),
-				Namespace: ns,
-			},
+			Name:      resourceName(shared.Resource1ID),
+			Namespace: ns,
 			Entries: []ucpv1alpha1.ResourceEntry{
 				{
 					ID:   shared.Resource1ID.String(),
@@ -647,10 +622,8 @@ func Test_APIServer_Client(t *testing.T) {
 
 		// First we create the resource
 		resource := ucpv1alpha1.Resource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      resourceName(shared.Resource1ID),
-				Namespace: ns,
-			},
+			Name:      resourceName(shared.Resource1ID),
+			Namespace: ns,
 			Entries: []ucpv1alpha1.ResourceEntry{
 				{
 					ID:   shared.Resource1ID.String(),

--- a/pkg/components/queue/apiserver/client.go
+++ b/pkg/components/queue/apiserver/client.go
@@ -170,13 +170,11 @@ func (c *Client) Enqueue(ctx context.Context, msg *queue.Message, options ...que
 	}
 
 	resource := &v1alpha1.QueueMessage{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      id,
-			Namespace: c.opts.Namespace,
-			Labels: map[string]string{
-				LabelNextVisibleAt: int64toa(now.UnixNano()),
-				LabelQueueName:     c.opts.Name,
-			},
+		Name:      id,
+		Namespace: c.opts.Namespace,
+		Labels: map[string]string{
+			LabelNextVisibleAt: int64toa(now.UnixNano()),
+			LabelQueueName:     c.opts.Name,
 		},
 		Spec: v1alpha1.QueueMessageSpec{
 			DequeueCount: 0,

--- a/pkg/components/queue/apiserver/client_test.go
+++ b/pkg/components/queue/apiserver/client_test.go
@@ -55,17 +55,15 @@ func TestGetTimeFromString(t *testing.T) {
 
 func TestCopyMessage(t *testing.T) {
 	msg := &queue.Message{
-		Metadata: queue.Metadata{ID: "testid"},
+		ID: "testid",
 	}
 	now := time.Now()
 	queueM := &v1alpha1.QueueMessage{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "applications.core.10101010",
-			Namespace: "radius-test",
-			Labels: map[string]string{
-				LabelNextVisibleAt: int64toa(now.UnixNano()),
-				LabelQueueName:     "applications.core",
-			},
+		Name:      "applications.core.10101010",
+		Namespace: "radius-test",
+		Labels: map[string]string{
+			LabelNextVisibleAt: int64toa(now.UnixNano()),
+			LabelQueueName:     "applications.core",
 		},
 		Spec: v1alpha1.QueueMessageSpec{
 			DequeueCount: 2,

--- a/pkg/components/queue/client_test.go
+++ b/pkg/components/queue/client_test.go
@@ -39,15 +39,13 @@ func TestStartDequeuer(t *testing.T) {
 	lastDequeueCh := make(chan struct{})
 
 	firstCall := mockCli.EXPECT().Dequeue(gomock.Any(), gomock.Any()).Return(&Message{
-		Metadata: Metadata{
-			ID:            "testID",
-			DequeueCount:  1,
-			EnqueueAt:     time.Now(),
-			ExpireAt:      time.Now().Add(10 * time.Hour),
-			NextVisibleAt: time.Now().Add(5 * time.Minute),
-		},
-		ContentType: JSONContentType,
-		Data:        []byte("{}"),
+		ID:            "testID",
+		DequeueCount:  1,
+		EnqueueAt:     time.Now(),
+		ExpireAt:      time.Now().Add(10 * time.Hour),
+		NextVisibleAt: time.Now().Add(5 * time.Minute),
+		ContentType:   JSONContentType,
+		Data:          []byte("{}"),
 	}, nil)
 
 	secondCall := mockCli.EXPECT().Dequeue(gomock.Any(), gomock.Any()).Return(nil, ErrInvalidMessage).After(firstCall.Call)

--- a/pkg/components/secret/kubernetes/client.go
+++ b/pkg/components/secret/kubernetes/client.go
@@ -23,7 +23,6 @@ import (
 	"github.com/radius-project/radius/pkg/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	k8s_error "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	controller_runtime "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -63,11 +62,9 @@ func (c *Client) Save(ctx context.Context, name string, value []byte) error {
 	data := make(map[string][]byte)
 	data[SecretKey] = value
 	secret := &corev1.Secret{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      name,
-			Namespace: RadiusNamespace,
-		},
-		Data: data,
+		Name:      name,
+		Namespace: RadiusNamespace,
+		Data:      data,
 	}
 	// check if secret already exists or not
 	res := &corev1.Secret{}
@@ -93,10 +90,8 @@ func (c *Client) Delete(ctx context.Context, name string) error {
 	}
 
 	secretObject := &corev1.Secret{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      name,
-			Namespace: RadiusNamespace,
-		},
+		Name:      name,
+		Namespace: RadiusNamespace,
 	}
 	err := c.K8sClient.Delete(ctx, secretObject)
 	if err != nil {

--- a/pkg/controller/reconciler/annotations_test.go
+++ b/pkg/controller/reconciler/annotations_test.go
@@ -56,10 +56,8 @@ func Test_readAnnotations(t *testing.T) {
 		{
 			name: "radius-disabled-with-annotation",
 			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						AnnotationRadiusEnabled: "false",
-					},
+				Annotations: map[string]string{
+					AnnotationRadiusEnabled: "false",
 				},
 			},
 			annotations: deploymentAnnotations{
@@ -72,9 +70,7 @@ func Test_readAnnotations(t *testing.T) {
 		{
 			name: "radius-disabled-empty-annotation-map",
 			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
+				Annotations: map[string]string{},
 			},
 			annotations: deploymentAnnotations{
 				Configuration:     nil,
@@ -98,12 +94,10 @@ func Test_readAnnotations(t *testing.T) {
 		{
 			name: "radius-was-enabled-now-disabled-with-annotations",
 			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						AnnotationRadiusEnabled:           "false",
-						AnnotationRadiusConfigurationHash: "configuration-hash",
-						AnnotationRadiusStatus:            string(dsm),
-					},
+				Annotations: map[string]string{
+					AnnotationRadiusEnabled:           "false",
+					AnnotationRadiusConfigurationHash: "configuration-hash",
+					AnnotationRadiusStatus:            string(dsm),
 				},
 			},
 			annotations: deploymentAnnotations{
@@ -116,15 +110,13 @@ func Test_readAnnotations(t *testing.T) {
 		{
 			name: "radius-enabled-with-annotations",
 			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						AnnotationRadiusEnabled:                              "true",
-						AnnotationRadiusConfigurationHash:                    "configuration-hash",
-						AnnotationRadiusStatus:                               string(dsm),
-						AnnotationRadiusApplication:                          "test-application",
-						AnnotationRadiusEnvironment:                          "test-environment",
-						AnnotationRadiusConnectionPrefix + "test-connection": "test-connection-value",
-					},
+				Annotations: map[string]string{
+					AnnotationRadiusEnabled:                              "true",
+					AnnotationRadiusConfigurationHash:                    "configuration-hash",
+					AnnotationRadiusStatus:                               string(dsm),
+					AnnotationRadiusApplication:                          "test-application",
+					AnnotationRadiusEnvironment:                          "test-environment",
+					AnnotationRadiusConnectionPrefix + "test-connection": "test-connection-value",
 				},
 			},
 			annotations: deploymentAnnotations{
@@ -143,15 +135,13 @@ func Test_readAnnotations(t *testing.T) {
 		{
 			name: "status-unmarshal-error",
 			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						AnnotationRadiusEnabled:                              "true",
-						AnnotationRadiusConfigurationHash:                    "configuration-hash",
-						AnnotationRadiusStatus:                               string(invalidDeploymentStatus),
-						AnnotationRadiusApplication:                          "test-application",
-						AnnotationRadiusEnvironment:                          "test-environment",
-						AnnotationRadiusConnectionPrefix + "test-connection": "test-connection-value",
-					},
+				Annotations: map[string]string{
+					AnnotationRadiusEnabled:                              "true",
+					AnnotationRadiusConfigurationHash:                    "configuration-hash",
+					AnnotationRadiusStatus:                               string(invalidDeploymentStatus),
+					AnnotationRadiusApplication:                          "test-application",
+					AnnotationRadiusEnvironment:                          "test-environment",
+					AnnotationRadiusConnectionPrefix + "test-connection": "test-connection-value",
 				},
 			},
 			annotations: deploymentAnnotations{
@@ -163,10 +153,8 @@ func Test_readAnnotations(t *testing.T) {
 		{
 			name: "status-invalid-container-id",
 			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						AnnotationRadiusStatus: `{"scope":"/planes/radius/local/resourceGroups/controller-test","container":"not-a-resource-id"}`,
-					},
+				Annotations: map[string]string{
+					AnnotationRadiusStatus: `{"scope":"/planes/radius/local/resourceGroups/controller-test","container":"not-a-resource-id"}`,
 				},
 			},
 			annotations: deploymentAnnotations{ConfigurationHash: ""},
@@ -175,10 +163,8 @@ func Test_readAnnotations(t *testing.T) {
 		{
 			name: "status-scope-container-mismatch-allowed",
 			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						AnnotationRadiusStatus: `{"scope":"/planes/radius/local/resourceGroups/controller-test","container":"/planes/radius/local/resourceGroups/other/providers/Applications.Core/containers/test-container"}`,
-					},
+				Annotations: map[string]string{
+					AnnotationRadiusStatus: `{"scope":"/planes/radius/local/resourceGroups/controller-test","container":"/planes/radius/local/resourceGroups/other/providers/Applications.Core/containers/test-container"}`,
 				},
 			},
 			// The reconciler intentionally produces this transitional state when the environment or
@@ -196,10 +182,8 @@ func Test_readAnnotations(t *testing.T) {
 		{
 			name: "status-container-wrong-resource-type",
 			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						AnnotationRadiusStatus: `{"scope":"/planes/radius/local/resourceGroups/controller-test","container":"/planes/radius/local/resourceGroups/controller-test/providers/Applications.Core/applications/test-app"}`,
-					},
+				Annotations: map[string]string{
+					AnnotationRadiusStatus: `{"scope":"/planes/radius/local/resourceGroups/controller-test","container":"/planes/radius/local/resourceGroups/controller-test/providers/Applications.Core/applications/test-app"}`,
 				},
 			},
 			annotations: deploymentAnnotations{ConfigurationHash: ""},
@@ -208,10 +192,8 @@ func Test_readAnnotations(t *testing.T) {
 		{
 			name: "status-only-scope-set",
 			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						AnnotationRadiusStatus: `{"scope":"/planes/radius/local/resourceGroups/controller-test"}`,
-					},
+				Annotations: map[string]string{
+					AnnotationRadiusStatus: `{"scope":"/planes/radius/local/resourceGroups/controller-test"}`,
 				},
 			},
 			annotations: deploymentAnnotations{
@@ -225,10 +207,8 @@ func Test_readAnnotations(t *testing.T) {
 		{
 			name: "status-only-container-set",
 			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						AnnotationRadiusStatus: `{"container":"/planes/radius/local/resourceGroups/controller-test/providers/Applications.Core/containers/test-container"}`,
-					},
+				Annotations: map[string]string{
+					AnnotationRadiusStatus: `{"container":"/planes/radius/local/resourceGroups/controller-test/providers/Applications.Core/containers/test-container"}`,
 				},
 			},
 			annotations: deploymentAnnotations{ConfigurationHash: ""},
@@ -237,10 +217,8 @@ func Test_readAnnotations(t *testing.T) {
 		{
 			name: "status-invalid-scope-only",
 			deployment: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						AnnotationRadiusStatus: `{"scope":"not-a-scope"}`,
-					},
+				Annotations: map[string]string{
+					AnnotationRadiusStatus: `{"scope":"not-a-scope"}`,
 				},
 			},
 			annotations: deploymentAnnotations{ConfigurationHash: ""},

--- a/pkg/controller/reconciler/deployment_reconciler.go
+++ b/pkg/controller/reconciler/deployment_reconciler.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -537,7 +536,7 @@ func (r *DeploymentReconciler) updateDeployment(ctx context.Context, deployment 
 		removeSecretReference(deployment, fmt.Sprintf("%s-connections", deployment.Name))
 		delete(deployment.Spec.Template.ObjectMeta.Annotations, kubernetes.AnnotationSecretHash)
 
-		err := r.Client.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: secretName.Namespace, Name: secretName.Name}})
+		err := r.Client.Delete(ctx, &corev1.Secret{Namespace: secretName.Namespace, Name: secretName.Name})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete secret %s: %w", secretName.Name, err)
 		}
@@ -635,7 +634,7 @@ func (r *DeploymentReconciler) cleanupDeployment(ctx context.Context, deployment
 	delete(deployment.Spec.Template.ObjectMeta.Annotations, kubernetes.AnnotationSecretHash)
 
 	secretName := client.ObjectKey{Namespace: deployment.Namespace, Name: fmt.Sprintf("%s-connections", deployment.Name)}
-	err := r.Client.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: secretName.Namespace, Name: secretName.Name}})
+	err := r.Client.Delete(ctx, &corev1.Secret{Namespace: secretName.Namespace, Name: secretName.Name})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete secret %s: %w", secretName.Name, err)
 	}
@@ -677,10 +676,8 @@ func (r *DeploymentReconciler) findDeploymentsForRecipe(ctx context.Context, obj
 	requests := []reconcile.Request{}
 	for _, item := range deployments.Items {
 		requests = append(requests, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      item.GetName(),
-				Namespace: item.GetNamespace(),
-			},
+			Name:      item.GetName(),
+			Namespace: item.GetNamespace(),
 		})
 	}
 	return requests

--- a/pkg/controller/reconciler/deployment_reconciler_test.go
+++ b/pkg/controller/reconciler/deployment_reconciler_test.go
@@ -33,7 +33,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -91,7 +90,7 @@ func Test_DeploymentReconciler_StartDeleteOperationIfNeeded_OwnershipMismatch_Bl
 		EventRecorder: record.NewFakeRecorder(10),
 	}
 
-	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "current-app", Namespace: "current-namespace"}}
+	deployment := &appsv1.Deployment{Name: "current-app", Namespace: "current-namespace"}
 	containerID := "/planes/radius/local/resourceGroups/tenant-b/providers/Applications.Core/containers/other-container"
 
 	radius.Update(func() {
@@ -123,7 +122,7 @@ func Test_DeploymentReconciler_StartPutOrDeleteOperationIfNeeded_OwnershipMismat
 		EventRecorder: record.NewFakeRecorder(10),
 	}
 
-	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "current-app", Namespace: "current-namespace"}}
+	deployment := &appsv1.Deployment{Name: "current-app", Namespace: "current-namespace"}
 	otherContainerID := "/planes/radius/local/resourceGroups/tenant-b/providers/Applications.Core/containers/other-container"
 
 	radius.Update(func() {
@@ -164,7 +163,7 @@ func Test_DeploymentReconciler_StartDeleteOperationIfNeeded_OwnershipMatch_Allow
 		EventRecorder: record.NewFakeRecorder(10),
 	}
 
-	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "current-app", Namespace: "current-namespace"}}
+	deployment := &appsv1.Deployment{Name: "current-app", Namespace: "current-namespace"}
 	containerID := "/planes/radius/local/resourceGroups/tenant-a/providers/Applications.Core/containers/current-app"
 
 	radius.Update(func() {
@@ -203,7 +202,7 @@ func Test_DeploymentReconciler_RadiusEnabled_ThenDeploymentDeleted(t *testing.T)
 	radius, client := SetupDeploymentTest(t)
 
 	name := types.NamespacedName{Namespace: "deployment-enabled-deleted", Name: "test-deployment-enabled-deleted"}
-	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	err := client.Create(ctx, &corev1.Namespace{Name: name.Namespace})
 	require.NoError(t, err)
 
 	deployment := makeDeployment(name)
@@ -249,7 +248,7 @@ func Test_DeploymentReconciler_ChangeEnvironmentAndApplication(t *testing.T) {
 	radius, client := SetupDeploymentTest(t)
 
 	name := types.NamespacedName{Namespace: "deployment-change-envapp", Name: "test-deployment-change-envapp"}
-	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	err := client.Create(ctx, &corev1.Namespace{Name: name.Namespace})
 	require.NoError(t, err)
 
 	deployment := makeDeployment(name)
@@ -323,7 +322,7 @@ func Test_DeploymentReconciler_RadiusEnabled_ThenRadiusDisabled(t *testing.T) {
 	radius, client := SetupDeploymentTest(t)
 
 	name := types.NamespacedName{Namespace: "deployment-enabled-disabled", Name: "test-deployment-enabled-disabled"}
-	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	err := client.Create(ctx, &corev1.Namespace{Name: name.Namespace})
 	require.NoError(t, err)
 
 	deployment := makeDeployment(name)
@@ -375,7 +374,7 @@ func Test_DeploymentReconciler_Connections(t *testing.T) {
 
 	name := types.NamespacedName{Namespace: "deployment-connections", Name: "test-deployment-connections"}
 	secretName := types.NamespacedName{Namespace: name.Namespace, Name: fmt.Sprintf("%s-connections", name.Name)}
-	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	err := client.Create(ctx, &corev1.Namespace{Name: name.Namespace})
 	require.NoError(t, err)
 
 	deployment := makeDeployment(name)
@@ -487,8 +486,8 @@ func Test_DeploymentReconciler_Connections(t *testing.T) {
 	expectedEnvFrom := []corev1.EnvFromSource{
 		{
 			SecretRef: &corev1.SecretEnvSource{
-				LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-connections", deployment.Name)},
-				Optional:             new(false),
+				Name:     fmt.Sprintf("%s-connections", deployment.Name),
+				Optional: new(false),
 			},
 		},
 	}
@@ -568,7 +567,7 @@ func Test_DeploymentReconciler_RadiusDisabled_ThenRadiusDisabled_ByAnnotation(t 
 		Namespace: "deployment-disabled-disabled-by-annotation",
 		Name:      "test-deployment-disabled-disabled-by-annotation",
 	}
-	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	err := client.Create(ctx, &corev1.Namespace{Name: name.Namespace})
 	require.NoError(t, err)
 
 	deployment := makeDeployment(name)
@@ -614,7 +613,7 @@ func Test_DeploymentReconciler_RadiusDisabled_ThenRadiusDisabled(t *testing.T) {
 		Namespace: "deployment-disabled-disabled",
 		Name:      "test-deployment-disabled-disabled",
 	}
-	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	err := client.Create(ctx, &corev1.Namespace{Name: name.Namespace})
 	require.NoError(t, err)
 
 	deployment := makeDeployment(name)

--- a/pkg/controller/reconciler/deployment_util.go
+++ b/pkg/controller/reconciler/deployment_util.go
@@ -42,8 +42,8 @@ func addSecretReference(deployment *appsv1.Deployment, secretName string) bool {
 
 	from := corev1.EnvFromSource{
 		SecretRef: &corev1.SecretEnvSource{
-			LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
-			Optional:             new(false),
+			Name:     secretName,
+			Optional: new(false),
 		},
 	}
 

--- a/pkg/controller/reconciler/deployment_util_test.go
+++ b/pkg/controller/reconciler/deployment_util_test.go
@@ -27,13 +27,13 @@ import (
 func Test_addSecretReference_AlreadyPresent(t *testing.T) {
 	expected := []corev1.EnvFromSource{
 		{
-			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "secret"}},
+			SecretRef: &corev1.SecretEnvSource{Name: "secret"},
 		},
 		{
-			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+			SecretRef: &corev1.SecretEnvSource{Name: "another"},
 		},
 		{
-			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+			ConfigMapRef: &corev1.ConfigMapEnvSource{Name: "config"},
 		},
 	}
 
@@ -49,23 +49,23 @@ func Test_addSecretReference_ReferenceAdded(t *testing.T) {
 	expected := []corev1.EnvFromSource{
 
 		{
-			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+			SecretRef: &corev1.SecretEnvSource{Name: "another"},
 		},
 		{
-			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+			ConfigMapRef: &corev1.ConfigMapEnvSource{Name: "config"},
 		},
 		{
-			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "secret"}, Optional: new(false)},
+			SecretRef: &corev1.SecretEnvSource{Name: "secret", Optional: new(false)},
 		},
 	}
 
 	deployment := makeDeployment(types.NamespacedName{})
 	deployment.Spec.Template.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{
 		{
-			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+			SecretRef: &corev1.SecretEnvSource{Name: "another"},
 		},
 		{
-			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+			ConfigMapRef: &corev1.ConfigMapEnvSource{Name: "config"},
 		},
 	}
 
@@ -77,10 +77,10 @@ func Test_addSecretReference_ReferenceAdded(t *testing.T) {
 func Test_removeSecretReference_AlreadyRemoved(t *testing.T) {
 	expected := []corev1.EnvFromSource{
 		{
-			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+			SecretRef: &corev1.SecretEnvSource{Name: "another"},
 		},
 		{
-			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+			ConfigMapRef: &corev1.ConfigMapEnvSource{Name: "config"},
 		},
 	}
 
@@ -95,23 +95,23 @@ func Test_removeSecretReference_AlreadyRemoved(t *testing.T) {
 func Test_removeSecretReference_ReferenceRemoved(t *testing.T) {
 	expected := []corev1.EnvFromSource{
 		{
-			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+			SecretRef: &corev1.SecretEnvSource{Name: "another"},
 		},
 		{
-			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+			ConfigMapRef: &corev1.ConfigMapEnvSource{Name: "config"},
 		},
 	}
 
 	deployment := makeDeployment(types.NamespacedName{})
 	deployment.Spec.Template.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{
 		{
-			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "secret"}},
+			SecretRef: &corev1.SecretEnvSource{Name: "secret"},
 		},
 		{
-			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+			SecretRef: &corev1.SecretEnvSource{Name: "another"},
 		},
 		{
-			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+			ConfigMapRef: &corev1.ConfigMapEnvSource{Name: "config"},
 		},
 	}
 

--- a/pkg/controller/reconciler/deploymentresource_reconciler_test.go
+++ b/pkg/controller/reconciler/deploymentresource_reconciler_test.go
@@ -97,7 +97,7 @@ func Test_DeploymentResourceReconciler_Basic(t *testing.T) {
 	_, _, k8sClient := SetupDeploymentTemplateTest(t)
 
 	name := types.NamespacedName{Namespace: TestDeploymentResourceNamespace, Name: TestDeploymentResourceName}
-	err := k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	err := k8sClient.Create(ctx, &corev1.Namespace{Name: name.Namespace})
 	require.NoError(t, err)
 
 	deployment := makeDeploymentResource(name, TestDeploymentResourceID)
@@ -125,7 +125,7 @@ func Test_DeploymentResourceReconciler_DeleteRetryBackoff(t *testing.T) {
 	_, mockDeploymentClient, k8sClient := SetupDeploymentResourceTest(t)
 
 	name := types.NamespacedName{Namespace: "deploymentresource-deleteretry", Name: TestDeploymentResourceName}
-	err := k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	err := k8sClient.Create(ctx, &corev1.Namespace{Name: name.Namespace})
 	require.NoError(t, err)
 
 	// A finalizer keeps the DR alive past Delete. The DeploymentResource must be controlled by a
@@ -140,19 +140,17 @@ func Test_DeploymentResourceReconciler_DeleteRetryBackoff(t *testing.T) {
 
 	resourceID := fmt.Sprintf("/planes/radius/local/resourcegroups/%s/providers/Applications.Core/containers/%s", name.Namespace, name.Name)
 	deployment := &radappiov1alpha3.DeploymentResource{
-		ObjectMeta: ctrl.ObjectMeta{
-			Namespace:  name.Namespace,
-			Name:       name.Name,
-			Finalizers: []string{DeploymentResourceFinalizer},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         radappiov1alpha3.GroupVersion.String(),
-					Kind:               deploymentTemplateKind,
-					Name:               owner.Name,
-					UID:                owner.UID,
-					Controller:         to.Ptr(true),
-					BlockOwnerDeletion: to.Ptr(true),
-				},
+		Namespace:  name.Namespace,
+		Name:       name.Name,
+		Finalizers: []string{DeploymentResourceFinalizer},
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion:         radappiov1alpha3.GroupVersion.String(),
+				Kind:               deploymentTemplateKind,
+				Name:               owner.Name,
+				UID:                owner.UID,
+				Controller:         to.Ptr(true),
+				BlockOwnerDeletion: to.Ptr(true),
 			},
 		},
 		Spec: radappiov1alpha3.DeploymentResourceSpec{Id: resourceID},
@@ -195,7 +193,7 @@ func Test_DeploymentResourceReconciler_SkipsDeleteOutsideTemplateScope(t *testin
 	_, mockDeploymentClient, k8sClient := SetupDeploymentResourceTest(t)
 
 	name := types.NamespacedName{Namespace: "deploymentresource-outofscope", Name: "out-of-scope"}
-	err := k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	err := k8sClient.Create(ctx, &corev1.Namespace{Name: name.Namespace})
 	require.NoError(t, err)
 
 	// An owning DeploymentTemplate scoped to its own resource group.
@@ -209,19 +207,17 @@ func Test_DeploymentResourceReconciler_SkipsDeleteOutsideTemplateScope(t *testin
 	// Spec.Id points at a resource in a DIFFERENT resource group than the owning template's scope.
 	outOfScopeID := "/planes/radius/local/resourcegroups/other-group/providers/Applications.Core/environments/default"
 	deployment := &radappiov1alpha3.DeploymentResource{
-		ObjectMeta: ctrl.ObjectMeta{
-			Namespace:  name.Namespace,
-			Name:       name.Name,
-			Finalizers: []string{DeploymentResourceFinalizer},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         radappiov1alpha3.GroupVersion.String(),
-					Kind:               deploymentTemplateKind,
-					Name:               owner.Name,
-					UID:                owner.UID,
-					Controller:         to.Ptr(true),
-					BlockOwnerDeletion: to.Ptr(true),
-				},
+		Namespace:  name.Namespace,
+		Name:       name.Name,
+		Finalizers: []string{DeploymentResourceFinalizer},
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion:         radappiov1alpha3.GroupVersion.String(),
+				Kind:               deploymentTemplateKind,
+				Name:               owner.Name,
+				UID:                owner.UID,
+				Controller:         to.Ptr(true),
+				BlockOwnerDeletion: to.Ptr(true),
 			},
 		},
 		Spec: radappiov1alpha3.DeploymentResourceSpec{Id: outOfScopeID},

--- a/pkg/controller/reconciler/deploymenttemplate_reconciler.go
+++ b/pkg/controller/reconciler/deploymenttemplate_reconciler.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -221,10 +220,8 @@ func (r *DeploymentTemplateReconciler) reconcileOperation(ctx context.Context, d
 				}
 
 				deploymentResource := &radappiov1alpha3.DeploymentResource{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: deploymentTemplate.Namespace,
-					},
+					Name:      resourceName,
+					Namespace: deploymentTemplate.Namespace,
 					Spec: radappiov1alpha3.DeploymentResourceSpec{
 						Id: outputResourceId,
 					},
@@ -256,10 +253,8 @@ func (r *DeploymentTemplateReconciler) reconcileOperation(ctx context.Context, d
 				}
 
 				err = r.Client.Delete(ctx, &radappiov1alpha3.DeploymentResource{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: deploymentTemplate.Namespace,
-					},
+					Name:      resourceName,
+					Namespace: deploymentTemplate.Namespace,
 				})
 				if client.IgnoreNotFound(err) != nil {
 					return ctrl.Result{}, err

--- a/pkg/controller/reconciler/deploymenttemplate_reconciler_test.go
+++ b/pkg/controller/reconciler/deploymenttemplate_reconciler_test.go
@@ -289,7 +289,7 @@ func Test_DeploymentTemplateReconciler_Basic(t *testing.T) {
 
 	// Create k8s namespace for the test.
 	namespacedName := types.NamespacedName{Namespace: testNamespace, Name: testName}
-	err = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: testNamespace}})
+	err = k8sClient.Create(ctx, &corev1.Namespace{Name: testNamespace})
 	require.NoError(t, err)
 
 	// Create the DeploymentTemplate resource.
@@ -345,7 +345,7 @@ func Test_DeploymentTemplateReconciler_FailureRecovery(t *testing.T) {
 
 	// Create k8s namespace for the test.
 	namespacedName := types.NamespacedName{Namespace: testNamespace, Name: testName}
-	err = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: testNamespace}})
+	err = k8sClient.Create(ctx, &corev1.Namespace{Name: testNamespace})
 	require.NoError(t, err)
 
 	// Create the DeploymentTemplate resource.
@@ -365,7 +365,7 @@ func Test_DeploymentTemplateReconciler_FailureRecovery(t *testing.T) {
 		require.True(t, ok, "failed to find resource")
 
 		resource.Properties.ProvisioningState = to.Ptr(armdeployments.ProvisioningStateFailed)
-		state.Value = sdkclients.ClientCreateOrUpdateResponse{DeploymentExtended: armdeployments.DeploymentExtended{Properties: resource.Properties}}
+		state.Value = sdkclients.ClientCreateOrUpdateResponse{Properties: resource.Properties}
 	})
 
 	// DeploymentTemplate should (eventually) start a new provisioning operation
@@ -412,7 +412,7 @@ func Test_DeploymentTemplateReconciler_WithResources(t *testing.T) {
 
 	// Create k8s namespace for the test.
 	namespacedName := types.NamespacedName{Namespace: testNamespace, Name: testName}
-	err = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: testNamespace}})
+	err = k8sClient.Create(ctx, &corev1.Namespace{Name: testNamespace})
 	require.NoError(t, err)
 
 	// Create the DeploymentTemplate resource.
@@ -431,7 +431,7 @@ func Test_DeploymentTemplateReconciler_WithResources(t *testing.T) {
 		resource.Properties.OutputResources = []*armdeployments.ResourceReference{
 			{ID: new("/planes/radius/local/resourceGroups/deploymenttemplate-withresources/providers/Applications.Core/environments/deploymenttemplate-withresources-env")},
 		}
-		state.Value = sdkclients.ClientCreateOrUpdateResponse{DeploymentExtended: armdeployments.DeploymentExtended{Properties: resource.Properties}}
+		state.Value = sdkclients.ClientCreateOrUpdateResponse{Properties: resource.Properties}
 	})
 
 	// DeploymentTemplate should be ready after the operation completes.
@@ -489,7 +489,7 @@ func Test_DeploymentTemplateReconciler_Update(t *testing.T) {
 
 	// Create k8s namespace for the test.
 	namespacedName := types.NamespacedName{Namespace: testNamespace, Name: testName}
-	err = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: testNamespace}})
+	err = k8sClient.Create(ctx, &corev1.Namespace{Name: testNamespace})
 	require.NoError(t, err)
 
 	// Create the DeploymentTemplate resource.
@@ -508,7 +508,7 @@ func Test_DeploymentTemplateReconciler_Update(t *testing.T) {
 		resource.Properties.OutputResources = []*armdeployments.ResourceReference{
 			{ID: new("/planes/radius/local/resourceGroups/deploymenttemplate-update/providers/Applications.Core/environments/deploymenttemplate-update-env")},
 		}
-		state.Value = sdkclients.ClientCreateOrUpdateResponse{DeploymentExtended: armdeployments.DeploymentExtended{Properties: resource.Properties}}
+		state.Value = sdkclients.ClientCreateOrUpdateResponse{Properties: resource.Properties}
 	})
 
 	// DeploymentTemplate should be ready after the operation completes.
@@ -557,7 +557,7 @@ func Test_DeploymentTemplateReconciler_Update(t *testing.T) {
 		resource.Properties.OutputResources = []*armdeployments.ResourceReference{
 			{ID: new("/planes/radius/local/resourceGroups/deploymenttemplate-update/providers/Applications.Core/environments/deploymenttemplate-update-env")},
 		}
-		state.Value = sdkclients.ClientCreateOrUpdateResponse{DeploymentExtended: armdeployments.DeploymentExtended{Properties: resource.Properties}}
+		state.Value = sdkclients.ClientCreateOrUpdateResponse{Properties: resource.Properties}
 	})
 
 	// DeploymentTemplate should be Ready again after the operation completes.
@@ -618,7 +618,7 @@ func Test_DeploymentTemplateReconciler_OutputResources(t *testing.T) {
 
 	// Create k8s namespace for the test.
 	namespacedName := types.NamespacedName{Namespace: testNamespace, Name: testName}
-	err = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: testNamespace}})
+	err = k8sClient.Create(ctx, &corev1.Namespace{Name: testNamespace})
 	require.NoError(t, err)
 
 	// Create the DeploymentTemplate resource.
@@ -639,7 +639,7 @@ func Test_DeploymentTemplateReconciler_OutputResources(t *testing.T) {
 			{ID: new("/planes/radius/local/resourceGroups/deploymenttemplate-outputresources/providers/Applications.Core/applications/deploymenttemplate-outputresources-application")},
 			{ID: new("/planes/radius/local/resourceGroups/deploymenttemplate-outputresources/providers/Applications.Core/containers/deploymenttemplate-outputresources-container")},
 		}
-		state.Value = sdkclients.ClientCreateOrUpdateResponse{DeploymentExtended: armdeployments.DeploymentExtended{Properties: resource.Properties}}
+		state.Value = sdkclients.ClientCreateOrUpdateResponse{Properties: resource.Properties}
 	})
 
 	// DeploymentTemplate should be ready after the operation completes.
@@ -708,7 +708,7 @@ func Test_DeploymentTemplateReconciler_OutputResources(t *testing.T) {
 			{ID: new("/planes/radius/local/resourceGroups/deploymenttemplate-outputresources/providers/Applications.Core/environments/deploymenttemplate-outputresources-environment")},
 			{ID: new("/planes/radius/local/resourceGroups/deploymenttemplate-outputresources/providers/Applications.Core/applications/deploymenttemplate-outputresources-application")},
 		}
-		state.Value = sdkclients.ClientCreateOrUpdateResponse{DeploymentExtended: armdeployments.DeploymentExtended{Properties: resource.Properties}}
+		state.Value = sdkclients.ClientCreateOrUpdateResponse{Properties: resource.Properties}
 	})
 
 	// Complete the delete operation on the container resource.
@@ -792,7 +792,7 @@ func Test_DeploymentTemplateReconciler_ReadyPendingCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	namespacedName := types.NamespacedName{Namespace: testNamespace, Name: testName}
-	err = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: testNamespace}})
+	err = k8sClient.Create(ctx, &corev1.Namespace{Name: testNamespace})
 	require.NoError(t, err)
 
 	deploymentTemplate := makeDeploymentTemplate(namespacedName, template, providerConfig, parameters)
@@ -815,7 +815,7 @@ func Test_DeploymentTemplateReconciler_ReadyPendingCleanup(t *testing.T) {
 			{ID: new(appID)},
 			{ID: new(containerID)},
 		}
-		state.Value = sdkclients.ClientCreateOrUpdateResponse{DeploymentExtended: armdeployments.DeploymentExtended{Properties: resource.Properties}}
+		state.Value = sdkclients.ClientCreateOrUpdateResponse{Properties: resource.Properties}
 	})
 
 	_ = waitForDeploymentTemplateStateReady(t, k8sClient, namespacedName)
@@ -841,7 +841,7 @@ func Test_DeploymentTemplateReconciler_ReadyPendingCleanup(t *testing.T) {
 			{ID: new(envID)},
 			{ID: new(appID)},
 		}
-		state.Value = sdkclients.ClientCreateOrUpdateResponse{DeploymentExtended: armdeployments.DeploymentExtended{Properties: resource.Properties}}
+		state.Value = sdkclients.ClientCreateOrUpdateResponse{Properties: resource.Properties}
 	})
 
 	// The container DR's delete operation is still pending in the mock, so
@@ -890,7 +890,7 @@ func Test_DeploymentTemplateReconciler_NilOutputResourcesTriggersCleanup(t *test
 	require.NoError(t, err)
 
 	namespacedName := types.NamespacedName{Namespace: testNamespace, Name: testName}
-	err = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: testNamespace}})
+	err = k8sClient.Create(ctx, &corev1.Namespace{Name: testNamespace})
 	require.NoError(t, err)
 
 	deploymentTemplate := makeDeploymentTemplate(namespacedName, template, providerConfig, parameters)
@@ -913,7 +913,7 @@ func Test_DeploymentTemplateReconciler_NilOutputResourcesTriggersCleanup(t *test
 			{ID: new(appID)},
 			{ID: new(containerID)},
 		}
-		state.Value = sdkclients.ClientCreateOrUpdateResponse{DeploymentExtended: armdeployments.DeploymentExtended{Properties: resource.Properties}}
+		state.Value = sdkclients.ClientCreateOrUpdateResponse{Properties: resource.Properties}
 	})
 
 	_ = waitForDeploymentTemplateStateReady(t, k8sClient, namespacedName)

--- a/pkg/controller/reconciler/flux_controller.go
+++ b/pkg/controller/reconciler/flux_controller.go
@@ -20,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -263,9 +262,7 @@ func (r *FluxController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 		// Create the namespace if it doesn't exist
 		namespaceObj := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
-			},
+			Name: namespace,
 		}
 
 		if err := r.Client.Create(ctx, namespaceObj); err != nil {
@@ -399,10 +396,8 @@ func (r *FluxController) createOrUpdateDeploymentTemplate(ctx context.Context, f
 
 		// If the DeploymentTemplate doesn't exist, create it
 		deploymentTemplate := &radappiov1alpha3.DeploymentTemplate{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fileName,
-				Namespace: namespace,
-			},
+			Name:      fileName,
+			Namespace: namespace,
 			Spec: radappiov1alpha3.DeploymentTemplateSpec{
 				Template:       template,
 				Parameters:     parameters,

--- a/pkg/controller/reconciler/flux_controller_test.go
+++ b/pkg/controller/reconciler/flux_controller_test.go
@@ -305,9 +305,7 @@ func runFluxControllerTest(t *testing.T, opts runFluxControllerTestOptions, step
 		for ns := range namespacesToCleanup {
 			t.Logf("Cleaning up namespace: %s", ns)
 			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: ns,
-				},
+				Name: ns,
 			}
 			err := opts.client.Delete(cleanupCtx, namespace)
 			if err != nil && k8sclient.IgnoreNotFound(err) != nil {
@@ -339,9 +337,7 @@ func runFluxControllerTest(t *testing.T, opts runFluxControllerTestOptions, step
 					require.NoError(t, err)
 				}
 				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: namespaceName,
-					},
+					Name: namespaceName,
 				}
 				err := opts.client.Create(ctx, namespace)
 				require.NoError(t, err)
@@ -416,14 +412,10 @@ func runFluxControllerTest(t *testing.T, opts runFluxControllerTestOptions, step
 
 func makeGitRepository(namespacedName types.NamespacedName, url string) sourcev1.GitRepository {
 	return sourcev1.GitRepository{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "GitRepository",
-			APIVersion: "source.toolkit.fluxcd.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      namespacedName.Name,
-			Namespace: namespacedName.Namespace,
-		},
+		Kind:       "GitRepository",
+		APIVersion: "source.toolkit.fluxcd.io/v1",
+		Name:       namespacedName.Name,
+		Namespace:  namespacedName.Namespace,
 		Spec: sourcev1.GitRepositorySpec{
 			URL: url,
 		},

--- a/pkg/controller/reconciler/flux_gitrepository_predicate_test.go
+++ b/pkg/controller/reconciler/flux_gitrepository_predicate_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/fluxcd/pkg/apis/meta"
@@ -44,9 +43,7 @@ func TestGitRepositoryRevisionChangePredicate_Create(t *testing.T) {
 			name: "Source has no artifact",
 			event: event.CreateEvent{
 				Object: &sourcev1.GitRepository{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-repo",
-					},
+					Name: "test-repo",
 				},
 			},
 			expected: false,
@@ -55,9 +52,7 @@ func TestGitRepositoryRevisionChangePredicate_Create(t *testing.T) {
 			name: "Source has an artifact",
 			event: event.CreateEvent{
 				Object: &sourcev1.GitRepository{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-repo",
-					},
+					Name: "test-repo",
 					Status: sourcev1.GitRepositoryStatus{
 						Artifact: &meta.Artifact{
 							Revision: "test-revision",
@@ -89,9 +84,7 @@ func TestGitRepositoryRevisionChangePredicate_Update(t *testing.T) {
 			name: "Source ObjectOld is nil",
 			event: event.UpdateEvent{
 				ObjectNew: &sourcev1.GitRepository{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-repo",
-					},
+					Name: "test-repo",
 				},
 			},
 			expected: false,
@@ -100,9 +93,7 @@ func TestGitRepositoryRevisionChangePredicate_Update(t *testing.T) {
 			name: "Source ObjectNew is nil",
 			event: event.UpdateEvent{
 				ObjectOld: &sourcev1.GitRepository{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-repo",
-					},
+					Name: "test-repo",
 				},
 			},
 			expected: false,
@@ -112,9 +103,7 @@ func TestGitRepositoryRevisionChangePredicate_Update(t *testing.T) {
 			event: event.UpdateEvent{
 				ObjectOld: &corev1.Pod{},
 				ObjectNew: &sourcev1.GitRepository{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-repo",
-					},
+					Name: "test-repo",
 				},
 			},
 			expected: false,
@@ -123,9 +112,7 @@ func TestGitRepositoryRevisionChangePredicate_Update(t *testing.T) {
 			name: "Source ObjectNew is not a sourcev1.Source",
 			event: event.UpdateEvent{
 				ObjectOld: &sourcev1.GitRepository{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-repo",
-					},
+					Name: "test-repo",
 				},
 				ObjectNew: &corev1.Pod{},
 			},
@@ -135,14 +122,10 @@ func TestGitRepositoryRevisionChangePredicate_Update(t *testing.T) {
 			name: "Sources ObjectOld and ObjectNew have no artifact",
 			event: event.UpdateEvent{
 				ObjectOld: &sourcev1.GitRepository{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-repo",
-					},
+					Name: "test-repo",
 				},
 				ObjectNew: &sourcev1.GitRepository{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-repo",
-					},
+					Name: "test-repo",
 				},
 			},
 			expected: false,
@@ -151,9 +134,7 @@ func TestGitRepositoryRevisionChangePredicate_Update(t *testing.T) {
 			name: "Source ObjectNew and ObjectOld are the same",
 			event: event.UpdateEvent{
 				ObjectOld: &sourcev1.GitRepository{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-repo",
-					},
+					Name: "test-repo",
 					Status: sourcev1.GitRepositoryStatus{
 						Artifact: &meta.Artifact{
 							Revision: "test-revision",
@@ -161,9 +142,7 @@ func TestGitRepositoryRevisionChangePredicate_Update(t *testing.T) {
 					},
 				},
 				ObjectNew: &sourcev1.GitRepository{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-repo",
-					},
+					Name: "test-repo",
 					Status: sourcev1.GitRepositoryStatus{
 						Artifact: &meta.Artifact{
 							Revision: "test-revision",
@@ -177,9 +156,7 @@ func TestGitRepositoryRevisionChangePredicate_Update(t *testing.T) {
 			name: "Source ObjectNew and ObjectOld have different revisions",
 			event: event.UpdateEvent{
 				ObjectOld: &sourcev1.GitRepository{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-repo",
-					},
+					Name: "test-repo",
 					Status: sourcev1.GitRepositoryStatus{
 						Artifact: &meta.Artifact{
 							Revision: "test-revision",
@@ -187,9 +164,7 @@ func TestGitRepositoryRevisionChangePredicate_Update(t *testing.T) {
 					},
 				},
 				ObjectNew: &sourcev1.GitRepository{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-repo",
-					},
+					Name: "test-repo",
 					Status: sourcev1.GitRepositoryStatus{
 						Artifact: &meta.Artifact{
 							Revision: "test-revision-different",

--- a/pkg/controller/reconciler/main_test.go
+++ b/pkg/controller/reconciler/main_test.go
@@ -26,7 +26,6 @@ import (
 	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -124,25 +123,19 @@ func initializeWebhookInEnvironment(env *envtest.Environment) {
 	env.WebhookInstallOptions = envtest.WebhookInstallOptions{
 		ValidatingWebhooks: []*admissionv1.ValidatingWebhookConfiguration{
 			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "recipe-webhook-config",
-				},
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "ValidatingWebhookConfiguration",
-					APIVersion: "admissionregistration.k8s.io/v1",
-				},
+				Name:       "recipe-webhook-config",
+				Kind:       "ValidatingWebhookConfiguration",
+				APIVersion: "admissionregistration.k8s.io/v1",
 				Webhooks: []admissionv1.ValidatingWebhook{
 					{
 						Name: "recipe-webhook.radapp.io",
 						Rules: []admissionv1.RuleWithOperations{
 							{
-								Operations: []admissionv1.OperationType{"CREATE", "UPDATE"},
-								Rule: admissionv1.Rule{
-									APIGroups:   []string{"radapp.io"},
-									APIVersions: []string{"v1alpha3"},
-									Resources:   []string{"recipes"},
-									Scope:       &defaultScopeV1,
-								},
+								Operations:  []admissionv1.OperationType{"CREATE", "UPDATE"},
+								APIGroups:   []string{"radapp.io"},
+								APIVersions: []string{"v1alpha3"},
+								Resources:   []string{"recipes"},
+								Scope:       &defaultScopeV1,
 							},
 						},
 						FailurePolicy: &failedTypeV1,

--- a/pkg/controller/reconciler/mock_radius_client_test.go
+++ b/pkg/controller/reconciler/mock_radius_client_test.go
@@ -265,7 +265,7 @@ func (ec *mockEnvironmentClient) List(ctx context.Context, options *corerpv20231
 		}
 	}
 
-	return corerpv20231001preview.EnvironmentsClientListByScopeResponse{EnvironmentResourceListResult: corerpv20231001preview.EnvironmentResourceListResult{Value: environments}}, nil
+	return corerpv20231001preview.EnvironmentsClientListByScopeResponse{Value: environments}, nil
 }
 
 var _ ResourceGroupClient = (*mockResourceGroupClient)(nil)

--- a/pkg/controller/reconciler/recipe_reconciler.go
+++ b/pkg/controller/reconciler/recipe_reconciler.go
@@ -442,10 +442,8 @@ func (r *RecipeReconciler) updateSecret(ctx context.Context, recipe *radappiov1a
 	if recipe.Spec.SecretName != recipe.Status.Secret.Name && recipe.Status.Secret.Name != "" {
 		logger.Info("Deleting stale secret", "secret", recipe.Status.Secret.Name)
 		err := r.Client.Delete(ctx, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      recipe.Status.Secret.Name,
-				Namespace: recipe.Namespace,
-			},
+			Name:      recipe.Status.Secret.Name,
+			Namespace: recipe.Namespace,
 		})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete stale secret %s: %w", recipe.Status.Secret.Name, err)
@@ -476,12 +474,10 @@ func (r *RecipeReconciler) updateSecret(ctx context.Context, recipe *radappiov1a
 	// Initialize the secret if it doesn't exist.
 	if secret == nil {
 		secret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      recipe.Spec.SecretName,
-				Namespace: recipe.Namespace,
-				OwnerReferences: []metav1.OwnerReference{
-					*metav1.NewControllerRef(recipe, radappiov1alpha3.GroupVersion.WithKind("Recipe")),
-				},
+			Name:      recipe.Spec.SecretName,
+			Namespace: recipe.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(recipe, radappiov1alpha3.GroupVersion.WithKind("Recipe")),
 			},
 		}
 
@@ -539,10 +535,8 @@ func (r *RecipeReconciler) deleteSecret(ctx context.Context, recipe *radappiov1a
 	if recipe.Status.Secret.Name != "" {
 		logger.Info("Deleting secret.", "secret", recipe.Status.Secret.Name)
 		err := r.Client.Delete(ctx, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      recipe.Status.Secret.Name,
-				Namespace: recipe.Namespace,
-			},
+			Name:      recipe.Status.Secret.Name,
+			Namespace: recipe.Namespace,
 		})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete secret %s: %w", recipe.Status.Secret.Name, err)

--- a/pkg/controller/reconciler/recipe_reconciler_test.go
+++ b/pkg/controller/reconciler/recipe_reconciler_test.go
@@ -73,7 +73,7 @@ func Test_RecipeReconciler_WithoutSecret(t *testing.T) {
 	radius, client := SetupRecipeTest(t)
 
 	name := types.NamespacedName{Namespace: "recipe-without-secret", Name: "test-recipe-withoutsecret"}
-	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	err := client.Create(ctx, &corev1.Namespace{Name: name.Namespace})
 	require.NoError(t, err)
 
 	recipe := makeRecipe(name, "Applications.Core/extenders")
@@ -115,7 +115,7 @@ func Test_RecipeReconciler_ChangeEnvironmentAndApplication(t *testing.T) {
 	radius, client := SetupRecipeTest(t)
 
 	name := types.NamespacedName{Namespace: "recipe-change-envapp", Name: "test-recipe-change-envapp"}
-	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	err := client.Create(ctx, &corev1.Namespace{Name: name.Namespace})
 	require.NoError(t, err)
 
 	recipe := makeRecipe(name, "Applications.Core/extenders")
@@ -192,7 +192,7 @@ func Test_RecipeReconciler_FailureRecovery(t *testing.T) {
 	radius, client := SetupRecipeTest(t)
 
 	name := types.NamespacedName{Namespace: "recipe-failure-recovery", Name: "test-recipe-failure-recovery"}
-	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	err := client.Create(ctx, &corev1.Namespace{Name: name.Namespace})
 	require.NoError(t, err)
 
 	recipe := makeRecipe(name, "Applications.Core/extenders")
@@ -256,7 +256,7 @@ func Test_RecipeReconciler_WithSecret(t *testing.T) {
 	radius, client := SetupRecipeTest(t)
 
 	name := types.NamespacedName{Namespace: "recipe-withsecret", Name: "test-recipe-withsecret"}
-	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	err := client.Create(ctx, &corev1.Namespace{Name: name.Namespace})
 	require.NoError(t, err)
 
 	recipe := makeRecipe(name, "Applications.Core/extenders")

--- a/pkg/controller/reconciler/recipe_webhook_test.go
+++ b/pkg/controller/reconciler/recipe_webhook_test.go
@@ -59,7 +59,7 @@ func Test_ValidateRecipe_Type(t *testing.T) {
 		namespace := types.NamespacedName{Namespace: defaultNamespace, Name: recipeName}
 		recipe := makeRecipe(namespace, invalidResourceType)
 
-		err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: namespace.Name}})
+		err := client.Create(ctx, &corev1.Namespace{Name: namespace.Name})
 		require.NoError(t, err)
 
 		// Webhook is expected to trigger during this call and return an error.
@@ -79,7 +79,7 @@ func Test_ValidateRecipe_Type(t *testing.T) {
 		namespace := types.NamespacedName{Namespace: defaultNamespace, Name: recipeName}
 		recipe := makeRecipe(namespace, validResourceType)
 
-		err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: namespace.Name}})
+		err := client.Create(ctx, &corev1.Namespace{Name: namespace.Name})
 		require.NoError(t, err)
 
 		err = client.Create(ctx, recipe)
@@ -109,7 +109,7 @@ func Test_ValidateRecipe_Type(t *testing.T) {
 		namespace := types.NamespacedName{Namespace: defaultNamespace, Name: recipeName}
 		recipe := makeRecipe(namespace, validResourceType)
 
-		err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: namespace.Name}})
+		err := client.Create(ctx, &corev1.Namespace{Name: namespace.Name})
 		require.NoError(t, err)
 
 		err = client.Create(ctx, recipe)

--- a/pkg/controller/reconciler/shared_test.go
+++ b/pkg/controller/reconciler/shared_test.go
@@ -34,7 +34,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -104,10 +103,8 @@ func createEnvironment(radius *mockRadiusClient, resourceGroup, name string) {
 
 func makeRecipe(name types.NamespacedName, resourceType string) *radappiov1alpha3.Recipe {
 	return &radappiov1alpha3.Recipe{
-		ObjectMeta: ctrl.ObjectMeta{
-			Namespace: name.Namespace,
-			Name:      name.Name,
-		},
+		Namespace: name.Namespace,
+		Name:      name.Name,
 		Spec: radappiov1alpha3.RecipeSpec{
 			Type: resourceType,
 		},
@@ -224,11 +221,9 @@ func waitForSecretData(t *testing.T, client client.Client, name types.Namespaced
 
 func makeDeployment(name types.NamespacedName) *appsv1.Deployment {
 	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name.Name,
-			Namespace:   name.Namespace,
-			Annotations: map[string]string{},
-		},
+		Name:        name.Name,
+		Namespace:   name.Namespace,
+		Annotations: map[string]string{},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -256,10 +251,8 @@ func makeDeployment(name types.NamespacedName) *appsv1.Deployment {
 
 func makeDeploymentTemplate(name types.NamespacedName, template, providerConfig string, parameters map[string]string) *radappiov1alpha3.DeploymentTemplate {
 	return &radappiov1alpha3.DeploymentTemplate{
-		ObjectMeta: ctrl.ObjectMeta{
-			Namespace: name.Namespace,
-			Name:      name.Name,
-		},
+		Namespace: name.Namespace,
+		Name:      name.Name,
 		Spec: radappiov1alpha3.DeploymentTemplateSpec{
 			Template:       template,
 			ProviderConfig: providerConfig,
@@ -270,10 +263,8 @@ func makeDeploymentTemplate(name types.NamespacedName, template, providerConfig 
 
 func makeDeploymentResource(name types.NamespacedName, id string) *radappiov1alpha3.DeploymentResource {
 	return &radappiov1alpha3.DeploymentResource{
-		ObjectMeta: ctrl.ObjectMeta{
-			Namespace: name.Namespace,
-			Name:      name.Name,
-		},
+		Namespace: name.Namespace,
+		Name:      name.Name,
 		Spec: radappiov1alpha3.DeploymentResourceSpec{
 			Id: id,
 		},

--- a/pkg/corerp/api/v20231001preview/application_conversion.go
+++ b/pkg/corerp/api/v20231001preview/application_conversion.go
@@ -27,19 +27,13 @@ import (
 func (src *ApplicationResource) ConvertTo() (v1.DataModelInterface, error) {
 	// Note: SystemData conversion isn't required since this property comes ARM and datastore.
 	converted := &datamodel.Application{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 		Properties: datamodel.ApplicationProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Environment: to.String(src.Properties.Environment),

--- a/pkg/corerp/api/v20231001preview/container_conversion.go
+++ b/pkg/corerp/api/v20231001preview/container_conversion.go
@@ -108,19 +108,13 @@ func (src *ContainerResource) ConvertTo() (v1.DataModelInterface, error) {
 	}
 
 	converted := &datamodel.ContainerResource{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 		Properties: datamodel.ContainerProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Application: to.String(src.Properties.Application),

--- a/pkg/corerp/api/v20231001preview/environment_conversion.go
+++ b/pkg/corerp/api/v20231001preview/environment_conversion.go
@@ -40,21 +40,15 @@ const (
 func (src *EnvironmentResource) ConvertTo() (v1.DataModelInterface, error) {
 	// Note: SystemData conversion isn't required since this property comes ARM and datastore.
 	converted := &datamodel.Environment{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				CreatedAPIVersion:      Version,
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
-		Properties: datamodel.EnvironmentProperties{},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		CreatedAPIVersion:      Version,
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
+		Properties:             datamodel.EnvironmentProperties{},
 	}
 
 	envCompute, err := toEnvironmentComputeDataModel(src.Properties.Compute)

--- a/pkg/corerp/api/v20231001preview/environment_conversion_test.go
+++ b/pkg/corerp/api/v20231001preview/environment_conversion_test.go
@@ -41,19 +41,13 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "environmentresource-with-workload-identity.json",
 			expected: &datamodel.Environment{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
-						Name: "env0",
-						Type: "Applications.Core/environments",
-						Tags: map[string]string{},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "2023-10-01-preview",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-				},
+				ID:                     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
+				Name:                   "env0",
+				Type:                   "Applications.Core/environments",
+				Tags:                   map[string]string{},
+				CreatedAPIVersion:      "2023-10-01-preview",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
 				Properties: datamodel.EnvironmentProperties{
 					Compute: rpv1.EnvironmentCompute{
 						Kind: "kubernetes",
@@ -98,19 +92,13 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "environmentresource.json",
 			expected: &datamodel.Environment{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
-						Name: "env0",
-						Type: "Applications.Core/environments",
-						Tags: map[string]string{},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "2023-10-01-preview",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-				},
+				ID:                     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
+				Name:                   "env0",
+				Type:                   "Applications.Core/environments",
+				Tags:                   map[string]string{},
+				CreatedAPIVersion:      "2023-10-01-preview",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
 				Properties: datamodel.EnvironmentProperties{
 					Compute: rpv1.EnvironmentCompute{
 						Kind: "kubernetes",
@@ -219,19 +207,13 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "environmentresourceemptyext.json",
 			expected: &datamodel.Environment{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
-						Name: "env0",
-						Type: "Applications.Core/environments",
-						Tags: map[string]string{},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "2023-10-01-preview",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-				},
+				ID:                     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
+				Name:                   "env0",
+				Type:                   "Applications.Core/environments",
+				Tags:                   map[string]string{},
+				CreatedAPIVersion:      "2023-10-01-preview",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
 				Properties: datamodel.EnvironmentProperties{
 					Compute: rpv1.EnvironmentCompute{
 						Kind: "kubernetes",
@@ -261,19 +243,13 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "environmentresourceemptyext2.json",
 			expected: &datamodel.Environment{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
-						Name: "env0",
-						Type: "Applications.Core/environments",
-						Tags: map[string]string{},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "2023-10-01-preview",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-				},
+				ID:                     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
+				Name:                   "env0",
+				Type:                   "Applications.Core/environments",
+				Tags:                   map[string]string{},
+				CreatedAPIVersion:      "2023-10-01-preview",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
 				Properties: datamodel.EnvironmentProperties{
 					Compute: rpv1.EnvironmentCompute{
 						Kind: "kubernetes",
@@ -303,19 +279,13 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "environmentresource-with-simulated-enabled.json",
 			expected: &datamodel.Environment{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
-						Name: "env0",
-						Type: "Applications.Core/environments",
-						Tags: map[string]string{},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "2023-10-01-preview",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-				},
+				ID:                     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
+				Name:                   "env0",
+				Type:                   "Applications.Core/environments",
+				Tags:                   map[string]string{},
+				CreatedAPIVersion:      "2023-10-01-preview",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
 				Properties: datamodel.EnvironmentProperties{
 					Compute: rpv1.EnvironmentCompute{
 						Kind: "kubernetes",
@@ -332,19 +302,13 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "environmentresource-with-acicompute.json",
 			expected: &datamodel.Environment{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
-						Name: "env0",
-						Type: "Applications.Core/environments",
-						Tags: map[string]string{},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "2023-10-01-preview",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-				},
+				ID:                     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
+				Name:                   "env0",
+				Type:                   "Applications.Core/environments",
+				Tags:                   map[string]string{},
+				CreatedAPIVersion:      "2023-10-01-preview",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
 				Properties: datamodel.EnvironmentProperties{
 					Compute: rpv1.EnvironmentCompute{
 						Kind: "aci",

--- a/pkg/corerp/api/v20231001preview/extender_conversion.go
+++ b/pkg/corerp/api/v20231001preview/extender_conversion.go
@@ -30,19 +30,13 @@ import (
 // conversion fails.
 func (src *ExtenderResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.Extender{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 		Properties: datamodel.ExtenderProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Environment: to.String(src.Properties.Environment),

--- a/pkg/corerp/api/v20231001preview/extender_conversion_test.go
+++ b/pkg/corerp/api/v20231001preview/extender_conversion_test.go
@@ -40,20 +40,14 @@ func TestExtender_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "extender resource provisioning manual",
 			file: "extender_manual.json",
 			expected: &datamodel.Extender{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/extenders/extender0",
-						Name: "extender0",
-						Type: datamodel.ExtenderResourceType,
-						Tags: map[string]string{},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
-				},
+				ID:                     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/extenders/extender0",
+				Name:                   "extender0",
+				Type:                   datamodel.ExtenderResourceType,
+				Tags:                   map[string]string{},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.ExtenderProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
@@ -70,20 +64,14 @@ func TestExtender_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "extender resource provisioning manual (no secrets)",
 			file: "extender_manual_nosecrets.json",
 			expected: &datamodel.Extender{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/extenders/extender0",
-						Name: "extender0",
-						Type: datamodel.ExtenderResourceType,
-						Tags: map[string]string{},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
-				},
+				ID:                     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/extenders/extender0",
+				Name:                   "extender0",
+				Type:                   datamodel.ExtenderResourceType,
+				Tags:                   map[string]string{},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.ExtenderProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
@@ -99,20 +87,14 @@ func TestExtender_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "extender resource recipe",
 			file: "extender_recipe.json",
 			expected: &datamodel.Extender{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/extenders/extender0",
-						Name: "extender0",
-						Type: datamodel.ExtenderResourceType,
-						Tags: map[string]string{},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
-				},
+				ID:                     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/extenders/extender0",
+				Name:                   "extender0",
+				Type:                   datamodel.ExtenderResourceType,
+				Tags:                   map[string]string{},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.ExtenderProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",

--- a/pkg/corerp/api/v20231001preview/gateway_conversion.go
+++ b/pkg/corerp/api/v20231001preview/gateway_conversion.go
@@ -71,19 +71,13 @@ func (src *GatewayResource) ConvertTo() (v1.DataModelInterface, error) {
 	}
 
 	converted := &datamodel.Gateway{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 		Properties: datamodel.GatewayProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Application: to.String(src.Properties.Application),

--- a/pkg/corerp/api/v20231001preview/secretstore_conversion.go
+++ b/pkg/corerp/api/v20231001preview/secretstore_conversion.go
@@ -19,33 +19,24 @@ package v20231001preview
 import (
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/corerp/datamodel"
-	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	"github.com/radius-project/radius/pkg/to"
 )
 
 // ConvertTo converts from the versioned SecretStoreResource resource to version-agnostic datamodel.
 func (src *SecretStoreResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.SecretStore{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 		Properties: &datamodel.SecretStoreProperties{
-			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Application: to.String(src.Properties.Application),
-			},
-			Resource: to.String(src.Properties.Resource),
-			Type:     toSecretStoreDataTypeDataModel(src.Properties.Type),
-			Data:     toSecretValuePropertiesDataModel(src.Properties.Data),
+			Application: to.String(src.Properties.Application),
+			Resource:    to.String(src.Properties.Resource),
+			Type:        toSecretStoreDataTypeDataModel(src.Properties.Type),
+			Data:        toSecretValuePropertiesDataModel(src.Properties.Data),
 		},
 	}
 	return converted, nil

--- a/pkg/corerp/api/v20231001preview/volume_conversion.go
+++ b/pkg/corerp/api/v20231001preview/volume_conversion.go
@@ -26,19 +26,13 @@ import (
 // ConvertTo converts from the versioned Volume resource to version-agnostic datamodel.
 func (src *VolumeResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.VolumeResource{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.GetVolumeProperties().ProvisioningState),
-			},
-		},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.GetVolumeProperties().ProvisioningState),
 		Properties: datamodel.VolumeResourceProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Application: to.String(src.Properties.GetVolumeProperties().Application),

--- a/pkg/corerp/api/v20250801preview/application_conversion.go
+++ b/pkg/corerp/api/v20250801preview/application_conversion.go
@@ -26,19 +26,13 @@ import (
 // ConvertTo converts from the versioned ApplicationResource to version-agnostic datamodel.
 func (src *ApplicationResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.Application_v20250801preview{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 		Properties: datamodel.ApplicationProperties_v20250801preview{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Environment: to.String(src.Properties.Environment),

--- a/pkg/corerp/api/v20250801preview/bicepsettings_conversion.go
+++ b/pkg/corerp/api/v20250801preview/bicepsettings_conversion.go
@@ -25,21 +25,15 @@ import (
 // ConvertTo converts from the versioned BicepSettings resource to version-agnostic datamodel.
 func (src *BicepSettingsResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.BicepSettings{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				CreatedAPIVersion:      Version,
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
-		Properties: datamodel.BicepSettingsResourceProperties{},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		CreatedAPIVersion:      Version,
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
+		Properties:             datamodel.BicepSettingsResourceProperties{},
 	}
 
 	if len(src.Properties.RegistryAuthentications) > 0 {

--- a/pkg/corerp/api/v20250801preview/bicepsettings_conversion_test.go
+++ b/pkg/corerp/api/v20250801preview/bicepsettings_conversion_test.go
@@ -182,11 +182,7 @@ func TestBicepSettings_RoundTrip_Identity(t *testing.T) {
 // storage and one host's secret leaks into the other.
 func TestBicepSettings_ConvertFrom_TwoEntriesAreDistinct(t *testing.T) {
 	dm := &datamodel.BicepSettings{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID: bicepSettingsID, Name: bicepSettingsName, Type: bicepSettingsType, Location: bicepSettingsLocation,
-			},
-		},
+		ID: bicepSettingsID, Name: bicepSettingsName, Type: bicepSettingsType, Location: bicepSettingsLocation,
 		Properties: datamodel.BicepSettingsResourceProperties{
 			RegistryAuthentications: map[string]datamodel.BicepRegistryAuthentication{
 				"hostA": {

--- a/pkg/corerp/api/v20250801preview/environment_conversion.go
+++ b/pkg/corerp/api/v20250801preview/environment_conversion.go
@@ -27,21 +27,15 @@ import (
 func (src *EnvironmentResource) ConvertTo() (v1.DataModelInterface, error) {
 	// Note: SystemData conversion isn't required since this property comes ARM and datastore.
 	converted := &datamodel.Environment_v20250801preview{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				CreatedAPIVersion:      Version,
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
-		Properties: datamodel.EnvironmentProperties_v20250801preview{},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		CreatedAPIVersion:      Version,
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
+		Properties:             datamodel.EnvironmentProperties_v20250801preview{},
 	}
 
 	// Convert RecipePacks

--- a/pkg/corerp/api/v20250801preview/environment_conversion_test.go
+++ b/pkg/corerp/api/v20250801preview/environment_conversion_test.go
@@ -85,22 +85,16 @@ func TestEnvironmentConvertVersionedToDataModel(t *testing.T) {
 
 func TestEnvironmentConvertDataModelToVersioned(t *testing.T) {
 	dataModelResource := &datamodel.Environment_v20250801preview{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       "/planes/radius/local/resourceGroups/testGroup/providers/Radius.Core/environments/test-env",
-				Name:     "test-env",
-				Type:     "Radius.Core/environments",
-				Location: "West US",
-				Tags: map[string]string{
-					"env": "test",
-				},
-			},
-			InternalMetadata: v1.InternalMetadata{
-				CreatedAPIVersion:      Version,
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: v1.ProvisioningStateSucceeded,
-			},
+		ID:       "/planes/radius/local/resourceGroups/testGroup/providers/Radius.Core/environments/test-env",
+		Name:     "test-env",
+		Type:     "Radius.Core/environments",
+		Location: "West US",
+		Tags: map[string]string{
+			"env": "test",
 		},
+		CreatedAPIVersion:      Version,
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: v1.ProvisioningStateSucceeded,
 		Properties: datamodel.EnvironmentProperties_v20250801preview{
 			RecipePacks: []string{"/planes/radius/local/providers/Radius.Core/recipePacks/test-pack"},
 			RecipeParameters: map[string]map[string]any{

--- a/pkg/corerp/api/v20250801preview/recipepack_conversion.go
+++ b/pkg/corerp/api/v20250801preview/recipepack_conversion.go
@@ -26,21 +26,15 @@ import (
 func (src *RecipePackResource) ConvertTo() (v1.DataModelInterface, error) {
 	// Note: SystemData conversion isn't required since this property comes ARM and datastore.
 	converted := &datamodel.RecipePack{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				CreatedAPIVersion:      Version,
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
-		Properties: datamodel.RecipePackProperties{},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		CreatedAPIVersion:      Version,
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
+		Properties:             datamodel.RecipePackProperties{},
 	}
 
 	// Convert Recipes

--- a/pkg/corerp/api/v20250801preview/terraformsettings_conversion.go
+++ b/pkg/corerp/api/v20250801preview/terraformsettings_conversion.go
@@ -25,21 +25,15 @@ import (
 // ConvertTo converts from the versioned TerraformSettings resource to version-agnostic datamodel.
 func (src *TerraformSettingsResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.TerraformSettings{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				CreatedAPIVersion:      Version,
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
-		Properties: datamodel.TerraformSettingsResourceProperties{},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		CreatedAPIVersion:      Version,
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
+		Properties:             datamodel.TerraformSettingsResourceProperties{},
 	}
 
 	if src.Properties.Terraformrc != nil {

--- a/pkg/corerp/api/v20250801preview/terraformsettings_conversion_test.go
+++ b/pkg/corerp/api/v20250801preview/terraformsettings_conversion_test.go
@@ -212,11 +212,7 @@ func TestTerraformSettings_CredentialsAreIndependentEntries(t *testing.T) {
 	// Guards against pointer-aliasing bugs in the credentials map: each host's
 	// Secret must point to its own value, not share storage across iterations.
 	dm := &datamodel.TerraformSettings{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID: tfConfigID, Name: tfConfigName, Type: tfConfigType, Location: tfConfigLocation,
-			},
-		},
+		ID: tfConfigID, Name: tfConfigName, Type: tfConfigType, Location: tfConfigLocation,
 		Properties: datamodel.TerraformSettingsResourceProperties{
 			Terraformrc: datamodel.TerraformrcConfig{
 				Credentials: map[string]datamodel.TerraformCredentialConfig{

--- a/pkg/corerp/backend/controller/createorupdateresource.go
+++ b/pkg/corerp/backend/controller/createorupdateresource.go
@@ -123,9 +123,7 @@ func (c *CreateOrUpdateResource) Run(ctx context.Context, request *ctrl.Request)
 	}
 
 	nr := &database.Object{
-		Metadata: database.Metadata{
-			ID: request.ResourceID,
-		},
+		ID:   request.ResourceID,
 		Data: deploymentDataModel,
 	}
 	err = c.DatabaseClient().Save(ctx, nr, database.WithETag(obj.ETag))

--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -23,6 +23,7 @@ import (
 	"maps"
 	"net"
 	"os"
+	"slices"
 	"strings"
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
@@ -364,8 +365,8 @@ func (dp *deploymentProcessor) Delete(ctx context.Context, id resources.ID, depl
 	logger := ucplog.FromContextOrDiscard(ctx)
 
 	// Loop over each output resource and delete in reverse dependency order - resource deployed last should be deleted first
-	for i := len(deployedOutputResources) - 1; i >= 0; i-- {
-		outputResource := deployedOutputResources[i]
+	for _, outputResource := range slices.Backward(deployedOutputResources) {
+
 		resourceType := outputResource.GetResourceType()
 		outputResourceModel, err := dp.appmodel.LookupOutputResourceModel(resourceType)
 		if err != nil {

--- a/pkg/corerp/backend/deployment/deploymentprocessor_test.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor_test.go
@@ -34,7 +34,6 @@ import (
 	dsrp_dm "github.com/radius-project/radius/pkg/datastoresrp/datamodel"
 	dynamicrp_dm "github.com/radius-project/radius/pkg/dynamicrp/datamodel"
 	"github.com/radius-project/radius/pkg/portableresources"
-	pr_dm "github.com/radius-project/radius/pkg/portableresources/datamodel"
 	pr_renderers "github.com/radius-project/radius/pkg/portableresources/renderers"
 	"github.com/radius-project/radius/pkg/resourcemodel"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
@@ -98,11 +97,7 @@ func setup(t *testing.T) SharedMocks {
 		})
 
 	app := datamodel.Application{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
-			},
-		},
+		ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
 		Properties: datamodel.ApplicationProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/test-env",
@@ -111,12 +106,8 @@ func setup(t *testing.T) SharedMocks {
 	}
 
 	env := datamodel.Environment{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/test-env",
-				Name: "test-env",
-			},
-		},
+		ID:   "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/test-env",
+		Name: "test-env",
 		Properties: datamodel.EnvironmentProperties{
 			Compute: rpv1.EnvironmentCompute{
 				Kind: "kubernetes",
@@ -196,11 +187,7 @@ func getTestResourceID(id string) resources.ID {
 
 func buildDynamicResourceWithRecipe() dynamicrp_dm.DynamicResource {
 	return dynamicrp_dm.DynamicResource{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID: "/planes/radius/local/resourcegroups/default/providers/Test.Datastores/postgres/postgresudt",
-			},
-		},
+		ID: "/planes/radius/local/resourcegroups/default/providers/Test.Datastores/postgres/postgresudt",
 		Properties: map[string]any{
 			"application": "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
 			"environment": "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
@@ -223,33 +210,27 @@ func buildDynamicResourceWithRecipe() dynamicrp_dm.DynamicResource {
 
 func buildMongoDBWithRecipe() dsrp_dm.MongoDatabase {
 	return dsrp_dm.MongoDatabase{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Datastores/mongoDatabases/test-mongo",
-			},
-		},
+		ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Datastores/mongoDatabases/test-mongo",
 		Properties: dsrp_dm.MongoDatabaseProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
 				Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
 			},
 		},
-		PortableResourceMetadata: pr_dm.PortableResourceMetadata{
-			RecipeData: portableresources.RecipeData{
-				RecipeProperties: portableresources.RecipeProperties{
-					ResourceRecipe: portableresources.ResourceRecipe{
-						Name: "mongoDB",
-						Parameters: map[string]any{
-							"ResourceGroup": "testRG",
-							"Subscription":  "Radius-Test",
-						},
+		RecipeData: portableresources.RecipeData{
+			RecipeProperties: portableresources.RecipeProperties{
+				ResourceRecipe: portableresources.ResourceRecipe{
+					Name: "mongoDB",
+					Parameters: map[string]any{
+						"ResourceGroup": "testRG",
+						"Subscription":  "Radius-Test",
 					},
-					TemplatePath: "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 				},
-				APIVersion: clientv2.DocumentDBManagementClientAPIVersion,
-				Resources: []string{"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account",
-					"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database"},
+				TemplatePath: "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 			},
+			APIVersion: clientv2.DocumentDBManagementClientAPIVersion,
+			Resources: []string{"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account",
+				"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database"},
 		},
 	}
 }
@@ -310,11 +291,7 @@ func Test_Render(t *testing.T) {
 	ctx := t.Context()
 
 	env := datamodel.Environment{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
-			},
-		},
+		ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
 		Properties: datamodel.EnvironmentProperties{
 			Compute: rpv1.EnvironmentCompute{
 				Kind: rpv1.KubernetesComputeKind,
@@ -340,18 +317,12 @@ func Test_Render(t *testing.T) {
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
 
 		cr := database.Object{
-			Metadata: database.Metadata{
-				ID: testResource.ID,
-			},
+			ID:   testResource.ID,
 			Data: testResource,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
 		application := datamodel.Application{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
-				},
-			},
+			ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
 			Properties: datamodel.ApplicationProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
@@ -359,26 +330,18 @@ func Test_Render(t *testing.T) {
 			},
 		}
 		ar := database.Object{
-			Metadata: database.Metadata{
-				ID: application.ID,
-			},
+			ID:   application.ID,
 			Data: application,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&ar, nil)
 		er := database.Object{
-			Metadata: database.Metadata{
-				ID: env.ID,
-			},
+			ID:   env.ID,
 			Data: env,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
 
 		mongoResource := dsrp_dm.MongoDatabase{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Datastores/mongoDatabases/test-mongo",
-				},
-			},
+			ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Datastores/mongoDatabases/test-mongo",
 			Properties: dsrp_dm.MongoDatabaseProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
@@ -386,9 +349,7 @@ func Test_Render(t *testing.T) {
 			},
 		}
 		mr := database.Object{
-			Metadata: database.Metadata{
-				ID: mongoResource.ID,
-			},
+			ID:   mongoResource.ID,
 			Data: mongoResource,
 		}
 
@@ -411,18 +372,12 @@ func Test_Render(t *testing.T) {
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return([]resources.ID{}, nil, nil)
 
 		cr := database.Object{
-			Metadata: database.Metadata{
-				ID: testResource.ID,
-			},
+			ID:   testResource.ID,
 			Data: testResource,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
 		application := datamodel.Application{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
-				},
-			},
+			ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
 			Properties: datamodel.ApplicationProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
@@ -430,16 +385,12 @@ func Test_Render(t *testing.T) {
 			},
 		}
 		ar := database.Object{
-			Metadata: database.Metadata{
-				ID: application.ID,
-			},
+			ID:   application.ID,
 			Data: application,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&ar, nil)
 		er := database.Object{
-			Metadata: database.Metadata{
-				ID: env.ID,
-			},
+			ID:   env.ID,
 			Data: env,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
@@ -461,18 +412,12 @@ func Test_Render(t *testing.T) {
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return([]resources.ID{}, nil, nil)
 
 		cr := database.Object{
-			Metadata: database.Metadata{
-				ID: testResource.ID,
-			},
+			ID:   testResource.ID,
 			Data: testResource,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
 		application := datamodel.Application{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
-				},
-			},
+			ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
 			Properties: datamodel.ApplicationProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
@@ -480,16 +425,12 @@ func Test_Render(t *testing.T) {
 			},
 		}
 		ar := database.Object{
-			Metadata: database.Metadata{
-				ID: application.ID,
-			},
+			ID:   application.ID,
 			Data: application,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&ar, nil)
 		er := database.Object{
-			Metadata: database.Metadata{
-				ID: env.ID,
-			},
+			ID:   env.ID,
 			Data: env,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
@@ -510,18 +451,12 @@ func Test_Render(t *testing.T) {
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(renderers.RendererOutput{}, errors.New("failed to render the resource"))
 
 		cr := database.Object{
-			Metadata: database.Metadata{
-				ID: testResource.ID,
-			},
+			ID:   testResource.ID,
 			Data: testResource,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
 		application := datamodel.Application{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
-				},
-			},
+			ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
 			Properties: datamodel.ApplicationProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
@@ -529,16 +464,12 @@ func Test_Render(t *testing.T) {
 			},
 		}
 		ar := database.Object{
-			Metadata: database.Metadata{
-				ID: application.ID,
-			},
+			ID:   application.ID,
 			Data: application,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&ar, nil)
 		er := database.Object{
-			Metadata: database.Metadata{
-				ID: env.ID,
-			},
+			ID:   env.ID,
 			Data: env,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
@@ -597,9 +528,7 @@ func Test_Render(t *testing.T) {
 		testResource.Properties.Application = "invalid-app-id"
 
 		cr := database.Object{
-			Metadata: database.Metadata{
-				ID: testResource.ID,
-			},
+			ID:   testResource.ID,
 			Data: testResource,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
@@ -619,9 +548,7 @@ func Test_Render(t *testing.T) {
 		testResource.Properties.Application = ""
 
 		cr := database.Object{
-			Metadata: database.Metadata{
-				ID: testResource.ID,
-			},
+			ID:   testResource.ID,
 			Data: testResource,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
@@ -640,9 +567,7 @@ func Test_Render(t *testing.T) {
 		testResource.Properties.Application = "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/app/test-application"
 
 		cr := database.Object{
-			Metadata: database.Metadata{
-				ID: testResource.ID,
-			},
+			ID:   testResource.ID,
 			Data: testResource,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
@@ -667,18 +592,12 @@ func Test_Render(t *testing.T) {
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return([]resources.ID{}, nil, nil)
 
 		cr := database.Object{
-			Metadata: database.Metadata{
-				ID: testResource.ID,
-			},
+			ID:   testResource.ID,
 			Data: testResource,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
 		application := datamodel.Application{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
-				},
-			},
+			ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
 			Properties: datamodel.ApplicationProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
@@ -686,16 +605,12 @@ func Test_Render(t *testing.T) {
 			},
 		}
 		ar := database.Object{
-			Metadata: database.Metadata{
-				ID: application.ID,
-			},
+			ID:   application.ID,
 			Data: application,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&ar, nil)
 		er := database.Object{
-			Metadata: database.Metadata{
-				ID: env.ID,
-			},
+			ID:   env.ID,
 			Data: env,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
@@ -717,18 +632,12 @@ func Test_Render(t *testing.T) {
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return([]resources.ID{}, nil, nil)
 
 		cr := database.Object{
-			Metadata: database.Metadata{
-				ID: testResource.ID,
-			},
+			ID:   testResource.ID,
 			Data: testResource,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
 		application := datamodel.Application{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
-				},
-			},
+			ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
 			Properties: datamodel.ApplicationProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
@@ -736,16 +645,12 @@ func Test_Render(t *testing.T) {
 			},
 		}
 		ar := database.Object{
-			Metadata: database.Metadata{
-				ID: application.ID,
-			},
+			ID:   application.ID,
 			Data: application,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&ar, nil)
 		er := database.Object{
-			Metadata: database.Metadata{
-				ID: env.ID,
-			},
+			ID:   env.ID,
 			Data: env,
 		}
 		mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
@@ -760,19 +665,13 @@ func Test_Render(t *testing.T) {
 func setupDeployMocks(mocks SharedMocks, simulated bool) {
 	testResource := getTestResource()
 	cr := database.Object{
-		Metadata: database.Metadata{
-			ID: testResource.ID,
-		},
+		ID:   testResource.ID,
 		Data: testResource,
 	}
 	mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
 
 	app := datamodel.Application{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
-			},
-		},
+		ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
 		Properties: datamodel.ApplicationProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/test-env",
@@ -781,20 +680,14 @@ func setupDeployMocks(mocks SharedMocks, simulated bool) {
 	}
 
 	ar := database.Object{
-		Metadata: database.Metadata{
-			ID: mocks.testApp.ID,
-		},
+		ID:   mocks.testApp.ID,
 		Data: app,
 	}
 	mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&ar, nil)
 
 	env := datamodel.Environment{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/test-env",
-				Name: "test-env",
-			},
-		},
+		ID:   "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/test-env",
+		Name: "test-env",
 		Properties: datamodel.EnvironmentProperties{
 			Compute: rpv1.EnvironmentCompute{
 				Kind: "kubernetes",
@@ -811,9 +704,7 @@ func setupDeployMocks(mocks SharedMocks, simulated bool) {
 	}
 
 	er := database.Object{
-		Metadata: database.Metadata{
-			ID: mocks.testEnv.ID,
-		},
+		ID:   mocks.testEnv.ID,
 		Data: env,
 	}
 	mocks.databaseClient.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
@@ -1007,12 +898,8 @@ func Test_getEnvOptions_PublicEndpointOverride(t *testing.T) {
 	dp := deploymentProcessor{mocks.model, nil, nil, nil}
 
 	env := &datamodel.Environment{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/test-env",
-				Name: "test-env",
-			},
-		},
+		ID:   "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/test-env",
+		Name: "test-env",
 		Properties: datamodel.EnvironmentProperties{
 			Compute: rpv1.EnvironmentCompute{
 				Kind: rpv1.KubernetesComputeKind,
@@ -1076,9 +963,7 @@ func Test_getResourceDataByID(t *testing.T) {
 		mongoResource := buildMongoDBWithRecipe()
 		mongoResource.PortableResourceMetadata.RecipeData = portableresources.RecipeData{}
 		mr := database.Object{
-			Metadata: database.Metadata{
-				ID: mongoResource.ID,
-			},
+			ID:   mongoResource.ID,
 			Data: mongoResource,
 		}
 
@@ -1094,9 +979,7 @@ func Test_getResourceDataByID(t *testing.T) {
 		postgresResource := buildDynamicResourceWithRecipe()
 
 		mr := database.Object{
-			Metadata: database.Metadata{
-				ID: postgresResource.ID,
-			},
+			ID:   postgresResource.ID,
 			Data: postgresResource,
 		}
 

--- a/pkg/corerp/datamodel/converter/recipepack_converter_test.go
+++ b/pkg/corerp/datamodel/converter/recipepack_converter_test.go
@@ -39,22 +39,16 @@ func TestRecipePackDataModelToVersioned(t *testing.T) {
 		{
 			name: "valid conversion to 2025-08-01-preview",
 			dataModel: &datamodel.RecipePack{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/test-sub/resourceGroups/test-rg/providers/Radius.Core/recipePacks/test-pack",
-						Name:     "test-pack",
-						Type:     "Radius.Core/recipePacks",
-						Location: "global",
-						Tags: map[string]string{
-							"env": "test",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "2025-08-01-preview",
-						UpdatedAPIVersion:      "2025-08-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateSucceeded,
-					},
+				ID:       "/subscriptions/test-sub/resourceGroups/test-rg/providers/Radius.Core/recipePacks/test-pack",
+				Name:     "test-pack",
+				Type:     "Radius.Core/recipePacks",
+				Location: "global",
+				Tags: map[string]string{
+					"env": "test",
 				},
+				CreatedAPIVersion:      "2025-08-01-preview",
+				UpdatedAPIVersion:      "2025-08-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateSucceeded,
 				Properties: datamodel.RecipePackProperties{
 					Recipes: map[string]*datamodel.RecipeDefinition{
 						"Applications.Core/containers": {
@@ -84,14 +78,10 @@ func TestRecipePackDataModelToVersioned(t *testing.T) {
 		{
 			name: "minimal recipe pack",
 			dataModel: &datamodel.RecipePack{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/test-sub/resourceGroups/test-rg/providers/Radius.Core/recipePacks/minimal-pack",
-						Name:     "minimal-pack",
-						Type:     "Radius.Core/recipePacks",
-						Location: "global",
-					},
-				},
+				ID:         "/subscriptions/test-sub/resourceGroups/test-rg/providers/Radius.Core/recipePacks/minimal-pack",
+				Name:       "minimal-pack",
+				Type:       "Radius.Core/recipePacks",
+				Location:   "global",
 				Properties: datamodel.RecipePackProperties{},
 			},
 			version:      v20250801preview.Version,
@@ -184,22 +174,16 @@ func TestRecipePackDataModelFromVersioned(t *testing.T) {
 			version:     v20250801preview.Version,
 			expectError: false,
 			expected: &datamodel.RecipePack{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/test-sub/resourceGroups/test-rg/providers/Radius.Core/recipePacks/test-pack",
-						Name:     "test-pack",
-						Type:     "Radius.Core/recipePacks",
-						Location: "global",
-						Tags: map[string]string{
-							"env": "test",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "2025-08-01-preview",
-						UpdatedAPIVersion:      "2025-08-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateSucceeded,
-					},
+				ID:       "/subscriptions/test-sub/resourceGroups/test-rg/providers/Radius.Core/recipePacks/test-pack",
+				Name:     "test-pack",
+				Type:     "Radius.Core/recipePacks",
+				Location: "global",
+				Tags: map[string]string{
+					"env": "test",
 				},
+				CreatedAPIVersion:      "2025-08-01-preview",
+				UpdatedAPIVersion:      "2025-08-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateSucceeded,
 				Properties: datamodel.RecipePackProperties{
 					Recipes: map[string]*datamodel.RecipeDefinition{
 						"Applications.Core/containers": {
@@ -235,19 +219,13 @@ func TestRecipePackDataModelFromVersioned(t *testing.T) {
 			version:     v20250801preview.Version,
 			expectError: false,
 			expected: &datamodel.RecipePack{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/test-sub/resourceGroups/test-rg/providers/Radius.Core/recipePacks/minimal-pack",
-						Name:     "minimal-pack",
-						Type:     "Radius.Core/recipePacks",
-						Location: "global",
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion: "2025-08-01-preview",
-						UpdatedAPIVersion: "2025-08-01-preview",
-					},
-				},
-				Properties: datamodel.RecipePackProperties{},
+				ID:                "/subscriptions/test-sub/resourceGroups/test-rg/providers/Radius.Core/recipePacks/minimal-pack",
+				Name:              "minimal-pack",
+				Type:              "Radius.Core/recipePacks",
+				Location:          "global",
+				CreatedAPIVersion: "2025-08-01-preview",
+				UpdatedAPIVersion: "2025-08-01-preview",
+				Properties:        datamodel.RecipePackProperties{},
 			},
 		},
 		{
@@ -269,18 +247,12 @@ func TestRecipePackDataModelFromVersioned(t *testing.T) {
 			version:     v20250801preview.Version,
 			expectError: false,
 			expected: &datamodel.RecipePack{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/test-sub/resourceGroups/test-rg/providers/Radius.Core/recipePacks/default-plainhttp",
-						Name:     "default-plainhttp",
-						Type:     "Radius.Core/recipePacks",
-						Location: "global",
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion: "2025-08-01-preview",
-						UpdatedAPIVersion: "2025-08-01-preview",
-					},
-				},
+				ID:                "/subscriptions/test-sub/resourceGroups/test-rg/providers/Radius.Core/recipePacks/default-plainhttp",
+				Name:              "default-plainhttp",
+				Type:              "Radius.Core/recipePacks",
+				Location:          "global",
+				CreatedAPIVersion: "2025-08-01-preview",
+				UpdatedAPIVersion: "2025-08-01-preview",
 				Properties: datamodel.RecipePackProperties{
 					Recipes: map[string]*datamodel.RecipeDefinition{
 						"Applications.Core/containers": {
@@ -312,18 +284,12 @@ func TestRecipePackDataModelFromVersioned(t *testing.T) {
 			version:     v20250801preview.Version,
 			expectError: false,
 			expected: &datamodel.RecipePack{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/test-sub/resourceGroups/test-rg/providers/Radius.Core/recipePacks/explicit-plainhttp",
-						Name:     "explicit-plainhttp",
-						Type:     "Radius.Core/recipePacks",
-						Location: "global",
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion: "2025-08-01-preview",
-						UpdatedAPIVersion: "2025-08-01-preview",
-					},
-				},
+				ID:                "/subscriptions/test-sub/resourceGroups/test-rg/providers/Radius.Core/recipePacks/explicit-plainhttp",
+				Name:              "explicit-plainhttp",
+				Type:              "Radius.Core/recipePacks",
+				Location:          "global",
+				CreatedAPIVersion: "2025-08-01-preview",
+				UpdatedAPIVersion: "2025-08-01-preview",
 				Properties: datamodel.RecipePackProperties{
 					Recipes: map[string]*datamodel.RecipeDefinition{
 						"Applications.Datastores/sqlDatabases": {
@@ -407,22 +373,16 @@ func TestRecipePackDataModelFromVersioned(t *testing.T) {
 func TestRecipePackRoundTripConversion(t *testing.T) {
 	// Test round-trip conversion: datamodel -> versioned -> JSON -> versioned -> datamodel
 	originalDataModel := &datamodel.RecipePack{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       "/subscriptions/test-sub/resourceGroups/test-rg/providers/Radius.Core/recipePacks/round-trip-pack",
-				Name:     "round-trip-pack",
-				Type:     "Radius.Core/recipePacks",
-				Location: "global",
-				Tags: map[string]string{
-					"purpose": "testing",
-				},
-			},
-			InternalMetadata: v1.InternalMetadata{
-				CreatedAPIVersion:      "2025-08-01-preview",
-				UpdatedAPIVersion:      "2025-08-01-preview",
-				AsyncProvisioningState: v1.ProvisioningStateSucceeded,
-			},
+		ID:       "/subscriptions/test-sub/resourceGroups/test-rg/providers/Radius.Core/recipePacks/round-trip-pack",
+		Name:     "round-trip-pack",
+		Type:     "Radius.Core/recipePacks",
+		Location: "global",
+		Tags: map[string]string{
+			"purpose": "testing",
 		},
+		CreatedAPIVersion:      "2025-08-01-preview",
+		UpdatedAPIVersion:      "2025-08-01-preview",
+		AsyncProvisioningState: v1.ProvisioningStateSucceeded,
 		Properties: datamodel.RecipePackProperties{
 			Recipes: map[string]*datamodel.RecipeDefinition{
 				"Applications.Core/containers": {
@@ -484,14 +444,10 @@ func TestRecipePackEdgeCases(t *testing.T) {
 		{
 			name: "empty recipes map",
 			dataModel: &datamodel.RecipePack{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/test/empty-recipes",
-						Name:     "empty-recipes",
-						Type:     "Radius.Core/recipePacks",
-						Location: "global",
-					},
-				},
+				ID:       "/test/empty-recipes",
+				Name:     "empty-recipes",
+				Type:     "Radius.Core/recipePacks",
+				Location: "global",
 				Properties: datamodel.RecipePackProperties{
 					Recipes: map[string]*datamodel.RecipeDefinition{},
 				},
@@ -501,14 +457,10 @@ func TestRecipePackEdgeCases(t *testing.T) {
 		{
 			name: "nil recipes map",
 			dataModel: &datamodel.RecipePack{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/test/nil-recipes",
-						Name:     "nil-recipes",
-						Type:     "Radius.Core/recipePacks",
-						Location: "global",
-					},
-				},
+				ID:       "/test/nil-recipes",
+				Name:     "nil-recipes",
+				Type:     "Radius.Core/recipePacks",
+				Location: "global",
 				Properties: datamodel.RecipePackProperties{
 					Recipes: nil,
 				},
@@ -518,14 +470,10 @@ func TestRecipePackEdgeCases(t *testing.T) {
 		{
 			name: "empty referenced by list",
 			dataModel: &datamodel.RecipePack{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/test/empty-refs",
-						Name:     "empty-refs",
-						Type:     "Radius.Core/recipePacks",
-						Location: "global",
-					},
-				},
+				ID:       "/test/empty-refs",
+				Name:     "empty-refs",
+				Type:     "Radius.Core/recipePacks",
+				Location: "global",
 				Properties: datamodel.RecipePackProperties{
 					ReferencedBy: []string{},
 				},

--- a/pkg/corerp/frontend/controller/applications/getgraph_test.go
+++ b/pkg/corerp/frontend/controller/applications/getgraph_test.go
@@ -246,9 +246,7 @@ func TestGetGraphRun_ComputeGraphSuccess(t *testing.T) {
 		EXPECT().
 		Get(gomock.Any(), gomock.Any()).
 		Return(rpctest.FakeStoreObject(&datamodel.Application{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{ID: appIDStr},
-			},
+			ID: appIDStr,
 			Properties: datamodel.ApplicationProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{Environment: envIDStr},
 			},

--- a/pkg/corerp/frontend/controller/applications/graph_util_test.go
+++ b/pkg/corerp/frontend/controller/applications/graph_util_test.go
@@ -731,20 +731,18 @@ func Test_azureTenantID(t *testing.T) {
 			t.Cleanup(server.Close)
 
 			opts := &policy.ClientOptions{
-				ClientOptions: azpolicy.ClientOptions{
-					Transport: server.Client(),
-					Cloud: cloud.Configuration{
-						Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
-							cloud.ResourceManager: {
-								Endpoint: server.URL,
-								Audience: "https://management.core.windows.net",
-							},
+				Transport: server.Client(),
+				Cloud: cloud.Configuration{
+					Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+						cloud.ResourceManager: {
+							Endpoint: server.URL,
+							Audience: "https://management.core.windows.net",
 						},
 					},
-					InsecureAllowCredentialWithHTTP: true,
-					Retry: azpolicy.RetryOptions{
-						MaxRetries: -1, // disable retries so 5xx responses don't slow the test
-					},
+				},
+				InsecureAllowCredentialWithHTTP: true,
+				Retry: azpolicy.RetryOptions{
+					MaxRetries: -1, // disable retries so 5xx responses don't slow the test
 				},
 			}
 

--- a/pkg/corerp/frontend/controller/applications/updatefilter.go
+++ b/pkg/corerp/frontend/controller/applications/updatefilter.go
@@ -35,7 +35,6 @@ import (
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -151,7 +150,7 @@ func CreateAppScopedNamespace(ctx context.Context, newResource, oldResource *dat
 		return nil, err
 	}
 
-	err = namespaceClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: kubeNamespace}})
+	err = namespaceClient.Create(ctx, &corev1.Namespace{Name: kubeNamespace})
 	if apierrors.IsAlreadyExists(err) {
 		logger.Info("Using existing namespace", "namespace", kubeNamespace)
 	} else if err != nil {

--- a/pkg/corerp/frontend/controller/applications/updatefilter_test.go
+++ b/pkg/corerp/frontend/controller/applications/updatefilter_test.go
@@ -320,11 +320,7 @@ func TestCreateAppScopedNamespace_invalid_property(t *testing.T) {
 			Return(rpctest.FakeStoreObject(envdm), nil)
 
 		newResource := &datamodel.Application{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: testAppID,
-				},
-			},
+			ID: testAppID,
 			Properties: datamodel.ApplicationProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Environment: testEnvID,
@@ -374,11 +370,7 @@ func TestCreateAppScopedNamespace_invalid_property(t *testing.T) {
 		}
 
 		newResource := &datamodel.Application{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: testAppID,
-				},
-			},
+			ID: testAppID,
 			Properties: datamodel.ApplicationProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Environment: testEnvID,

--- a/pkg/corerp/frontend/controller/applications/v20250801preview/getgraph_test.go
+++ b/pkg/corerp/frontend/controller/applications/v20250801preview/getgraph_test.go
@@ -126,9 +126,7 @@ func TestGetGraphRun_20250801Preview_ComputeGraphSuccess(t *testing.T) {
 		EXPECT().
 		Get(gomock.Any(), gomock.Any()).
 		Return(rpctest.FakeStoreObject(&datamodel.Application_v20250801preview{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{ID: appIDStr},
-			},
+			ID: appIDStr,
 			Properties: datamodel.ApplicationProperties_v20250801preview{
 				BasicResourceProperties: rpv1.BasicResourceProperties{Environment: envIDStr},
 			},

--- a/pkg/corerp/frontend/controller/containers/validator_test.go
+++ b/pkg/corerp/frontend/controller/containers/validator_test.go
@@ -94,11 +94,7 @@ func TestValidateAndMutateRequest_IdentityProperty(t *testing.T) {
 		{
 			desc: "valid runtime.kubernetes.base",
 			newResource: &datamodel.ContainerResource{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						Name: "magpie",
-					},
-				},
+				Name: "magpie",
 				Properties: datamodel.ContainerProperties{
 					Runtimes: &datamodel.RuntimeProperties{
 						Kubernetes: &datamodel.KubernetesRuntime{
@@ -108,11 +104,7 @@ func TestValidateAndMutateRequest_IdentityProperty(t *testing.T) {
 				},
 			},
 			mutatedResource: &datamodel.ContainerResource{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						Name: "magpie",
-					},
-				},
+				Name: "magpie",
 				Properties: datamodel.ContainerProperties{
 					Runtimes: &datamodel.RuntimeProperties{
 						Kubernetes: &datamodel.KubernetesRuntime{
@@ -199,11 +191,7 @@ func TestValidateManifest(t *testing.T) {
 	fakeServiceWithNamespace := fmt.Sprintf(k8sutil.FakeServiceTemplate, "magpie", "namespace: app-scoped")
 
 	validResource := &datamodel.ContainerResource{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				Name: "magpie",
-			},
-		},
+		Name:       "magpie",
 		Properties: datamodel.ContainerProperties{},
 	}
 

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
@@ -36,7 +36,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ ctrl.Controller = (*CreateOrUpdateEnvironment)(nil)
@@ -112,7 +111,7 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, w http.ResponseWrit
 		}
 	} else if newResource.Properties.Compute.Kind == rpv1.KubernetesComputeKind {
 		// Create environment namespace if it doesn't exist.
-		err = e.Options().KubeClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+		err = e.Options().KubeClient.Create(ctx, &corev1.Namespace{Name: namespace})
 		if apierrors.IsAlreadyExists(err) {
 			logger.Info("Using existing namespace", "namespace", namespace)
 		} else if err != nil {

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
@@ -34,7 +34,6 @@ import (
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	"github.com/radius-project/radius/test/k8sutil"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/google/uuid"
@@ -113,7 +112,7 @@ func TestCreateOrUpdateEnvironmentRun_20231001Preview(t *testing.T) {
 			}
 
 			if tt.existingNamespace {
-				err = opts.KubeClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: envDataModel.Properties.Compute.KubernetesCompute.Namespace}})
+				err = opts.KubeClient.Create(ctx, &corev1.Namespace{Name: envDataModel.Properties.Compute.KubernetesCompute.Namespace})
 				require.NoError(t, err)
 			}
 			ctl, err := NewCreateOrUpdateEnvironment(opts)
@@ -163,8 +162,8 @@ func TestCreateOrUpdateEnvironmentRun_20231001Preview(t *testing.T) {
 				Get(gomock.Any(), gomock.Any()).
 				DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 					return &database.Object{
-						Metadata: database.Metadata{ID: id, ETag: tt.resourceETag},
-						Data:     envDataModel,
+						ID: id, ETag: tt.resourceETag,
+						Data: envDataModel,
 					}, nil
 				})
 
@@ -296,8 +295,8 @@ func TestCreateOrUpdateEnvironmentRun_20231001Preview(t *testing.T) {
 				Get(gomock.Any(), gomock.Any()).
 				DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 					return &database.Object{
-						Metadata: database.Metadata{ID: id, ETag: tt.resourceEtag},
-						Data:     envDataModel,
+						ID: id, ETag: tt.resourceEtag,
+						Data: envDataModel,
 					}, nil
 				})
 
@@ -376,8 +375,8 @@ func TestCreateOrUpdateEnvironmentRun_20231001Preview(t *testing.T) {
 				Get(gomock.Any(), gomock.Any()).
 				DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 					return &database.Object{
-						Metadata: database.Metadata{ID: id, ETag: tt.resourceEtag},
-						Data:     envDataModel,
+						ID: id, ETag: tt.resourceEtag,
+						Data: envDataModel,
 					}, nil
 				})
 
@@ -385,9 +384,7 @@ func TestCreateOrUpdateEnvironmentRun_20231001Preview(t *testing.T) {
 
 			items := []database.Object{
 				{
-					Metadata: database.Metadata{
-						ID: uuid.New().String(),
-					},
+					ID:   uuid.New().String(),
 					Data: conflictDataModel,
 				},
 			}
@@ -472,7 +469,7 @@ func TestCreateOrUpdateEnvironment_NamespaceConflictError(t *testing.T) {
 			require.Equal(t, "applications.core/environments", strings.ToLower(query.ResourceType))
 
 			return &database.ObjectQueryResult{
-				Items: []database.Object{{Metadata: database.Metadata{ID: conflictingEnvID}, Data: conflicting}},
+				Items: []database.Object{{ID: conflictingEnvID, Data: conflicting}},
 			}, nil
 		})
 

--- a/pkg/corerp/frontend/controller/environments/getrecipemetadata.go
+++ b/pkg/corerp/frontend/controller/environments/getrecipemetadata.go
@@ -116,10 +116,8 @@ func (r *GetRecipeMetadata) GetRecipeMetadataFromRegistry(ctx context.Context, r
 
 	recipeParameters = make(map[string]any)
 	recipeData, err := r.Engine.GetRecipeMetadata(ctx, engine.GetRecipeMetadataOptions{
-		BaseOptions: engine.BaseOptions{
-			Recipe: recipes.ResourceMetadata{
-				EnvironmentID: envID,
-			},
+		Recipe: recipes.ResourceMetadata{
+			EnvironmentID: envID,
 		},
 		RecipeDefinition: recipeDefinition,
 	})

--- a/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
+++ b/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
@@ -55,8 +55,8 @@ func TestGetRecipeMetadataRun_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id, ETag: "etag"},
-					Data:     envDataModel,
+					ID: id, ETag: "etag",
+					Data: envDataModel,
 				}, nil
 			})
 		ctx := rpctest.NewARMRequestContext(req)
@@ -76,10 +76,8 @@ func TestGetRecipeMetadataRun_20231001Preview(t *testing.T) {
 			},
 		}
 		mEngine.EXPECT().GetRecipeMetadata(ctx, engine.GetRecipeMetadataOptions{
-			BaseOptions: engine.BaseOptions{
-				Recipe: recipes.ResourceMetadata{
-					EnvironmentID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0",
-				},
+			Recipe: recipes.ResourceMetadata{
+				EnvironmentID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0",
 			},
 			RecipeDefinition: recipeDefinition,
 		}).Return(recipeData, nil)
@@ -110,8 +108,8 @@ func TestGetRecipeMetadataRun_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id, ETag: "etag"},
-					Data:     envDataModel,
+					ID: id, ETag: "etag",
+					Data: envDataModel,
 				}, nil
 			})
 		ctx := rpctest.NewARMRequestContext(req)
@@ -131,10 +129,8 @@ func TestGetRecipeMetadataRun_20231001Preview(t *testing.T) {
 			},
 		}
 		mEngine.EXPECT().GetRecipeMetadata(ctx, engine.GetRecipeMetadataOptions{
-			BaseOptions: engine.BaseOptions{
-				Recipe: recipes.ResourceMetadata{
-					EnvironmentID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0",
-				},
+			Recipe: recipes.ResourceMetadata{
+				EnvironmentID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0",
 			},
 			RecipeDefinition: recipeDefinition,
 		}).Return(recipeData, nil)
@@ -202,8 +198,8 @@ func TestGetRecipeMetadataRun_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id, ETag: "etag"},
-					Data:     envDataModel,
+					ID: id, ETag: "etag",
+					Data: envDataModel,
 				}, nil
 			})
 
@@ -241,8 +237,8 @@ func TestGetRecipeMetadataRun_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id, ETag: "etag"},
-					Data:     envDataModel,
+					ID: id, ETag: "etag",
+					Data: envDataModel,
 				}, nil
 			})
 		ctx := rpctest.NewARMRequestContext(req)
@@ -256,10 +252,8 @@ func TestGetRecipeMetadataRun_20231001Preview(t *testing.T) {
 		}
 		engineErr := fmt.Errorf("could not find driver %s", "invalidDriver")
 		mEngine.EXPECT().GetRecipeMetadata(ctx, engine.GetRecipeMetadataOptions{
-			BaseOptions: engine.BaseOptions{
-				Recipe: recipes.ResourceMetadata{
-					EnvironmentID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0",
-				},
+			Recipe: recipes.ResourceMetadata{
+				EnvironmentID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0",
 			},
 			RecipeDefinition: recipeDefinition,
 		}).Return(nil, engineErr)

--- a/pkg/corerp/frontend/controller/environments/v20250801preview/createorupdateenvironment_test.go
+++ b/pkg/corerp/frontend/controller/environments/v20250801preview/createorupdateenvironment_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // testRecipePackID is the recipe pack referenced by the shared environment test
@@ -132,9 +131,7 @@ func TestCreateOrUpdateEnvironmentRun_20250801Preview(t *testing.T) {
 			}
 
 			defaultNamespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
-				},
+				Name: "default",
 			}
 			opts := ctrl.Options{
 				DatabaseClient: databaseClient,
@@ -186,8 +183,8 @@ func TestCreateOrUpdateEnvironmentRun_20250801Preview(t *testing.T) {
 				Get(gomock.Any(), gomock.Any()).
 				DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 					return &database.Object{
-						Metadata: database.Metadata{ID: id, ETag: tt.resourceETag},
-						Data:     envDataModel,
+						ID: id, ETag: tt.resourceETag,
+						Data: envDataModel,
 					}, nil
 				})
 
@@ -206,9 +203,7 @@ func TestCreateOrUpdateEnvironmentRun_20250801Preview(t *testing.T) {
 			}
 
 			defaultNamespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
-				},
+				Name: "default",
 			}
 			opts := ctrl.Options{
 				DatabaseClient: databaseClient,
@@ -275,9 +270,7 @@ func TestCreateOrUpdateEnvironmentRun_20250801Preview(t *testing.T) {
 			}
 
 			defaultNamespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
-				},
+				Name: "default",
 			}
 			opts := ctrl.Options{
 				DatabaseClient: databaseClient,
@@ -321,8 +314,8 @@ func TestCreateOrUpdateEnvironmentRun_20250801Preview(t *testing.T) {
 				Get(gomock.Any(), gomock.Any()).
 				DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 					return &database.Object{
-						Metadata: database.Metadata{ID: id, ETag: tt.resourceEtag},
-						Data:     envDataModel,
+						ID: id, ETag: tt.resourceEtag,
+						Data: envDataModel,
 					}, nil
 				})
 
@@ -342,9 +335,7 @@ func TestCreateOrUpdateEnvironmentRun_20250801Preview(t *testing.T) {
 			}
 
 			defaultNamespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
-				},
+				Name: "default",
 			}
 			opts := ctrl.Options{
 				DatabaseClient: databaseClient,
@@ -386,13 +377,13 @@ func TestCreateOrUpdateEnvironment_NamespaceUniqueness(t *testing.T) {
 	// conflictingEnvironment returns a stored Radius.Core environment using the "default" namespace.
 	conflictingEnvironment := func(id string) database.Object {
 		env := &datamodel.Environment_v20250801preview{
-			BaseResource: v1.BaseResource{TrackedResource: v1.TrackedResource{ID: id}},
+			ID: id,
 		}
 		env.Properties.Providers = &datamodel.Providers_v20250801preview{
 			Kubernetes: &datamodel.ProvidersKubernetes_v20250801preview{Namespace: "default"},
 		}
 
-		return database.Object{Metadata: database.Metadata{ID: id}, Data: env}
+		return database.Object{ID: id, Data: env}
 	}
 
 	testCases := []struct {
@@ -473,7 +464,7 @@ func TestCreateOrUpdateEnvironment_NamespaceUniqueness(t *testing.T) {
 
 			opts := ctrl.Options{
 				DatabaseClient: databaseClient,
-				KubeClient:     k8sutil.NewFakeKubeClient(nil, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}),
+				KubeClient:     k8sutil.NewFakeKubeClient(nil, &corev1.Namespace{Name: "default"}),
 			}
 
 			ctl, err := NewCreateOrUpdateEnvironmentv20250801preview(opts)
@@ -845,9 +836,7 @@ func TestCreateOrUpdateEnvironment_RecipePackValidation(t *testing.T) {
 			}
 
 			defaultNamespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
-				},
+				Name: "default",
 			}
 			opts := ctrl.Options{
 				DatabaseClient: databaseClient,
@@ -957,7 +946,7 @@ func TestCreateOrUpdateEnvironment_RecipePackNormalization(t *testing.T) {
 			return nil
 		})
 
-	defaultNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	defaultNamespace := &corev1.Namespace{Name: "default"}
 	opts := ctrl.Options{
 		DatabaseClient: databaseClient,
 		KubeClient:     k8sutil.NewFakeKubeClient(nil, defaultNamespace),
@@ -1054,8 +1043,8 @@ func TestCreateOrUpdateEnvironment_NamespaceImmutability(t *testing.T) {
 				Get(gomock.Any(), gomock.Any()).
 				DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 					return &database.Object{
-						Metadata: database.Metadata{ID: id, ETag: "resource-etag"},
-						Data:     &stored,
+						ID: id, ETag: "resource-etag",
+						Data: &stored,
 					}, nil
 				}).AnyTimes()
 
@@ -1081,7 +1070,7 @@ func TestCreateOrUpdateEnvironment_NamespaceImmutability(t *testing.T) {
 
 			opts := ctrl.Options{
 				DatabaseClient: databaseClient,
-				KubeClient:     k8sutil.NewFakeKubeClient(nil, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}),
+				KubeClient:     k8sutil.NewFakeKubeClient(nil, &corev1.Namespace{Name: "default"}),
 			}
 
 			ctl, err := NewCreateOrUpdateEnvironmentv20250801preview(opts)

--- a/pkg/corerp/frontend/controller/environments/v20250801preview/validateconfigref_test.go
+++ b/pkg/corerp/frontend/controller/environments/v20250801preview/validateconfigref_test.go
@@ -133,8 +133,8 @@ func TestValidateConfigRef_HappyPath_TerraformSettings(t *testing.T) {
 	databaseClient.EXPECT().
 		Get(gomock.Any(), tfConfigID).
 		Return(&database.Object{
-			Metadata: database.Metadata{ID: tfConfigID, ETag: "etag-1"},
-			Data:     versioned,
+			ID: tfConfigID, ETag: "etag-1",
+			Data: versioned,
 		}, nil)
 
 	e := newControllerForValidateConfigRef(databaseClient)
@@ -153,8 +153,8 @@ func TestValidateConfigRef_HappyPath_BicepSettings(t *testing.T) {
 	databaseClient.EXPECT().
 		Get(gomock.Any(), bicepSettingsID).
 		Return(&database.Object{
-			Metadata: database.Metadata{ID: bicepSettingsID, ETag: "etag-1"},
-			Data:     versioned,
+			ID: bicepSettingsID, ETag: "etag-1",
+			Data: versioned,
 		}, nil)
 
 	e := newControllerForValidateConfigRef(databaseClient)

--- a/pkg/corerp/frontend/controller/extenders/listsecretsextender_test.go
+++ b/pkg/corerp/frontend/controller/extenders/listsecretsextender_test.go
@@ -93,8 +93,8 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id},
-					Data:     extenderDataModel,
+					ID:   id,
+					Data: extenderDataModel,
 				}, nil
 			})
 

--- a/pkg/corerp/frontend/controller/recipepacks/createorupdaterecipepack_test.go
+++ b/pkg/corerp/frontend/controller/recipepacks/createorupdaterecipepack_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	ctrl "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
 	"github.com/radius-project/radius/pkg/armrpc/rpctest"
 	"github.com/radius-project/radius/pkg/components/database"
@@ -177,14 +176,10 @@ func getTestModels() (*v20250801preview.RecipePackResource, *datamodel.RecipePac
 	}
 
 	recipePackDataModel := &datamodel.RecipePack{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       resourceID,
-				Name:     resourceName,
-				Type:     datamodel.RecipePackResourceType,
-				Location: location,
-			},
-		},
+		ID:       resourceID,
+		Name:     resourceName,
+		Type:     datamodel.RecipePackResourceType,
+		Location: location,
 		Properties: datamodel.RecipePackProperties{
 			Recipes: map[string]*datamodel.RecipeDefinition{
 				"Applications.Core/extenders": {

--- a/pkg/corerp/frontend/controller/secretstores/kubernetes.go
+++ b/pkg/corerp/frontend/controller/secretstores/kubernetes.go
@@ -35,7 +35,6 @@ import (
 	resources_kubernetes "github.com/radius-project/radius/pkg/ucp/resources/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -251,12 +250,10 @@ func UpsertSecret(ctx context.Context, newResource, old *datamodel.SecretStore, 
 
 		app, _ := resources.ParseResource(newResource.Properties.Application)
 		ksecret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: ns,
-				Labels:    kubernetes.MakeDescriptiveLabels(app.Name(), name, ResourceTypeName),
-			},
-			Data: map[string][]byte{},
+			Name:      name,
+			Namespace: ns,
+			Labels:    kubernetes.MakeDescriptiveLabels(app.Name(), name, ResourceTypeName),
+			Data:      map[string][]byte{},
 		}
 	} else if err != nil {
 		return nil, err

--- a/pkg/corerp/frontend/controller/secretstores/kubernetes_test.go
+++ b/pkg/corerp/frontend/controller/secretstores/kubernetes_test.go
@@ -34,7 +34,6 @@ import (
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -361,11 +360,9 @@ func TestUpsertSecret(t *testing.T) {
 		newResource := testutil.MustGetTestData[datamodel.SecretStore](testFileCertValueFrom)
 
 		ksecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "letsencrypt-prod",
-				Namespace: "default",
-			},
-			Data: map[string][]byte{},
+			Name:      "letsencrypt-prod",
+			Namespace: "default",
+			Data:      map[string][]byte{},
 		}
 		opt := &controller.Options{
 			KubeClient: k8sutil.NewFakeKubeClient(nil, ksecret),
@@ -385,10 +382,8 @@ func TestUpsertSecret(t *testing.T) {
 		newResource.Properties.Resource = "default/secret"
 
 		ksecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "secret",
-				Namespace: "default",
-			},
+			Name:      "secret",
+			Namespace: "default",
 			Data: map[string][]byte{
 				"private.key": []byte("private key value"),
 			},
@@ -639,12 +634,10 @@ func TestDeleteSecret(t *testing.T) {
 		res := testutil.MustGetTestData[datamodel.SecretStore](testFileCertValueFrom)
 
 		ksecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "letsencrypt-prod",
-				Namespace: "default",
-				Labels: map[string]string{
-					kubernetes.LabelRadiusResourceType: "test",
-				},
+			Name:      "letsencrypt-prod",
+			Namespace: "default",
+			Labels: map[string]string{
+				kubernetes.LabelRadiusResourceType: "test",
 			},
 			Data: map[string][]byte{},
 		}
@@ -664,11 +657,9 @@ func TestDeleteSecret(t *testing.T) {
 		res := testutil.MustGetTestData[datamodel.SecretStore](testFileCertValueFrom)
 
 		ksecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "letsencrypt-prod",
-				Namespace: "default",
-			},
-			Data: map[string][]byte{},
+			Name:      "letsencrypt-prod",
+			Namespace: "default",
+			Data:      map[string][]byte{},
 		}
 		opt := &controller.Options{
 			KubeClient: k8sutil.NewFakeKubeClient(nil, ksecret),

--- a/pkg/corerp/frontend/controller/secretstores/listsecrets_test.go
+++ b/pkg/corerp/frontend/controller/secretstores/listsecrets_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestListSecrets_20231001Preview(t *testing.T) {
@@ -76,16 +75,14 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id, ETag: "etag"},
-					Data:     secretdm,
+					ID: id, ETag: "etag",
+					Data: secretdm,
 				}, nil
 			})
 		ctx := rpctest.NewARMRequestContext(req)
 		ksecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "letsencrypt-prod",
-				Namespace: "default",
-			},
+			Name:      "letsencrypt-prod",
+			Namespace: "default",
 			Data: map[string][]byte{
 				"tls.crt": []byte("cert"),
 				"tls.key": []byte("key"),
@@ -133,21 +130,17 @@ func TestListSecrets_InvalidKubernetesSecret(t *testing.T) {
 		{
 			name: "backing kubernetes secret not found",
 			in: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "notfound",
-					Namespace: "default",
-				},
-				Data: map[string][]byte{},
+				Name:      "notfound",
+				Namespace: "default",
+				Data:      map[string][]byte{},
 			},
 			err: errors.New("referenced secret is not found"),
 		},
 		{
 			name: "secret is not found",
 			in: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "letsencrypt-prod",
-					Namespace: "default",
-				},
+				Name:      "letsencrypt-prod",
+				Namespace: "default",
 				Data: map[string][]byte{
 					"tls.crt": []byte("dGxzLmtleS1wcmlrZXkK"),
 				},
@@ -157,10 +150,8 @@ func TestListSecrets_InvalidKubernetesSecret(t *testing.T) {
 		{
 			name: "invalid base64 encoded secret",
 			in: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "letsencrypt-prod",
-					Namespace: "default",
-				},
+				Name:      "letsencrypt-prod",
+				Namespace: "default",
 				Data: map[string][]byte{
 					"tls.crt": []byte("dGxzLmtleS1wcmlrZXkK"),
 					"tls.key": []byte("_"),
@@ -177,8 +168,8 @@ func TestListSecrets_InvalidKubernetesSecret(t *testing.T) {
 				Get(gomock.Any(), gomock.Any()).
 				DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 					return &database.Object{
-						Metadata: database.Metadata{ID: id, ETag: "etag"},
-						Data:     secretdm,
+						ID: id, ETag: "etag",
+						Data: secretdm,
 					}, nil
 				})
 			ctx := rpctest.NewARMRequestContext(req)

--- a/pkg/corerp/frontend/controller/util/namespace_test.go
+++ b/pkg/corerp/frontend/controller/util/namespace_test.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"testing"
 
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/components/database"
 	"github.com/radius-project/radius/pkg/corerp/datamodel"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
@@ -41,28 +40,24 @@ const (
 // legacyEnvironment builds a stored Applications.Core/environments record.
 func legacyEnvironment(id string, namespace string, kind rpv1.EnvironmentComputeKind) database.Object {
 	env := &datamodel.Environment{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{ID: id},
-		},
+		ID: id,
 	}
 	env.Properties.Compute.Kind = kind
 	env.Properties.Compute.KubernetesCompute.Namespace = namespace
 
-	return database.Object{Metadata: database.Metadata{ID: id}, Data: env}
+	return database.Object{ID: id, Data: env}
 }
 
 // previewEnvironment builds a stored Radius.Core/environments record.
 func previewEnvironment(id string, namespace string) database.Object {
 	env := &datamodel.Environment_v20250801preview{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{ID: id},
-		},
+		ID: id,
 	}
 	env.Properties.Providers = &datamodel.Providers_v20250801preview{
 		Kubernetes: &datamodel.ProvidersKubernetes_v20250801preview{Namespace: namespace},
 	}
 
-	return database.Object{Metadata: database.Metadata{ID: id}, Data: env}
+	return database.Object{ID: id, Data: env}
 }
 
 // expectQueries stubs the two namespace queries, returning legacyItems for the

--- a/pkg/corerp/frontend/controller/volumes/validator_test.go
+++ b/pkg/corerp/frontend/controller/volumes/validator_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -56,13 +55,9 @@ func TestValidateRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	crdFakeClient := k8sutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apiextensions.k8s.io/v1",
-			Kind:       "CustomResourceDefinition",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: secretProviderClassesCRD,
-		},
+		APIVersion: "apiextensions.k8s.io/v1",
+		Kind:       "CustomResourceDefinition",
+		Name:       secretProviderClassesCRD,
 	})
 
 	// Create default Kubernetes fake client.

--- a/pkg/corerp/handlers/kubernetes_deployment_waiter_test.go
+++ b/pkg/corerp/handlers/kubernetes_deployment_waiter_test.go
@@ -35,15 +35,11 @@ import (
 )
 
 var testDeployment = &v1.Deployment{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       "Deployment",
-		APIVersion: "apps/v1",
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:        "test-deployment",
-		Namespace:   "test-namespace",
-		Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
-	},
+	Kind:        "Deployment",
+	APIVersion:  "apps/v1",
+	Name:        "test-deployment",
+	Namespace:   "test-namespace",
+	Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
 	Spec: v1.DeploymentSpec{
 		Replicas: new(int32(1)),
 		Selector: &metav1.LabelSelector{
@@ -66,17 +62,15 @@ var testDeployment = &v1.Deployment{
 
 func addReplicaSetToDeployment(t *testing.T, ctx context.Context, clientset *fake.Clientset, deployment *v1.Deployment) *v1.ReplicaSet {
 	replicaSet := &v1.ReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-replicaset-1",
-			Namespace:   deployment.Namespace,
-			Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
-					Group:   v1.SchemeGroupVersion.Group,
-					Version: v1.SchemeGroupVersion.Version,
-					Kind:    "Deployment",
-				}),
-			},
+		Name:        "test-replicaset-1",
+		Namespace:   deployment.Namespace,
+		Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
+		OwnerReferences: []metav1.OwnerReference{
+			*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
+				Group:   v1.SchemeGroupVersion.Group,
+				Version: v1.SchemeGroupVersion.Version,
+				Kind:    "Deployment",
+			}),
 		},
 	}
 
@@ -109,14 +103,12 @@ func TestWaitUntilReady_NewResource(t *testing.T) {
 
 	// Create first deployment that will be watched
 	deployment := &v1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-deployment",
-			Namespace: "test-namespace",
-			Labels: map[string]string{
-				kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
-			},
-			Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
+		Name:      "test-deployment",
+		Namespace: "test-namespace",
+		Labels: map[string]string{
+			kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
 		},
+		Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
 		Spec: v1.DeploymentSpec{
 			Replicas: new(int32(1)),
 			Selector: &metav1.LabelSelector{
@@ -159,11 +151,9 @@ func TestWaitUntilReady_Timeout(t *testing.T) {
 	ctx := t.Context()
 	// Create first deployment that will be watched
 	deployment := &v1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-deployment",
-			Namespace:   "test-namespace",
-			Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
-		},
+		Name:        "test-deployment",
+		Namespace:   "test-namespace",
+		Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
 		Status: v1.DeploymentStatus{
 			Conditions: []v1.DeploymentCondition{
 				{
@@ -196,11 +186,9 @@ func TestWaitUntilReady_DifferentResourceName(t *testing.T) {
 	ctx := t.Context()
 	// Create first deployment that will be watched
 	deployment := &v1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-deployment",
-			Namespace:   "test-namespace",
-			Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
-		},
+		Name:        "test-deployment",
+		Namespace:   "test-namespace",
+		Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
 		Status: v1.DeploymentStatus{
 			Conditions: []v1.DeploymentCondition{
 				{
@@ -224,10 +212,8 @@ func TestWaitUntilReady_DifferentResourceName(t *testing.T) {
 	}
 
 	err := handler.deploymentWaiter.waitUntilReady(ctx, &v1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "not-matched-deployment",
-			Namespace: "test-namespace",
-		},
+		Name:      "not-matched-deployment",
+		Namespace: "test-namespace",
 	})
 
 	// It must be timed out because the name of the deployment does not match.
@@ -241,11 +227,9 @@ func TestGetPodsInDeployment(t *testing.T) {
 
 	// Create a Deployment object
 	deployment := &v1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-deployment",
-			Namespace:   "test-namespace",
-			Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
-		},
+		Name:        "test-deployment",
+		Namespace:   "test-namespace",
+		Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
 		Spec: v1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -257,51 +241,45 @@ func TestGetPodsInDeployment(t *testing.T) {
 
 	// Create a ReplicaSet object
 	replicaset := &v1.ReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-replicaset",
-			Namespace: "test-namespace",
-			Labels: map[string]string{
-				"app": "test-app",
-			},
-			Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
-			UID:         "1234",
+		Name:      "test-replicaset",
+		Namespace: "test-namespace",
+		Labels: map[string]string{
+			"app": "test-app",
 		},
+		Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
+		UID:         "1234",
 	}
 
 	// Create a Pod object
 	pod1 := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod1",
-			Namespace: "test-namespace",
-			Labels: map[string]string{
-				"app": "test-app",
-			},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Kind:       "ReplicaSet",
-					Name:       replicaset.Name,
-					Controller: new(true),
-					UID:        "1234",
-				},
+		Name:      "test-pod1",
+		Namespace: "test-namespace",
+		Labels: map[string]string{
+			"app": "test-app",
+		},
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				Kind:       "ReplicaSet",
+				Name:       replicaset.Name,
+				Controller: new(true),
+				UID:        "1234",
 			},
 		},
 	}
 
 	// Create a Pod object
 	pod2 := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod2",
-			Namespace: "test-namespace",
-			Labels: map[string]string{
-				"app": "doesnotmatch",
-			},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Kind:       "ReplicaSet",
-					Name:       "xyz",
-					Controller: new(true),
-					UID:        "1234",
-				},
+		Name:      "test-pod2",
+		Namespace: "test-namespace",
+		Labels: map[string]string{
+			"app": "doesnotmatch",
+		},
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				Kind:       "ReplicaSet",
+				Name:       "xyz",
+				Controller: new(true),
+				UID:        "1234",
 			},
 		},
 	}
@@ -334,57 +312,49 @@ func TestGetCurrentReplicaSetForDeployment(t *testing.T) {
 
 	// Create a Deployment object
 	deployment := &v1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-deployment",
-			Namespace:   "test-namespace",
-			Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
-		},
+		Name:        "test-deployment",
+		Namespace:   "test-namespace",
+		Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
 	}
 
 	// Create a ReplicaSet object with a higher revision than the other ReplicaSet
 	replicaSet1 := &v1.ReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-replicaset-1",
-			Namespace:   "test-namespace",
-			Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
-					Group:   v1.SchemeGroupVersion.Group,
-					Version: v1.SchemeGroupVersion.Version,
-					Kind:    "Deployment",
-				}),
-			},
+		Name:        "test-replicaset-1",
+		Namespace:   "test-namespace",
+		Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
+		OwnerReferences: []metav1.OwnerReference{
+			*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
+				Group:   v1.SchemeGroupVersion.Group,
+				Version: v1.SchemeGroupVersion.Version,
+				Kind:    "Deployment",
+			}),
 		},
 	}
 	// Create another ReplicaSet object with a lower revision than the other ReplicaSet
 	replicaSet2 := &v1.ReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-replicaset-2",
-			Namespace:   "test-namespace",
-			Annotations: map[string]string{"deployment.kubernetes.io/revision": "0"},
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
-					Group:   v1.SchemeGroupVersion.Group,
-					Version: v1.SchemeGroupVersion.Version,
-					Kind:    "Deployment",
-				}),
-			},
+		Name:        "test-replicaset-2",
+		Namespace:   "test-namespace",
+		Annotations: map[string]string{"deployment.kubernetes.io/revision": "0"},
+		OwnerReferences: []metav1.OwnerReference{
+			*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
+				Group:   v1.SchemeGroupVersion.Group,
+				Version: v1.SchemeGroupVersion.Version,
+				Kind:    "Deployment",
+			}),
 		},
 	}
 
 	// Create another ReplicaSet object with a higher revision than the other ReplicaSet
 	replicaSet3 := &v1.ReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-replicaset-3",
-			Namespace:   "test-namespace",
-			Annotations: map[string]string{"deployment.kubernetes.io/revision": "3"},
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
-					Group:   v1.SchemeGroupVersion.Group,
-					Version: v1.SchemeGroupVersion.Version,
-					Kind:    "Deployment",
-				}),
-			},
+		Name:        "test-replicaset-3",
+		Namespace:   "test-namespace",
+		Annotations: map[string]string{"deployment.kubernetes.io/revision": "3"},
+		OwnerReferences: []metav1.OwnerReference{
+			*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
+				Group:   v1.SchemeGroupVersion.Group,
+				Version: v1.SchemeGroupVersion.Version,
+				Kind:    "Deployment",
+			}),
 		},
 	}
 
@@ -415,11 +385,9 @@ func TestGetCurrentReplicaSetForDeployment(t *testing.T) {
 
 func TestCheckPodStatus(t *testing.T) {
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod",
-			Namespace: "test-namespace",
-		},
-		Status: corev1.PodStatus{},
+		Name:      "test-pod",
+		Namespace: "test-namespace",
+		Status:    corev1.PodStatus{},
 	}
 
 	podTests := []struct {
@@ -587,12 +555,10 @@ func TestCheckAllPodsReady_Success(t *testing.T) {
 
 	// Create a pod
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod",
-			Namespace: "test-namespace",
-			Labels: map[string]string{
-				"app": "test",
-			},
+		Name:      "test-pod",
+		Namespace: "test-namespace",
+		Labels: map[string]string{
+			"app": "test",
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -647,18 +613,16 @@ func TestCheckAllPodsReady_Fail(t *testing.T) {
 
 	// Create a pod
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod1",
-			Namespace: "test-namespace",
-			Labels: map[string]string{
-				"app": "test",
-			},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Kind:       "ReplicaSet",
-					Name:       replicaSet.Name,
-					Controller: new(true),
-				},
+		Name:      "test-pod1",
+		Namespace: "test-namespace",
+		Labels: map[string]string{
+			"app": "test",
+		},
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				Kind:       "ReplicaSet",
+				Name:       replicaSet.Name,
+				Controller: new(true),
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -712,18 +676,16 @@ func TestCheckDeploymentStatus_AllReady(t *testing.T) {
 
 	// Create a Pod object
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod1",
-			Namespace: "test-namespace",
-			Labels: map[string]string{
-				"app": "test",
-			},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Kind:       "ReplicaSet",
-					Name:       replicaSet.Name,
-					Controller: new(true),
-				},
+		Name:      "test-pod1",
+		Namespace: "test-namespace",
+		Labels: map[string]string{
+			"app": "test",
+		},
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				Kind:       "ReplicaSet",
+				Name:       replicaSet.Name,
+				Controller: new(true),
 			},
 		},
 		Status: corev1.PodStatus{
@@ -789,12 +751,10 @@ func TestCheckDeploymentStatus_NoReplicaSetsFound(t *testing.T) {
 
 	// Create a Pod object
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod1",
-			Namespace: "test-namespace",
-			Labels: map[string]string{
-				"app": "test",
-			},
+		Name:      "test-pod1",
+		Namespace: "test-namespace",
+		Labels: map[string]string{
+			"app": "test",
 		},
 		Status: corev1.PodStatus{
 			Conditions: []corev1.PodCondition{
@@ -862,18 +822,16 @@ func TestCheckDeploymentStatus_PodsNotReady(t *testing.T) {
 
 	// Create a Pod object
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod1",
-			Namespace: "test-namespace",
-			Labels: map[string]string{
-				"app": "test",
-			},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Kind:       "ReplicaSet",
-					Name:       replicaSet.Name,
-					Controller: new(true),
-				},
+		Name:      "test-pod1",
+		Namespace: "test-namespace",
+		Labels: map[string]string{
+			"app": "test",
+		},
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				Kind:       "ReplicaSet",
+				Name:       replicaSet.Name,
+				Controller: new(true),
 			},
 		},
 		Status: corev1.PodStatus{
@@ -947,18 +905,16 @@ func TestCheckDeploymentStatus_ObservedGenerationMismatch(t *testing.T) {
 
 	// Create a Pod object
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod1",
-			Namespace: "test-namespace",
-			Labels: map[string]string{
-				"app": "test",
-			},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Kind:       "ReplicaSet",
-					Name:       replicaSet.Name,
-					Controller: new(true),
-				},
+		Name:      "test-pod1",
+		Namespace: "test-namespace",
+		Labels: map[string]string{
+			"app": "test",
+		},
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				Kind:       "ReplicaSet",
+				Name:       replicaSet.Name,
+				Controller: new(true),
 			},
 		},
 		Status: corev1.PodStatus{
@@ -1025,18 +981,16 @@ func TestCheckDeploymentStatus_DeploymentNotProgressing(t *testing.T) {
 
 	// Create a Pod object
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod1",
-			Namespace: "test-namespace",
-			Labels: map[string]string{
-				"app": "test",
-			},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Kind:       "ReplicaSet",
-					Name:       replicaSet.Name,
-					Controller: new(true),
-				},
+		Name:      "test-pod1",
+		Namespace: "test-namespace",
+		Labels: map[string]string{
+			"app": "test",
+		},
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				Kind:       "ReplicaSet",
+				Name:       replicaSet.Name,
+				Controller: new(true),
 			},
 		},
 		Status: corev1.PodStatus{

--- a/pkg/corerp/handlers/kubernetes_http_proxy_waiter_test.go
+++ b/pkg/corerp/handlers/kubernetes_http_proxy_waiter_test.go
@@ -23,7 +23,6 @@ import (
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/radius-project/radius/pkg/kubernetes"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic/dynamicinformer"
@@ -136,10 +135,8 @@ func TestHTTPProxyWaiter_WaitUntilReadyTimeoutGetsNamespacedHTTPProxy(t *testing
 	httpProxy.Status = contourv1.HTTPProxyStatus{
 		Conditions: []contourv1.DetailedCondition{
 			{
-				Condition: metav1.Condition{
-					Message: "still reconciling",
-					Reason:  "Waiting",
-				},
+				Message: "still reconciling",
+				Reason:  "Waiting",
 			},
 		},
 	}
@@ -163,13 +160,11 @@ func TestHTTPProxyWaiter_WaitUntilReadyTimeoutGetsNamespacedHTTPProxy(t *testing
 func TestCheckHTTPProxyStatus_ValidStatus(t *testing.T) {
 
 	httpProxy := &contourv1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "example.com",
-			Labels: map[string]string{
-				kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
-				kubernetes.LabelName:      "example.com",
-			},
+		Namespace: "default",
+		Name:      "example.com",
+		Labels: map[string]string{
+			kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
+			kubernetes.LabelName:      "example.com",
 		},
 		Status: contourv1.HTTPProxyStatus{
 			CurrentStatus: HTTPProxyStatusValid,
@@ -188,10 +183,8 @@ func TestCheckHTTPProxyStatus_ValidStatus(t *testing.T) {
 
 	// create a mock object
 	obj := &contourv1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "example.com",
-		},
+		Namespace: "default",
+		Name:      "example.com",
 	}
 
 	// create a channel for the done signal
@@ -252,13 +245,11 @@ func TestCheckHTTPProxyStatus_ValidRootProxyWithOverriddenLabels(t *testing.T) {
 func TestCheckHTTPProxyStatus_InvalidStatusForRootProxy(t *testing.T) {
 
 	httpProxy := &contourv1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "example.com",
-			Labels: map[string]string{
-				kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
-				kubernetes.LabelName:      "example.com",
-			},
+		Namespace: "default",
+		Name:      "example.com",
+		Labels: map[string]string{
+			kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
+			kubernetes.LabelName:      "example.com",
 		},
 		Spec: contourv1.HTTPProxySpec{
 			VirtualHost: &contourv1.VirtualHost{
@@ -277,10 +268,8 @@ func TestCheckHTTPProxyStatus_InvalidStatusForRootProxy(t *testing.T) {
 			Conditions: []contourv1.DetailedCondition{
 				{
 					// specify Condition of type json
-					Condition: metav1.Condition{
-						Type:   HTTPProxyConditionValid,
-						Status: contourv1.ConditionFalse,
-					},
+					Type:   HTTPProxyConditionValid,
+					Status: contourv1.ConditionFalse,
 					Errors: []contourv1.SubCondition{
 						{
 							Type:    HTTPProxyConditionValid,
@@ -306,10 +295,8 @@ func TestCheckHTTPProxyStatus_InvalidStatusForRootProxy(t *testing.T) {
 
 	// create a mock object
 	obj := &contourv1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "example.com",
-		},
+		Namespace: "default",
+		Name:      "example.com",
 	}
 
 	// create a channel for the done signal
@@ -380,13 +367,11 @@ func TestCheckHTTPProxyStatus_InvalidStatusForRootProxyWithRoutes(t *testing.T) 
 
 func TestCheckHTTPProxyStatus_InvalidStatusForRouteProxy(t *testing.T) {
 	httpProxyRoute := &contourv1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "example.com",
-			Labels: map[string]string{
-				kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
-				kubernetes.LabelName:      "example.com",
-			},
+		Namespace: "default",
+		Name:      "example.com",
+		Labels: map[string]string{
+			kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
+			kubernetes.LabelName:      "example.com",
 		},
 		Spec: contourv1.HTTPProxySpec{
 			Routes: []contourv1.Route{
@@ -411,10 +396,8 @@ func TestCheckHTTPProxyStatus_InvalidStatusForRouteProxy(t *testing.T) {
 			Conditions: []contourv1.DetailedCondition{
 				{
 					// specify Condition of type json
-					Condition: metav1.Condition{
-						Type:   HTTPProxyConditionValid,
-						Status: contourv1.ConditionFalse,
-					},
+					Type:   HTTPProxyConditionValid,
+					Status: contourv1.ConditionFalse,
 					Errors: []contourv1.SubCondition{
 						{
 							Type:    HTTPProxyConditionValid,
@@ -440,10 +423,8 @@ func TestCheckHTTPProxyStatus_InvalidStatusForRouteProxy(t *testing.T) {
 
 	// create a mock object
 	obj := &contourv1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "example.com",
-		},
+		Namespace: "default",
+		Name:      "example.com",
 	}
 
 	// create a channel for the done signal
@@ -466,13 +447,11 @@ func TestCheckHTTPProxyStatus_InvalidStatusForRouteProxy(t *testing.T) {
 func TestCheckHTTPProxyStatus_WrongName(t *testing.T) {
 
 	httpProxy := &contourv1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "abcd.com",
-			Labels: map[string]string{
-				kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
-				kubernetes.LabelName:      "abcd.com",
-			},
+		Namespace: "default",
+		Name:      "abcd.com",
+		Labels: map[string]string{
+			kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
+			kubernetes.LabelName:      "abcd.com",
 		},
 		Spec: contourv1.HTTPProxySpec{
 			VirtualHost: &contourv1.VirtualHost{
@@ -491,10 +470,8 @@ func TestCheckHTTPProxyStatus_WrongName(t *testing.T) {
 			Conditions: []contourv1.DetailedCondition{
 				{
 					// specify Condition of type json
-					Condition: metav1.Condition{
-						Type:   HTTPProxyConditionValid,
-						Status: contourv1.ConditionFalse,
-					},
+					Type:   HTTPProxyConditionValid,
+					Status: contourv1.ConditionFalse,
 					Errors: []contourv1.SubCondition{
 						{
 							Type:    HTTPProxyConditionValid,
@@ -521,10 +498,8 @@ func TestCheckHTTPProxyStatus_WrongName(t *testing.T) {
 
 	// create a mock object
 	obj := &contourv1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "example.com",
-		},
+		Namespace: "default",
+		Name:      "example.com",
 	}
 
 	// create a channel for the done signal
@@ -545,14 +520,10 @@ func TestCheckHTTPProxyStatus_WrongName(t *testing.T) {
 
 func newTestHTTPProxy(spec contourv1.HTTPProxySpec) *contourv1.HTTPProxy {
 	return &contourv1.HTTPProxy{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: contourv1.SchemeGroupVersion.String(),
-			Kind:       "HTTPProxy",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "example.com",
-		},
-		Spec: spec,
+		APIVersion: contourv1.SchemeGroupVersion.String(),
+		Kind:       "HTTPProxy",
+		Namespace:  "default",
+		Name:       "example.com",
+		Spec:       spec,
 	}
 }

--- a/pkg/corerp/handlers/kubernetes_test.go
+++ b/pkg/corerp/handlers/kubernetes_test.go
@@ -56,14 +56,10 @@ func TestPut(t *testing.T) {
 							Type:     "core/Secret",
 						},
 						Data: &corev1.Secret{
-							TypeMeta: metav1.TypeMeta{
-								Kind:       "Secret",
-								APIVersion: "core/v1",
-							},
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "test-secret",
-								Namespace: "test-namespace",
-							},
+							Kind:       "Secret",
+							APIVersion: "core/v1",
+							Name:       "test-secret",
+							Namespace:  "test-namespace",
 						},
 					},
 				},
@@ -128,14 +124,10 @@ func TestPut(t *testing.T) {
 func TestPut_ContourHTTPProxyRouteChildSkipsWait(t *testing.T) {
 	ctx := t.Context()
 	httpProxy := &contourv1.HTTPProxy{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: contourv1.SchemeGroupVersion.String(),
-			Kind:       "HTTPProxy",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "route-proxy",
-			Namespace: "test-namespace",
-		},
+		APIVersion: contourv1.SchemeGroupVersion.String(),
+		Kind:       "HTTPProxy",
+		Name:       "route-proxy",
+		Namespace:  "test-namespace",
 		Spec: contourv1.HTTPProxySpec{
 			Routes: []contourv1.Route{
 				{
@@ -177,14 +169,10 @@ func TestPut_ContourHTTPProxyRouteChildSkipsWait(t *testing.T) {
 func TestPut_ContourHTTPProxyRootWaits(t *testing.T) {
 	ctx := t.Context()
 	httpProxy := &contourv1.HTTPProxy{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: contourv1.SchemeGroupVersion.String(),
-			Kind:       "HTTPProxy",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "root-proxy",
-			Namespace: "test-namespace",
-		},
+		APIVersion: contourv1.SchemeGroupVersion.String(),
+		Kind:       "HTTPProxy",
+		Name:       "root-proxy",
+		Namespace:  "test-namespace",
 		Spec: contourv1.HTTPProxySpec{
 			VirtualHost: &contourv1.VirtualHost{
 				Fqdn: "example.com",
@@ -264,14 +252,10 @@ func TestDelete(t *testing.T) {
 	ctx := t.Context()
 	// Create first deployment that will be watched
 	deployment := &v1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Deployment",
-			APIVersion: "apps/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-deployment",
-			Namespace: "test-namespace",
-		},
+		Kind:       "Deployment",
+		APIVersion: "apps/v1",
+		Name:       "test-deployment",
+		Namespace:  "test-namespace",
 	}
 
 	dc := &k8sutil.DiscoveryClient{
@@ -333,10 +317,8 @@ func TestConvertToUnstructured(t *testing.T) {
 						Type:     "apps/Deployment",
 					},
 					Data: &v1.Deployment{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-deployment",
-							Namespace: "test-namespace",
-						},
+						Name:      "test-deployment",
+						Namespace: "test-namespace",
 					},
 				},
 			},
@@ -369,10 +351,8 @@ func TestConvertToUnstructured(t *testing.T) {
 						Type:     "apps/Deployment",
 					},
 					Data: &v1.Deployment{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-deployment",
-							Namespace: "test-namespace",
-						},
+						Name:      "test-deployment",
+						Namespace: "test-namespace",
 					},
 				},
 			},

--- a/pkg/corerp/renderers/container/azure/fileshare.go
+++ b/pkg/corerp/renderers/container/azure/fileshare.go
@@ -29,8 +29,8 @@ import (
 // TODO: This is unused code now. We will enable file share later.
 func MakeAzureFileShareVolumeSpec(volumeName string, persistentVolume *datamodel.PersistentVolume, applicationName string, options renderers.RenderOptions) (corev1.Volume, corev1.VolumeMount, error) { //nolint:all
 	// Make volume spec
-	volumeSpec := corev1.Volume{}
-	volumeSpec.Name = volumeName
+	volumeSpec := corev1.Volume{
+		Name: volumeName}
 	volumeSpec.VolumeSource.AzureFile = &corev1.AzureFileVolumeSource{}
 	volumeSpec.AzureFile.SecretName = applicationName
 	resourceID, err := resources.ParseResource(persistentVolume.Source)
@@ -41,8 +41,8 @@ func MakeAzureFileShareVolumeSpec(volumeName string, persistentVolume *datamodel
 	volumeSpec.AzureFile.ShareName = shareName
 
 	// Make volumeMount spec
-	volumeMountSpec := corev1.VolumeMount{}
-	volumeMountSpec.Name = volumeName
+	volumeMountSpec := corev1.VolumeMount{
+		Name: volumeName}
 	if persistentVolume != nil && persistentVolume.Permission == datamodel.VolumePermissionRead {
 		volumeMountSpec.MountPath = persistentVolume.MountPath
 		volumeMountSpec.ReadOnly = true

--- a/pkg/corerp/renderers/container/azure/identity_test.go
+++ b/pkg/corerp/renderers/container/azure/identity_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -104,15 +103,11 @@ func TestMakeRoleAssignments(t *testing.T) {
 
 func TestSetWorkloadIdentityServiceAccount(t *testing.T) {
 	base := &corev1.ServiceAccount{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ServiceAccount",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-cntr",
-			Labels:      map[string]string{},
-			Annotations: map[string]string{},
-		},
+		Kind:        "ServiceAccount",
+		APIVersion:  "v1",
+		Name:        "test-cntr",
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
 	}
 
 	fi := SetWorkloadIdentityServiceAccount(base)

--- a/pkg/corerp/renderers/container/azure/keyvaultvolume.go
+++ b/pkg/corerp/renderers/container/azure/keyvaultvolume.go
@@ -28,7 +28,6 @@ import (
 	"github.com/radius-project/radius/pkg/ucp/resources"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	csiv1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 )
 
@@ -43,14 +42,12 @@ func MakeKeyVaultVolumeSpec(volumeName string, mountPath, spcName string) (corev
 	// Make Volume Spec which uses the SecretProvider created above
 	volumeSpec := corev1.Volume{
 		Name: volumeName,
-		VolumeSource: corev1.VolumeSource{
-			CSI: &corev1.CSIVolumeSource{
-				Driver: "secrets-store.csi.k8s.io",
-				// We will support only Read operations
-				ReadOnly: new(true),
-				VolumeAttributes: map[string]string{
-					"secretProviderClass": spcName,
-				},
+		CSI: &corev1.CSIVolumeSource{
+			Driver: "secrets-store.csi.k8s.io",
+			// We will support only Read operations
+			ReadOnly: new(true),
+			VolumeAttributes: map[string]string{
+				"secretProviderClass": spcName,
 			},
 		},
 	}
@@ -112,17 +109,13 @@ func MakeKeyVaultSecretProviderClass(appName, name string, res *datamodel.Volume
 	}
 
 	secretProvider := &csiv1.SecretProviderClass{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "SecretProviderClass",
-			APIVersion: "secrets-store.csi.x-k8s.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      kubernetes.NormalizeResourceName(name),
-			Namespace: envOpt.Namespace,
-			Labels:    kubernetes.MakeDescriptiveLabels(appName, res.Name, res.Type),
-			Annotations: map[string]string{
-				kubernetes.AnnotationIdentityType: string(envOpt.Identity.Kind),
-			},
+		Kind:       "SecretProviderClass",
+		APIVersion: "secrets-store.csi.x-k8s.io/v1",
+		Name:       kubernetes.NormalizeResourceName(name),
+		Namespace:  envOpt.Namespace,
+		Labels:     kubernetes.MakeDescriptiveLabels(appName, res.Name, res.Type),
+		Annotations: map[string]string{
+			kubernetes.AnnotationIdentityType: string(envOpt.Identity.Kind),
 		},
 		Spec: csiv1.SecretProviderClassSpec{
 			Provider:   "azure",

--- a/pkg/corerp/renderers/container/azure/keyvaultvolume_test.go
+++ b/pkg/corerp/renderers/container/azure/keyvaultvolume_test.go
@@ -19,7 +19,6 @@ package azure
 import (
 	"testing"
 
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/corerp/datamodel"
 	"github.com/radius-project/radius/pkg/corerp/handlers"
 	"github.com/radius-project/radius/pkg/corerp/renderers"
@@ -37,13 +36,11 @@ func TestMakeKeyVaultVolumeSpec(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, corev1.Volume{
 		Name: "kvvol",
-		VolumeSource: corev1.VolumeSource{
-			CSI: &corev1.CSIVolumeSource{
-				Driver:   "secrets-store.csi.k8s.io",
-				ReadOnly: new(true),
-				VolumeAttributes: map[string]string{
-					"secretProviderClass": "azkv",
-				},
+		CSI: &corev1.CSIVolumeSource{
+			Driver:   "secrets-store.csi.k8s.io",
+			ReadOnly: new(true),
+			VolumeAttributes: map[string]string{
+				"secretProviderClass": "azkv",
 			},
 		},
 	}, v)
@@ -97,12 +94,8 @@ func TestMakeKeyVaultSecretProviderClass(t *testing.T) {
 	}
 
 	vol := &datamodel.VolumeResource{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				Name: "test-cntr",
-				Type: "applications.core/volumes",
-			},
-		},
+		Name: "test-cntr",
+		Type: "applications.core/volumes",
 		Properties: datamodel.VolumeResourceProperties{
 			Kind: datamodel.AzureKeyVaultVolume,
 			AzureKeyVault: &datamodel.AzureKeyVaultVolumeProperties{

--- a/pkg/corerp/renderers/container/manifest.go
+++ b/pkg/corerp/renderers/container/manifest.go
@@ -62,10 +62,8 @@ func getDeploymentBase(manifest kubeutil.ObjectManifest, appName string, r *data
 	name := kubernetes.NormalizeResourceName(r.Name)
 
 	defaultDeployment := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Deployment",
-			APIVersion: "apps/v1",
-		},
+		Kind:       "Deployment",
+		APIVersion: "apps/v1",
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{},
 			Template: corev1.PodTemplateSpec{
@@ -125,10 +123,8 @@ func getDeploymentBase(manifest kubeutil.ObjectManifest, appName string, r *data
 // Otherwise, populate default resources.
 func getServiceBase(manifest kubeutil.ObjectManifest, appName string, r *datamodel.ContainerResource, options *renderers.RenderOptions) *corev1.Service {
 	defaultService := &corev1.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
+		Kind:       "Service",
+		APIVersion: "v1",
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{},
 			Type:     corev1.ServiceTypeClusterIP,
@@ -146,10 +142,8 @@ func getServiceBase(manifest kubeutil.ObjectManifest, appName string, r *datamod
 // Otherwise, populate default resources.
 func getServiceAccountBase(manifest kubeutil.ObjectManifest, appName string, r *datamodel.ContainerResource, options *renderers.RenderOptions) *corev1.ServiceAccount {
 	defaultAccount := &corev1.ServiceAccount{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ServiceAccount",
-			APIVersion: "v1",
-		},
+		Kind:       "ServiceAccount",
+		APIVersion: "v1",
 	}
 
 	if resource := manifest.GetFirst(corev1.SchemeGroupVersion.WithKind("ServiceAccount")); resource != nil {

--- a/pkg/corerp/renderers/container/manifest_test.go
+++ b/pkg/corerp/renderers/container/manifest_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/corerp/datamodel"
 	"github.com/radius-project/radius/pkg/corerp/renderers"
 	"github.com/radius-project/radius/pkg/kubeutil"
@@ -37,13 +36,9 @@ import (
 
 var (
 	testResource = &datamodel.ContainerResource{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   "/subscriptions/test-sub-id/resourceGroups/test-group/providers/Applications.Core/containers/test-container",
-				Name: "test-container",
-				Type: "Applications.Core/containers",
-			},
-		},
+		ID:   "/subscriptions/test-sub-id/resourceGroups/test-group/providers/Applications.Core/containers/test-container",
+		Name: "test-container",
+		Type: "Applications.Core/containers",
 	}
 	testOptions = &renderers.RenderOptions{Environment: renderers.EnvironmentOptions{Namespace: "test-ns"}}
 )
@@ -269,23 +264,19 @@ func TestGetDeploymentBase(t *testing.T) {
 			name:     "without base manifest",
 			manifest: kubeutil.ObjectManifest{},
 			expected: &appsv1.Deployment{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Deployment",
-					APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "test-container",
+				Namespace:  "test-ns",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "radius-rp",
+					"app.kubernetes.io/name":       "test-container",
+					"app.kubernetes.io/part-of":    "test",
+					"radapp.io/application":        "test",
+					"radapp.io/resource":           "test-container",
+					"radapp.io/resource-type":      "applications.core-containers",
 				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-container",
-					Namespace: "test-ns",
-					Labels: map[string]string{
-						"app.kubernetes.io/managed-by": "radius-rp",
-						"app.kubernetes.io/name":       "test-container",
-						"app.kubernetes.io/part-of":    "test",
-						"radapp.io/application":        "test",
-						"radapp.io/resource":           "test-container",
-						"radapp.io/resource-type":      "applications.core-containers",
-					},
-					Annotations: map[string]string{},
-				},
+				Annotations: map[string]string{},
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{},
 					Template: corev1.PodTemplateSpec{
@@ -309,18 +300,14 @@ func TestGetDeploymentBase(t *testing.T) {
 			manifest: kubeutil.ObjectManifest{
 				appsv1.SchemeGroupVersion.WithKind("Deployment"): []runtime.Object{
 					&appsv1.Deployment{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "Deployment",
-							APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						APIVersion: "apps/v1",
+						Name:       "test-container",
+						Labels: map[string]string{
+							"label0": "value0",
 						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-container",
-							Labels: map[string]string{
-								"label0": "value0",
-							},
-							Annotations: map[string]string{
-								"annotation0": "value0",
-							},
+						Annotations: map[string]string{
+							"annotation0": "value0",
 						},
 						Spec: appsv1.DeploymentSpec{
 							Selector: &metav1.LabelSelector{},
@@ -342,25 +329,21 @@ func TestGetDeploymentBase(t *testing.T) {
 				},
 			},
 			expected: &appsv1.Deployment{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Deployment",
-					APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "test-container",
+				Namespace:  "test-ns",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "radius-rp",
+					"app.kubernetes.io/name":       "test-container",
+					"app.kubernetes.io/part-of":    "test",
+					"label0":                       "value0",
+					"radapp.io/application":        "test",
+					"radapp.io/resource":           "test-container",
+					"radapp.io/resource-type":      "applications.core-containers",
 				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-container",
-					Namespace: "test-ns",
-					Labels: map[string]string{
-						"app.kubernetes.io/managed-by": "radius-rp",
-						"app.kubernetes.io/name":       "test-container",
-						"app.kubernetes.io/part-of":    "test",
-						"label0":                       "value0",
-						"radapp.io/application":        "test",
-						"radapp.io/resource":           "test-container",
-						"radapp.io/resource-type":      "applications.core-containers",
-					},
-					Annotations: map[string]string{
-						"annotation0": "value0",
-					},
+				Annotations: map[string]string{
+					"annotation0": "value0",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{},
@@ -403,23 +386,19 @@ func TestGetServiceBase(t *testing.T) {
 			name:     "without base manifest",
 			manifest: kubeutil.ObjectManifest{},
 			expected: &corev1.Service{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Service",
-					APIVersion: "v1",
+				Kind:       "Service",
+				APIVersion: "v1",
+				Name:       "test-container",
+				Namespace:  "test-ns",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "radius-rp",
+					"app.kubernetes.io/name":       "test-container",
+					"app.kubernetes.io/part-of":    "test",
+					"radapp.io/application":        "test",
+					"radapp.io/resource":           "test-container",
+					"radapp.io/resource-type":      "applications.core-containers",
 				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-container",
-					Namespace: "test-ns",
-					Labels: map[string]string{
-						"app.kubernetes.io/managed-by": "radius-rp",
-						"app.kubernetes.io/name":       "test-container",
-						"app.kubernetes.io/part-of":    "test",
-						"radapp.io/application":        "test",
-						"radapp.io/resource":           "test-container",
-						"radapp.io/resource-type":      "applications.core-containers",
-					},
-					Annotations: map[string]string{},
-				},
+				Annotations: map[string]string{},
 				Spec: corev1.ServiceSpec{
 					Selector: map[string]string{},
 					Type:     corev1.ServiceTypeClusterIP,
@@ -431,18 +410,14 @@ func TestGetServiceBase(t *testing.T) {
 			manifest: kubeutil.ObjectManifest{
 				corev1.SchemeGroupVersion.WithKind("Service"): []runtime.Object{
 					&corev1.Service{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "Service",
-							APIVersion: "v1",
+						Kind:       "Service",
+						APIVersion: "v1",
+						Name:       "test-container",
+						Labels: map[string]string{
+							"label0": "value0",
 						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-container",
-							Labels: map[string]string{
-								"label0": "value0",
-							},
-							Annotations: map[string]string{
-								"annotation0": "value0",
-							},
+						Annotations: map[string]string{
+							"annotation0": "value0",
 						},
 						Spec: corev1.ServiceSpec{
 							Selector: map[string]string{},
@@ -451,25 +426,21 @@ func TestGetServiceBase(t *testing.T) {
 				},
 			},
 			expected: &corev1.Service{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Service",
-					APIVersion: "v1",
+				Kind:       "Service",
+				APIVersion: "v1",
+				Name:       "test-container",
+				Namespace:  "test-ns",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "radius-rp",
+					"app.kubernetes.io/name":       "test-container",
+					"app.kubernetes.io/part-of":    "test",
+					"label0":                       "value0",
+					"radapp.io/application":        "test",
+					"radapp.io/resource":           "test-container",
+					"radapp.io/resource-type":      "applications.core-containers",
 				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-container",
-					Namespace: "test-ns",
-					Labels: map[string]string{
-						"app.kubernetes.io/managed-by": "radius-rp",
-						"app.kubernetes.io/name":       "test-container",
-						"app.kubernetes.io/part-of":    "test",
-						"label0":                       "value0",
-						"radapp.io/application":        "test",
-						"radapp.io/resource":           "test-container",
-						"radapp.io/resource-type":      "applications.core-containers",
-					},
-					Annotations: map[string]string{
-						"annotation0": "value0",
-					},
+				Annotations: map[string]string{
+					"annotation0": "value0",
 				},
 				Spec: corev1.ServiceSpec{
 					Selector: map[string]string{},
@@ -496,23 +467,19 @@ func TestGetServiceAccountBase(t *testing.T) {
 			name:     "without base manifest",
 			manifest: kubeutil.ObjectManifest{},
 			expected: &corev1.ServiceAccount{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "ServiceAccount",
-					APIVersion: "v1",
+				Kind:       "ServiceAccount",
+				APIVersion: "v1",
+				Name:       "test-container",
+				Namespace:  "test-ns",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "radius-rp",
+					"app.kubernetes.io/name":       "test-container",
+					"app.kubernetes.io/part-of":    "test",
+					"radapp.io/application":        "test",
+					"radapp.io/resource":           "test-container",
+					"radapp.io/resource-type":      "applications.core-containers",
 				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-container",
-					Namespace: "test-ns",
-					Labels: map[string]string{
-						"app.kubernetes.io/managed-by": "radius-rp",
-						"app.kubernetes.io/name":       "test-container",
-						"app.kubernetes.io/part-of":    "test",
-						"radapp.io/application":        "test",
-						"radapp.io/resource":           "test-container",
-						"radapp.io/resource-type":      "applications.core-containers",
-					},
-					Annotations: map[string]string{},
-				},
+				Annotations: map[string]string{},
 			},
 		},
 		{
@@ -520,42 +487,34 @@ func TestGetServiceAccountBase(t *testing.T) {
 			manifest: kubeutil.ObjectManifest{
 				corev1.SchemeGroupVersion.WithKind("ServiceAccount"): []runtime.Object{
 					&corev1.ServiceAccount{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "ServiceAccount",
-							APIVersion: "v1",
+						Kind:       "ServiceAccount",
+						APIVersion: "v1",
+						Name:       "test-container",
+						Labels: map[string]string{
+							"label0": "value0",
 						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test-container",
-							Labels: map[string]string{
-								"label0": "value0",
-							},
-							Annotations: map[string]string{
-								"annotation0": "value0",
-							},
+						Annotations: map[string]string{
+							"annotation0": "value0",
 						},
 					},
 				},
 			},
 			expected: &corev1.ServiceAccount{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "ServiceAccount",
-					APIVersion: "v1",
+				Kind:       "ServiceAccount",
+				APIVersion: "v1",
+				Name:       "test-container",
+				Namespace:  "test-ns",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "radius-rp",
+					"app.kubernetes.io/name":       "test-container",
+					"app.kubernetes.io/part-of":    "test",
+					"label0":                       "value0",
+					"radapp.io/application":        "test",
+					"radapp.io/resource":           "test-container",
+					"radapp.io/resource-type":      "applications.core-containers",
 				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-container",
-					Namespace: "test-ns",
-					Labels: map[string]string{
-						"app.kubernetes.io/managed-by": "radius-rp",
-						"app.kubernetes.io/name":       "test-container",
-						"app.kubernetes.io/part-of":    "test",
-						"label0":                       "value0",
-						"radapp.io/application":        "test",
-						"radapp.io/resource":           "test-container",
-						"radapp.io/resource-type":      "applications.core-containers",
-					},
-					Annotations: map[string]string{
-						"annotation0": "value0",
-					},
+				Annotations: map[string]string{
+					"annotation0": "value0",
 				},
 			},
 		},

--- a/pkg/corerp/renderers/container/rbac.go
+++ b/pkg/corerp/renderers/container/rbac.go
@@ -18,7 +18,6 @@ package container
 
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/radius-project/radius/pkg/corerp/datamodel"
 	"github.com/radius-project/radius/pkg/kubernetes"
@@ -29,15 +28,11 @@ func makeRBACRole(appName, name, namespace string, resource *datamodel.Container
 	labels := kubernetes.MakeDescriptiveLabels(appName, resource.Name, resource.Type)
 
 	role := &rbacv1.Role{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Role",
-			APIVersion: "rbac.authorization.k8s.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      kubernetes.NormalizeResourceName(name),
-			Namespace: namespace,
-			Labels:    labels,
-		},
+		Kind:       "Role",
+		APIVersion: "rbac.authorization.k8s.io/v1",
+		Name:       kubernetes.NormalizeResourceName(name),
+		Namespace:  namespace,
+		Labels:     labels,
 		// At this time, we support only secret rbac permission for the namespace.
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -57,15 +52,11 @@ func makeRBACRoleBinding(appName, name, saName, namespace string, resource *data
 	labels := kubernetes.MakeDescriptiveLabels(appName, resource.Name, resource.Type)
 
 	bindings := &rbacv1.RoleBinding{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "RoleBinding",
-			APIVersion: "rbac.authorization.k8s.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      kubernetes.NormalizeResourceName(name),
-			Namespace: namespace,
-			Labels:    labels,
-		},
+		Kind:       "RoleBinding",
+		APIVersion: "rbac.authorization.k8s.io/v1",
+		Name:       kubernetes.NormalizeResourceName(name),
+		Namespace:  namespace,
+		Labels:     labels,
 		RoleRef: rbacv1.RoleRef{
 			Kind:     "Role",
 			Name:     kubernetes.NormalizeResourceName(name),

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -670,10 +670,8 @@ func convertEnvVar(key string, env datamodel.EnvironmentVariable, options render
 				Name: key,
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: name,
-						},
-						Key: env.ValueFrom.SecretRef.Key,
+						Name: name,
+						Key:  env.ValueFrom.SecretRef.Key,
 					},
 				},
 			}, nil
@@ -683,10 +681,8 @@ func convertEnvVar(key string, env datamodel.EnvironmentVariable, options render
 				Name: key,
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: env.ValueFrom.SecretRef.Source,
-						},
-						Key: env.ValueFrom.SecretRef.Key,
+						Name: env.ValueFrom.SecretRef.Source,
+						Key:  env.ValueFrom.SecretRef.Key,
 					},
 				},
 			}, nil
@@ -759,10 +755,8 @@ func updateEnvAndSecretData(connName string, resourceName string, environmentVar
 		}
 		source := corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: kubernetes.NormalizeResourceName(resourceName),
-				},
-				Key: name,
+				Name: kubernetes.NormalizeResourceName(resourceName),
+				Key:  name,
 			},
 		}
 
@@ -895,17 +889,13 @@ func (r Renderer) setContainerHealthProbeConfig(probeSpec *corev1.Probe, config 
 
 func (r Renderer) makeSecret(resource datamodel.ContainerResource, applicationName string, secrets map[string][]byte, options renderers.RenderOptions) rpv1.OutputResource {
 	secret := corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: corev1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      kubernetes.NormalizeResourceName(resource.Name),
-			Namespace: options.Environment.Namespace,
-			Labels:    kubernetes.MakeDescriptiveLabels(applicationName, resource.Name, resource.ResourceTypeName()),
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: secrets,
+		Kind:       "Secret",
+		APIVersion: corev1.SchemeGroupVersion.String(),
+		Name:       kubernetes.NormalizeResourceName(resource.Name),
+		Namespace:  options.Environment.Namespace,
+		Labels:     kubernetes.MakeDescriptiveLabels(applicationName, resource.Name, resource.ResourceTypeName()),
+		Type:       corev1.SecretTypeOpaque,
+		Data:       secrets,
 	}
 
 	output := rpv1.NewKubernetesOutputResource(rpv1.LocalIDSecret, &secret, secret.ObjectMeta)

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	apiv1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/corerp/datamodel"
 	"github.com/radius-project/radius/pkg/corerp/handlers"
 	"github.com/radius-project/radius/pkg/corerp/renderers"
@@ -103,13 +102,9 @@ var (
 
 func makeResource(properties datamodel.ContainerProperties) *datamodel.ContainerResource {
 	resource := datamodel.ContainerResource{
-		BaseResource: apiv1.BaseResource{
-			TrackedResource: apiv1.TrackedResource{
-				ID:   "/subscriptions/test-sub-id/resourceGroups/test-group/providers/Applications.Core/containers/test-container",
-				Name: resourceName,
-				Type: "Applications.Core/containers",
-			},
-		},
+		ID:         "/subscriptions/test-sub-id/resourceGroups/test-group/providers/Applications.Core/containers/test-container",
+		Name:       resourceName,
+		Type:       "Applications.Core/containers",
 		Properties: properties,
 	}
 	return &resource
@@ -149,15 +144,9 @@ func makeRadiusResourceID(t *testing.T, resourceType string, resourceName string
 
 func makeDynamicResource() *dynamicrp_dm.DynamicResource {
 	return &dynamicrp_dm.DynamicResource{
-		BaseResource: apiv1.BaseResource{
-			TrackedResource: apiv1.TrackedResource{
-				ID:   "/planes/radius/local/resourceGroups/test-resourcegroup/providers/Applications.Test/testType/test-resource",
-				Type: "Applications.Test/testType",
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion: "2024-01-01",
-			},
-		},
+		ID:                "/planes/radius/local/resourceGroups/test-resourcegroup/providers/Applications.Test/testType/test-resource",
+		Type:              "Applications.Test/testType",
+		UpdatedAPIVersion: "2024-01-01",
 		Properties: map[string]any{
 			"property1": "value1",
 			"property2": 2,
@@ -171,9 +160,7 @@ func Test_GetDependencyIDs_Success(t *testing.T) {
 	testStorageResourceID := "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Microsoft.Storage/storageaccounts/testaccount/fileservices/default/shares/testShareName"
 	testAzureResourceID := makeAzureResourceID(t, "Microsoft.ServiceBus/namespaces", "testAzureResource")
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Connections: map[string]datamodel.ConnectionProperties{
 			"A": {
 				Source: makeRadiusResourceID(t, "Applications.Datastores/redisCaches", "A").String(),
@@ -239,10 +226,8 @@ func Test_GetDependencyIDs_Success(t *testing.T) {
 				"vol1": {
 					Kind: datamodel.Persistent,
 					Persistent: &datamodel.PersistentVolume{
-						VolumeBase: datamodel.VolumeBase{
-							MountPath: "/tmpfs",
-						},
-						Source: testStorageResourceID,
+						MountPath: "/tmpfs",
+						Source:    testStorageResourceID,
 					},
 				},
 			},
@@ -331,9 +316,7 @@ func Test_GetDependencyIDs_InvalidAzureResourceId(t *testing.T) {
 // If you add minor features, add them here.
 func Test_Render_Basic(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Env: map[string]datamodel.EnvironmentVariable{
@@ -374,15 +357,9 @@ func Test_Render_Basic(t *testing.T) {
 		envVarSource3: {
 			ResourceID: resources.MustParse(envVarSource3),
 			Resource: &datamodel.SecretStore{
-				BaseResource: apiv1.BaseResource{
-					TrackedResource: apiv1.TrackedResource{
-						ID: envVarSource3,
-					},
-				},
+				ID: envVarSource3,
 				Properties: &datamodel.SecretStoreProperties{
-					BasicResourceProperties: rpv1.BasicResourceProperties{
-						Application: applicationResourceID,
-					},
+					Application: applicationResourceID,
 				},
 			},
 		},
@@ -434,26 +411,20 @@ func Test_Render_Basic(t *testing.T) {
 			{Name: envVarName1, Value: envVarValue1},
 			{Name: envVarName2, ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: envVarSource2,
-					},
-					Key: envVarValue2,
+					Name: envVarSource2,
+					Key:  envVarValue2,
 				},
 			}},
 			{Name: envVarName3, ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: envVarSource3,
-					},
-					Key: envVarValue3,
+					Name: envVarSource3,
+					Key:  envVarValue3,
 				},
 			}},
 			{Name: envVarName4, ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: envVarSource4,
-					},
-					Key: envVarValue4,
+					Name: envVarSource4,
+					Key:  envVarValue4,
 				},
 			}},
 		}
@@ -465,9 +436,7 @@ func Test_Render_Basic(t *testing.T) {
 
 func Test_Render_WithInvalidEnvironmentVariables(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Env: map[string]datamodel.EnvironmentVariable{
@@ -487,9 +456,7 @@ func Test_Render_WithInvalidEnvironmentVariables(t *testing.T) {
 
 func Test_Render_WithCommandArgsWorkingDir(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Env: map[string]datamodel.EnvironmentVariable{
@@ -553,9 +520,7 @@ func Test_Render_WithCommandArgsWorkingDir(t *testing.T) {
 
 func Test_Render_Manual(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Container: datamodel.Container{
 			Image: "none",
 		},
@@ -588,9 +553,7 @@ func Test_Render_Manual(t *testing.T) {
 
 func Test_Render_PortWithoutRoute(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Ports: map[string]datamodel.ContainerPort{
@@ -637,9 +600,7 @@ func Test_Render_Connections(t *testing.T) {
 	containerConnectionPort := "80"
 
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Connections: map[string]datamodel.ConnectionProperties{
 			"A": {
 				Source: makeRadiusResourceID(t, "SomeProvider/ResourceType", "A").String(),
@@ -706,10 +667,8 @@ func Test_Render_Connections(t *testing.T) {
 				Name: "CONNECTION_A_COMPUTEDKEY1",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: secretName,
-						},
-						Key: "CONNECTION_A_COMPUTEDKEY1",
+						Name: secretName,
+						Key:  "CONNECTION_A_COMPUTEDKEY1",
 					},
 				},
 			},
@@ -717,10 +676,8 @@ func Test_Render_Connections(t *testing.T) {
 				Name: "CONNECTION_A_COMPUTEDKEY2",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: secretName,
-						},
-						Key: "CONNECTION_A_COMPUTEDKEY2",
+						Name: secretName,
+						Key:  "CONNECTION_A_COMPUTEDKEY2",
 					},
 				},
 			},
@@ -740,10 +697,8 @@ func Test_Render_Connections(t *testing.T) {
 				Name: "CONNECTION_DYNAMICRESOURCE_PROPERTY1",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: secretName,
-						},
-						Key: "CONNECTION_DYNAMICRESOURCE_PROPERTY1",
+						Name: secretName,
+						Key:  "CONNECTION_DYNAMICRESOURCE_PROPERTY1",
 					},
 				},
 			},
@@ -751,10 +706,8 @@ func Test_Render_Connections(t *testing.T) {
 				Name: "CONNECTION_DYNAMICRESOURCE_PROPERTY2",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: secretName,
-						},
-						Key: "CONNECTION_DYNAMICRESOURCE_PROPERTY2",
+						Name: secretName,
+						Key:  "CONNECTION_DYNAMICRESOURCE_PROPERTY2",
 					},
 				},
 			},
@@ -762,10 +715,8 @@ func Test_Render_Connections(t *testing.T) {
 				Name: "CONNECTION_DYNAMICRESOURCE_PROPERTY3",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: secretName,
-						},
-						Key: "CONNECTION_DYNAMICRESOURCE_PROPERTY3",
+						Name: secretName,
+						Key:  "CONNECTION_DYNAMICRESOURCE_PROPERTY3",
 					},
 				},
 			},
@@ -800,9 +751,7 @@ func Test_Render_Connections(t *testing.T) {
 
 func Test_RenderConnections_DisableDefaultEnvVars(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Connections: map[string]datamodel.ConnectionProperties{
 			"A": {
 				Source:                makeRadiusResourceID(t, "SomeProvider/ResourceType", "A").String(),
@@ -849,9 +798,7 @@ func Test_RenderConnections_DisableDefaultEnvVars(t *testing.T) {
 // of the hash, just that it can change when the data changes.
 func Test_Render_Connections_SecretsGetHashed(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Connections: map[string]datamodel.ConnectionProperties{
 			"A": {
 				Source: makeRadiusResourceID(t, "SomeProvider/ResourceType", "A").String(),
@@ -912,9 +859,7 @@ func Test_Render_Connections_SecretsGetHashed(t *testing.T) {
 
 func Test_Render_ConnectionWithRoleAssignment(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Connections: map[string]datamodel.ConnectionProperties{
 			"A": {
 				Source: makeAzureResourceID(t, "SomeProvider/ResourceType", "A").String(),
@@ -1053,9 +998,7 @@ func Test_Render_AzureConnection(t *testing.T) {
 	testARMID := makeAzureResourceID(t, "SomeProvider/ResourceType", "test-azure-resource").String()
 	expectedRole := "administrator"
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Connections: map[string]datamodel.ConnectionProperties{
 			"testAzureResourceConnection": {
 				Source: testARMID,
@@ -1124,9 +1067,7 @@ func Test_Render_AzureConnection(t *testing.T) {
 func Test_Render_AzureConnectionEmptyRoleAllowed(t *testing.T) {
 	testARMID := makeAzureResourceID(t, "SomeProvider/ResourceType", "test-azure-resource").String()
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Connections: map[string]datamodel.ConnectionProperties{
 			"testAzureResourceConnection": {
 				Source: testARMID,
@@ -1156,9 +1097,7 @@ func Test_Render_EphemeralVolumes(t *testing.T) {
 	const tempVolName = "TempVolume"
 	const tempVolMountPath = "/tmpfs"
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Env: map[string]datamodel.EnvironmentVariable{
@@ -1173,9 +1112,7 @@ func Test_Render_EphemeralVolumes(t *testing.T) {
 				tempVolName: {
 					Kind: datamodel.Ephemeral,
 					Ephemeral: &datamodel.EphemeralVolume{
-						VolumeBase: datamodel.VolumeBase{
-							MountPath: tempVolMountPath,
-						},
+						MountPath:    tempVolMountPath,
 						ManagedStore: datamodel.ManagedStoreMemory,
 					},
 				},
@@ -1217,10 +1154,8 @@ func Test_Render_EphemeralVolumes(t *testing.T) {
 		expectedVolumes := []corev1.Volume{
 			{
 				Name: tempVolName,
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{
-						Medium: corev1.StorageMediumMemory,
-					},
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium: corev1.StorageMediumMemory,
 				},
 			},
 		}
@@ -1239,19 +1174,15 @@ func Test_Render_PersistentAzureFileShareVolumes(t *testing.T) {
 	testResourceID := fmt.Sprintf("/subscriptions/%s/resourceGroups/test/providers/Microsoft.Storage/storageaccounts/testaccount/fileservices/default/share/%s", uuid.New(), testShareName)
 
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Volumes: map[string]datamodel.VolumeProperties{
 				tempVolName: {
 					Kind: datamodel.Persistent,
 					Persistent: &datamodel.PersistentVolume{
-						VolumeBase: datamodel.VolumeBase{
-							MountPath: tempVolMountPath,
-						},
-						Source: testResourceID,
+						MountPath: tempVolMountPath,
+						Source:    testResourceID,
 					},
 				},
 			},
@@ -1305,9 +1236,7 @@ func Test_Render_PersistentAzureFileShareVolumes(t *testing.T) {
 
 func Test_Render_PersistentAzureKeyVaultVolumes(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 
 		Container: datamodel.Container{
 			Image: "someimage:latest",
@@ -1315,10 +1244,8 @@ func Test_Render_PersistentAzureKeyVaultVolumes(t *testing.T) {
 				tempVolName: {
 					Kind: datamodel.Persistent,
 					Persistent: &datamodel.PersistentVolume{
-						VolumeBase: datamodel.VolumeBase{
-							MountPath: tempVolMountPath,
-						},
-						Source: testResourceID,
+						MountPath: tempVolMountPath,
+						Source:    testResourceID,
 					},
 				},
 			},
@@ -1331,11 +1258,7 @@ func Test_Render_PersistentAzureKeyVaultVolumes(t *testing.T) {
 		testResourceID: {
 			ResourceID: resourceID,
 			Resource: &datamodel.VolumeResource{
-				BaseResource: apiv1.BaseResource{
-					TrackedResource: apiv1.TrackedResource{
-						Name: testVolName,
-					},
-				},
+				Name: testVolName,
 				Properties: datamodel.VolumeResourceProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: applicationResourceID,
@@ -1418,9 +1341,7 @@ func outputResourcesToResourceTypeMap(resources []rpv1.OutputResource) map[strin
 
 func Test_Render_RestartPolicy(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 		},
@@ -1450,9 +1371,7 @@ func Test_Render_RestartPolicy(t *testing.T) {
 
 func Test_Render_ReadinessProbeHttpGet(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Env: map[string]datamodel.EnvironmentVariable{
@@ -1466,15 +1385,13 @@ func Test_Render_ReadinessProbeHttpGet(t *testing.T) {
 			ReadinessProbe: datamodel.HealthProbeProperties{
 				Kind: datamodel.HTTPGetHealthProbe,
 				HTTPGet: &datamodel.HTTPGetHealthProbeProperties{
-					HealthProbeBase: datamodel.HealthProbeBase{
-						InitialDelaySeconds: new(float32(30)),
-						FailureThreshold:    new(float32(10)),
-						PeriodSeconds:       new(float32(2)),
-						TimeoutSeconds:      new(float32(5)),
-					},
-					Path:          "/healthz",
-					ContainerPort: 8080,
-					Headers:       map[string]string{"header1": "value1"},
+					InitialDelaySeconds: new(float32(30)),
+					FailureThreshold:    new(float32(10)),
+					PeriodSeconds:       new(float32(2)),
+					TimeoutSeconds:      new(float32(5)),
+					Path:                "/healthz",
+					ContainerPort:       8080,
+					Headers:             map[string]string{"header1": "value1"},
 				},
 			},
 		},
@@ -1511,20 +1428,18 @@ func Test_Render_ReadinessProbeHttpGet(t *testing.T) {
 			FailureThreshold:    10,
 			PeriodSeconds:       2,
 			TimeoutSeconds:      5,
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/healthz",
-					Port: intstr.FromInt(8080),
-					HTTPHeaders: []corev1.HTTPHeader{
-						{
-							Name:  "header1",
-							Value: "value1",
-						},
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/healthz",
+				Port: intstr.FromInt(8080),
+				HTTPHeaders: []corev1.HTTPHeader{
+					{
+						Name:  "header1",
+						Value: "value1",
 					},
 				},
-				TCPSocket: nil,
-				Exec:      nil,
 			},
+			TCPSocket: nil,
+			Exec:      nil,
 		}
 
 		require.Equal(t, expectedReadinessProbe, container.ReadinessProbe)
@@ -1533,9 +1448,7 @@ func Test_Render_ReadinessProbeHttpGet(t *testing.T) {
 
 func Test_Render_ReadinessProbeTcp(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Env: map[string]datamodel.EnvironmentVariable{
@@ -1549,13 +1462,11 @@ func Test_Render_ReadinessProbeTcp(t *testing.T) {
 			ReadinessProbe: datamodel.HealthProbeProperties{
 				Kind: datamodel.TCPHealthProbe,
 				TCP: &datamodel.TCPHealthProbeProperties{
-					HealthProbeBase: datamodel.HealthProbeBase{
-						InitialDelaySeconds: new(float32(30)),
-						FailureThreshold:    new(float32(10)),
-						PeriodSeconds:       new(float32(2)),
-						TimeoutSeconds:      new(float32(5)),
-					},
-					ContainerPort: 8080,
+					InitialDelaySeconds: new(float32(30)),
+					FailureThreshold:    new(float32(10)),
+					PeriodSeconds:       new(float32(2)),
+					TimeoutSeconds:      new(float32(5)),
+					ContainerPort:       8080,
 				},
 			},
 		},
@@ -1592,13 +1503,11 @@ func Test_Render_ReadinessProbeTcp(t *testing.T) {
 			FailureThreshold:    10,
 			PeriodSeconds:       2,
 			TimeoutSeconds:      5,
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: nil,
-				TCPSocket: &corev1.TCPSocketAction{
-					Port: intstr.FromInt(8080),
-				},
-				Exec: nil,
+			HTTPGet:             nil,
+			TCPSocket: &corev1.TCPSocketAction{
+				Port: intstr.FromInt(8080),
 			},
+			Exec: nil,
 		}
 
 		require.Equal(t, expectedReadinessProbe, container.ReadinessProbe)
@@ -1607,9 +1516,7 @@ func Test_Render_ReadinessProbeTcp(t *testing.T) {
 
 func Test_Render_LivenessProbeExec(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Env: map[string]datamodel.EnvironmentVariable{
@@ -1623,13 +1530,11 @@ func Test_Render_LivenessProbeExec(t *testing.T) {
 			LivenessProbe: datamodel.HealthProbeProperties{
 				Kind: datamodel.ExecHealthProbe,
 				Exec: &datamodel.ExecHealthProbeProperties{
-					HealthProbeBase: datamodel.HealthProbeBase{
-						InitialDelaySeconds: new(float32(30)),
-						FailureThreshold:    new(float32(10)),
-						PeriodSeconds:       new(float32(2)),
-						TimeoutSeconds:      new(float32(5)),
-					},
-					Command: "a b c",
+					InitialDelaySeconds: new(float32(30)),
+					FailureThreshold:    new(float32(10)),
+					PeriodSeconds:       new(float32(2)),
+					TimeoutSeconds:      new(float32(5)),
+					Command:             "a b c",
 				},
 			},
 		},
@@ -1666,12 +1571,10 @@ func Test_Render_LivenessProbeExec(t *testing.T) {
 			FailureThreshold:    10,
 			PeriodSeconds:       2,
 			TimeoutSeconds:      5,
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet:   nil,
-				TCPSocket: nil,
-				Exec: &corev1.ExecAction{
-					Command: []string{"a", "b", "c"},
-				},
+			HTTPGet:             nil,
+			TCPSocket:           nil,
+			Exec: &corev1.ExecAction{
+				Command: []string{"a", "b", "c"},
 			},
 		}
 
@@ -1681,9 +1584,7 @@ func Test_Render_LivenessProbeExec(t *testing.T) {
 
 func Test_Render_LivenessProbeWithDefaults(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			LivenessProbe: datamodel.HealthProbeProperties{
@@ -1727,12 +1628,10 @@ func Test_Render_LivenessProbeWithDefaults(t *testing.T) {
 			FailureThreshold:    DefaultFailureThreshold,
 			PeriodSeconds:       DefaultPeriodSeconds,
 			TimeoutSeconds:      DefaultTimeoutSeconds,
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet:   nil,
-				TCPSocket: nil,
-				Exec: &corev1.ExecAction{
-					Command: []string{"a", "b", "c"},
-				},
+			HTTPGet:             nil,
+			TCPSocket:           nil,
+			Exec: &corev1.ExecAction{
+				Command: []string{"a", "b", "c"},
 			},
 		}
 
@@ -1745,9 +1644,7 @@ func Test_DNS_Service_Generation(t *testing.T) {
 	var servicePortNumber int32 = 80
 	t.Run("verify service generation", func(t *testing.T) {
 		properties := datamodel.ContainerProperties{
-			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Application: applicationResourceID,
-			},
+			Application: applicationResourceID,
 			Container: datamodel.Container{
 				Image: "someimage:latest",
 				Ports: map[string]datamodel.ContainerPort{
@@ -1794,9 +1691,7 @@ func Test_DNS_Service_Generation(t *testing.T) {
 
 func Test_Render_ImagePullPolicySpecified(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Container: datamodel.Container{
 			Image:           "someimage:latest",
 			ImagePullPolicy: "Never",
@@ -1856,9 +1751,7 @@ func Test_Render_StrategicPatchMerge(t *testing.T) {
 }
 `
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: applicationResourceID,
-		},
+		Application: applicationResourceID,
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Env: map[string]datamodel.EnvironmentVariable{
@@ -1939,9 +1832,7 @@ func Test_Render_BaseManifest(t *testing.T) {
 						"ephemeralVolume": {
 							Kind: datamodel.Ephemeral,
 							Ephemeral: &datamodel.EphemeralVolume{
-								VolumeBase: datamodel.VolumeBase{
-									MountPath: "/mnt/ephemeral",
-								},
+								MountPath:    "/mnt/ephemeral",
 								ManagedStore: datamodel.ManagedStoreMemory,
 							},
 						},
@@ -2008,14 +1899,14 @@ func Test_Render_BaseManifest(t *testing.T) {
 
 func renderOptionsEnvAndAppKubeMetadata() renderers.RenderOptions {
 	dependencies := map[string]renderers.RendererDependency{}
-	option := renderers.RenderOptions{Dependencies: dependencies}
+	option := renderers.RenderOptions{Dependencies: dependencies,
 
-	option.Application = renderers.ApplicationOptions{
-		KubernetesMetadata: &datamodel.KubeMetadataExtension{
-			Annotations: getAppSetup().appKubeMetadataExt.Annotations,
-			Labels:      getAppSetup().appKubeMetadataExt.Labels,
-		},
-	}
+		Application: renderers.ApplicationOptions{
+			KubernetesMetadata: &datamodel.KubeMetadataExtension{
+				Annotations: getAppSetup().appKubeMetadataExt.Annotations,
+				Labels:      getAppSetup().appKubeMetadataExt.Labels,
+			},
+		}}
 
 	return option
 }

--- a/pkg/corerp/renderers/container/volumes.go
+++ b/pkg/corerp/renderers/container/volumes.go
@@ -25,8 +25,8 @@ import (
 // Create the volume specs for Pod.
 func makeEphemeralVolume(volumeName string, volume *datamodel.EphemeralVolume) (corev1.Volume, corev1.VolumeMount, error) {
 	// Make volume spec
-	volumeSpec := corev1.Volume{}
-	volumeSpec.Name = volumeName
+	volumeSpec := corev1.Volume{
+		Name: volumeName}
 	volumeSpec.VolumeSource.EmptyDir = &corev1.EmptyDirVolumeSource{}
 	if volume != nil && volume.ManagedStore == datamodel.ManagedStoreMemory {
 		volumeSpec.VolumeSource.EmptyDir.Medium = corev1.StorageMediumMemory
@@ -35,9 +35,9 @@ func makeEphemeralVolume(volumeName string, volume *datamodel.EphemeralVolume) (
 	}
 
 	// Make volumeMount spec
-	volumeMountSpec := corev1.VolumeMount{}
-	volumeMountSpec.MountPath = volume.MountPath
-	volumeMountSpec.Name = volumeName
+	volumeMountSpec := corev1.VolumeMount{
+		MountPath: volume.MountPath,
+		Name:      volumeName}
 
 	return volumeSpec, volumeMountSpec, nil
 }

--- a/pkg/corerp/renderers/daprextension/renderer_test.go
+++ b/pkg/corerp/renderers/daprextension/renderer_test.go
@@ -66,9 +66,7 @@ func Test_Render_Success(t *testing.T) {
 	renderer := &Renderer{Inner: &noop{}}
 
 	ctnrProperties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 		},
@@ -106,13 +104,9 @@ func Test_Render_Success(t *testing.T) {
 
 func makeResource(properties datamodel.ContainerProperties) *datamodel.ContainerResource {
 	resource := datamodel.ContainerResource{
-		BaseResource: apiv1.BaseResource{
-			TrackedResource: apiv1.TrackedResource{
-				ID:   "/subscriptions/test-sub-id/resourceGroups/test-group/providers/Applications.Core/containers/test-container",
-				Name: "test-container",
-				Type: "Applications.Core/containers",
-			},
-		},
+		ID:         "/subscriptions/test-sub-id/resourceGroups/test-group/providers/Applications.Core/containers/test-container",
+		Name:       "test-container",
+		Type:       "Applications.Core/containers",
 		Properties: properties,
 	}
 	return &resource

--- a/pkg/corerp/renderers/gateway/render.go
+++ b/pkg/corerp/renderers/gateway/render.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/corerp/datamodel"
@@ -262,16 +261,12 @@ func MakeRootHTTPProxy(ctx context.Context, options renderers.RenderOptions, gat
 
 	// The root HTTPProxy object acts as the Gateway
 	rootHTTPProxy := &contourv1.HTTPProxy{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "HTTPProxy",
-			APIVersion: contourv1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        kubernetes.NormalizeResourceName(resourceName),
-			Namespace:   options.Environment.Namespace,
-			Labels:      renderers.GetLabels(options, applicationName, resourceName, gateway.ResourceTypeName()),
-			Annotations: renderers.GetAnnotations(options),
-		},
+		Kind:        "HTTPProxy",
+		APIVersion:  contourv1.SchemeGroupVersion.String(),
+		Name:        kubernetes.NormalizeResourceName(resourceName),
+		Namespace:   options.Environment.Namespace,
+		Labels:      renderers.GetLabels(options, applicationName, resourceName, gateway.ResourceTypeName()),
+		Annotations: renderers.GetAnnotations(options),
 		Spec: contourv1.HTTPProxySpec{
 			VirtualHost: virtualHost,
 			Includes:    includes,
@@ -376,16 +371,12 @@ func MakeRoutesHTTPProxies(ctx context.Context, options renderers.RenderOptions,
 		}
 
 		httpProxyObject := &contourv1.HTTPProxy{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "HTTPProxy",
-				APIVersion: contourv1.SchemeGroupVersion.String(),
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        routeResourceName,
-				Namespace:   options.Environment.Namespace,
-				Labels:      renderers.GetLabels(options, applicationName, routeName, resource.ResourceTypeName()),
-				Annotations: renderers.GetAnnotations(options),
-			},
+			Kind:        "HTTPProxy",
+			APIVersion:  contourv1.SchemeGroupVersion.String(),
+			Name:        routeResourceName,
+			Namespace:   options.Environment.Namespace,
+			Labels:      renderers.GetLabels(options, applicationName, routeName, resource.ResourceTypeName()),
+			Annotations: renderers.GetAnnotations(options),
 			Spec: contourv1.HTTPProxySpec{
 				Routes: []contourv1.Route{
 					{

--- a/pkg/corerp/renderers/gateway/render_test.go
+++ b/pkg/corerp/renderers/gateway/render_test.go
@@ -121,9 +121,7 @@ func Test_Render_WithIPAndNoHostname(t *testing.T) {
 	r := &Renderer{}
 
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 	})
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -156,9 +154,7 @@ func Test_Render_WithIPAndPrefix(t *testing.T) {
 		Hostname: &datamodel.GatewayPropertiesHostname{
 			Prefix: prefix,
 		},
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 	})
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -192,9 +188,7 @@ func Test_Render_WithIPAndFQHostname(t *testing.T) {
 		Hostname: &datamodel.GatewayPropertiesHostname{
 			FullyQualifiedHostname: expectedHostname,
 		},
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 	})
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -227,9 +221,7 @@ func Test_Render_WithFQHostname_OverridesPrefix(t *testing.T) {
 			Prefix:                 prefix,
 			FullyQualifiedHostname: expectedHostname,
 		},
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 	})
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -255,9 +247,7 @@ func Test_Render_PublicEndpointOverride(t *testing.T) {
 	r := &Renderer{}
 
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 	})
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -284,9 +274,7 @@ func Test_Render_PublicEndpointOverride_OverridesAll(t *testing.T) {
 
 	expectedPublicEndpoint := "this_CouldbeAnyString"
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 		Hostname: &datamodel.GatewayPropertiesHostname{
 			Prefix:                 "test",
 			FullyQualifiedHostname: "testagain",
@@ -318,9 +306,7 @@ func Test_Render_PublicEndpointOverride_WithEmptyIP(t *testing.T) {
 	expectedPublicEndpoint := "www.contoso.com"
 	expectedFQDN := "www.contoso.com"
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 	})
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -348,9 +334,7 @@ func Test_Render_LocalhostPublicEndpointOverride(t *testing.T) {
 	expectedFQDN := "localhost"
 	expectedPublicEndpoint := "http://localhost:8080"
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 	})
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -377,9 +361,7 @@ func Test_Render_Hostname(t *testing.T) {
 
 	expectedPublicEndpoint := fmt.Sprintf("http://%s", testHostname)
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 	})
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -407,9 +389,7 @@ func Test_Render_Hostname_WithPort(t *testing.T) {
 	expectedFQDN := "www.contoso.com"
 	expectedPublicEndpoint := "http://www.contoso.com:32434"
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 	})
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -438,9 +418,7 @@ func Test_Render_Hostname_WithPrefix(t *testing.T) {
 	expectedFQDN := fmt.Sprintf("%s.%s", prefix, testHostname)
 	expectedPublicEndpoint := fmt.Sprintf("http://%s", expectedFQDN)
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 		Hostname: &datamodel.GatewayPropertiesHostname{
 			Prefix: prefix,
 		},
@@ -472,9 +450,7 @@ func Test_Render_Hostname_WithPrefixAndPort(t *testing.T) {
 	expectedFQDN := fmt.Sprintf("%s.%s", prefix, testHostname)
 	expectedPublicEndpoint := fmt.Sprintf("http://%s:%s", expectedFQDN, testPort)
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 		Hostname: &datamodel.GatewayPropertiesHostname{
 			Prefix: prefix,
 		},
@@ -503,9 +479,7 @@ func Test_Render_WithMissingPublicIP(t *testing.T) {
 	r := &Renderer{}
 
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 	})
 	resource := makeResource(properties)
 	appId, err := resources.ParseResource(resource.Properties.Application)
@@ -541,9 +515,7 @@ func Test_Render_Fails_SSLPassthroughWithRoutePath(t *testing.T) {
 	routes = append(routes, route)
 	r := &Renderer{}
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 		TLS: &datamodel.GatewayPropertiesTLS{
 			SSLPassthrough: true,
 		},
@@ -578,9 +550,7 @@ func Test_Render_Fails_SSLPassthroughWithMultipleRoutes(t *testing.T) {
 
 	r := &Renderer{}
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 		TLS: &datamodel.GatewayPropertiesTLS{
 			SSLPassthrough: true,
 		},
@@ -614,10 +584,8 @@ func Test_Render_WithTimeoutPolicy(t *testing.T) {
 	}
 	routes = append(routes, route)
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Routes: routes,
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Routes:      routes,
 	}
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -673,10 +641,8 @@ func Test_Render_WithUnsetBackendRequestTimeoutPolicy(t *testing.T) {
 	}
 	routes = append(routes, route)
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Routes: routes,
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Routes:      routes,
 	}
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -733,10 +699,8 @@ func Test_Render_WithInvalidTimeoutPolicy(t *testing.T) {
 	}
 	routes = append(routes, route)
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Routes: routes,
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Routes:      routes,
 	}
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -755,9 +719,7 @@ func Test_Render_Fails_WithNoRoute(t *testing.T) {
 	r := &Renderer{}
 
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 	}
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -777,9 +739,7 @@ func Test_Render_FQDNOverride(t *testing.T) {
 
 	expectedPublicEndpoint := fmt.Sprintf("http://%s", testHostname)
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 		Hostname: &datamodel.GatewayPropertiesHostname{
 			FullyQualifiedHostname: testHostname,
 		},
@@ -808,10 +768,8 @@ func Test_Render_Fails_WithoutFQHostnameOrPrefix(t *testing.T) {
 	r := &Renderer{}
 
 	properties, _ := makeTestGateway(datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Hostname: &datamodel.GatewayPropertiesHostname{},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Hostname:    &datamodel.GatewayPropertiesHostname{},
 	})
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -836,10 +794,8 @@ func Test_Render_Single_Route(t *testing.T) {
 	}
 	routes = append(routes, route)
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Routes: routes,
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Routes:      routes,
 	}
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -889,10 +845,8 @@ func TestRender_SingleRoute_EnableWebsockets(t *testing.T) {
 	}
 	routes = append(routes, route)
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Routes: routes,
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Routes:      routes,
 	}
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -942,11 +896,9 @@ func Test_Render_SSLPassthrough(t *testing.T) {
 		SSLPassthrough: true,
 	}
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Routes: routes,
-		TLS:    tls,
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Routes:      routes,
+		TLS:         tls,
 	}
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -1017,10 +969,8 @@ func Test_Render_Multiple_Routes(t *testing.T) {
 	routes = append(routes, routeA)
 	routes = append(routes, routeB)
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Routes: routes,
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Routes:      routes,
 	}
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -1082,10 +1032,8 @@ func Test_Render_MultipleRoutes_OrderOutputResourcesDeploysRouteChildrenBeforeRo
 		},
 	}
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Routes: routes,
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Routes:      routes,
 	}
 	resource := makeResource(properties)
 	environmentOptions := getEnvironmentOptions("", testExternalIP, "", false, false)
@@ -1132,10 +1080,8 @@ func Test_Render_Route_WithPrefixRewrite(t *testing.T) {
 	}
 	routes = append(routes, route)
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Routes: routes,
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Routes:      routes,
 	}
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -1216,10 +1162,8 @@ func Test_Render_Route_WithMultiplePrefixRewrite(t *testing.T) {
 	routes = append(routes, routeC)
 	routes = append(routes, routeD)
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Routes: routes,
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Routes:      routes,
 	}
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -1317,9 +1261,7 @@ func Test_Render_WithDependencies(t *testing.T) {
 	}
 	routes = append(routes, route)
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 		TLS: &datamodel.GatewayPropertiesTLS{
 			CertificateFrom: secret.ID,
 		},
@@ -1385,10 +1327,8 @@ func Test_Render_WithEnvironment_KubernetesMetadata(t *testing.T) {
 	}
 	routes = append(routes, route)
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Routes: routes,
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Routes:      routes,
 	}
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -1437,10 +1377,8 @@ func Test_Render_WithEnvironmentApplication_KubernetesMetadata(t *testing.T) {
 	}
 	routes = append(routes, route)
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Routes: routes,
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Routes:      routes,
 	}
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -1494,10 +1432,8 @@ func Test_RenderDNS_WithEnvironmentApplication_KubernetesMetadata(t *testing.T) 
 	path := "/routea"
 	routes = append(routes, routeA)
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Routes: routes,
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Routes:      routes,
 	}
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -1548,10 +1484,8 @@ func Test_RenderDNS_WithEnvironment_KubernetesMetadata(t *testing.T) {
 	path := "/routea"
 	routes = append(routes, routeA)
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
-		Routes: routes,
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		Routes:      routes,
 	}
 	resource := makeResource(properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -1592,9 +1526,7 @@ func Test_Render_With_TLSTermination(t *testing.T) {
 	secretName := "myapp-tls-secret"
 	secretStoreResourceId := makeSecretStoreResourceID(secretName)
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
 		TLS: &datamodel.GatewayPropertiesTLS{
 			MinimumProtocolVersion: "1.2",
 			CertificateFrom:        secretStoreResourceId,
@@ -1803,25 +1735,17 @@ func makeSecretStoreResourceID(secretStoreName string) string {
 
 func makeResource(properties datamodel.GatewayProperties) *datamodel.Gateway {
 	return &datamodel.Gateway{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   "/subscriptions/test-sub-id/resourceGroups/test-group/providers/Applications.Core/gateways/test-gateway",
-				Name: resourceName,
-				Type: "Applications.Core/gateways",
-			},
-		},
+		ID:         "/subscriptions/test-sub-id/resourceGroups/test-group/providers/Applications.Core/gateways/test-gateway",
+		Name:       resourceName,
+		Type:       "Applications.Core/gateways",
 		Properties: properties,
 	}
 }
 
 func makeSecretStoreResource(properties datamodel.SecretStoreProperties) *datamodel.SecretStore {
 	return &datamodel.SecretStore{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/secretStores/test-secretstore",
-				Name: "test-secretstore",
-			},
-		},
+		ID:         "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/secretStores/test-secretstore",
+		Name:       "test-secretstore",
 		Properties: &properties,
 	}
 }
@@ -1845,10 +1769,8 @@ func makeTestGateway(config datamodel.GatewayProperties) (datamodel.GatewayPrope
 	}
 
 	properties := datamodel.GatewayProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: config.Application,
-		},
-		Hostname: config.Hostname,
+		Application: config.Application,
+		Hostname:    config.Hostname,
 		Routes: []datamodel.GatewayRoute{
 			defaultRoute,
 		},

--- a/pkg/corerp/renderers/kubernetesmetadata/render_test.go
+++ b/pkg/corerp/renderers/kubernetesmetadata/render_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ renderers.Renderer = (*noop)(nil)
@@ -33,14 +32,10 @@ func (r *noop) GetDependencyIDs(ctx context.Context, resource apiv1.DataModelInt
 func (r *noop) Render(ctx context.Context, dm apiv1.DataModelInterface, options renderers.RenderOptions) (renderers.RendererOutput, error) {
 	// Return a deployment so the kubernetes metadata extension renderer can modify it
 	deployment := appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-deployment",
-			Namespace: "test-namespace",
-		},
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Deployment",
-			APIVersion: "apps/v1",
-		},
+		Name:       "test-deployment",
+		Namespace:  "test-namespace",
+		Kind:       "Deployment",
+		APIVersion: "apps/v1",
 	}
 
 	// Populate Meta labels with existing values
@@ -153,13 +148,9 @@ func TestApplicationDataModelToVersioned(t *testing.T) {
 
 func makeResource(properties datamodel.ContainerProperties) *datamodel.ContainerResource {
 	resource := datamodel.ContainerResource{
-		BaseResource: apiv1.BaseResource{
-			TrackedResource: apiv1.TrackedResource{
-				ID:   container,
-				Name: "test-container",
-				Type: "Applications.Core/containers",
-			},
-		},
+		ID:         container,
+		Name:       "test-container",
+		Type:       "Applications.Core/containers",
 		Properties: properties,
 	}
 	return &resource
@@ -168,9 +159,7 @@ func makeResource(properties datamodel.ContainerProperties) *datamodel.Container
 func makeProperties(isEmpty bool, hasReservedKey bool) datamodel.ContainerProperties {
 	if isEmpty {
 		return datamodel.ContainerProperties{
-			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Application: application,
-			},
+			Application: application,
 			Container: datamodel.Container{
 				Image: "someimage:latest",
 			},
@@ -183,9 +172,7 @@ func makeProperties(isEmpty bool, hasReservedKey bool) datamodel.ContainerProper
 	)
 
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: application,
-		},
+		Application: application,
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 		},

--- a/pkg/corerp/renderers/manualscale/render_test.go
+++ b/pkg/corerp/renderers/manualscale/render_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/radius-project/radius/pkg/kubernetes"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	"github.com/radius-project/radius/pkg/ucp/resources"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -44,14 +43,10 @@ func (r *noop) GetDependencyIDs(ctx context.Context, resource v1.DataModelInterf
 func (r *noop) Render(ctx context.Context, dm v1.DataModelInterface, options renderers.RenderOptions) (renderers.RendererOutput, error) {
 	// Return a deployment so the manualscale extension can modify it
 	deployment := appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-deployment",
-			Namespace: "test-namespace",
-		},
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Deployment",
-			APIVersion: "apps/v1",
-		},
+		Name:       "test-deployment",
+		Namespace:  "test-namespace",
+		Kind:       "Deployment",
+		APIVersion: "apps/v1",
 	}
 	resources := []rpv1.OutputResource{rpv1.NewKubernetesOutputResource(rpv1.LocalIDDeployment, &deployment, deployment.ObjectMeta)}
 	return renderers.RendererOutput{Resources: resources}, nil
@@ -104,9 +99,7 @@ func Test_Render_NoExtension(t *testing.T) {
 	renderer := &Renderer{Inner: &noop{}}
 
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 		},
@@ -127,13 +120,9 @@ func Test_Render_NoExtension(t *testing.T) {
 
 func makeResource(properties datamodel.ContainerProperties) *datamodel.ContainerResource {
 	resource := datamodel.ContainerResource{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   "/subscriptions/test-sub-id/resourceGroups/test-group/providers/Applications.Core/containers/test-container",
-				Name: "test-container",
-				Type: "Applications.Core/containers",
-			},
-		},
+		ID:         "/subscriptions/test-sub-id/resourceGroups/test-group/providers/Applications.Core/containers/test-container",
+		Name:       "test-container",
+		Type:       "Applications.Core/containers",
 		Properties: properties,
 	}
 	return &resource
@@ -141,9 +130,7 @@ func makeResource(properties datamodel.ContainerProperties) *datamodel.Container
 
 func makeProperties(replicas *int32) datamodel.ContainerProperties {
 	properties := datamodel.ContainerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
-		},
+		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 		},

--- a/pkg/crypto/encryption/keyprovider_test.go
+++ b/pkg/crypto/encryption/keyprovider_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/radius-project/radius/test/k8sutil"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubectl/pkg/scheme"
 	controller_runtime "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -71,10 +70,8 @@ func TestKubernetesKeyProvider_GetCurrentKey(t *testing.T) {
 			setupFunc: func(k8sClient controller_runtime.Client) {
 				keyStoreJSON := createTestKeyStore(t, map[int][]byte{1: validKey}, 1)
 				secret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      DefaultEncryptionKeySecretName,
-						Namespace: RadiusNamespace,
-					},
+					Name:      DefaultEncryptionKeySecretName,
+					Namespace: RadiusNamespace,
 					Data: map[string][]byte{
 						DefaultEncryptionKeySecretKey: keyStoreJSON,
 					},
@@ -97,10 +94,8 @@ func TestKubernetesKeyProvider_GetCurrentKey(t *testing.T) {
 				}
 				keyStoreJSON := createTestKeyStore(t, map[int][]byte{1: key1, 2: key2}, 2)
 				secret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      DefaultEncryptionKeySecretName,
-						Namespace: RadiusNamespace,
-					},
+					Name:      DefaultEncryptionKeySecretName,
+					Namespace: RadiusNamespace,
 					Data: map[string][]byte{
 						DefaultEncryptionKeySecretKey: keyStoreJSON,
 					},
@@ -123,10 +118,8 @@ func TestKubernetesKeyProvider_GetCurrentKey(t *testing.T) {
 			setupFunc: func(k8sClient controller_runtime.Client) {
 				keyStoreJSON := createTestKeyStore(t, map[int][]byte{1: validKey}, 1)
 				secret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "custom-secret",
-						Namespace: "custom-namespace",
-					},
+					Name:      "custom-secret",
+					Namespace: "custom-namespace",
 					Data: map[string][]byte{
 						"custom-key": keyStoreJSON,
 					},
@@ -153,10 +146,8 @@ func TestKubernetesKeyProvider_GetCurrentKey(t *testing.T) {
 			name: "error-key-not-in-secret",
 			setupFunc: func(k8sClient controller_runtime.Client) {
 				secret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      DefaultEncryptionKeySecretName,
-						Namespace: RadiusNamespace,
-					},
+					Name:      DefaultEncryptionKeySecretName,
+					Namespace: RadiusNamespace,
 					Data: map[string][]byte{
 						"wrong-key": []byte("{}"),
 					},
@@ -172,10 +163,8 @@ func TestKubernetesKeyProvider_GetCurrentKey(t *testing.T) {
 			name: "error-invalid-json",
 			setupFunc: func(k8sClient controller_runtime.Client) {
 				secret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      DefaultEncryptionKeySecretName,
-						Namespace: RadiusNamespace,
-					},
+					Name:      DefaultEncryptionKeySecretName,
+					Namespace: RadiusNamespace,
 					Data: map[string][]byte{
 						DefaultEncryptionKeySecretKey: []byte("not-valid-json"),
 					},
@@ -192,10 +181,8 @@ func TestKubernetesKeyProvider_GetCurrentKey(t *testing.T) {
 			setupFunc: func(k8sClient controller_runtime.Client) {
 				keyStoreJSON := createTestKeyStore(t, map[int][]byte{1: validKey}, 99)
 				secret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      DefaultEncryptionKeySecretName,
-						Namespace: RadiusNamespace,
-					},
+					Name:      DefaultEncryptionKeySecretName,
+					Namespace: RadiusNamespace,
 					Data: map[string][]byte{
 						DefaultEncryptionKeySecretKey: keyStoreJSON,
 					},
@@ -213,10 +200,8 @@ func TestKubernetesKeyProvider_GetCurrentKey(t *testing.T) {
 				shortKey := make([]byte, 16) // Too short
 				keyStoreJSON := createTestKeyStore(t, map[int][]byte{1: shortKey}, 1)
 				secret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      DefaultEncryptionKeySecretName,
-						Namespace: RadiusNamespace,
-					},
+					Name:      DefaultEncryptionKeySecretName,
+					Namespace: RadiusNamespace,
 					Data: map[string][]byte{
 						DefaultEncryptionKeySecretKey: keyStoreJSON,
 					},
@@ -275,10 +260,8 @@ func TestKubernetesKeyProvider_GetKeyByVersion(t *testing.T) {
 			setupFunc: func(k8sClient controller_runtime.Client) {
 				keyStoreJSON := createTestKeyStore(t, map[int][]byte{1: key1, 2: key2}, 2)
 				secret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      DefaultEncryptionKeySecretName,
-						Namespace: RadiusNamespace,
-					},
+					Name:      DefaultEncryptionKeySecretName,
+					Namespace: RadiusNamespace,
 					Data: map[string][]byte{
 						DefaultEncryptionKeySecretKey: keyStoreJSON,
 					},
@@ -294,10 +277,8 @@ func TestKubernetesKeyProvider_GetKeyByVersion(t *testing.T) {
 			setupFunc: func(k8sClient controller_runtime.Client) {
 				keyStoreJSON := createTestKeyStore(t, map[int][]byte{1: key1, 2: key2}, 2)
 				secret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      DefaultEncryptionKeySecretName,
-						Namespace: RadiusNamespace,
-					},
+					Name:      DefaultEncryptionKeySecretName,
+					Namespace: RadiusNamespace,
 					Data: map[string][]byte{
 						DefaultEncryptionKeySecretKey: keyStoreJSON,
 					},
@@ -313,10 +294,8 @@ func TestKubernetesKeyProvider_GetKeyByVersion(t *testing.T) {
 			setupFunc: func(k8sClient controller_runtime.Client) {
 				keyStoreJSON := createTestKeyStore(t, map[int][]byte{1: key1}, 1)
 				secret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      DefaultEncryptionKeySecretName,
-						Namespace: RadiusNamespace,
-					},
+					Name:      DefaultEncryptionKeySecretName,
+					Namespace: RadiusNamespace,
 					Data: map[string][]byte{
 						DefaultEncryptionKeySecretKey: keyStoreJSON,
 					},

--- a/pkg/daprrp/api/v20231001preview/configurationstore_conversion.go
+++ b/pkg/daprrp/api/v20231001preview/configurationstore_conversion.go
@@ -24,7 +24,6 @@ import (
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/daprrp/datamodel"
 	"github.com/radius-project/radius/pkg/portableresources"
-	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	"github.com/radius-project/radius/pkg/to"
 )
 
@@ -32,10 +31,8 @@ import (
 // if the mode is not specified or if the required properties for the mode are not specified.
 func (src *DaprConfigurationStoreResource) ConvertTo() (v1.DataModelInterface, error) {
 	daprConfigurationStoreProperties := datamodel.DaprConfigurationStoreProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Environment: to.String(src.Properties.Environment),
-			Application: to.String(src.Properties.Application),
-		},
+		Environment: to.String(src.Properties.Environment),
+		Application: to.String(src.Properties.Application),
 	}
 
 	trackedResource := v1.TrackedResource{

--- a/pkg/daprrp/api/v20231001preview/configurationstore_conversion_test.go
+++ b/pkg/daprrp/api/v20231001preview/configurationstore_conversion_test.go
@@ -41,23 +41,17 @@ func TestDaprConfigurationStore_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "Manual provisioning of a DaprConfigurationStore",
 			file: "configurationstore_manual_resource.json",
 			expected: &datamodel.DaprConfigurationStore{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Dapr/configurationStores/test-dcs",
-						Name:     "test-dcs",
-						Type:     controller.DaprConfigurationStoresResourceType,
-						Location: v1.LocationGlobal,
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
+				ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Dapr/configurationStores/test-dcs",
+				Name:     "test-dcs",
+				Type:     controller.DaprConfigurationStoresResourceType,
+				Location: v1.LocationGlobal,
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.DaprConfigurationStoreProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/test-app",
@@ -83,23 +77,17 @@ func TestDaprConfigurationStore_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "Provisioning by a Recipe of a configuration store",
 			file: "configurationstore_recipe_resource.json",
 			expected: &datamodel.DaprConfigurationStore{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Dapr/configurationStores/test-dcs",
-						Name:     "test-dcs",
-						Type:     controller.DaprConfigurationStoresResourceType,
-						Location: v1.LocationGlobal,
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
+				ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Dapr/configurationStores/test-dcs",
+				Name:     "test-dcs",
+				Type:     controller.DaprConfigurationStoresResourceType,
+				Location: v1.LocationGlobal,
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.DaprConfigurationStoreProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/test-app",

--- a/pkg/daprrp/api/v20231001preview/pubsubbroker_conversion.go
+++ b/pkg/daprrp/api/v20231001preview/pubsubbroker_conversion.go
@@ -24,7 +24,6 @@ import (
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/daprrp/datamodel"
 	"github.com/radius-project/radius/pkg/portableresources"
-	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	"github.com/radius-project/radius/pkg/to"
 )
 
@@ -32,10 +31,8 @@ import (
 // if the mode is not specified or if the required properties for the mode are not specified.
 func (src *DaprPubSubBrokerResource) ConvertTo() (v1.DataModelInterface, error) {
 	daprPubSubproperties := datamodel.DaprPubSubBrokerProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Environment: to.String(src.Properties.Environment),
-			Application: to.String(src.Properties.Application),
-		},
+		Environment: to.String(src.Properties.Environment),
+		Application: to.String(src.Properties.Application),
 	}
 
 	trackedResource := v1.TrackedResource{

--- a/pkg/daprrp/api/v20231001preview/pubsubbroker_conversion_test.go
+++ b/pkg/daprrp/api/v20231001preview/pubsubbroker_conversion_test.go
@@ -41,23 +41,17 @@ func TestDaprPubSubBroker_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "Manual provisioning of a DaprPubSubBroker",
 			file: "pubsubbroker_manual_resource.json",
 			expected: &datamodel.DaprPubSubBroker{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Dapr/pubSubBrokers/test-dpsb",
-						Name:     "test-dpsb",
-						Type:     dapr_ctrl.DaprPubSubBrokersResourceType,
-						Location: v1.LocationGlobal,
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
+				ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Dapr/pubSubBrokers/test-dpsb",
+				Name:     "test-dpsb",
+				Type:     dapr_ctrl.DaprPubSubBrokersResourceType,
+				Location: v1.LocationGlobal,
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.DaprPubSubBrokerProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/test-app",
@@ -83,23 +77,17 @@ func TestDaprPubSubBroker_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "Provisioning by a Recipe of a pubSubBroker",
 			file: "pubsubbroker_recipe_resource.json",
 			expected: &datamodel.DaprPubSubBroker{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Dapr/pubSubBrokers/test-dpsb",
-						Name:     "test-dpsb",
-						Type:     dapr_ctrl.DaprPubSubBrokersResourceType,
-						Location: v1.LocationGlobal,
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
+				ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Dapr/pubSubBrokers/test-dpsb",
+				Name:     "test-dpsb",
+				Type:     dapr_ctrl.DaprPubSubBrokersResourceType,
+				Location: v1.LocationGlobal,
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.DaprPubSubBrokerProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/test-app",

--- a/pkg/daprrp/api/v20231001preview/secretstore_conversion.go
+++ b/pkg/daprrp/api/v20231001preview/secretstore_conversion.go
@@ -32,19 +32,13 @@ import (
 // resourceProvisioning is set to manual and the required fields are not specified.
 func (src *DaprSecretStoreResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.DaprSecretStore{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 		Properties: datamodel.DaprSecretStoreProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Environment: to.String(src.Properties.Environment),

--- a/pkg/daprrp/api/v20231001preview/secretstore_conversion_test.go
+++ b/pkg/daprrp/api/v20231001preview/secretstore_conversion_test.go
@@ -41,23 +41,17 @@ func TestDaprSecretStore_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "secretstore manual resource",
 			file: "secretstore_manual_resource.json",
 			expected: &datamodel.DaprSecretStore{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Dapr/secretStores/test-dss",
-						Name:     "test-dss",
-						Type:     dapr_ctrl.DaprSecretStoresResourceType,
-						Location: v1.LocationGlobal,
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
+				ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Dapr/secretStores/test-dss",
+				Name:     "test-dss",
+				Type:     dapr_ctrl.DaprSecretStoresResourceType,
+				Location: v1.LocationGlobal,
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.DaprSecretStoreProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/test-app",
@@ -78,23 +72,17 @@ func TestDaprSecretStore_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "secretstore recipe resource",
 			file: "secretstore_recipe_resource.json",
 			expected: &datamodel.DaprSecretStore{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Dapr/secretStores/test-dss",
-						Name:     "test-dss",
-						Type:     dapr_ctrl.DaprSecretStoresResourceType,
-						Location: v1.LocationGlobal,
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
+				ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Dapr/secretStores/test-dss",
+				Name:     "test-dss",
+				Type:     dapr_ctrl.DaprSecretStoresResourceType,
+				Location: v1.LocationGlobal,
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.DaprSecretStoreProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/test-app",

--- a/pkg/daprrp/api/v20231001preview/statestore_conversion.go
+++ b/pkg/daprrp/api/v20231001preview/statestore_conversion.go
@@ -8,7 +8,6 @@ import (
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/daprrp/datamodel"
 	"github.com/radius-project/radius/pkg/portableresources"
-	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	"github.com/radius-project/radius/pkg/to"
 )
 
@@ -16,10 +15,8 @@ import (
 // if the resourceProvisioning is set to manual and the required fields are not specified.
 func (src *DaprStateStoreResource) ConvertTo() (v1.DataModelInterface, error) {
 	daprStateStoreProperties := datamodel.DaprStateStoreProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Environment: to.String(src.Properties.Environment),
-			Application: to.String(src.Properties.Application),
-		},
+		Environment: to.String(src.Properties.Environment),
+		Application: to.String(src.Properties.Application),
 	}
 
 	trackedResource := v1.TrackedResource{

--- a/pkg/daprrp/api/v20231001preview/statestore_conversion_test.go
+++ b/pkg/daprrp/api/v20231001preview/statestore_conversion_test.go
@@ -50,23 +50,17 @@ func TestDaprStateStore_ConvertVersionedToDataModel(t *testing.T) {
 			convertedResource := dm.(*datamodel.DaprStateStore)
 
 			expected := &datamodel.DaprStateStore{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Dapr/stateStores/stateStore0",
-						Name:     "stateStore0",
-						Type:     dapr_ctrl.DaprStateStoresResourceType,
-						Location: v1.LocationGlobal,
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
+				ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Dapr/stateStores/stateStore0",
+				Name:     "stateStore0",
+				Type:     dapr_ctrl.DaprStateStoresResourceType,
+				Location: v1.LocationGlobal,
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.DaprStateStoreProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",

--- a/pkg/daprrp/processors/configurationstores/processor_test.go
+++ b/pkg/daprrp/processors/configurationstores/processor_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"testing"
 
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/daprrp/datamodel"
 	dapr_ctrl "github.com/radius-project/radius/pkg/daprrp/frontend/controller"
 	"github.com/radius-project/radius/pkg/kubernetes"
@@ -54,11 +53,7 @@ func Test_Process(t *testing.T) {
 		}
 
 		resource := &datamodel.DaprConfigurationStore{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: componentName,
-				},
-			},
+			Name: componentName,
 			Properties: datamodel.DaprConfigurationStoreProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Application: appID,
@@ -125,13 +120,9 @@ func Test_Process(t *testing.T) {
 			{
 				description: "Raw values",
 				properties: &datamodel.DaprConfigurationStoreProperties{
-					BasicResourceProperties: rpv1.BasicResourceProperties{
-						Application: appID,
-						Environment: envID,
-					},
-					BasicDaprResourceProperties: rpv1.BasicDaprResourceProperties{
-						ComponentName: componentName,
-					},
+					Application:          appID,
+					Environment:          envID,
+					ComponentName:        componentName,
 					ResourceProvisioning: portableresources.ResourceProvisioningManual,
 					Metadata: map[string]*rpv1.DaprComponentMetadataValue{
 						"config": {
@@ -168,13 +159,9 @@ func Test_Process(t *testing.T) {
 			{
 				description: "With secret store",
 				properties: &datamodel.DaprConfigurationStoreProperties{
-					BasicResourceProperties: rpv1.BasicResourceProperties{
-						Application: appID,
-						Environment: envID,
-					},
-					BasicDaprResourceProperties: rpv1.BasicDaprResourceProperties{
-						ComponentName: componentName,
-					},
+					Application:          appID,
+					Environment:          envID,
+					ComponentName:        componentName,
 					ResourceProvisioning: portableresources.ResourceProvisioningManual,
 					Metadata: map[string]*rpv1.DaprComponentMetadataValue{
 						"config": {
@@ -232,14 +219,10 @@ func Test_Process(t *testing.T) {
 		for _, tc := range testset {
 			t.Run(tc.description, func(t *testing.T) {
 				processor := Processor{
-					Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}),
+					Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{Name: "test-namespace"}),
 				}
 				resource := &datamodel.DaprConfigurationStore{
-					BaseResource: v1.BaseResource{
-						TrackedResource: v1.TrackedResource{
-							Name: "some-other-name",
-						},
-					},
+					Name:       "some-other-name",
 					Properties: *tc.properties,
 				}
 				options := processors.Options{
@@ -283,15 +266,11 @@ func Test_Process(t *testing.T) {
 
 	t.Run("success - manual (no application)", func(t *testing.T) {
 		processor := Processor{
-			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}),
+			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{Name: "test-namespace"}),
 		}
 
 		resource := &datamodel.DaprConfigurationStore{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: "some-other-name",
-				},
-			},
+			Name: "some-other-name",
 			Properties: datamodel.DaprConfigurationStoreProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Environment: envID,
@@ -378,11 +357,7 @@ func Test_Process(t *testing.T) {
 		}
 
 		resource := &datamodel.DaprConfigurationStore{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: "some-other-name",
-				},
-			},
+			Name: "some-other-name",
 			Properties: datamodel.DaprConfigurationStoreProperties{
 				BasicDaprResourceProperties: rpv1.BasicDaprResourceProperties{
 					ComponentName: componentName,
@@ -461,15 +436,11 @@ func Test_Process(t *testing.T) {
 		require.NoError(t, err)
 
 		processor := Processor{
-			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}, &existing),
+			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{Name: "test-namespace"}, &existing),
 		}
 
 		resource := &datamodel.DaprConfigurationStore{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: "some-other-name",
-				},
-			},
+			Name: "some-other-name",
 			Properties: datamodel.DaprConfigurationStoreProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Application: appID,

--- a/pkg/daprrp/processors/pubsubbrokers/processor_test.go
+++ b/pkg/daprrp/processors/pubsubbrokers/processor_test.go
@@ -19,7 +19,6 @@ package pubsubbrokers
 import (
 	"testing"
 
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/daprrp/datamodel"
 	dapr_ctrl "github.com/radius-project/radius/pkg/daprrp/frontend/controller"
 	"github.com/radius-project/radius/pkg/kubernetes"
@@ -53,11 +52,7 @@ func Test_Process(t *testing.T) {
 		}
 
 		resource := &datamodel.DaprPubSubBroker{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: componentName,
-				},
-			},
+			Name: componentName,
 			Properties: datamodel.DaprPubSubBrokerProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Application: appID,
@@ -124,13 +119,9 @@ func Test_Process(t *testing.T) {
 			{
 				description: "Raw values",
 				properties: &datamodel.DaprPubSubBrokerProperties{
-					BasicResourceProperties: rpv1.BasicResourceProperties{
-						Application: appID,
-						Environment: envID,
-					},
-					BasicDaprResourceProperties: rpv1.BasicDaprResourceProperties{
-						ComponentName: componentName,
-					},
+					Application:          appID,
+					Environment:          envID,
+					ComponentName:        componentName,
 					ResourceProvisioning: portableresources.ResourceProvisioningManual,
 					Metadata: map[string]*rpv1.DaprComponentMetadataValue{
 						"config": {
@@ -167,13 +158,9 @@ func Test_Process(t *testing.T) {
 			{
 				description: "With secret store",
 				properties: &datamodel.DaprPubSubBrokerProperties{
-					BasicResourceProperties: rpv1.BasicResourceProperties{
-						Application: appID,
-						Environment: envID,
-					},
-					BasicDaprResourceProperties: rpv1.BasicDaprResourceProperties{
-						ComponentName: componentName,
-					},
+					Application:          appID,
+					Environment:          envID,
+					ComponentName:        componentName,
 					ResourceProvisioning: portableresources.ResourceProvisioningManual,
 					Metadata: map[string]*rpv1.DaprComponentMetadataValue{
 						"config": {
@@ -231,14 +218,10 @@ func Test_Process(t *testing.T) {
 		for _, tc := range testset {
 			t.Run(tc.description, func(t *testing.T) {
 				processor := Processor{
-					Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}),
+					Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{Name: "test-namespace"}),
 				}
 				resource := &datamodel.DaprPubSubBroker{
-					BaseResource: v1.BaseResource{
-						TrackedResource: v1.TrackedResource{
-							Name: "some-other-name",
-						},
-					},
+					Name:       "some-other-name",
 					Properties: *tc.properties,
 				}
 				options := processors.Options{
@@ -282,15 +265,11 @@ func Test_Process(t *testing.T) {
 
 	t.Run("success - manual (no application)", func(t *testing.T) {
 		processor := Processor{
-			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}),
+			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{Name: "test-namespace"}),
 		}
 
 		resource := &datamodel.DaprPubSubBroker{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: "some-other-name",
-				},
-			},
+			Name: "some-other-name",
 			Properties: datamodel.DaprPubSubBrokerProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Environment: envID,
@@ -377,11 +356,7 @@ func Test_Process(t *testing.T) {
 		}
 
 		resource := &datamodel.DaprPubSubBroker{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: "some-other-name",
-				},
-			},
+			Name: "some-other-name",
 			Properties: datamodel.DaprPubSubBrokerProperties{
 				BasicDaprResourceProperties: rpv1.BasicDaprResourceProperties{
 					ComponentName: componentName,
@@ -460,14 +435,10 @@ func Test_Process(t *testing.T) {
 		require.NoError(t, err)
 
 		processor := Processor{
-			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}, &existing),
+			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{Name: "test-namespace"}, &existing),
 		}
 		resource := &datamodel.DaprPubSubBroker{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: "some-other-name",
-				},
-			},
+			Name: "some-other-name",
 			Properties: datamodel.DaprPubSubBrokerProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Application: appID,

--- a/pkg/daprrp/processors/secretstores/processor_test.go
+++ b/pkg/daprrp/processors/secretstores/processor_test.go
@@ -19,7 +19,6 @@ package secretstores
 import (
 	"testing"
 
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/daprrp/datamodel"
 	dapr_ctrl "github.com/radius-project/radius/pkg/daprrp/frontend/controller"
 	"github.com/radius-project/radius/pkg/kubernetes"
@@ -50,11 +49,7 @@ func Test_Process(t *testing.T) {
 		}
 
 		resource := &datamodel.DaprSecretStore{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: componentName,
-				},
-			},
+			Name: componentName,
 			Properties: datamodel.DaprSecretStoreProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Application: applicationID,
@@ -108,15 +103,11 @@ func Test_Process(t *testing.T) {
 
 	t.Run("success - values", func(t *testing.T) {
 		processor := Processor{
-			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}),
+			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{Name: "test-namespace"}),
 		}
 
 		resource := &datamodel.DaprSecretStore{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: "some-other-name",
-				},
-			},
+			Name: "some-other-name",
 			Properties: datamodel.DaprSecretStoreProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Application: applicationID,
@@ -195,15 +186,11 @@ func Test_Process(t *testing.T) {
 
 	t.Run("success - values (no application)", func(t *testing.T) {
 		processor := Processor{
-			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}),
+			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{Name: "test-namespace"}),
 		}
 
 		resource := &datamodel.DaprSecretStore{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: "some-other-name",
-				},
-			},
+			Name: "some-other-name",
 			Properties: datamodel.DaprSecretStoreProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Environment: envID,
@@ -286,11 +273,7 @@ func Test_Process(t *testing.T) {
 		}
 
 		resource := &datamodel.DaprSecretStore{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: "some-other-name",
-				},
-			},
+			Name: "some-other-name",
 			Properties: datamodel.DaprSecretStoreProperties{
 				BasicDaprResourceProperties: rpv1.BasicDaprResourceProperties{
 					ComponentName: componentName,
@@ -359,14 +342,10 @@ func Test_Process(t *testing.T) {
 		require.NoError(t, err)
 
 		processor := Processor{
-			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}, &existing),
+			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{Name: "test-namespace"}, &existing),
 		}
 		resource := &datamodel.DaprSecretStore{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: "some-other-name",
-				},
-			},
+			Name: "some-other-name",
 			Properties: datamodel.DaprSecretStoreProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Application: applicationID,

--- a/pkg/daprrp/processors/statestores/processor_test.go
+++ b/pkg/daprrp/processors/statestores/processor_test.go
@@ -19,7 +19,6 @@ package statestores
 import (
 	"testing"
 
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/daprrp/datamodel"
 	dapr_ctrl "github.com/radius-project/radius/pkg/daprrp/frontend/controller"
 	"github.com/radius-project/radius/pkg/kubernetes"
@@ -54,11 +53,7 @@ func Test_Process(t *testing.T) {
 		}
 
 		resource := &datamodel.DaprStateStore{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: componentName,
-				},
-			},
+			Name: componentName,
 			Properties: datamodel.DaprStateStoreProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Application: applicationID,
@@ -120,12 +115,8 @@ func Test_Process(t *testing.T) {
 			{
 				description: "Raw values",
 				properties: &datamodel.DaprStateStoreProperties{
-					BasicResourceProperties: rpv1.BasicResourceProperties{
-						Application: applicationID,
-					},
-					BasicDaprResourceProperties: rpv1.BasicDaprResourceProperties{
-						ComponentName: componentName,
-					},
+					Application:          applicationID,
+					ComponentName:        componentName,
 					ResourceProvisioning: portableresources.ResourceProvisioningManual,
 					Metadata: map[string]*rpv1.DaprComponentMetadataValue{
 						"config": {
@@ -162,12 +153,8 @@ func Test_Process(t *testing.T) {
 			{
 				description: "With secret store",
 				properties: &datamodel.DaprStateStoreProperties{
-					BasicResourceProperties: rpv1.BasicResourceProperties{
-						Application: applicationID,
-					},
-					BasicDaprResourceProperties: rpv1.BasicDaprResourceProperties{
-						ComponentName: componentName,
-					},
+					Application:          applicationID,
+					ComponentName:        componentName,
 					ResourceProvisioning: portableresources.ResourceProvisioningManual,
 					Metadata: map[string]*rpv1.DaprComponentMetadataValue{
 						"config": {
@@ -225,14 +212,10 @@ func Test_Process(t *testing.T) {
 			t.Run(tc.description, func(t *testing.T) {
 
 				processor := Processor{
-					Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}),
+					Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{Name: "test-namespace"}),
 				}
 				resource := &datamodel.DaprStateStore{
-					BaseResource: v1.BaseResource{
-						TrackedResource: v1.TrackedResource{
-							Name: "some-other-name",
-						},
-					},
+					Name:       "some-other-name",
 					Properties: *tc.properties,
 				}
 				options := processors.Options{
@@ -276,15 +259,11 @@ func Test_Process(t *testing.T) {
 
 	t.Run("success - manual (no application)", func(t *testing.T) {
 		processor := Processor{
-			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}),
+			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{Name: "test-namespace"}),
 		}
 
 		resource := &datamodel.DaprStateStore{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: "some-other-name",
-				},
-			},
+			Name: "some-other-name",
 			Properties: datamodel.DaprStateStoreProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Environment: envID,
@@ -371,11 +350,7 @@ func Test_Process(t *testing.T) {
 		}
 
 		resource := &datamodel.DaprStateStore{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: "some-other-name",
-				},
-			},
+			Name: "some-other-name",
 			Properties: datamodel.DaprStateStoreProperties{
 				BasicDaprResourceProperties: rpv1.BasicDaprResourceProperties{
 					ComponentName: componentName,
@@ -450,14 +425,10 @@ func Test_Process(t *testing.T) {
 		require.NoError(t, err)
 
 		processor := Processor{
-			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}, &existing),
+			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{Name: "test-namespace"}, &existing),
 		}
 		resource := &datamodel.DaprStateStore{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: "some-other-name",
-				},
-			},
+			Name: "some-other-name",
 			Properties: datamodel.DaprStateStoreProperties{
 				BasicResourceProperties: rpv1.BasicResourceProperties{
 					Application: applicationID,

--- a/pkg/datastoresrp/api/v20231001preview/mongodatabase_conversion.go
+++ b/pkg/datastoresrp/api/v20231001preview/mongodatabase_conversion.go
@@ -28,19 +28,13 @@ import (
 // returning an error if any of the inputs are invalid.
 func (src *MongoDatabaseResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.MongoDatabase{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 		Properties: datamodel.MongoDatabaseProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Environment: to.String(src.Properties.Environment),

--- a/pkg/datastoresrp/api/v20231001preview/mongodatabase_conversion_test.go
+++ b/pkg/datastoresrp/api/v20231001preview/mongodatabase_conversion_test.go
@@ -42,20 +42,14 @@ func TestMongoDatabase_ConvertVersionedToDataModel(t *testing.T) {
 			file: "mongodatabaseresource2.json",
 			desc: "mongodb resource provisioning manual (with resources)",
 			expected: &datamodel.MongoDatabase{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Datastores/mongoDatabases/mongo0",
-						Name: "mongo0",
-						Type: ds_ctrl.MongoDatabasesResourceType,
-						Tags: map[string]string{},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
-				},
+				ID:                     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Datastores/mongoDatabases/mongo0",
+				Name:                   "mongo0",
+				Type:                   ds_ctrl.MongoDatabasesResourceType,
+				Tags:                   map[string]string{},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.MongoDatabaseProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
@@ -73,20 +67,14 @@ func TestMongoDatabase_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "mongodb resource named recipe",
 			file: "mongodatabaseresource_recipe.json",
 			expected: &datamodel.MongoDatabase{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Datastores/mongoDatabases/mongo0",
-						Name: "mongo0",
-						Type: ds_ctrl.MongoDatabasesResourceType,
-						Tags: map[string]string{},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
-				},
+				ID:                     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Datastores/mongoDatabases/mongo0",
+				Name:                   "mongo0",
+				Type:                   ds_ctrl.MongoDatabasesResourceType,
+				Tags:                   map[string]string{},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.MongoDatabaseProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
@@ -104,20 +92,14 @@ func TestMongoDatabase_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "mongodb resource default recipe with overridden values",
 			file: "mongodatabaseresource_recipe2.json",
 			expected: &datamodel.MongoDatabase{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Datastores/mongoDatabases/mongo0",
-						Name: "mongo0",
-						Type: ds_ctrl.MongoDatabasesResourceType,
-						Tags: map[string]string{},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
-				},
+				ID:                     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Datastores/mongoDatabases/mongo0",
+				Name:                   "mongo0",
+				Type:                   ds_ctrl.MongoDatabasesResourceType,
+				Tags:                   map[string]string{},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.MongoDatabaseProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
@@ -134,20 +116,14 @@ func TestMongoDatabase_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "mongodb resource provisioning manual (without resources)",
 			file: "mongodatabaseresource.json",
 			expected: &datamodel.MongoDatabase{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Datastores/mongoDatabases/mongo0",
-						Name: "mongo0",
-						Type: ds_ctrl.MongoDatabasesResourceType,
-						Tags: map[string]string{},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
-				},
+				ID:                     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Datastores/mongoDatabases/mongo0",
+				Name:                   "mongo0",
+				Type:                   ds_ctrl.MongoDatabasesResourceType,
+				Tags:                   map[string]string{},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.MongoDatabaseProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",

--- a/pkg/datastoresrp/api/v20231001preview/rediscache_conversion.go
+++ b/pkg/datastoresrp/api/v20231001preview/rediscache_conversion.go
@@ -28,19 +28,13 @@ import (
 // and returns an error if the inputs are invalid.
 func (src *RedisCacheResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.RedisCache{
-		BaseResource: v1.BaseResource{
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-		},
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
 		Properties: datamodel.RedisCacheProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Environment: to.String(src.Properties.Environment),

--- a/pkg/datastoresrp/api/v20231001preview/rediscache_conversion_test.go
+++ b/pkg/datastoresrp/api/v20231001preview/rediscache_conversion_test.go
@@ -374,18 +374,14 @@ func TestRedisCacheSecrets_ConvertFromValidation(t *testing.T) {
 
 func createBaseResource() v1.BaseResource {
 	return v1.BaseResource{
-		TrackedResource: v1.TrackedResource{
-			ID:   RedisID,
-			Name: "redis0",
-			Type: ds_ctrl.RedisCachesResourceType,
-			Tags: map[string]string{},
-		},
-		InternalMetadata: v1.InternalMetadata{
-			CreatedAPIVersion:      "",
-			UpdatedAPIVersion:      "2023-10-01-preview",
-			AsyncProvisioningState: v1.ProvisioningStateAccepted,
-		},
-		SystemData: v1.SystemData{},
+		ID:                     RedisID,
+		Name:                   "redis0",
+		Type:                   ds_ctrl.RedisCachesResourceType,
+		Tags:                   map[string]string{},
+		CreatedAPIVersion:      "",
+		UpdatedAPIVersion:      "2023-10-01-preview",
+		AsyncProvisioningState: v1.ProvisioningStateAccepted,
+		SystemData:             v1.SystemData{},
 	}
 }
 

--- a/pkg/datastoresrp/api/v20231001preview/sqldatabase_conversion.go
+++ b/pkg/datastoresrp/api/v20231001preview/sqldatabase_conversion.go
@@ -28,19 +28,13 @@ import (
 // and returns an error if the inputs are invalid.
 func (src *SQLDatabaseResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.SqlDatabase{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 		Properties: datamodel.SqlDatabaseProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Environment: to.String(src.Properties.Environment),

--- a/pkg/datastoresrp/api/v20231001preview/sqldatabase_conversion_test.go
+++ b/pkg/datastoresrp/api/v20231001preview/sqldatabase_conversion_test.go
@@ -41,23 +41,17 @@ func TestSqlDatabase_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "sqldatabase manual resource",
 			file: "sqldatabase_manual_resource.json",
 			expected: &datamodel.SqlDatabase{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Datastores/sqlDatabases/sql0",
-						Name:     "sql0",
-						Type:     ds_ctrl.SqlDatabasesResourceType,
-						Location: v1.LocationGlobal,
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
+				ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Datastores/sqlDatabases/sql0",
+				Name:     "sql0",
+				Type:     ds_ctrl.SqlDatabasesResourceType,
+				Location: v1.LocationGlobal,
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.SqlDatabaseProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/test-app",
@@ -84,23 +78,17 @@ func TestSqlDatabase_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "sqldatabase recipe resource",
 			file: "sqldatabase_recipe_resource.json",
 			expected: &datamodel.SqlDatabase{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Datastores/sqlDatabases/sql0",
-						Name:     "sql0",
-						Type:     ds_ctrl.SqlDatabasesResourceType,
-						Location: v1.LocationGlobal,
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
+				ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Datastores/sqlDatabases/sql0",
+				Name:     "sql0",
+				Type:     ds_ctrl.SqlDatabasesResourceType,
+				Location: v1.LocationGlobal,
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.SqlDatabaseProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/test-app",

--- a/pkg/datastoresrp/frontend/controller/mongodatabases/listsecretsmongodatabase_test.go
+++ b/pkg/datastoresrp/frontend/controller/mongodatabases/listsecretsmongodatabase_test.go
@@ -87,8 +87,8 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id},
-					Data:     mongoDataModel,
+					ID:   id,
+					Data: mongoDataModel,
 				}, nil
 			})
 
@@ -127,8 +127,8 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id},
-					Data:     mongoDataModel,
+					ID:   id,
+					Data: mongoDataModel,
 				}, nil
 			})
 
@@ -188,8 +188,8 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id},
-					Data:     mongoDataModel,
+					ID:   id,
+					Data: mongoDataModel,
 				}, nil
 			})
 

--- a/pkg/datastoresrp/frontend/controller/rediscaches/listsecretsrediscache_test.go
+++ b/pkg/datastoresrp/frontend/controller/rediscaches/listsecretsrediscache_test.go
@@ -86,8 +86,8 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id},
-					Data:     redisDataModel,
+					ID:   id,
+					Data: redisDataModel,
 				}, nil
 			})
 
@@ -125,8 +125,8 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id},
-					Data:     redisDataModel,
+					ID:   id,
+					Data: redisDataModel,
 				}, nil
 			})
 
@@ -186,8 +186,8 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id},
-					Data:     redisDataModel,
+					ID:   id,
+					Data: redisDataModel,
 				}, nil
 			})
 

--- a/pkg/datastoresrp/frontend/controller/sqldatabases/listsecretssqldatabase_test.go
+++ b/pkg/datastoresrp/frontend/controller/sqldatabases/listsecretssqldatabase_test.go
@@ -89,8 +89,8 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id},
-					Data:     sqlDataModel,
+					ID:   id,
+					Data: sqlDataModel,
 				}, nil
 			})
 
@@ -127,8 +127,8 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id},
-					Data:     sqlDataModel,
+					ID:   id,
+					Data: sqlDataModel,
 				}, nil
 			})
 
@@ -187,8 +187,8 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id},
-					Data:     sqlDataModel,
+					ID:   id,
+					Data: sqlDataModel,
 				}, nil
 			})
 

--- a/pkg/dynamicrp/api/dynamicresource_conversion.go
+++ b/pkg/dynamicrp/api/dynamicresource_conversion.go
@@ -53,19 +53,13 @@ func (d *DynamicResource) ConvertTo() (v1.DataModelInterface, error) {
 	}
 
 	dm := &datamodel.DynamicResource{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(d.ID),
-				Name:     to.String(d.Name),
-				Type:     to.String(d.Type),
-				Location: to.String(d.Location),
-				Tags:     to.StringMap(d.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion: apiVersion,
-			},
-		},
-		Properties: properties,
+		ID:                to.String(d.ID),
+		Name:              to.String(d.Name),
+		Type:              to.String(d.Type),
+		Location:          to.String(d.Location),
+		Tags:              to.StringMap(d.Tags),
+		UpdatedAPIVersion: apiVersion,
+		Properties:        properties,
 	}
 
 	return dm, nil

--- a/pkg/dynamicrp/api/dynamicresource_conversion_test.go
+++ b/pkg/dynamicrp/api/dynamicresource_conversion_test.go
@@ -36,20 +36,14 @@ func Test_DynamicResource_ConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "dynamicresource-resource.json",
 			expected: &datamodel.DynamicResource{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/planes/radius/local/resourceGroups/test/providers/Applications.Test/testResources/testResource",
-						Name:     "testResource",
-						Type:     "Applications.Test/testResources",
-						Location: "global",
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						UpdatedAPIVersion: "2025-08-01-preview",
-					},
+				ID:       "/planes/radius/local/resourceGroups/test/providers/Applications.Test/testResources/testResource",
+				Name:     "testResource",
+				Type:     "Applications.Test/testResources",
+				Location: "global",
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				UpdatedAPIVersion: "2025-08-01-preview",
 				Properties: map[string]any{
 					"message": "Hello, world!",
 				},

--- a/pkg/dynamicrp/backend/controller/dynamicresource_test.go
+++ b/pkg/dynamicrp/backend/controller/dynamicresource_test.go
@@ -24,7 +24,6 @@ import (
 
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	ctrl "github.com/radius-project/radius/pkg/armrpc/asyncoperation/controller"
 	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
@@ -123,9 +122,7 @@ func testUCPClientFactory() (*v20231001preview.ClientFactory, error) {
 		Get: func(ctx context.Context, planeName, resourceProviderName, resourceTypeName string, options *v20231001preview.ResourceTypesClientGetOptions) (resp azfake.Responder[v20231001preview.ResourceTypesClientGetResponse], errResp azfake.ErrorResponder) {
 			resourceType := resourceProviderName + resources.SegmentSeparator + resourceTypeName
 			response := v20231001preview.ResourceTypesClientGetResponse{
-				ResourceTypeResource: v20231001preview.ResourceTypeResource{
-					Name: new(resourceTypeName),
-				},
+				Name: new(resourceTypeName),
 			}
 
 			switch resourceType {
@@ -147,11 +144,9 @@ func testUCPClientFactory() (*v20231001preview.ClientFactory, error) {
 	}
 
 	return v20231001preview.NewClientFactory(&aztoken.AnonymousCredential{}, &armpolicy.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: fake.NewServerFactoryTransport(&fake.ServerFactory{
-				ResourceTypesServer: resourceTypesServer,
-			}),
-		},
+		Transport: fake.NewServerFactoryTransport(&fake.ServerFactory{
+			ResourceTypesServer: resourceTypesServer,
+		}),
 	})
 }
 

--- a/pkg/dynamicrp/backend/processor/dynamicresource.go
+++ b/pkg/dynamicrp/backend/processor/dynamicresource.go
@@ -269,7 +269,7 @@ func GetSchemaForResourceType(ctx context.Context, ucp *v20231001preview.ClientF
 
 	plane := ID.PlaneNamespace()
 	planeName := strings.Split(plane, "/")[1]
-	resourceProvider := strings.Split(ID.ProviderNamespace(), "/")[0]
+	resourceProvider, _, _ := strings.Cut(ID.ProviderNamespace(), "/")
 	resourceType := strings.Split(ID.Type(), "/")[1]
 
 	response, err := ucp.NewAPIVersionsClient().Get(

--- a/pkg/dynamicrp/backend/processor/dynamicresource_test.go
+++ b/pkg/dynamicrp/backend/processor/dynamicresource_test.go
@@ -26,8 +26,6 @@ import (
 
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
 	"github.com/radius-project/radius/pkg/dynamicrp/backend/secret"
 	"github.com/radius-project/radius/pkg/dynamicrp/datamodel"
@@ -52,15 +50,9 @@ func Test_Process(t *testing.T) {
 	application := "test-application"
 	t.Run("success", func(t *testing.T) {
 		resource := &datamodel.DynamicResource{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID:   "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
-					Type: "Applications.Test/testRecipeResources",
-				},
-				InternalMetadata: v1.InternalMetadata{
-					UpdatedAPIVersion: "2024-01-01",
-				},
-			},
+			ID:                "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
+			Type:              "Applications.Test/testRecipeResources",
+			UpdatedAPIVersion: "2024-01-01",
 			Properties: map[string]any{
 				"status": map[string]any{},
 			},
@@ -125,15 +117,9 @@ func Test_Process(t *testing.T) {
 	// test to check if the properties like environment, application , status etc are not overwritten if they are provided as part of the recipe output.
 	t.Run("do not overwite basic properties", func(t *testing.T) {
 		resource := &datamodel.DynamicResource{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID:   "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
-					Type: "Applications.Test/testRecipeResources",
-				},
-				InternalMetadata: v1.InternalMetadata{
-					UpdatedAPIVersion: "2024-01-01",
-				},
-			},
+			ID:                "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
+			Type:              "Applications.Test/testRecipeResources",
+			UpdatedAPIVersion: "2024-01-01",
 			Properties: map[string]any{
 				"environment": environment,
 				"application": application,
@@ -211,13 +197,9 @@ func Test_Process(t *testing.T) {
 		require.NoError(t, err)
 
 		resource := &datamodel.DynamicResource{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID:   "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
-					Type: "Applications.Test/testRecipeResources",
-				},
-				InternalMetadata: v1.InternalMetadata{UpdatedAPIVersion: "2024-01-01"},
-			},
+			ID:                "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
+			Type:              "Applications.Test/testRecipeResources",
+			UpdatedAPIVersion: "2024-01-01",
 			Properties: map[string]any{
 				"environment": environment,
 				"application": application,
@@ -282,14 +264,10 @@ func Test_Process(t *testing.T) {
 		require.NoError(t, err)
 
 		resource := &datamodel.DynamicResource{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID:   "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
-					Type: "Applications.Test/testRecipeResources",
-				},
-				InternalMetadata: v1.InternalMetadata{UpdatedAPIVersion: "2024-01-01"},
-			},
-			Properties: map[string]any{"status": map[string]any{}},
+			ID:                "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
+			Type:              "Applications.Test/testRecipeResources",
+			UpdatedAPIVersion: "2024-01-01",
+			Properties:        map[string]any{"status": map[string]any{}},
 		}
 		options := processors.Options{
 			RecipeOutput: &recipes.RecipeOutput{
@@ -325,10 +303,8 @@ func Test_Process(t *testing.T) {
 		cf, err := testUCPClientFactoryWithSecrets("password")
 		require.NoError(t, err)
 		resource := &datamodel.DynamicResource{
-			BaseResource: v1.BaseResource{
-				TrackedResource:  v1.TrackedResource{ID: "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource"},
-				InternalMetadata: v1.InternalMetadata{UpdatedAPIVersion: "2024-01-01"},
-			},
+			ID:                "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
+			UpdatedAPIVersion: "2024-01-01",
 			Properties: map[string]any{
 				"status":  map[string]any{},
 				"secrets": map[string]any{"name": "old-secret-name"},
@@ -349,14 +325,10 @@ func Test_Process(t *testing.T) {
 		require.NoError(t, err)
 
 		resource := &datamodel.DynamicResource{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID:   "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
-					Type: "Applications.Test/testRecipeResources",
-				},
-				InternalMetadata: v1.InternalMetadata{UpdatedAPIVersion: "2024-01-01"},
-			},
-			Properties: map[string]any{"status": map[string]any{}},
+			ID:                "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
+			Type:              "Applications.Test/testRecipeResources",
+			UpdatedAPIVersion: "2024-01-01",
+			Properties:        map[string]any{"status": map[string]any{}},
 		}
 		options := processors.Options{
 			RecipeOutput: &recipes.RecipeOutput{
@@ -388,14 +360,10 @@ func Test_Process(t *testing.T) {
 		require.NoError(t, err)
 
 		resource := &datamodel.DynamicResource{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID:   "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
-					Type: "Applications.Test/testRecipeResources",
-				},
-				InternalMetadata: v1.InternalMetadata{UpdatedAPIVersion: "2024-01-01"},
-			},
-			Properties: map[string]any{"status": map[string]any{}},
+			ID:                "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
+			Type:              "Applications.Test/testRecipeResources",
+			UpdatedAPIVersion: "2024-01-01",
+			Properties:        map[string]any{"status": map[string]any{}},
 		}
 		options := processors.Options{
 			RecipeOutput: &recipes.RecipeOutput{
@@ -423,13 +391,9 @@ func Test_Process(t *testing.T) {
 
 		resourceID := "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource"
 		resource := &datamodel.DynamicResource{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID:   resourceID,
-					Type: "Applications.Test/testRecipeResources",
-				},
-				InternalMetadata: v1.InternalMetadata{UpdatedAPIVersion: "2024-01-01"},
-			},
+			ID:                resourceID,
+			Type:              "Applications.Test/testRecipeResources",
+			UpdatedAPIVersion: "2024-01-01",
 			// A prior deploy materialized a managed secret and left the reference behind.
 			Properties: map[string]any{
 				"secrets": map[string]any{"name": "test-resource-secrets"},
@@ -457,7 +421,7 @@ func Test_Process(t *testing.T) {
 		p := DynamicProcessor{SecretMaterializer: mat}
 		resourceID := "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource"
 		resource := &datamodel.DynamicResource{
-			BaseResource: v1.BaseResource{TrackedResource: v1.TrackedResource{ID: resourceID}},
+			ID: resourceID,
 			Properties: map[string]any{
 				"status":  map[string]any{},
 				"secrets": map[string]any{"name": "test-resource-secrets"},
@@ -478,13 +442,9 @@ func Test_Process(t *testing.T) {
 
 		resourceID := "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource"
 		resource := &datamodel.DynamicResource{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID:   resourceID,
-					Type: "Applications.Test/testRecipeResources",
-				},
-				InternalMetadata: v1.InternalMetadata{UpdatedAPIVersion: "2024-01-01"},
-			},
+			ID:                resourceID,
+			Type:              "Applications.Test/testRecipeResources",
+			UpdatedAPIVersion: "2024-01-01",
 			Properties: map[string]any{
 				"secrets": map[string]any{"name": "test-resource-secrets"},
 			},
@@ -514,13 +474,9 @@ func Test_Process(t *testing.T) {
 
 		resourceID := "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource"
 		resource := &datamodel.DynamicResource{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID:   resourceID,
-					Type: "Applications.Test/testRecipeResources",
-				},
-				InternalMetadata: v1.InternalMetadata{UpdatedAPIVersion: "2024-01-01"},
-			},
+			ID:                resourceID,
+			Type:              "Applications.Test/testRecipeResources",
+			UpdatedAPIVersion: "2024-01-01",
 			Properties: map[string]any{
 				"status":  map[string]any{},
 				"secrets": map[string]any{"name": "test-resource-secrets"},
@@ -559,14 +515,10 @@ func Test_Process(t *testing.T) {
 		require.NoError(t, err)
 
 		resource := &datamodel.DynamicResource{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID:   "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
-					Type: "Applications.Test/testRecipeResources",
-				},
-				InternalMetadata: v1.InternalMetadata{UpdatedAPIVersion: "2024-01-01"},
-			},
-			Properties: map[string]any{"status": map[string]any{}},
+			ID:                "/planes/radius/local/resourceGroups/test-group/providers/Applications.Test/testRecipeResources/test-resource",
+			Type:              "Applications.Test/testRecipeResources",
+			UpdatedAPIVersion: "2024-01-01",
+			Properties:        map[string]any{"status": map[string]any{}},
 		}
 		options := processors.Options{
 			RecipeOutput: &recipes.RecipeOutput{
@@ -637,10 +589,8 @@ func testUCPClientFactoryWithSchema(schema map[string]any) (*v20231001preview.Cl
 	apiVersionServer := fake.APIVersionsServer{
 		Get: func(ctx context.Context, planeName, resourceProviderName, resourceTypeName string, apiVersionName string, options *v20231001preview.APIVersionsClientGetOptions) (resp azfake.Responder[v20231001preview.APIVersionsClientGetResponse], errResp azfake.ErrorResponder) {
 			response := v20231001preview.APIVersionsClientGetResponse{
-				APIVersionResource: v20231001preview.APIVersionResource{
-					Properties: &v20231001preview.APIVersionProperties{
-						Schema: schema,
-					},
+				Properties: &v20231001preview.APIVersionProperties{
+					Schema: schema,
 				},
 			}
 			resp.SetResponse(http.StatusOK, response, nil)
@@ -649,11 +599,9 @@ func testUCPClientFactoryWithSchema(schema map[string]any) (*v20231001preview.Cl
 	}
 
 	return v20231001preview.NewClientFactory(&aztoken.AnonymousCredential{}, &armpolicy.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: fake.NewServerFactoryTransport(&fake.ServerFactory{
-				APIVersionsServer: apiVersionServer,
-			}),
-		},
+		Transport: fake.NewServerFactoryTransport(&fake.ServerFactory{
+			APIVersionsServer: apiVersionServer,
+		}),
 	})
 }
 
@@ -661,17 +609,15 @@ func testUCPClientFactory() (*v20231001preview.ClientFactory, error) {
 	apiVersionServer := fake.APIVersionsServer{
 		Get: func(ctx context.Context, planeName, resourceProviderName, resourceTypeName string, apiVersionName string, options *v20231001preview.APIVersionsClientGetOptions) (resp azfake.Responder[v20231001preview.APIVersionsClientGetResponse], errResp azfake.ErrorResponder) {
 			response := v20231001preview.APIVersionsClientGetResponse{
-				APIVersionResource: v20231001preview.APIVersionResource{
-					Properties: &v20231001preview.APIVersionProperties{
-						Schema: map[string]any{
-							"properties": map[string]any{
-								"environment": map[string]any{},
-								"application": map[string]any{},
-								"host":        map[string]any{},
-								"database":    map[string]any{},
-								"port":        map[string]any{},
-								"username":    map[string]any{},
-							},
+				Properties: &v20231001preview.APIVersionProperties{
+					Schema: map[string]any{
+						"properties": map[string]any{
+							"environment": map[string]any{},
+							"application": map[string]any{},
+							"host":        map[string]any{},
+							"database":    map[string]any{},
+							"port":        map[string]any{},
+							"username":    map[string]any{},
 						},
 					},
 				},
@@ -683,11 +629,9 @@ func testUCPClientFactory() (*v20231001preview.ClientFactory, error) {
 	}
 
 	return v20231001preview.NewClientFactory(&aztoken.AnonymousCredential{}, &armpolicy.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: fake.NewServerFactoryTransport(&fake.ServerFactory{
-				APIVersionsServer: apiVersionServer,
-			}),
-		},
+		Transport: fake.NewServerFactoryTransport(&fake.ServerFactory{
+			APIVersionsServer: apiVersionServer,
+		}),
 	})
 }
 
@@ -736,11 +680,9 @@ func TestGetSchemaForResourceType(t *testing.T) {
 		}
 
 		clientFactory, err := v20231001preview.NewClientFactory(&aztoken.AnonymousCredential{}, &armpolicy.ClientOptions{
-			ClientOptions: policy.ClientOptions{
-				Transport: fake.NewServerFactoryTransport(&fake.ServerFactory{
-					APIVersionsServer: apiVersionServer,
-				}),
-			},
+			Transport: fake.NewServerFactoryTransport(&fake.ServerFactory{
+				APIVersionsServer: apiVersionServer,
+			}),
 		})
 		require.NoError(t, err)
 
@@ -759,10 +701,8 @@ func TestGetSchemaForResourceType(t *testing.T) {
 		apiVersionServer := fake.APIVersionsServer{
 			Get: func(ctx context.Context, planeName string, providerNamespace string, resourceTypeName string, apiVersionName string, options *v20231001preview.APIVersionsClientGetOptions) (resp azfake.Responder[v20231001preview.APIVersionsClientGetResponse], errResp azfake.ErrorResponder) {
 				response := v20231001preview.APIVersionsClientGetResponse{
-					APIVersionResource: v20231001preview.APIVersionResource{
-						Properties: &v20231001preview.APIVersionProperties{
-							Schema: nil, // No schema
-						},
+					Properties: &v20231001preview.APIVersionProperties{
+						Schema: nil, // No schema
 					},
 				}
 				resp.SetResponse(http.StatusOK, response, nil)
@@ -771,11 +711,9 @@ func TestGetSchemaForResourceType(t *testing.T) {
 		}
 
 		clientFactory, err := v20231001preview.NewClientFactory(&aztoken.AnonymousCredential{}, &armpolicy.ClientOptions{
-			ClientOptions: policy.ClientOptions{
-				Transport: fake.NewServerFactoryTransport(&fake.ServerFactory{
-					APIVersionsServer: apiVersionServer,
-				}),
-			},
+			Transport: fake.NewServerFactoryTransport(&fake.ServerFactory{
+				APIVersionsServer: apiVersionServer,
+			}),
 		})
 		require.NoError(t, err)
 

--- a/pkg/dynamicrp/backend/secret/materializer_test.go
+++ b/pkg/dynamicrp/backend/secret/materializer_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
 	genfake "github.com/radius-project/radius/pkg/cli/clients_new/generated/fake"
 	"github.com/radius-project/radius/pkg/ucp/resources"
@@ -95,7 +94,7 @@ func Test_Materialize(t *testing.T) {
 		},
 	})
 
-	m := NewMaterializer(&arm.ClientOptions{ClientOptions: policy.ClientOptions{Transport: transport}})
+	m := NewMaterializer(&arm.ClientOptions{Transport: transport})
 
 	result, err := m.Materialize(t.Context(), Request{
 		OwnerResourceID: testOwnerID,
@@ -136,7 +135,7 @@ func Test_Materialize_OmitsEmptyApplication(t *testing.T) {
 		},
 	})
 
-	m := NewMaterializer(&arm.ClientOptions{ClientOptions: policy.ClientOptions{Transport: transport}})
+	m := NewMaterializer(&arm.ClientOptions{Transport: transport})
 
 	_, err := m.Materialize(t.Context(), Request{
 		OwnerResourceID: testOwnerID,
@@ -192,7 +191,7 @@ func Test_Delete(t *testing.T) {
 		},
 	})
 
-	m := NewMaterializer(&arm.ClientOptions{ClientOptions: policy.ClientOptions{Transport: transport}})
+	m := NewMaterializer(&arm.ClientOptions{Transport: transport})
 
 	require.NoError(t, m.Delete(t.Context(), testOwnerID))
 	ownerID, err := resources.ParseResource(testOwnerID)
@@ -210,7 +209,7 @@ func Test_Delete_NotFoundIsIgnored(t *testing.T) {
 		},
 	})
 
-	m := NewMaterializer(&arm.ClientOptions{ClientOptions: policy.ClientOptions{Transport: transport}})
+	m := NewMaterializer(&arm.ClientOptions{Transport: transport})
 
 	require.NoError(t, m.Delete(t.Context(), testOwnerID))
 }

--- a/pkg/dynamicrp/frontend/encryptionfilter_test.go
+++ b/pkg/dynamicrp/frontend/encryptionfilter_test.go
@@ -23,7 +23,6 @@ import (
 
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
 	"github.com/radius-project/radius/pkg/crypto/encryption"
@@ -286,9 +285,7 @@ func testUCPClientFactoryWithError() (*v20231001preview.ClientFactory, error) {
 	}
 
 	return v20231001preview.NewClientFactory(&aztoken.AnonymousCredential{}, &armpolicy.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: fake.NewAPIVersionsServerTransport(&apiVersionsServer),
-		},
+		Transport: fake.NewAPIVersionsServerTransport(&apiVersionsServer),
 	})
 }
 
@@ -296,11 +293,9 @@ func createFakeUCPClientFactory(schema map[string]any) (*v20231001preview.Client
 	apiVersionsServer := fake.APIVersionsServer{
 		Get: func(ctx context.Context, planeName, resourceProviderName, resourceTypeName, apiVersionName string, options *v20231001preview.APIVersionsClientGetOptions) (resp azfake.Responder[v20231001preview.APIVersionsClientGetResponse], errResp azfake.ErrorResponder) {
 			response := v20231001preview.APIVersionsClientGetResponse{
-				APIVersionResource: v20231001preview.APIVersionResource{
-					Name: new(apiVersionName),
-					Properties: &v20231001preview.APIVersionProperties{
-						Schema: schema,
-					},
+				Name: new(apiVersionName),
+				Properties: &v20231001preview.APIVersionProperties{
+					Schema: schema,
 				},
 			}
 			resp.SetResponse(http.StatusOK, response, nil)
@@ -309,8 +304,6 @@ func createFakeUCPClientFactory(schema map[string]any) (*v20231001preview.Client
 	}
 
 	return v20231001preview.NewClientFactory(&aztoken.AnonymousCredential{}, &armpolicy.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: fake.NewAPIVersionsServerTransport(&apiVersionsServer),
-		},
+		Transport: fake.NewAPIVersionsServerTransport(&apiVersionsServer),
 	})
 }

--- a/pkg/dynamicrp/frontend/getresource_test.go
+++ b/pkg/dynamicrp/frontend/getresource_test.go
@@ -56,18 +56,12 @@ func newTestGetController(t *testing.T, databaseClient database.Client, ucpClien
 
 func newGetTestDynamicResource(provisioningState v1.ProvisioningState, properties map[string]any) *datamodel.DynamicResource {
 	return &datamodel.DynamicResource{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   testResourceID,
-				Name: "myResource",
-				Type: "Applications.Test/testResources",
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      testAPIVersion,
-				AsyncProvisioningState: provisioningState,
-			},
-		},
-		Properties: properties,
+		ID:                     testResourceID,
+		Name:                   "myResource",
+		Type:                   "Applications.Test/testResources",
+		UpdatedAPIVersion:      testAPIVersion,
+		AsyncProvisioningState: provisioningState,
+		Properties:             properties,
 	}
 }
 

--- a/pkg/dynamicrp/frontend/listresources_test.go
+++ b/pkg/dynamicrp/frontend/listresources_test.go
@@ -56,18 +56,12 @@ func newTestListController(t *testing.T, databaseClient database.Client, ucpClie
 
 func newTestDynamicResource(id string, name string, provisioningState v1.ProvisioningState, properties map[string]any) *datamodel.DynamicResource {
 	return &datamodel.DynamicResource{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   id,
-				Name: name,
-				Type: "Applications.Test/testResources",
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      testAPIVersion,
-				AsyncProvisioningState: provisioningState,
-			},
-		},
-		Properties: properties,
+		ID:                     id,
+		Name:                   name,
+		Type:                   "Applications.Test/testResources",
+		UpdatedAPIVersion:      testAPIVersion,
+		AsyncProvisioningState: provisioningState,
+		Properties:             properties,
 	}
 }
 

--- a/pkg/dynamicrp/integrationtest/dynamic/operations_test.go
+++ b/pkg/dynamicrp/integrationtest/dynamic/operations_test.go
@@ -59,14 +59,12 @@ func Test_Dynamic_OperationResultAndStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	operation := &statusmanager.Status{
-		AsyncOperationStatus: v1.AsyncOperationStatus{
-			ID:     operationStatusID,
-			Name:   operationName,
-			Status: v1.ProvisioningStateUpdating,
-		},
+		ID:     operationStatusID,
+		Name:   operationName,
+		Status: v1.ProvisioningStateUpdating,
 	}
 
-	err = databaseClient.Save(ctx, &database.Object{Data: operation, Metadata: database.Metadata{ID: operationStatusID}})
+	err = databaseClient.Save(ctx, &database.Object{Data: operation, ID: operationStatusID})
 	require.NoError(t, err)
 
 	// Now let's query it again, we should find it.

--- a/pkg/dynamicrp/options.go
+++ b/pkg/dynamicrp/options.go
@@ -90,11 +90,10 @@ func NewOptions(ctx context.Context, config *Config) (*Options, error) {
 	var err error
 	options := Options{
 		Config: config,
-	}
 
-	options.QueueProvider = queueprovider.New(config.Queue)
-	options.SecretProvider = secretprovider.NewSecretProvider(config.Secrets)
-	options.DatabaseProvider = databaseprovider.FromOptions(config.Database)
+		QueueProvider:    queueprovider.New(config.Queue),
+		SecretProvider:   secretprovider.NewSecretProvider(config.Secrets),
+		DatabaseProvider: databaseprovider.FromOptions(config.Database)}
 
 	databaseClient, err := options.DatabaseProvider.GetClient(ctx)
 	if err != nil {

--- a/pkg/dynamicrp/testhost/host.go
+++ b/pkg/dynamicrp/testhost/host.go
@@ -41,7 +41,6 @@ import (
 	ucptesthost "github.com/radius-project/radius/pkg/ucp/testhost"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -181,10 +180,8 @@ func setupFakeKubernetesClient(t *testing.T, options *dynamicrp.Options) {
 
 	// Create the encryption key secret
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      encryption.DefaultEncryptionKeySecretName,
-			Namespace: encryption.RadiusNamespace,
-		},
+		Name:      encryption.DefaultEncryptionKeySecretName,
+		Namespace: encryption.RadiusNamespace,
 		Data: map[string][]byte{
 			encryption.DefaultEncryptionKeySecretKey: keyStoreJSON,
 		},

--- a/pkg/messagingrp/api/v20231001preview/rabbitmq_conversion.go
+++ b/pkg/messagingrp/api/v20231001preview/rabbitmq_conversion.go
@@ -28,19 +28,13 @@ import (
 // and returns it or an error if the inputs are invalid.
 func (src *RabbitMQQueueResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.RabbitMQQueue{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      Version,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		UpdatedAPIVersion:      Version,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 		Properties: datamodel.RabbitMQQueueProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Environment: to.String(src.Properties.Environment),

--- a/pkg/messagingrp/api/v20231001preview/rabbitmq_conversion_test.go
+++ b/pkg/messagingrp/api/v20231001preview/rabbitmq_conversion_test.go
@@ -41,23 +41,17 @@ func TestRabbitMQQueue_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "rabbitmq manual resource",
 			file: "rabbitmq_manual_resource.json",
 			expected: &datamodel.RabbitMQQueue{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Messaging/rabbitMQQueues/rabbitmq0",
-						Name:     "rabbitmq0",
-						Type:     msg_ctrl.RabbitMQQueuesResourceType,
-						Location: v1.LocationGlobal,
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
+				ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Messaging/rabbitMQQueues/rabbitmq0",
+				Name:     "rabbitmq0",
+				Type:     msg_ctrl.RabbitMQQueuesResourceType,
+				Location: v1.LocationGlobal,
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.RabbitMQQueueProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/test-app",
@@ -81,23 +75,17 @@ func TestRabbitMQQueue_ConvertVersionedToDataModel(t *testing.T) {
 			desc: "rabbitmq recipe resource",
 			file: "rabbitmq_recipe_resource.json",
 			expected: &datamodel.RabbitMQQueue{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Messaging/rabbitMQQueues/rabbitmq0",
-						Name:     "rabbitmq0",
-						Type:     msg_ctrl.RabbitMQQueuesResourceType,
-						Location: v1.LocationGlobal,
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						CreatedAPIVersion:      "",
-						UpdatedAPIVersion:      "2023-10-01-preview",
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-					SystemData: v1.SystemData{},
+				ID:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Messaging/rabbitMQQueues/rabbitmq0",
+				Name:     "rabbitmq0",
+				Type:     msg_ctrl.RabbitMQQueuesResourceType,
+				Location: v1.LocationGlobal,
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				CreatedAPIVersion:      "",
+				UpdatedAPIVersion:      "2023-10-01-preview",
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
+				SystemData:             v1.SystemData{},
 				Properties: datamodel.RabbitMQQueueProperties{
 					BasicResourceProperties: rpv1.BasicResourceProperties{
 						Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/test-app",

--- a/pkg/messagingrp/frontend/controller/rabbitmqqueues/listsecretsrabbitmq_test.go
+++ b/pkg/messagingrp/frontend/controller/rabbitmqqueues/listsecretsrabbitmq_test.go
@@ -83,8 +83,8 @@ func TestListSecrets_20231001Preview(t *testing.T) {
 			Get(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, id string, _ ...database.GetOptions) (*database.Object, error) {
 				return &database.Object{
-					Metadata: database.Metadata{ID: id},
-					Data:     rabbitMQDataModel,
+					ID:   id,
+					Data: rabbitMQDataModel,
 				}, nil
 			})
 

--- a/pkg/portableresources/backend/controller/createorupdateresource.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource.go
@@ -142,8 +142,8 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 				}
 
 				update := &database.Object{
-					Metadata: database.Metadata{ID: req.ResourceID},
-					Data:     resource,
+					ID:   req.ResourceID,
+					Data: resource,
 				}
 				if err = c.DatabaseClient().Save(ctx, update, database.WithETag(currentETag)); err != nil {
 					logger.Error(err, "Failed to persist redacted resource", "resourceID", req.ResourceID)
@@ -205,9 +205,7 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 	}
 
 	update := &database.Object{
-		Metadata: database.Metadata{
-			ID: req.ResourceID,
-		},
+		ID:   req.ResourceID,
 		Data: recipeDataModel.(rpv1.RadiusResourceModel),
 	}
 	err = c.DatabaseClient().Save(ctx, update, database.WithETag(currentETag))
@@ -227,15 +225,14 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 // when redactionCompleted is true the failure is made terminal (NewFailedResult) to prevent a retry that would fail
 // because sensitive data has already been nullified from the database.
 func (c *CreateOrUpdateResource[P, T]) handleRecipeError(ctx context.Context, err error, recipeDataModel datamodel.RecipeDataModel, resourceID string, etag string, logger logr.Logger, redactionCompleted bool) (ctrl.Result, error) {
-	var recipeErr *recipes.RecipeError
-	if errors.As(err, &recipeErr) {
+	if recipeErr, ok := errors.AsType[*recipes.RecipeError](err); ok {
 		logger.Error(recipeErr, fmt.Sprintf("failed to execute recipe. Encountered error while processing %s ", recipeErr.ErrorDetails.Target))
 
 		// Set the deployment status to the recipe error code
 		recipeDataModel.GetRecipe().DeploymentStatus = util.RecipeDeploymentStatus(recipeErr.DeploymentStatus)
 		update := &database.Object{
-			Metadata: database.Metadata{ID: resourceID},
-			Data:     recipeDataModel.(rpv1.RadiusResourceModel),
+			ID:   resourceID,
+			Data: recipeDataModel.(rpv1.RadiusResourceModel),
 		}
 
 		// Save portable resource with updated deployment status to track errors during deletion.
@@ -314,9 +311,7 @@ func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context
 	}
 
 	return c.engine.Execute(ctx, engine.ExecuteOptions{
-		BaseOptions: engine.BaseOptions{
-			Recipe: metadata,
-		},
+		Recipe:        metadata,
 		PreviousState: prevState,
 		Simulated:     simulated,
 	})

--- a/pkg/portableresources/backend/controller/createorupdateresource_test.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource_test.go
@@ -27,13 +27,11 @@ import (
 
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -512,9 +510,7 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 				stillPassing = false
 				eng.EXPECT().
 					Execute(gomock.Any(), engine.ExecuteOptions{
-						BaseOptions: engine.BaseOptions{
-							Recipe: recipeMetadata,
-						},
+						Recipe:        recipeMetadata,
 						PreviousState: prevState,
 					}).
 					Return(&recipes.RecipeOutput{}, tt.recipeErr).
@@ -522,9 +518,7 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 			} else if stillPassing {
 				eng.EXPECT().
 					Execute(gomock.Any(), engine.ExecuteOptions{
-						BaseOptions: engine.BaseOptions{
-							Recipe: recipeMetadata,
-						},
+						Recipe:        recipeMetadata,
 						PreviousState: prevState,
 					}).
 					Return(&recipes.RecipeOutput{}, nil).
@@ -619,7 +613,7 @@ func TestCreateOrUpdateResource_Run_RecipeErrorSurfacedWhenStatusSaveFails(t *te
 
 	msc.EXPECT().
 		Get(gomock.Any(), TestResourceID).
-		Return(&database.Object{Metadata: database.Metadata{ID: TestResourceID, ETag: "etag-1"}, Data: data}, nil).
+		Return(&database.Object{ID: TestResourceID, ETag: "etag-1", Data: data}, nil).
 		Times(1)
 
 	configuration := &recipes.Configuration{
@@ -714,7 +708,7 @@ func TestCreateOrUpdateResource_Run_SensitiveRedaction(t *testing.T) {
 
 	msc.EXPECT().
 		Get(gomock.Any(), TestResourceID).
-		Return(&database.Object{Metadata: database.Metadata{ID: TestResourceID, ETag: "etag-1"}, Data: data}, nil).
+		Return(&database.Object{ID: TestResourceID, ETag: "etag-1", Data: data}, nil).
 		Times(1)
 
 	ucpClient, err := testUCPClientFactory(map[string]any{
@@ -728,10 +722,8 @@ func TestCreateOrUpdateResource_Run_SensitiveRedaction(t *testing.T) {
 	require.NoError(t, err)
 
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      encryption.DefaultEncryptionKeySecretName,
-			Namespace: encryption.RadiusNamespace,
-		},
+		Name:      encryption.DefaultEncryptionKeySecretName,
+		Namespace: encryption.RadiusNamespace,
 		Data: map[string][]byte{
 			encryption.DefaultEncryptionKeySecretKey: mustKeyStoreJSON(t, key),
 		},
@@ -836,7 +828,7 @@ func TestCreateOrUpdateResource_Run_SensitiveMissingKey(t *testing.T) {
 
 	msc.EXPECT().
 		Get(gomock.Any(), TestResourceID).
-		Return(&database.Object{Metadata: database.Metadata{ID: TestResourceID, ETag: "etag-1"}, Data: data}, nil).
+		Return(&database.Object{ID: TestResourceID, ETag: "etag-1", Data: data}, nil).
 		Times(1)
 
 	ucpClient, err := testUCPClientFactory(map[string]any{
@@ -887,10 +879,8 @@ func testUCPClientFactory(schema map[string]any) (*v20231001preview.ClientFactor
 	apiVersionsServer := fake.APIVersionsServer{
 		Get: func(ctx context.Context, planeName string, resourceProviderName string, resourceTypeName string, apiVersionName string, options *v20231001preview.APIVersionsClientGetOptions) (resp azfake.Responder[v20231001preview.APIVersionsClientGetResponse], errResp azfake.ErrorResponder) {
 			response := v20231001preview.APIVersionsClientGetResponse{
-				APIVersionResource: v20231001preview.APIVersionResource{
-					Properties: &v20231001preview.APIVersionProperties{
-						Schema: schema,
-					},
+				Properties: &v20231001preview.APIVersionProperties{
+					Schema: schema,
 				},
 			}
 			resp.SetResponse(http.StatusOK, response, nil)
@@ -899,9 +889,7 @@ func testUCPClientFactory(schema map[string]any) (*v20231001preview.ClientFactor
 	}
 
 	return v20231001preview.NewClientFactory(&aztoken.AnonymousCredential{}, &armpolicy.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: fake.NewAPIVersionsServerTransport(&apiVersionsServer),
-		},
+		Transport: fake.NewAPIVersionsServerTransport(&apiVersionsServer),
 	})
 }
 
@@ -951,7 +939,7 @@ func TestCreateOrUpdateResource_Run_SensitiveNilKubeClient(t *testing.T) {
 
 	msc.EXPECT().
 		Get(gomock.Any(), TestResourceID).
-		Return(&database.Object{Metadata: database.Metadata{ID: TestResourceID, ETag: "etag-1"}, Data: data}, nil).
+		Return(&database.Object{ID: TestResourceID, ETag: "etag-1", Data: data}, nil).
 		Times(1)
 
 	ucpClient, err := testUCPClientFactory(map[string]any{
@@ -1041,7 +1029,7 @@ func TestCreateOrUpdateResource_Run_SensitiveRedactionSaveFails(t *testing.T) {
 
 	msc.EXPECT().
 		Get(gomock.Any(), TestResourceID).
-		Return(&database.Object{Metadata: database.Metadata{ID: TestResourceID, ETag: "etag-1"}, Data: data}, nil).
+		Return(&database.Object{ID: TestResourceID, ETag: "etag-1", Data: data}, nil).
 		Times(1)
 
 	ucpClient, err := testUCPClientFactory(map[string]any{
@@ -1055,10 +1043,8 @@ func TestCreateOrUpdateResource_Run_SensitiveRedactionSaveFails(t *testing.T) {
 	require.NoError(t, err)
 
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      encryption.DefaultEncryptionKeySecretName,
-			Namespace: encryption.RadiusNamespace,
-		},
+		Name:      encryption.DefaultEncryptionKeySecretName,
+		Namespace: encryption.RadiusNamespace,
 		Data: map[string][]byte{
 			encryption.DefaultEncryptionKeySecretKey: mustKeyStoreJSON(t, key),
 		},
@@ -1162,7 +1148,7 @@ func TestCreateOrUpdateResource_Run_SensitiveMultipleFields(t *testing.T) {
 
 	msc.EXPECT().
 		Get(gomock.Any(), TestResourceID).
-		Return(&database.Object{Metadata: database.Metadata{ID: TestResourceID, ETag: "etag-1"}, Data: data}, nil).
+		Return(&database.Object{ID: TestResourceID, ETag: "etag-1", Data: data}, nil).
 		Times(1)
 
 	ucpClient, err := testUCPClientFactory(map[string]any{
@@ -1185,10 +1171,8 @@ func TestCreateOrUpdateResource_Run_SensitiveMultipleFields(t *testing.T) {
 	require.NoError(t, err)
 
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      encryption.DefaultEncryptionKeySecretName,
-			Namespace: encryption.RadiusNamespace,
-		},
+		Name:      encryption.DefaultEncryptionKeySecretName,
+		Namespace: encryption.RadiusNamespace,
 		Data: map[string][]byte{
 			encryption.DefaultEncryptionKeySecretKey: mustKeyStoreJSON(t, key),
 		},

--- a/pkg/portableresources/backend/controller/deleteresource.go
+++ b/pkg/portableresources/backend/controller/deleteresource.go
@@ -93,9 +93,7 @@ func (c *DeleteResource[P, T]) Run(ctx context.Context, request *ctrl.Request) (
 		}
 
 		err = c.engine.Delete(ctx, engine.DeleteOptions{
-			BaseOptions: engine.BaseOptions{
-				Recipe: recipeData,
-			},
+			Recipe:          recipeData,
 			OutputResources: data.OutputResources(),
 		})
 		if err != nil {

--- a/pkg/portableresources/backend/controller/deleteresource_test.go
+++ b/pkg/portableresources/backend/controller/deleteresource_test.go
@@ -135,9 +135,7 @@ func TestDeleteResourceRun_20231001Preview(t *testing.T) {
 			if tt.getErr == nil {
 				eng.EXPECT().
 					Delete(gomock.Any(), engine.DeleteOptions{
-						BaseOptions: engine.BaseOptions{
-							Recipe: recipeData,
-						},
+						Recipe:          recipeData,
 						OutputResources: status.OutputResources,
 					}).
 					Return(tt.engDelErr).

--- a/pkg/portableresources/processors/resourceclient_test.go
+++ b/pkg/portableresources/processors/resourceclient_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/azure/armauth"
@@ -245,10 +244,8 @@ func Test_Delete_Kubernetes(t *testing.T) {
 
 	t.Run("success - lookup API Version (preferred namespaced resources)", func(t *testing.T) {
 		client := fake.NewClientBuilder().WithObjects(&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-name",
-				Namespace: "test-namespace",
-			},
+			Name:      "test-name",
+			Namespace: "test-namespace",
 		}).Build()
 
 		dc := &k8sutil.DiscoveryClient{
@@ -278,9 +275,7 @@ func Test_Delete_Kubernetes(t *testing.T) {
 
 	t.Run("success - lookup API Version (preferred empty namespace)", func(t *testing.T) {
 		client := fake.NewClientBuilder().WithObjects(&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-name",
-			},
+			Name: "test-name",
 		}).Build()
 
 		dc := &k8sutil.DiscoveryClient{
@@ -310,10 +305,8 @@ func Test_Delete_Kubernetes(t *testing.T) {
 
 	t.Run("failure - lookup API Version - resource list not found", func(t *testing.T) {
 		client := fake.NewClientBuilder().WithObjects(&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-name",
-				Namespace: "test-namespace",
-			},
+			Name:      "test-name",
+			Namespace: "test-namespace",
 		}).Build()
 
 		dc := &k8sutil.DiscoveryClient{
@@ -398,23 +391,21 @@ func newArmOptions(url string) *armauth.ArmConfig {
 
 func newClientOptions(c *http.Client, url string) *arm.ClientOptions {
 	return &arm.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: &wrapper{Client: c},
-			Cloud: cloud.Configuration{
-				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
-					cloud.ResourceManager: {
-						Endpoint: url,
-						Audience: "https://management.core.windows.net",
-					},
+		Transport: &wrapper{Client: c},
+		Cloud: cloud.Configuration{
+			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+				cloud.ResourceManager: {
+					Endpoint: url,
+					Audience: "https://management.core.windows.net",
 				},
 			},
-			// When updating azcore to 1.11.1 from 1.7.0, we saw that HTTPS check for Authentication was added.
-			// Link to the check: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azcore/runtime/policy_bearer_token.go#L118
-			//
-			// This check was failing for ARM requests over HTTP. To fix this, we set InsecureAllowCredentialWithHTTP to true.
-			// The reason it was failing is because the ARM requests are made over HTTP and the bearer token is being sent in the header.
-			InsecureAllowCredentialWithHTTP: true,
 		},
+		// When updating azcore to 1.11.1 from 1.7.0, we saw that HTTPS check for Authentication was added.
+		// Link to the check: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azcore/runtime/policy_bearer_token.go#L118
+		//
+		// This check was failing for ARM requests over HTTP. To fix this, we set InsecureAllowCredentialWithHTTP to true.
+		// The reason it was failing is because the ARM requests are made over HTTP and the bearer token is being sent in the header.
+		InsecureAllowCredentialWithHTTP: true,
 	}
 }
 

--- a/pkg/recipes/configloader/environment_v20250801_bridge_test.go
+++ b/pkg/recipes/configloader/environment_v20250801_bridge_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	v20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
 	"github.com/radius-project/radius/pkg/corerp/api/v20250801preview/fake"
 	"github.com/radius-project/radius/pkg/to"
@@ -44,12 +43,10 @@ const (
 // terraformSettings / bicepSettings requests to the supplied fake servers.
 func fakeArmOptions(tfSrv fake.TerraformSettingsServer, bcSrv fake.BicepSettingsServer) *arm.ClientOptions {
 	return &armpolicy.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: fake.NewServerFactoryTransport(&fake.ServerFactory{
-				TerraformSettingsServer: tfSrv,
-				BicepSettingsServer:     bcSrv,
-			}),
-		},
+		Transport: fake.NewServerFactoryTransport(&fake.ServerFactory{
+			TerraformSettingsServer: tfSrv,
+			BicepSettingsServer:     bcSrv,
+		}),
 	}
 }
 
@@ -75,28 +72,26 @@ func TestGetConfigurationV20250801_TerraformCredentialsAndEnvAndProviderInstalla
 		Get: func(ctx context.Context, rootScope string, name string, opts *v20250801.TerraformSettingsClientGetOptions) (resp azfake.Responder[v20250801.TerraformSettingsClientGetResponse], errResp azfake.ErrorResponder) {
 			require.Equal(t, tfConfigName, name)
 			resp.SetResponse(http.StatusOK, v20250801.TerraformSettingsClientGetResponse{
-				TerraformSettingsResource: v20250801.TerraformSettingsResource{
-					ID:       to.Ptr(tfConfigID),
-					Name:     to.Ptr(tfConfigName),
-					Type:     to.Ptr("Radius.Core/terraformSettings"),
-					Location: to.Ptr("global"),
-					Properties: &v20250801.TerraformSettingsProperties{
-						Terraformrc: &v20250801.TerraformrcConfig{
-							ProviderInstallation: &v20250801.TerraformProviderInstallation{
-								NetworkMirror: &v20250801.TerraformProviderMirror{
-									URL:     to.Ptr("https://mirror.example.com/"),
-									Include: to.SliceOfPtrs("hashicorp/aws"),
-								},
-							},
-							Credentials: map[string]*v20250801.TerraformCredentialConfig{
-								"app.terraform.io":     {Secret: to.Ptr("/planes/.../secretA")},
-								"registry.example.com": {Secret: to.Ptr("/planes/.../secretB")},
+				ID:       to.Ptr(tfConfigID),
+				Name:     to.Ptr(tfConfigName),
+				Type:     to.Ptr("Radius.Core/terraformSettings"),
+				Location: to.Ptr("global"),
+				Properties: &v20250801.TerraformSettingsProperties{
+					Terraformrc: &v20250801.TerraformrcConfig{
+						ProviderInstallation: &v20250801.TerraformProviderInstallation{
+							NetworkMirror: &v20250801.TerraformProviderMirror{
+								URL:     to.Ptr("https://mirror.example.com/"),
+								Include: to.SliceOfPtrs("hashicorp/aws"),
 							},
 						},
-						Env: map[string]*string{
-							"TF_LOG":      to.Ptr("DEBUG"),
-							"TF_LOG_PATH": to.Ptr("/tmp/tf.log"),
+						Credentials: map[string]*v20250801.TerraformCredentialConfig{
+							"app.terraform.io":     {Secret: to.Ptr("/planes/.../secretA")},
+							"registry.example.com": {Secret: to.Ptr("/planes/.../secretB")},
 						},
+					},
+					Env: map[string]*string{
+						"TF_LOG":      to.Ptr("DEBUG"),
+						"TF_LOG_PATH": to.Ptr("/tmp/tf.log"),
 					},
 				},
 			}, nil)
@@ -136,17 +131,15 @@ func TestGetConfigurationV20250801_BicepBasicAuthMapped(t *testing.T) {
 			require.Equal(t, bcConfigName, name)
 			method := v20250801.BicepAuthenticationMethodBasicAuth
 			resp.SetResponse(http.StatusOK, v20250801.BicepSettingsClientGetResponse{
-				BicepSettingsResource: v20250801.BicepSettingsResource{
-					ID:       to.Ptr(bcConfigID),
-					Name:     to.Ptr(bcConfigName),
-					Type:     to.Ptr("Radius.Core/bicepSettings"),
-					Location: to.Ptr("global"),
-					Properties: &v20250801.BicepSettingsProperties{
-						RegistryAuthentications: map[string]*v20250801.BicepRegistryAuthentication{
-							"corp.acr.io": {
-								AuthenticationMethod: &method,
-								BasicAuthSecretID:    to.Ptr("/planes/.../basic-secret"),
-							},
+				ID:       to.Ptr(bcConfigID),
+				Name:     to.Ptr(bcConfigName),
+				Type:     to.Ptr("Radius.Core/bicepSettings"),
+				Location: to.Ptr("global"),
+				Properties: &v20250801.BicepSettingsProperties{
+					RegistryAuthentications: map[string]*v20250801.BicepRegistryAuthentication{
+						"corp.acr.io": {
+							AuthenticationMethod: &method,
+							BasicAuthSecretID:    to.Ptr("/planes/.../basic-secret"),
 						},
 					},
 				},
@@ -178,26 +171,24 @@ func TestGetConfigurationV20250801_BicepEntriesWithoutBasicAuthSecretAreSkipped(
 			azure := v20250801.BicepAuthenticationMethodAzureWI
 			aws := v20250801.BicepAuthenticationMethodAwsIrsa
 			resp.SetResponse(http.StatusOK, v20250801.BicepSettingsClientGetResponse{
-				BicepSettingsResource: v20250801.BicepSettingsResource{
-					ID:       to.Ptr(bcConfigID),
-					Name:     to.Ptr(bcConfigName),
-					Type:     to.Ptr("Radius.Core/bicepSettings"),
-					Location: to.Ptr("global"),
-					Properties: &v20250801.BicepSettingsProperties{
-						RegistryAuthentications: map[string]*v20250801.BicepRegistryAuthentication{
-							"basic.acr.io": {
-								AuthenticationMethod: &basic,
-								BasicAuthSecretID:    to.Ptr("/planes/.../basic-secret"),
-							},
-							"azure.acr.io": {
-								AuthenticationMethod: &azure,
-								AzureWiClientID:      to.Ptr("client-id"),
-								AzureWiTenantID:      to.Ptr("tenant-id"),
-							},
-							"aws.ecr.io": {
-								AuthenticationMethod: &aws,
-								AwsIamRoleArn:        to.Ptr("arn:aws:iam::123:role/MyRole"),
-							},
+				ID:       to.Ptr(bcConfigID),
+				Name:     to.Ptr(bcConfigName),
+				Type:     to.Ptr("Radius.Core/bicepSettings"),
+				Location: to.Ptr("global"),
+				Properties: &v20250801.BicepSettingsProperties{
+					RegistryAuthentications: map[string]*v20250801.BicepRegistryAuthentication{
+						"basic.acr.io": {
+							AuthenticationMethod: &basic,
+							BasicAuthSecretID:    to.Ptr("/planes/.../basic-secret"),
+						},
+						"azure.acr.io": {
+							AuthenticationMethod: &azure,
+							AzureWiClientID:      to.Ptr("client-id"),
+							AzureWiTenantID:      to.Ptr("tenant-id"),
+						},
+						"aws.ecr.io": {
+							AuthenticationMethod: &aws,
+							AwsIamRoleArn:        to.Ptr("arn:aws:iam::123:role/MyRole"),
 						},
 					},
 				},
@@ -230,18 +221,16 @@ func TestGetConfigurationV20250801_BicepAllEntriesSkipped_LeavesAuthNil(t *testi
 		Get: func(ctx context.Context, rootScope string, name string, opts *v20250801.BicepSettingsClientGetOptions) (resp azfake.Responder[v20250801.BicepSettingsClientGetResponse], errResp azfake.ErrorResponder) {
 			azure := v20250801.BicepAuthenticationMethodAzureWI
 			resp.SetResponse(http.StatusOK, v20250801.BicepSettingsClientGetResponse{
-				BicepSettingsResource: v20250801.BicepSettingsResource{
-					ID:       to.Ptr(bcConfigID),
-					Name:     to.Ptr(bcConfigName),
-					Type:     to.Ptr("Radius.Core/bicepSettings"),
-					Location: to.Ptr("global"),
-					Properties: &v20250801.BicepSettingsProperties{
-						RegistryAuthentications: map[string]*v20250801.BicepRegistryAuthentication{
-							"azure.acr.io": {
-								AuthenticationMethod: &azure,
-								AzureWiClientID:      to.Ptr("client-id"),
-								AzureWiTenantID:      to.Ptr("tenant-id"),
-							},
+				ID:       to.Ptr(bcConfigID),
+				Name:     to.Ptr(bcConfigName),
+				Type:     to.Ptr("Radius.Core/bicepSettings"),
+				Location: to.Ptr("global"),
+				Properties: &v20250801.BicepSettingsProperties{
+					RegistryAuthentications: map[string]*v20250801.BicepRegistryAuthentication{
+						"azure.acr.io": {
+							AuthenticationMethod: &azure,
+							AzureWiClientID:      to.Ptr("client-id"),
+							AzureWiTenantID:      to.Ptr("tenant-id"),
 						},
 					},
 				},

--- a/pkg/recipes/configloader/secrets_test.go
+++ b/pkg/recipes/configloader/secrets_test.go
@@ -23,16 +23,15 @@ func Test_populateSecretData(t *testing.T) {
 			name:       "success - data for input secretKey1 returned",
 			secretKeys: []string{"secretKey1"},
 			secrets: &v20231001preview.SecretStoresClientListSecretsResponse{
-				SecretStoreListSecretsResult: v20231001preview.SecretStoreListSecretsResult{
-					Type: &secretStoreDataTypeGeneric,
-					Data: map[string]*v20231001preview.SecretValueProperties{
-						"secretKey1": {
-							Value: new("secretValue1"),
-						},
-						"secretKey2": {
-							Value: new("secretValue2"),
-						},
-					}},
+				Type: &secretStoreDataTypeGeneric,
+				Data: map[string]*v20231001preview.SecretValueProperties{
+					"secretKey1": {
+						Value: new("secretValue1"),
+					},
+					"secretKey2": {
+						Value: new("secretValue2"),
+					},
+				},
 			},
 			secretStoreID: "testSecretStore",
 			expectedSecrets: recipes.SecretData{
@@ -45,16 +44,15 @@ func Test_populateSecretData(t *testing.T) {
 			name:       "success - data for all keys returned with nil secretKeys input",
 			secretKeys: nil,
 			secrets: &v20231001preview.SecretStoresClientListSecretsResponse{
-				SecretStoreListSecretsResult: v20231001preview.SecretStoreListSecretsResult{
-					Type: &secretStoreDataTypeGeneric,
-					Data: map[string]*v20231001preview.SecretValueProperties{
-						"secretKey1": {
-							Value: new("secretValue1"),
-						},
-						"secretKey2": {
-							Value: new("secretValue2"),
-						},
-					}},
+				Type: &secretStoreDataTypeGeneric,
+				Data: map[string]*v20231001preview.SecretValueProperties{
+					"secretKey1": {
+						Value: new("secretValue1"),
+					},
+					"secretKey2": {
+						Value: new("secretValue2"),
+					},
+				},
 			},
 			secretStoreID: "testSecretStore",
 			expectedSecrets: recipes.SecretData{
@@ -70,9 +68,8 @@ func Test_populateSecretData(t *testing.T) {
 			name:       "success - returned with nil secretKeys input when no secret data exist",
 			secretKeys: nil,
 			secrets: &v20231001preview.SecretStoresClientListSecretsResponse{
-				SecretStoreListSecretsResult: v20231001preview.SecretStoreListSecretsResult{
-					Type: &secretStoreDataTypeGeneric,
-					Data: nil},
+				Type: &secretStoreDataTypeGeneric,
+				Data: nil,
 			},
 			secretStoreID: "testSecretStore",
 			expectedSecrets: recipes.SecretData{
@@ -94,9 +91,7 @@ func Test_populateSecretData(t *testing.T) {
 			name:       "fail - missing secret key",
 			secretKeys: []string{"missingKey"},
 			secrets: &v20231001preview.SecretStoresClientListSecretsResponse{
-				SecretStoreListSecretsResult: v20231001preview.SecretStoreListSecretsResult{
-					Type: &secretStoreDataTypeGeneric,
-				},
+				Type: &secretStoreDataTypeGeneric,
 			},
 			secretStoreID:   "testSecretStore",
 			expectedSecrets: recipes.SecretData{},
@@ -107,15 +102,14 @@ func Test_populateSecretData(t *testing.T) {
 			name:       "fail - missing secret type",
 			secretKeys: []string{"secretKey1"},
 			secrets: &v20231001preview.SecretStoresClientListSecretsResponse{
-				SecretStoreListSecretsResult: v20231001preview.SecretStoreListSecretsResult{
-					Data: map[string]*v20231001preview.SecretValueProperties{
-						"secretKey1": {
-							Value: new("secretValue1"),
-						},
-						"secretKey2": {
-							Value: new("secretValue2"),
-						},
-					}},
+				Data: map[string]*v20231001preview.SecretValueProperties{
+					"secretKey1": {
+						Value: new("secretValue1"),
+					},
+					"secretKey2": {
+						Value: new("secretValue2"),
+					},
+				},
 			},
 			secretStoreID:   "testSecretStore",
 			expectedSecrets: recipes.SecretData{},

--- a/pkg/recipes/configloader/security_secrets_test.go
+++ b/pkg/recipes/configloader/security_secrets_test.go
@@ -23,10 +23,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
@@ -252,7 +250,7 @@ func Test_loadSecuritySecret(t *testing.T) {
 			t.Parallel()
 
 			clientset := k8sfake.NewSimpleClientset(&corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "app-ns"},
+				Name: "my-secret", Namespace: "app-ns",
 				Data: map[string][]byte{
 					"username": []byte("admin"),
 					"password": []byte("p4ssw0rd"),
@@ -264,23 +262,19 @@ func Test_loadSecuritySecret(t *testing.T) {
 
 			loader := &secretsLoader{
 				ArmClientOptions: &arm.ClientOptions{
-					ClientOptions: policy.ClientOptions{
-						Transport: genfake.NewServerFactoryTransport(&genfake.ServerFactory{
-							GenericResourcesServer: genfake.GenericResourcesServer{
-								Get: func(ctx context.Context, resourceName string, options *generated.GenericResourcesClientGetOptions) (resp azfake.Responder[generated.GenericResourcesClientGetResponse], errResp azfake.ErrorResponder) {
-									require.Equal(t, "my-secret", resourceName)
-									resp.SetResponse(http.StatusOK, generated.GenericResourcesClientGetResponse{
-										GenericResource: generated.GenericResource{
-											ID:         to.Ptr(secretResourceID),
-											Name:       to.Ptr("my-secret"),
-											Properties: tt.properties,
-										},
-									}, nil)
-									return
-								},
+					Transport: genfake.NewServerFactoryTransport(&genfake.ServerFactory{
+						GenericResourcesServer: genfake.GenericResourcesServer{
+							Get: func(ctx context.Context, resourceName string, options *generated.GenericResourcesClientGetOptions) (resp azfake.Responder[generated.GenericResourcesClientGetResponse], errResp azfake.ErrorResponder) {
+								require.Equal(t, "my-secret", resourceName)
+								resp.SetResponse(http.StatusOK, generated.GenericResourcesClientGetResponse{
+									ID:         to.Ptr(secretResourceID),
+									Name:       to.Ptr("my-secret"),
+									Properties: tt.properties,
+								}, nil)
+								return
 							},
-						}),
-					},
+						},
+					}),
 				},
 				KubernetesProvider: provider,
 			}

--- a/pkg/recipes/driver/bicep/bicep_test.go
+++ b/pkg/recipes/driver/bicep/bicep_test.go
@@ -316,13 +316,11 @@ func Test_Bicep_PrepareRecipeResponse_Success(t *testing.T) {
 	}
 
 	opts := driver.ExecuteOptions{
-		BaseOptions: driver.BaseOptions{
-			Definition: recipes.EnvironmentDefinition{
-				Name:         "mongo-azure",
-				Driver:       recipes.TemplateKindBicep,
-				TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
-				ResourceType: "Applications.Datastores/mongoDatabases",
-			},
+		Definition: recipes.EnvironmentDefinition{
+			Name:         "mongo-azure",
+			Driver:       recipes.TemplateKindBicep,
+			TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
+			ResourceType: "Applications.Datastores/mongoDatabases",
 		},
 		PrevState: []string{},
 	}
@@ -537,19 +535,17 @@ func Test_Bicep_Execute_InvalidOutputMappingDoesNotDeploy(t *testing.T) {
 	}
 
 	output, err := driverBicep.Execute(t.Context(), driver.ExecuteOptions{
-		BaseOptions: driver.BaseOptions{
-			Recipe: recipes.ResourceMetadata{
-				Name:          "mongo",
-				ResourceID:    "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Datastores/mongoDatabases/mongo",
-				EnvironmentID: "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Core/environments/env",
-			},
-			Definition: recipes.EnvironmentDefinition{
-				Name:          "mongo-azure",
-				Driver:        recipes.TemplateKindBicep,
-				TemplatePath:  ts.TestImageURL,
-				ResourceType:  "Applications.Datastores/mongoDatabases",
-				SecretOutputs: map[string]string{"connectionString": "primaryConnectionString"},
-			},
+		Recipe: recipes.ResourceMetadata{
+			Name:          "mongo",
+			ResourceID:    "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Datastores/mongoDatabases/mongo",
+			EnvironmentID: "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Core/environments/env",
+		},
+		Definition: recipes.EnvironmentDefinition{
+			Name:          "mongo-azure",
+			Driver:        recipes.TemplateKindBicep,
+			TemplatePath:  ts.TestImageURL,
+			ResourceType:  "Applications.Datastores/mongoDatabases",
+			SecretOutputs: map[string]string{"connectionString": "primaryConnectionString"},
 		},
 	})
 

--- a/pkg/recipes/driver/bicep/containerimages.go
+++ b/pkg/recipes/driver/bicep/containerimages.go
@@ -319,7 +319,7 @@ func (d *bicepDriver) writeDockerConfig(ctx context.Context, registry, registryS
 }
 
 func dockerConfigAuthKey(registry string) (string, error) {
-	registryHost := strings.SplitN(registry, "/", 2)[0]
+	registryHost, _, _ := strings.Cut(registry, "/")
 	if registryHost == "" {
 		return "", fmt.Errorf("empty registry host")
 	}

--- a/pkg/recipes/driver/bicep/containerimages_test.go
+++ b/pkg/recipes/driver/bicep/containerimages_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/go-logr/logr/funcr"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/radius-project/radius/pkg/recipes"
 	"github.com/radius-project/radius/pkg/recipes/driver"
@@ -292,10 +291,10 @@ printf '{"imageReference":"%s/%s:built"}' "$registry" "$resource_name" > "$RADIU
 		map[string]any{"variables": map[string]any{containerImagesBuildScriptVariableName: script}},
 		imageBuildOutputs(value),
 		response,
-		driver.ExecuteOptions{BaseOptions: driver.BaseOptions{Definition: recipes.EnvironmentDefinition{
+		driver.ExecuteOptions{Definition: recipes.EnvironmentDefinition{
 			ResourceType: "radius.compute/containerimages",
 			Parameters:   map[string]any{registryParameterName: "ghcr.io/radius-project"},
-		}}},
+		}},
 	)
 	require.NoError(t, err)
 	require.Equal(t, "ghcr.io/radius-project/testimage:built", response.Values[imageReferenceValueName])
@@ -307,8 +306,8 @@ func Test_ExecuteImageBuildHook_UsesOnlyOperatorOwnedCredentials(t *testing.T) {
 	requireScriptShell(t)
 
 	secret := &corev1.Secret{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
-		ObjectMeta: metav1.ObjectMeta{Name: "operator-secret", Namespace: "testapp"},
+		APIVersion: "v1", Kind: "Secret",
+		Name: "operator-secret", Namespace: "testapp",
 		Data: map[string][]byte{
 			"username": []byte("operator"),
 			"password": []byte("s3cret"),
@@ -369,7 +368,7 @@ printf '{"imageReference":"operator.example/team/testimage:v1"}' > "$RADIUS_EXEC
 		map[string]any{"variables": map[string]any{containerImagesBuildScriptVariableName: script}},
 		imageBuildOutputs(value),
 		response,
-		driver.ExecuteOptions{BaseOptions: driver.BaseOptions{
+		driver.ExecuteOptions{
 			Configuration: recipes.Configuration{Runtime: recipes.RuntimeConfiguration{
 				Kubernetes: &recipes.KubernetesRuntime{Namespace: "testapp"},
 			}},
@@ -379,8 +378,7 @@ printf '{"imageReference":"operator.example/team/testimage:v1"}' > "$RADIUS_EXEC
 					registryParameterName:           "operator.example/team",
 					registrySecretNameParameterName: "operator-secret",
 				},
-			},
-		}},
+			}},
 	)
 	require.NoError(t, err)
 	require.Equal(t, "/api/v1/namespaces/testapp/secrets/operator-secret", <-requestPaths)
@@ -480,8 +478,8 @@ func Test_ExecuteImageBuild_UnauthenticatedBlanksDockerConfig(t *testing.T) {
 
 func Test_WriteDockerConfig_ReadsDecodedSecretFromTargetCluster(t *testing.T) {
 	secret := &corev1.Secret{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
-		ObjectMeta: metav1.ObjectMeta{Name: "ghcr-creds", Namespace: "testapp"},
+		APIVersion: "v1", Kind: "Secret",
+		Name: "ghcr-creds", Namespace: "testapp",
 		Data: map[string][]byte{
 			"username": []byte("octocat"),
 			"password": []byte("s3cret"),
@@ -519,9 +517,9 @@ users:
 
 	d := &bicepDriver{clusterAccessResolver: clusteraccess.NewResolver()}
 	dir := filepath.Join(t.TempDir(), "docker")
-	err = d.writeDockerConfig(t.Context(), "ghcr.io/radius-project", "ghcr-creds", dir, driver.ExecuteOptions{BaseOptions: driver.BaseOptions{Configuration: recipes.Configuration{
+	err = d.writeDockerConfig(t.Context(), "ghcr.io/radius-project", "ghcr-creds", dir, driver.ExecuteOptions{Configuration: recipes.Configuration{
 		Runtime: recipes.RuntimeConfiguration{Kubernetes: &recipes.KubernetesRuntime{Namespace: "testapp"}},
-	}}})
+	}})
 	require.NoError(t, err)
 	require.Equal(t, "/api/v1/namespaces/testapp/secrets/ghcr-creds", <-requestPaths)
 
@@ -568,9 +566,9 @@ func Test_DockerConfigAuthKey(t *testing.T) {
 
 func Test_WriteDockerConfig_SecretFailures(t *testing.T) {
 	registry, registrySecretName := "ghcr.io/org", "missing"
-	opts := driver.ExecuteOptions{BaseOptions: driver.BaseOptions{Configuration: recipes.Configuration{
+	opts := driver.ExecuteOptions{Configuration: recipes.Configuration{
 		Runtime: recipes.RuntimeConfiguration{Kubernetes: &recipes.KubernetesRuntime{Namespace: "testapp"}},
-	}}}
+	}}
 
 	err := (&bicepDriver{}).writeDockerConfig(t.Context(), registry, registrySecretName, t.TempDir(), opts)
 	require.ErrorContains(t, err, "no cluster access resolver configured")

--- a/pkg/recipes/driver/terraform/terraform_test.go
+++ b/pkg/recipes/driver/terraform/terraform_test.go
@@ -131,11 +131,9 @@ func Test_Terraform_Execute_Success(t *testing.T) {
 	tfExecutor.EXPECT().Deploy(ctx, gomock.Any()).Times(1).Return(expectedTFState, nil)
 
 	recipeOutput, err := tfDriver.Execute(ctx, driver.ExecuteOptions{
-		BaseOptions: driver.BaseOptions{
-			Configuration: envConfig,
-			Recipe:        recipeMetadata,
-			Definition:    envRecipe,
-		},
+		Configuration: envConfig,
+		Recipe:        recipeMetadata,
+		Definition:    envRecipe,
 	})
 	require.NoError(t, err)
 	require.Equal(t, expectedOutput, recipeOutput)
@@ -161,11 +159,9 @@ func Test_Terraform_Execute_DeploymentFailure(t *testing.T) {
 	tfExecutor.EXPECT().Deploy(ctx, gomock.Any()).Times(1).Return(nil, errors.New("Failed to deploy terraform module"))
 
 	_, err := tfDriver.Execute(ctx, driver.ExecuteOptions{
-		BaseOptions: driver.BaseOptions{
-			Configuration: envConfig,
-			Recipe:        recipeMetadata,
-			Definition:    envRecipe,
-		},
+		Configuration: envConfig,
+		Recipe:        recipeMetadata,
+		Definition:    envRecipe,
 	})
 	require.Error(t, err)
 	require.Equal(t, err, &recipeError)
@@ -216,11 +212,9 @@ func Test_Terraform_Execute_InvalidOutputMapping(t *testing.T) {
 			tfExecutor.EXPECT().Deploy(ctx, gomock.Any()).Times(1).Return(nil, tt.executionError)
 
 			output, err := tfDriver.Execute(ctx, driver.ExecuteOptions{
-				BaseOptions: driver.BaseOptions{
-					Configuration: envConfig,
-					Recipe:        recipeMetadata,
-					Definition:    envRecipe,
-				},
+				Configuration: envConfig,
+				Recipe:        recipeMetadata,
+				Definition:    envRecipe,
 			})
 
 			require.Nil(t, output)
@@ -271,11 +265,9 @@ func Test_Terraform_Execute_OutputsFailure(t *testing.T) {
 	tfExecutor.EXPECT().Deploy(ctx, gomock.Any()).Times(1).Return(expectedTFState, nil)
 
 	_, err := tfDriver.Execute(ctx, driver.ExecuteOptions{
-		BaseOptions: driver.BaseOptions{
-			Configuration: envConfig,
-			Recipe:        recipeMetadata,
-			Definition:    envRecipe,
-		},
+		Configuration: envConfig,
+		Recipe:        recipeMetadata,
+		Definition:    envRecipe,
 	})
 	require.Error(t, err)
 	require.Equal(t, err, &recipeError)
@@ -295,11 +287,9 @@ func Test_Terraform_Execute_EmptyPath(t *testing.T) {
 	}
 
 	_, err := tfDriver.Execute(t.Context(), driver.ExecuteOptions{
-		BaseOptions: driver.BaseOptions{
-			Configuration: envConfig,
-			Recipe:        recipeMetadata,
-			Definition:    envRecipe,
-		},
+		Configuration: envConfig,
+		Recipe:        recipeMetadata,
+		Definition:    envRecipe,
 	})
 	require.Error(t, err)
 	require.Equal(t, err, &expErr)
@@ -346,11 +336,9 @@ func Test_Terraform_Execute_EmptyOperationID_Success(t *testing.T) {
 		Return(expectedTFState, nil)
 
 	recipeOutput, err := tfDriver.Execute(ctx, driver.ExecuteOptions{
-		BaseOptions: driver.BaseOptions{
-			Configuration: envConfig,
-			Recipe:        recipeMetadata,
-			Definition:    envRecipe,
-		},
+		Configuration: envConfig,
+		Recipe:        recipeMetadata,
+		Definition:    envRecipe,
 	})
 	require.NoError(t, err)
 	require.Equal(t, expectedOutput, recipeOutput)
@@ -365,11 +353,9 @@ func Test_Terraform_Execute_MissingARMRequestContext_Panics(t *testing.T) {
 
 	require.Panics(t, func() {
 		_, _ = tfDriver.Execute(ctx, driver.ExecuteOptions{
-			BaseOptions: driver.BaseOptions{
-				Configuration: envConfig,
-				Recipe:        recipeMetadata,
-				Definition:    envRecipe,
-			},
+			Configuration: envConfig,
+			Recipe:        recipeMetadata,
+			Definition:    envRecipe,
 		})
 	})
 }
@@ -460,11 +446,9 @@ func Test_Terraform_Delete_Success(t *testing.T) {
 	tfExecutor.EXPECT().Delete(ctx, gomock.Any()).Times(1).Return(nil)
 
 	err := tfDriver.Delete(ctx, driver.DeleteOptions{
-		BaseOptions: driver.BaseOptions{
-			Configuration: envConfig,
-			Recipe:        recipeMetadata,
-			Definition:    envRecipe,
-		},
+		Configuration:   envConfig,
+		Recipe:          recipeMetadata,
+		Definition:      envRecipe,
 		OutputResources: []rpv1.OutputResource{},
 	})
 	require.NoError(t, err)
@@ -484,11 +468,9 @@ func Test_Terraform_Delete_EmptyPath(t *testing.T) {
 	}
 
 	err := tfDriver.Delete(t.Context(), driver.DeleteOptions{
-		BaseOptions: driver.BaseOptions{
-			Configuration: envConfig,
-			Recipe:        recipeMetadata,
-			Definition:    envRecipe,
-		},
+		Configuration:   envConfig,
+		Recipe:          recipeMetadata,
+		Definition:      envRecipe,
 		OutputResources: []rpv1.OutputResource{},
 	})
 	require.Error(t, err)
@@ -516,11 +498,9 @@ func Test_Terraform_Delete_Failure(t *testing.T) {
 	}
 
 	err := tfDriver.Delete(ctx, driver.DeleteOptions{
-		BaseOptions: driver.BaseOptions{
-			Configuration: envConfig,
-			Recipe:        recipeMetadata,
-			Definition:    envRecipe,
-		},
+		Configuration:   envConfig,
+		Recipe:          recipeMetadata,
+		Definition:      envRecipe,
 		OutputResources: []rpv1.OutputResource{},
 	})
 	require.Error(t, err)
@@ -550,11 +530,9 @@ func Test_Terraform_Execute_MissingSecretOutput(t *testing.T) {
 	}, nil)
 
 	output, err := tfDriver.Execute(ctx, driver.ExecuteOptions{
-		BaseOptions: driver.BaseOptions{
-			Configuration: envConfig,
-			Recipe:        recipeMetadata,
-			Definition:    envRecipe,
-		},
+		Configuration: envConfig,
+		Recipe:        recipeMetadata,
+		Definition:    envRecipe,
 	})
 
 	require.Nil(t, output)
@@ -971,21 +949,19 @@ func Test_Terraform_PrepareRecipeResponse(t *testing.T) {
 	}
 
 	opts := driver.ExecuteOptions{
-		BaseOptions: driver.BaseOptions{
-			Configuration: recipes.Configuration{
-				Providers: datamodel.Providers{
-					AWS: datamodel.ProvidersAWS{
-						Scope: "/planes/aws/aws/accounts/179022619019/regions/us-east-2",
-					},
+		Configuration: recipes.Configuration{
+			Providers: datamodel.Providers{
+				AWS: datamodel.ProvidersAWS{
+					Scope: "/planes/aws/aws/accounts/179022619019/regions/us-east-2",
 				},
 			},
-			Definition: recipes.EnvironmentDefinition{
-				Name:            "mongo-azure",
-				Driver:          recipes.TemplateKindTerraform,
-				TemplatePath:    "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
-				ResourceType:    "Applications.Datastores/mongoDatabases",
-				TemplateVersion: "1.0",
-			},
+		},
+		Definition: recipes.EnvironmentDefinition{
+			Name:            "mongo-azure",
+			Driver:          recipes.TemplateKindTerraform,
+			TemplatePath:    "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
+			ResourceType:    "Applications.Datastores/mongoDatabases",
+			TemplateVersion: "1.0",
 		},
 		PrevState: []string{},
 	}

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -97,13 +97,11 @@ func (e *engine) executeCore(ctx context.Context, recipe recipes.ResourceMetadat
 	}
 
 	res, err := driver.Execute(ctx, recipedriver.ExecuteOptions{
-		BaseOptions: recipedriver.BaseOptions{
-			Configuration: *configuration,
-			Recipe:        recipe,
-			Definition:    *definition,
-			Secrets:       secrets,
-		},
-		PrevState: prevState,
+		Configuration: *configuration,
+		Recipe:        recipe,
+		Definition:    *definition,
+		Secrets:       secrets,
+		PrevState:     prevState,
 	})
 	if err != nil {
 		return nil, definition, err
@@ -156,12 +154,10 @@ func (e *engine) deleteCore(ctx context.Context, recipe recipes.ResourceMetadata
 		return nil, err
 	}
 	err = driver.Delete(ctx, recipedriver.DeleteOptions{
-		BaseOptions: recipedriver.BaseOptions{
-			Configuration: *configuration,
-			Recipe:        recipe,
-			Definition:    *definition,
-			Secrets:       secrets,
-		},
+		Configuration:   *configuration,
+		Recipe:          recipe,
+		Definition:      *definition,
+		Secrets:         secrets,
 		OutputResources: outputResources,
 	})
 	if err != nil {

--- a/pkg/recipes/engine/engine_test.go
+++ b/pkg/recipes/engine/engine_test.go
@@ -114,20 +114,16 @@ func Test_Engine_Execute_Success(t *testing.T) {
 		Return(recipeDefinition, nil)
 	driver.EXPECT().
 		Execute(ctx, recipedriver.ExecuteOptions{
-			BaseOptions: recipedriver.BaseOptions{
-				Configuration: *envConfig,
-				Recipe:        recipeMetadata,
-				Definition:    *recipeDefinition,
-			},
-			PrevState: prevState,
+			Configuration: *envConfig,
+			Recipe:        recipeMetadata,
+			Definition:    *recipeDefinition,
+			PrevState:     prevState,
 		}).
 		Times(1).
 		Return(recipeResult, nil)
 
 	result, err := engine.Execute(ctx, ExecuteOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:        recipeMetadata,
 		PreviousState: prevState,
 	})
 	require.NoError(t, err)
@@ -174,9 +170,7 @@ func Test_Engine_Execute_SimulatedEnv_Success(t *testing.T) {
 	// Note: LoadRecipe is not called as the environment is simulated
 
 	result, err := engine.Execute(ctx, ExecuteOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:        recipeMetadata,
 		PreviousState: prevState,
 	})
 	require.NoError(t, err)
@@ -226,20 +220,16 @@ func Test_Engine_Execute_Failure(t *testing.T) {
 		Return(recipeDefinition, nil)
 	driver.EXPECT().
 		Execute(ctx, recipedriver.ExecuteOptions{
-			BaseOptions: recipedriver.BaseOptions{
-				Configuration: *envConfig,
-				Recipe:        recipeMetadata,
-				Definition:    *recipeDefinition,
-			},
-			PrevState: prevState,
+			Configuration: *envConfig,
+			Recipe:        recipeMetadata,
+			Definition:    *recipeDefinition,
+			PrevState:     prevState,
 		}).
 		Times(1).
 		Return(nil, errors.New("failed to execute recipe"))
 
 	result, err := engine.Execute(ctx, ExecuteOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:        recipeMetadata,
 		PreviousState: prevState,
 	})
 	require.Nil(t, result)
@@ -305,20 +295,16 @@ func Test_Engine_Terraform_Success(t *testing.T) {
 		Return(nil, nil)
 	driverWithSecrets.EXPECT().
 		Execute(ctx, recipedriver.ExecuteOptions{
-			BaseOptions: recipedriver.BaseOptions{
-				Configuration: *envConfig,
-				Recipe:        recipeMetadata,
-				Definition:    *recipeDefinition,
-			},
-			PrevState: prevState,
+			Configuration: *envConfig,
+			Recipe:        recipeMetadata,
+			Definition:    *recipeDefinition,
+			PrevState:     prevState,
 		}).
 		Times(1).
 		Return(recipeResult, nil)
 
 	result, err := engine.Execute(ctx, ExecuteOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:        recipeMetadata,
 		PreviousState: prevState,
 	})
 	require.NoError(t, err)
@@ -448,24 +434,20 @@ func Test_Engine_Terraform_Failure(t *testing.T) {
 					if tc.errExecute != nil {
 						driverWithSecrets.EXPECT().
 							Execute(ctx, recipedriver.ExecuteOptions{
-								BaseOptions: recipedriver.BaseOptions{
-									Configuration: *envConfig,
-									Recipe:        recipeMetadata,
-									Definition:    *recipeDefinition,
-								},
-								PrevState: prevState,
+								Configuration: *envConfig,
+								Recipe:        recipeMetadata,
+								Definition:    *recipeDefinition,
+								PrevState:     prevState,
 							}).
 							Times(1).
 							Return(nil, tc.errExecute)
 					} else {
 						driverWithSecrets.EXPECT().
 							Execute(ctx, recipedriver.ExecuteOptions{
-								BaseOptions: recipedriver.BaseOptions{
-									Configuration: *envConfig,
-									Recipe:        recipeMetadata,
-									Definition:    *recipeDefinition,
-								},
-								PrevState: prevState,
+								Configuration: *envConfig,
+								Recipe:        recipeMetadata,
+								Definition:    *recipeDefinition,
+								PrevState:     prevState,
 							}).
 							Times(1).
 							Return(recipeResult, nil)
@@ -474,9 +456,7 @@ func Test_Engine_Terraform_Failure(t *testing.T) {
 			}
 
 			result, err := engine.Execute(ctx, ExecuteOptions{
-				BaseOptions: BaseOptions{
-					Recipe: recipeMetadata,
-				},
+				Recipe:        recipeMetadata,
 				PreviousState: prevState,
 			})
 			if tc.errFindSecretRefs != nil || tc.errLoadSecrets != nil || tc.errExecute != nil || tc.errLoadSecretsNotFound != nil {
@@ -535,9 +515,7 @@ func Test_Engine_InvalidDriver(t *testing.T) {
 		Times(1).
 		Return(recipeDefinition, nil)
 	_, err := engine.Execute(ctx, ExecuteOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:        recipeMetadata,
 		PreviousState: prevState,
 	})
 	require.Error(t, err)
@@ -585,9 +563,7 @@ func Test_Engine_Lookup_Error(t *testing.T) {
 		Return(nil, errors.New("could not find recipe mongo-azure in environment env1"))
 
 	_, err := engine.Execute(ctx, ExecuteOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:        recipeMetadata,
 		PreviousState: prevState,
 	})
 	require.Error(t, err)
@@ -616,9 +592,7 @@ func Test_Engine_Load_Error(t *testing.T) {
 		Return(nil, errors.New("unable to fetch namespace information"))
 
 	_, err := engine.Execute(ctx, ExecuteOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:        recipeMetadata,
 		PreviousState: prevState,
 	})
 	require.Error(t, err)
@@ -655,20 +629,16 @@ func Test_Engine_Delete_Success(t *testing.T) {
 
 	driver.EXPECT().
 		Delete(ctx, recipedriver.DeleteOptions{
-			BaseOptions: recipedriver.BaseOptions{
-				Configuration: *envConfig,
-				Recipe:        recipeMetadata,
-				Definition:    recipeDefinition,
-			},
+			Configuration:   *envConfig,
+			Recipe:          recipeMetadata,
+			Definition:      recipeDefinition,
 			OutputResources: outputResources,
 		}).
 		Times(1).
 		Return(nil)
 
 	err := engine.Delete(ctx, DeleteOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:          recipeMetadata,
 		OutputResources: outputResources,
 	})
 	require.NoError(t, err)
@@ -700,9 +670,7 @@ func Test_Engine_Delete_SimulatedEnv_Success(t *testing.T) {
 		Return(envConfig, nil)
 
 	err := engine.Delete(ctx, DeleteOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:          recipeMetadata,
 		OutputResources: outputResources,
 	})
 	require.NoError(t, err)
@@ -739,11 +707,9 @@ func Test_Engine_Delete_Error(t *testing.T) {
 
 	driver.EXPECT().
 		Delete(ctx, recipedriver.DeleteOptions{
-			BaseOptions: recipedriver.BaseOptions{
-				Configuration: *envConfig,
-				Recipe:        recipeMetadata,
-				Definition:    recipeDefinition,
-			},
+			Configuration:   *envConfig,
+			Recipe:          recipeMetadata,
+			Definition:      recipeDefinition,
 			OutputResources: outputResources,
 		}).
 		Times(1).
@@ -751,9 +717,7 @@ func Test_Engine_Delete_Error(t *testing.T) {
 			outputResources[0].ID))
 
 	err := engine.Delete(ctx, DeleteOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:          recipeMetadata,
 		OutputResources: outputResources,
 	})
 	require.Error(t, err)
@@ -789,9 +753,7 @@ func Test_Delete_InvalidDriver(t *testing.T) {
 		Times(1).
 		Return(&recipeDefinition, nil)
 	err := engine.Delete(ctx, DeleteOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:          recipeMetadata,
 		OutputResources: outputResources,
 	})
 	require.Error(t, err)
@@ -826,9 +788,7 @@ func Test_Delete_Lookup_Error(t *testing.T) {
 		Times(1).
 		Return(nil, errors.New("could not find recipe mongo-azure in environment env1"))
 	err := engine.Delete(ctx, DeleteOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:          recipeMetadata,
 		OutputResources: outputResources,
 	})
 	require.Error(t, err)
@@ -863,9 +823,7 @@ func Test_Engine_GetRecipeMetadata_Success(t *testing.T) {
 	}).Times(1).Return(outputParams, nil)
 
 	recipeData, err := engine.GetRecipeMetadata(ctx, GetRecipeMetadataOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:           recipeMetadata,
 		RecipeDefinition: recipeDefinition,
 	})
 	require.NoError(t, err)
@@ -934,9 +892,7 @@ func Test_Engine_GetRecipeMetadata_Private_Module_Success(t *testing.T) {
 	}).Times(1).Return(outputParams, nil)
 
 	recipeData, err := engine.GetRecipeMetadata(ctx, GetRecipeMetadataOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:           recipeMetadata,
 		RecipeDefinition: *recipeDefinition,
 	})
 	require.NoError(t, err)
@@ -971,9 +927,7 @@ func Test_GetRecipeMetadata_Driver_Error(t *testing.T) {
 	}).Times(1).Return(nil, errors.New("driver failure"))
 
 	_, err := engine.GetRecipeMetadata(ctx, GetRecipeMetadataOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:           recipeMetadata,
 		RecipeDefinition: recipeDefinition,
 	})
 	require.Error(t, err)
@@ -1005,9 +959,7 @@ func Test_GetRecipeMetadata_Driver_InvalidDriver(t *testing.T) {
 		Times(1).
 		Return(envConfig, nil)
 	_, err := engine.GetRecipeMetadata(ctx, GetRecipeMetadataOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:           recipeMetadata,
 		RecipeDefinition: recipeDefinition,
 	})
 	require.Error(t, err)
@@ -1112,20 +1064,16 @@ func Test_Engine_Execute_With_Secrets_Success(t *testing.T) {
 		Return(nil, nil)
 	driverWithSecrets.EXPECT().
 		Execute(ctx, recipedriver.ExecuteOptions{
-			BaseOptions: recipedriver.BaseOptions{
-				Configuration: *envConfig,
-				Recipe:        recipeMetadata,
-				Definition:    *recipeDefinition,
-			},
-			PrevState: prevState,
+			Configuration: *envConfig,
+			Recipe:        recipeMetadata,
+			Definition:    *recipeDefinition,
+			PrevState:     prevState,
 		}).
 		Times(1).
 		Return(recipeResult, nil)
 
 	result, err := engine.Execute(ctx, ExecuteOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:        recipeMetadata,
 		PreviousState: prevState,
 	})
 	require.NoError(t, err)
@@ -1195,20 +1143,16 @@ func Test_Engine_Delete_With_Secrets_Success(t *testing.T) {
 		Return(nil, nil)
 	driverWithSecrets.EXPECT().
 		Delete(ctx, recipedriver.DeleteOptions{
-			BaseOptions: recipedriver.BaseOptions{
-				Configuration: *envConfig,
-				Recipe:        recipeMetadata,
-				Definition:    *recipeDefinition,
-			},
+			Configuration:   *envConfig,
+			Recipe:          recipeMetadata,
+			Definition:      *recipeDefinition,
 			OutputResources: outputResources,
 		}).
 		Times(1).
 		Return(nil)
 
 	err := engine.Delete(ctx, DeleteOptions{
-		BaseOptions: BaseOptions{
-			Recipe: recipeMetadata,
-		},
+		Recipe:          recipeMetadata,
 		OutputResources: outputResources,
 	})
 	require.NoError(t, err)

--- a/pkg/recipes/terraform/config/backends/kubernetes_test.go
+++ b/pkg/recipes/terraform/config/backends/kubernetes_test.go
@@ -176,10 +176,8 @@ func Test_BuildBackend_ExistingLegacyStateUsesLegacySuffix(t *testing.T) {
 	// Simulate a Terraform state secret created by an older version of Radius (legacy SHA-1 suffix).
 	clientset := fake.NewClientset()
 	_, err = clientset.CoreV1().Secrets(RadiusNamespace).Create(t.Context(), &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      KubernetesBackendNamePrefix + legacySuffix,
-			Namespace: RadiusNamespace,
-		},
+		Name:      KubernetesBackendNamePrefix + legacySuffix,
+		Namespace: RadiusNamespace,
 	}, metav1.CreateOptions{})
 	require.NoError(t, err)
 
@@ -195,10 +193,8 @@ func Test_BuildBackend_ExistingLegacyStateUsesLegacySuffix(t *testing.T) {
 func Test_ValidateBackendExists(t *testing.T) {
 	clientset := fake.NewClientset()
 	secret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-secret",
-			Namespace: RadiusNamespace,
-		},
+		Name:      "test-secret",
+		Namespace: RadiusNamespace,
 		Data: map[string][]byte{
 			"key": []byte("value"),
 		},

--- a/pkg/recipes/terraform/execute_test.go
+++ b/pkg/recipes/terraform/execute_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/radius-project/radius/pkg/recipes/terraform/config/backends"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -113,10 +112,8 @@ func TestDeleteSkipsOutputMappingValidation(t *testing.T) {
 	kubernetesClient.Fake.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		getAction := action.(k8stesting.GetAction)
 		return true, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      getAction.GetName(),
-				Namespace: backends.RadiusNamespace,
-			},
+			Name:      getAction.GetName(),
+			Namespace: backends.RadiusNamespace,
 		}, nil
 	})
 	kubernetesClient.Fake.PrependReactor("delete", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {

--- a/pkg/rp/frontend/resource_test.go
+++ b/pkg/rp/frontend/resource_test.go
@@ -92,26 +92,18 @@ type ResourceStatus struct {
 // ConvertTo converts a TestResource object to a TestResourceDataModel object and returns it.
 func (src *TestResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &TestResourceDataModel{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion:      testAPIVersion,
-				AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			},
-		},
+		ID:                     to.String(src.ID),
+		Name:                   to.String(src.Name),
+		Type:                   to.String(src.Type),
+		Location:               to.String(src.Location),
+		Tags:                   to.StringMap(src.Tags),
+		UpdatedAPIVersion:      testAPIVersion,
+		AsyncProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 		Properties: &TestResourceDataModelProperties{
-			BasicResourceProperties: rpv1.BasicResourceProperties{
-				Environment: to.String(src.Properties.Environment),
-				Application: to.String(src.Properties.Application),
-			},
-			PropertyA: to.String(src.Properties.PropertyA),
-			PropertyB: to.String(src.Properties.PropertyB),
+			Environment: to.String(src.Properties.Environment),
+			Application: to.String(src.Properties.Application),
+			PropertyA:   to.String(src.Properties.PropertyA),
+			PropertyB:   to.String(src.Properties.PropertyB),
 		},
 	}
 	return converted, nil

--- a/pkg/rp/frontend/validator_test.go
+++ b/pkg/rp/frontend/validator_test.go
@@ -45,16 +45,12 @@ func TestPrepareRadiusResource_OldResource_Nil(t *testing.T) {
 
 func TestPrepareRadiusResource_UnmatchedLinks(t *testing.T) {
 	oldResource := &TestResourceDataModel{Properties: &TestResourceDataModelProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Environment: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",
-			Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
-		},
+		Environment: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",
+		Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
 	}}
 	newResource := &TestResourceDataModel{Properties: &TestResourceDataModelProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Environment: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",
-			Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
-		},
+		Environment: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",
+		Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
 	}}
 
 	resp, err := PrepareRadiusResource(newTestARMContext(t), newResource, oldResource, &controller.Options{})
@@ -70,23 +66,19 @@ func TestPrepareRadiusResource_UnmatchedLinks(t *testing.T) {
 
 func TestPrepareRadiusResource_DeepCopy(t *testing.T) {
 	oldResource := &TestResourceDataModel{Properties: &TestResourceDataModelProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Environment: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",
-			Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
-			Status: rpv1.ResourceStatus{
-				OutputResources: []rpv1.OutputResource{
-					{
-						LocalID: "testID",
-					},
+		Environment: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",
+		Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
+		Status: rpv1.ResourceStatus{
+			OutputResources: []rpv1.OutputResource{
+				{
+					LocalID: "testID",
 				},
 			},
 		},
 	}}
 	newResource := &TestResourceDataModel{Properties: &TestResourceDataModelProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Environment: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",
-			Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
-		},
+		Environment: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",
+		Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
 	}}
 	resp, err := PrepareRadiusResource(newTestARMContext(t), newResource, oldResource, &controller.Options{})
 	require.NoError(t, err)
@@ -104,23 +96,19 @@ func TestPrepareDaprResource(t *testing.T) {
 
 	client := k8sutil.NewFakeKubeClient(crdScheme)
 	oldResource := &TestResourceDataModel{Properties: &TestResourceDataModelProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Environment: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",
-			Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
-			Status: rpv1.ResourceStatus{
-				OutputResources: []rpv1.OutputResource{
-					{
-						LocalID: "testID",
-					},
+		Environment: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",
+		Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
+		Status: rpv1.ResourceStatus{
+			OutputResources: []rpv1.OutputResource{
+				{
+					LocalID: "testID",
 				},
 			},
 		},
 	}}
 	newResource := &TestResourceDataModel{Properties: &TestResourceDataModelProperties{
-		BasicResourceProperties: rpv1.BasicResourceProperties{
-			Environment: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",
-			Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
-		},
+		Environment: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",
+		Application: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
 	}}
 	expectedResp := rest.NewDependencyMissingResponse(datamodel.DaprMissingError)
 	resp, err := PrepareDaprResource(newTestARMContext(t), newResource, oldResource, &controller.Options{KubeClient: client})

--- a/pkg/schema/annotations.go
+++ b/pkg/schema/annotations.go
@@ -65,7 +65,7 @@ func GetSchema(ctx context.Context, ucpClient *v20231001preview.ClientFactory, r
 
 	plane := ID.PlaneNamespace()
 	planeName := strings.Split(plane, "/")[1]
-	resourceProvider := strings.Split(resourceType, "/")[0]
+	resourceProvider, _, _ := strings.Cut(resourceType, "/")
 	resourceTypeName := strings.Split(resourceType, "/")[1]
 
 	// Fetch the API version resource which contains the schema

--- a/pkg/schema/annotations_test.go
+++ b/pkg/schema/annotations_test.go
@@ -23,7 +23,6 @@ import (
 
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
 	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview/fake"
@@ -551,10 +550,8 @@ func testUCPClientFactory(schema map[string]any) (*v20231001preview.ClientFactor
 		Get: func(ctx context.Context, planeName string, resourceProviderName string, resourceTypeName string, apiVersionName string, options *v20231001preview.APIVersionsClientGetOptions) (azfake.Responder[v20231001preview.APIVersionsClientGetResponse], azfake.ErrorResponder) {
 			resp := azfake.Responder[v20231001preview.APIVersionsClientGetResponse]{}
 			resp.SetResponse(http.StatusOK, v20231001preview.APIVersionsClientGetResponse{
-				APIVersionResource: v20231001preview.APIVersionResource{
-					Properties: &v20231001preview.APIVersionProperties{
-						Schema: schema,
-					},
+				Properties: &v20231001preview.APIVersionProperties{
+					Schema: schema,
 				},
 			}, nil)
 			return resp, azfake.ErrorResponder{}
@@ -562,11 +559,9 @@ func testUCPClientFactory(schema map[string]any) (*v20231001preview.ClientFactor
 	}
 
 	return v20231001preview.NewClientFactory(&aztoken.AnonymousCredential{}, &armpolicy.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: fake.NewServerFactoryTransport(&fake.ServerFactory{
-				APIVersionsServer: apiVersionsServer,
-			}),
-		},
+		Transport: fake.NewServerFactoryTransport(&fake.ServerFactory{
+			APIVersionsServer: apiVersionsServer,
+		}),
 	})
 }
 

--- a/pkg/sdk/clients/mock_resourcedeploymentsclient.go
+++ b/pkg/sdk/clients/mock_resourcedeploymentsclient.go
@@ -67,10 +67,8 @@ func (rdc *MockResourceDeploymentsClient) CreateOrUpdate(ctx context.Context, pa
 	defer rdc.lock.Unlock()
 
 	value := ClientCreateOrUpdateResponse{
-		DeploymentExtended: armdeployments.DeploymentExtended{
-			ID:         &resourceID,
-			Properties: &armdeployments.DeploymentPropertiesExtended{},
-		},
+		ID:         &resourceID,
+		Properties: &armdeployments.DeploymentPropertiesExtended{},
 	}
 	state := &OperationState{
 		Kind:       http.MethodPut,

--- a/pkg/sdk/pipeline.go
+++ b/pkg/sdk/pipeline.go
@@ -28,33 +28,31 @@ import (
 // removes the authorization header policy.
 func NewClientOptions(connection Connection) *arm.ClientOptions {
 	return &arm.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Cloud: cloud.Configuration{
-				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
-					cloud.ResourceManager: {
-						Endpoint: connection.Endpoint(),
-						Audience: "https://management.core.windows.net",
-					},
+		Cloud: cloud.Configuration{
+			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+				cloud.ResourceManager: {
+					Endpoint: connection.Endpoint(),
+					Audience: "https://management.core.windows.net",
 				},
 			},
-			PerRetryPolicies: []policy.Policy{
-				// Autorest will inject an empty bearer token, which conflicts with bearer auth
-				// when its used by Kubernetes. We don't *ever* need Autorest to handle auth for us
-				// so we just remove it.
-				//
-				// We'll solve this problem permanently by writing our own client.
-				&removeAuthorizationHeaderPolicy{},
-			},
-			Transport: connection.Client(),
-			// When updating azcore to 1.11.1 from 1.7.0, we saw that HTTPS check for Authentication was added.
-			// Link to the check: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azcore/runtime/policy_bearer_token.go#L118
-			//
-			// This check was failing for some unit tests because the ARM requests are made over HTTP and the bearer token is being sent in the header.
-			// This is a temporary fix to allow sending the bearer token over HTTP.
-			// We don't have any use cases where we send the bearer token over HTTP in production.
-			InsecureAllowCredentialWithHTTP: true,
 		},
-		DisableRPRegistration: true,
+		PerRetryPolicies: []policy.Policy{
+			// Autorest will inject an empty bearer token, which conflicts with bearer auth
+			// when its used by Kubernetes. We don't *ever* need Autorest to handle auth for us
+			// so we just remove it.
+			//
+			// We'll solve this problem permanently by writing our own client.
+			&removeAuthorizationHeaderPolicy{},
+		},
+		Transport: connection.Client(),
+		// When updating azcore to 1.11.1 from 1.7.0, we saw that HTTPS check for Authentication was added.
+		// Link to the check: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azcore/runtime/policy_bearer_token.go#L118
+		//
+		// This check was failing for some unit tests because the ARM requests are made over HTTP and the bearer token is being sent in the header.
+		// This is a temporary fix to allow sending the bearer token over HTTP.
+		// We don't have any use cases where we send the bearer token over HTTP in production.
+		InsecureAllowCredentialWithHTTP: true,
+		DisableRPRegistration:           true,
 	}
 }
 

--- a/pkg/server/apiservice.go
+++ b/pkg/server/apiservice.go
@@ -38,10 +38,8 @@ type APIService struct {
 // NewAPIService creates a new instance of APIService.
 func NewAPIService(options hostoptions.HostOptions, builder []builder.Builder) *APIService {
 	return &APIService{
-		Service: server.Service{
-			ProviderName: "radius",
-			Options:      options,
-		},
+		ProviderName:   "radius",
+		Options:        options,
 		handlerBuilder: builder,
 	}
 }

--- a/pkg/statearchive/oci/oci.go
+++ b/pkg/statearchive/oci/oci.go
@@ -34,7 +34,6 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
@@ -384,11 +383,11 @@ func createArtifact(ctx context.Context, name, root string) (*artifact, error) {
 	}
 
 	manifest := ocispec.Manifest{
-		Versioned:    specs.Versioned{SchemaVersion: 2},
-		MediaType:    ocispec.MediaTypeImageManifest,
-		ArtifactType: configMediaType,
-		Config:       configDesc,
-		Layers:       []ocispec.Descriptor{layerDesc},
+		SchemaVersion: 2,
+		MediaType:     ocispec.MediaTypeImageManifest,
+		ArtifactType:  configMediaType,
+		Config:        configDesc,
+		Layers:        []ocispec.Descriptor{layerDesc},
 	}
 	manifestBytes, err := json.Marshal(manifest)
 	if err != nil {

--- a/pkg/ucp/api/v20231001preview/apiversion_conversion.go
+++ b/pkg/ucp/api/v20231001preview/apiversion_conversion.go
@@ -25,18 +25,14 @@ import (
 // ConvertTo converts from the versioned APIVersionResource resource to version-agnostic datamodel.
 func (src *APIVersionResource) ConvertTo() (v1.DataModelInterface, error) {
 	dst := &datamodel.APIVersion{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   to.String(src.ID),
-				Name: to.String(src.Name),
-				Type: datamodel.APIVersionResourceType,
+		TrackedResource: v1.TrackedResource{
+			ID:   to.String(src.ID),
+			Name: to.String(src.Name),
+			Type: datamodel.APIVersionResourceType,
 
-				// NOTE: this is a child resource. It does not have a location, systemData, or tags.
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion: Version,
-			},
+			// NOTE: this is a child resource. It does not have a location, systemData, or tags.
 		},
+		UpdatedAPIVersion: Version,
 	}
 
 	dst.Properties = datamodel.APIVersionProperties{

--- a/pkg/ucp/api/v20231001preview/apiversion_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/apiversion_conversion_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/ucp/datamodel"
 	"github.com/radius-project/radius/test/testutil"
 
@@ -37,17 +36,11 @@ func Test_APIVersion_VersionedToDataModel(t *testing.T) {
 		{
 			filename: "apiversion_resource.json",
 			expected: &datamodel.APIVersion{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test/resourceTypes/testResources/apiVersions/2025-01-01",
-						Name: "2025-01-01",
-						Type: datamodel.APIVersionResourceType,
-					},
-					InternalMetadata: v1.InternalMetadata{
-						UpdatedAPIVersion: Version,
-					},
-				},
-				Properties: datamodel.APIVersionProperties{},
+				ID:                "/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test/resourceTypes/testResources/apiVersions/2025-01-01",
+				Name:              "2025-01-01",
+				Type:              datamodel.APIVersionResourceType,
+				UpdatedAPIVersion: Version,
+				Properties:        datamodel.APIVersionProperties{},
 			},
 		},
 	}

--- a/pkg/ucp/api/v20231001preview/aws_credential_conversion.go
+++ b/pkg/ucp/api/v20231001preview/aws_credential_conversion.go
@@ -37,19 +37,13 @@ func (cr *AwsCredentialResource) ConvertTo() (v1.DataModelInterface, error) {
 	}
 
 	converted := &datamodel.AWSCredential{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(cr.ID),
-				Name:     to.String(cr.Name),
-				Type:     to.String(cr.Type),
-				Location: to.String(cr.Location),
-				Tags:     to.StringMap(cr.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion: Version,
-			},
-		},
-		Properties: prop,
+		ID:                to.String(cr.ID),
+		Name:              to.String(cr.Name),
+		Type:              to.String(cr.Type),
+		Location:          to.String(cr.Location),
+		Tags:              to.StringMap(cr.Tags),
+		UpdatedAPIVersion: Version,
+		Properties:        prop,
 	}
 
 	return converted, nil

--- a/pkg/ucp/api/v20231001preview/aws_credential_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/aws_credential_conversion_test.go
@@ -37,20 +37,14 @@ func TestAWSCredentialConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "credentialresource-aws-accesskey.json",
 			expected: &datamodel.AWSCredential{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/planes/aws/aws/providers/System.AWS/credentials/default",
-						Name:     "default",
-						Type:     "System.AWS/credentials",
-						Location: "west-us-2",
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						UpdatedAPIVersion: Version,
-					},
+				ID:       "/planes/aws/aws/providers/System.AWS/credentials/default",
+				Name:     "default",
+				Type:     "System.AWS/credentials",
+				Location: "west-us-2",
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				UpdatedAPIVersion: Version,
 				Properties: &datamodel.AWSCredentialResourceProperties{
 					Kind: "AccessKey",
 					AWSCredential: &datamodel.AWSCredentialProperties{
@@ -70,20 +64,14 @@ func TestAWSCredentialConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "credentialresource-aws-irsa.json",
 			expected: &datamodel.AWSCredential{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/planes/aws/aws/providers/System.AWS/credentials/default",
-						Name:     "default",
-						Type:     "System.AWS/credentials",
-						Location: "west-us-2",
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						UpdatedAPIVersion: Version,
-					},
+				ID:       "/planes/aws/aws/providers/System.AWS/credentials/default",
+				Name:     "default",
+				Type:     "System.AWS/credentials",
+				Location: "west-us-2",
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				UpdatedAPIVersion: Version,
 				Properties: &datamodel.AWSCredentialResourceProperties{
 					Kind: "IRSA",
 					AWSCredential: &datamodel.AWSCredentialProperties{

--- a/pkg/ucp/api/v20231001preview/awsplane_conversion.go
+++ b/pkg/ucp/api/v20231001preview/awsplane_conversion.go
@@ -26,19 +26,13 @@ import (
 // ConvertTo converts from the versioned AWS Plane resource to version-agnostic datamodel.
 func (src *AwsPlaneResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.AWSPlane{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion: Version,
-			},
-		},
-		Properties: datamodel.AWSPlaneProperties{}, // Empty
+		ID:                to.String(src.ID),
+		Name:              to.String(src.Name),
+		Type:              to.String(src.Type),
+		Location:          to.String(src.Location),
+		Tags:              to.StringMap(src.Tags),
+		UpdatedAPIVersion: Version,
+		Properties:        datamodel.AWSPlaneProperties{}, // Empty
 	}
 
 	return converted, nil

--- a/pkg/ucp/api/v20231001preview/awsplane_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/awsplane_conversion_test.go
@@ -37,21 +37,15 @@ func Test_AWSPlane_ConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "awsplane-resource-empty.json",
 			expected: &datamodel.AWSPlane{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/planes/aws/aws",
-						Name:     "aws",
-						Type:     datamodel.AWSPlaneResourceType,
-						Location: "global",
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						UpdatedAPIVersion: Version,
-					},
+				ID:       "/planes/aws/aws",
+				Name:     "aws",
+				Type:     datamodel.AWSPlaneResourceType,
+				Location: "global",
+				Tags: map[string]string{
+					"env": "dev",
 				},
-				Properties: datamodel.AWSPlaneProperties{},
+				UpdatedAPIVersion: Version,
+				Properties:        datamodel.AWSPlaneProperties{},
 			},
 		},
 	}

--- a/pkg/ucp/api/v20231001preview/azure_credential_conversion.go
+++ b/pkg/ucp/api/v20231001preview/azure_credential_conversion.go
@@ -37,19 +37,13 @@ func (cr *AzureCredentialResource) ConvertTo() (v1.DataModelInterface, error) {
 	}
 
 	converted := &datamodel.AzureCredential{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(cr.ID),
-				Name:     to.String(cr.Name),
-				Type:     to.String(cr.Type),
-				Location: to.String(cr.Location),
-				Tags:     to.StringMap(cr.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion: Version,
-			},
-		},
-		Properties: prop,
+		ID:                to.String(cr.ID),
+		Name:              to.String(cr.Name),
+		Type:              to.String(cr.Type),
+		Location:          to.String(cr.Location),
+		Tags:              to.StringMap(cr.Tags),
+		UpdatedAPIVersion: Version,
+		Properties:        prop,
 	}
 
 	return converted, nil

--- a/pkg/ucp/api/v20231001preview/azure_credential_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/azure_credential_conversion_test.go
@@ -37,20 +37,14 @@ func TestAzureCredentialConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "credentialresource-azure-serviceprincipal.json",
 			expected: &datamodel.AzureCredential{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/planes/azure/azurecloud/providers/System.Azure/credentials/default",
-						Name:     "default",
-						Type:     "System.Azure/credentials",
-						Location: "west-us-2",
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						UpdatedAPIVersion: Version,
-					},
+				ID:       "/planes/azure/azurecloud/providers/System.Azure/credentials/default",
+				Name:     "default",
+				Type:     "System.Azure/credentials",
+				Location: "west-us-2",
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				UpdatedAPIVersion: Version,
 				Properties: &datamodel.AzureCredentialResourceProperties{
 					Kind: "ServicePrincipal",
 					AzureCredential: &datamodel.AzureCredentialProperties{
@@ -71,20 +65,14 @@ func TestAzureCredentialConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "credentialresource-azure-workloadidentity.json",
 			expected: &datamodel.AzureCredential{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/planes/azure/azurecloud/providers/System.Azure/credentials/default",
-						Name:     "default",
-						Type:     "System.Azure/credentials",
-						Location: "west-us-2",
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						UpdatedAPIVersion: Version,
-					},
+				ID:       "/planes/azure/azurecloud/providers/System.Azure/credentials/default",
+				Name:     "default",
+				Type:     "System.Azure/credentials",
+				Location: "west-us-2",
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				UpdatedAPIVersion: Version,
 				Properties: &datamodel.AzureCredentialResourceProperties{
 					Kind: "WorkloadIdentity",
 					AzureCredential: &datamodel.AzureCredentialProperties{

--- a/pkg/ucp/api/v20231001preview/azureplane_conversion.go
+++ b/pkg/ucp/api/v20231001preview/azureplane_conversion.go
@@ -26,18 +26,12 @@ import (
 // ConvertTo converts from the versioned Azure Plane resource to version-agnostic datamodel.
 func (src *AzurePlaneResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.AzurePlane{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion: Version,
-			},
-		},
+		ID:                to.String(src.ID),
+		Name:              to.String(src.Name),
+		Type:              to.String(src.Type),
+		Location:          to.String(src.Location),
+		Tags:              to.StringMap(src.Tags),
+		UpdatedAPIVersion: Version,
 		Properties: datamodel.AzurePlaneProperties{
 			URL: to.String(src.Properties.URL),
 		},

--- a/pkg/ucp/api/v20231001preview/azureplane_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/azureplane_conversion_test.go
@@ -37,20 +37,14 @@ func Test_AzurePlane_ConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "azureplane-resource-empty.json",
 			expected: &datamodel.AzurePlane{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/planes/azure/azurecloud",
-						Name:     "azurecloud",
-						Type:     datamodel.AzurePlaneResourceType,
-						Location: "global",
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						UpdatedAPIVersion: Version,
-					},
+				ID:       "/planes/azure/azurecloud",
+				Name:     "azurecloud",
+				Type:     datamodel.AzurePlaneResourceType,
+				Location: "global",
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				UpdatedAPIVersion: Version,
 				Properties: datamodel.AzurePlaneProperties{
 					URL: "https://management.azure.com",
 				},

--- a/pkg/ucp/api/v20231001preview/location_conversion.go
+++ b/pkg/ucp/api/v20231001preview/location_conversion.go
@@ -25,18 +25,14 @@ import (
 // ConvertTo converts from the versioned LocationResource resource to version-agnostic datamodel.
 func (src *LocationResource) ConvertTo() (v1.DataModelInterface, error) {
 	dst := &datamodel.Location{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   to.String(src.ID),
-				Name: to.String(src.Name),
-				Type: datamodel.LocationResourceType,
+		TrackedResource: v1.TrackedResource{
+			ID:   to.String(src.ID),
+			Name: to.String(src.Name),
+			Type: datamodel.LocationResourceType,
 
-				// NOTE: this is a child resource. It does not have a location, systemData, or tags.
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion: Version,
-			},
+			// NOTE: this is a child resource. It does not have a location, systemData, or tags.
 		},
+		UpdatedAPIVersion: Version,
 	}
 
 	dst.Properties = datamodel.LocationProperties{

--- a/pkg/ucp/api/v20231001preview/location_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/location_conversion_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/ucp/datamodel"
 	"github.com/radius-project/radius/test/testutil"
 
@@ -37,16 +36,10 @@ func Test_Location_VersionedToDataModel(t *testing.T) {
 		{
 			filename: "location_resource.json",
 			expected: &datamodel.Location{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test/locations/east",
-						Name: "east",
-						Type: datamodel.LocationResourceType,
-					},
-					InternalMetadata: v1.InternalMetadata{
-						UpdatedAPIVersion: Version,
-					},
-				},
+				ID:                "/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test/locations/east",
+				Name:              "east",
+				Type:              datamodel.LocationResourceType,
+				UpdatedAPIVersion: Version,
 				Properties: datamodel.LocationProperties{
 					Address: new("https://east.myrp.com"),
 					ResourceTypes: map[string]datamodel.LocationResourceTypeConfiguration{

--- a/pkg/ucp/api/v20231001preview/radiusplane_conversion.go
+++ b/pkg/ucp/api/v20231001preview/radiusplane_conversion.go
@@ -26,18 +26,12 @@ import (
 // ConvertTo converts from the versioned Radius Plane resource to version-agnostic datamodel.
 func (src *RadiusPlaneResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.RadiusPlane{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion: Version,
-			},
-		},
+		ID:                to.String(src.ID),
+		Name:              to.String(src.Name),
+		Type:              to.String(src.Type),
+		Location:          to.String(src.Location),
+		Tags:              to.StringMap(src.Tags),
+		UpdatedAPIVersion: Version,
 
 		Properties: datamodel.RadiusPlaneProperties{
 			ResourceProviders: to.StringMap(src.Properties.ResourceProviders),

--- a/pkg/ucp/api/v20231001preview/radiusplane_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/radiusplane_conversion_test.go
@@ -37,20 +37,14 @@ func Test_RadiusPlane_ConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "radiusplane-resource-empty.json",
 			expected: &datamodel.RadiusPlane{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/planes/radius/local",
-						Name:     "local",
-						Type:     datamodel.RadiusPlaneResourceType,
-						Location: "global",
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						UpdatedAPIVersion: Version,
-					},
+				ID:       "/planes/radius/local",
+				Name:     "local",
+				Type:     datamodel.RadiusPlaneResourceType,
+				Location: "global",
+				Tags: map[string]string{
+					"env": "dev",
 				},
+				UpdatedAPIVersion: Version,
 				Properties: datamodel.RadiusPlaneProperties{
 					ResourceProviders: map[string]string{
 						"Applications.Core": "http://applications-rp:9000",

--- a/pkg/ucp/api/v20231001preview/resourcegroup_conversion.go
+++ b/pkg/ucp/api/v20231001preview/resourcegroup_conversion.go
@@ -31,15 +31,11 @@ func (src *ResourceGroupResource) ConvertTo() (v1.DataModelInterface, error) {
 	// Note: SystemData conversion isn't required since this property comes ARM and datastore.
 
 	converted := &datamodel.ResourceGroup{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-		},
+		ID:       to.String(src.ID),
+		Name:     to.String(src.Name),
+		Type:     to.String(src.Type),
+		Location: to.String(src.Location),
+		Tags:     to.StringMap(src.Tags),
 	}
 
 	return converted, nil

--- a/pkg/ucp/api/v20231001preview/resourcegroup_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/resourcegroup_conversion_test.go
@@ -38,16 +38,12 @@ func TestResourceGroupConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "resourcegroup.json",
 			expected: &datamodel.ResourceGroup{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/planes/radius/local/resourceGroups/test-rg",
-						Name:     "test-rg",
-						Type:     resources.ResourceGroupType,
-						Location: v1.LocationGlobal,
-						Tags: map[string]string{
-							"env": "dev",
-						},
-					},
+				ID:       "/planes/radius/local/resourceGroups/test-rg",
+				Name:     "test-rg",
+				Type:     resources.ResourceGroupType,
+				Location: v1.LocationGlobal,
+				Tags: map[string]string{
+					"env": "dev",
 				},
 			},
 		},

--- a/pkg/ucp/api/v20231001preview/resourceprovider_conversion.go
+++ b/pkg/ucp/api/v20231001preview/resourceprovider_conversion.go
@@ -25,18 +25,12 @@ import (
 // ConvertTo converts from the versioned ResourceProviderResource resource to version-agnostic datamodel.
 func (src *ResourceProviderResource) ConvertTo() (v1.DataModelInterface, error) {
 	dst := &datamodel.ResourceProvider{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     datamodel.ResourceProviderResourceType,
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion: Version,
-			},
-		},
+		ID:                to.String(src.ID),
+		Name:              to.String(src.Name),
+		Type:              datamodel.ResourceProviderResourceType,
+		Location:          to.String(src.Location),
+		Tags:              to.StringMap(src.Tags),
+		UpdatedAPIVersion: Version,
 	}
 
 	return dst, nil

--- a/pkg/ucp/api/v20231001preview/resourceprovider_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/resourceprovider_conversion_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/ucp/datamodel"
 	"github.com/radius-project/radius/test/testutil"
 
@@ -37,19 +36,13 @@ func Test_ResourceProvider_VersionedToDataModel(t *testing.T) {
 		{
 			filename: "resourceprovider_resource.json",
 			expected: &datamodel.ResourceProvider{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:       "/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test",
-						Name:     "Applications.Test",
-						Type:     datamodel.ResourceProviderResourceType,
-						Location: "global",
-						Tags:     map[string]string{},
-					},
-					InternalMetadata: v1.InternalMetadata{
-						UpdatedAPIVersion: Version,
-					},
-				},
-				Properties: datamodel.ResourceProviderProperties{},
+				ID:                "/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test",
+				Name:              "Applications.Test",
+				Type:              datamodel.ResourceProviderResourceType,
+				Location:          "global",
+				Tags:              map[string]string{},
+				UpdatedAPIVersion: Version,
+				Properties:        datamodel.ResourceProviderProperties{},
 			},
 		},
 	}

--- a/pkg/ucp/api/v20231001preview/resourcetype_conversion.go
+++ b/pkg/ucp/api/v20231001preview/resourcetype_conversion.go
@@ -30,18 +30,14 @@ import (
 // ConvertTo converts from the versioned ResourceTypeResource resource to version-agnostic datamodel.
 func (src *ResourceTypeResource) ConvertTo() (v1.DataModelInterface, error) {
 	dst := &datamodel.ResourceType{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   to.String(src.ID),
-				Name: to.String(src.Name),
-				Type: datamodel.ResourceTypeResourceType,
+		TrackedResource: v1.TrackedResource{
+			ID:   to.String(src.ID),
+			Name: to.String(src.Name),
+			Type: datamodel.ResourceTypeResourceType,
 
-				// NOTE: this is a child resource. It does not have a location, systemData, or tags.
-			},
-			InternalMetadata: v1.InternalMetadata{
-				UpdatedAPIVersion: Version,
-			},
+			// NOTE: this is a child resource. It does not have a location, systemData, or tags.
 		},
+		UpdatedAPIVersion: Version,
 	}
 
 	capabilities := []string{}

--- a/pkg/ucp/api/v20231001preview/resourcetype_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/resourcetype_conversion_test.go
@@ -39,16 +39,10 @@ func Test_ResourceType_VersionedToDataModel(t *testing.T) {
 		{
 			filename: "resourcetype_resource.json",
 			expected: &datamodel.ResourceType{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   "/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test/resourceTypes/testResources",
-						Name: "testResources",
-						Type: datamodel.ResourceTypeResourceType,
-					},
-					InternalMetadata: v1.InternalMetadata{
-						UpdatedAPIVersion: Version,
-					},
-				},
+				ID:                "/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test/resourceTypes/testResources",
+				Name:              "testResources",
+				Type:              datamodel.ResourceTypeResourceType,
+				UpdatedAPIVersion: Version,
 				Properties: datamodel.ResourceTypeProperties{
 					Capabilities:      []string{},
 					DefaultAPIVersion: new("2025-01-01"),
@@ -206,13 +200,9 @@ func Test_ResourceType_ConvertTo_RejectsInvalidIcon(t *testing.T) {
 
 func Test_ResourceType_Icon_DataModelToVersioned(t *testing.T) {
 	dm := &datamodel.ResourceType{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   "/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test/resourceTypes/testResources",
-				Name: "testResources",
-				Type: datamodel.ResourceTypeResourceType,
-			},
-		},
+		ID:   "/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test/resourceTypes/testResources",
+		Name: "testResources",
+		Type: datamodel.ResourceTypeResourceType,
 		Properties: datamodel.ResourceTypeProperties{
 			Capabilities: []string{},
 			Icon:         new(`<svg/>`),

--- a/pkg/ucp/backend/controller/resourcegroups/trackedresourceprocess_test.go
+++ b/pkg/ucp/backend/controller/resourcegroups/trackedresourceprocess_test.go
@@ -63,30 +63,18 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	resourceGroup := &datamodel.ResourceGroup{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID: id.RootScope(),
-			},
-		},
+		ID: id.RootScope(),
 	}
 
 	resourceTypeResource := &datamodel.ResourceType{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				Name: "testResources",
-				ID:   resourceTypeID.String(),
-			},
-		},
+		Name:       "testResources",
+		ID:         resourceTypeID.String(),
 		Properties: datamodel.ResourceTypeProperties{},
 	}
 
 	locationResource := &datamodel.Location{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				Name: "global",
-				ID:   locationID.String(),
-			},
-		},
+		Name: "global",
+		ID:   locationID.String(),
 		Properties: datamodel.LocationProperties{
 			Address: new("https://localhost:1234"),
 			ResourceTypes: map[string]datamodel.LocationResourceTypeConfiguration{

--- a/pkg/ucp/backend/controller/resourceproviders/util.go
+++ b/pkg/ucp/backend/controller/resourceproviders/util.go
@@ -79,9 +79,7 @@ func updateResourceProviderSummaryWithETag(ctx context.Context, client database.
 		summary.Type = summaryID.Type()
 
 		obj = &database.Object{
-			Metadata: database.Metadata{
-				ID: summary.ID,
-			},
+			ID: summary.ID,
 		}
 	} else if errors.Is(err, &database.ErrNotFound{}) && policy == summaryNotFoundIgnore {
 		return nil

--- a/pkg/ucp/backend/controller/resourceproviders/util_test.go
+++ b/pkg/ucp/backend/controller/resourceproviders/util_test.go
@@ -166,10 +166,8 @@ func Test_UpdateResourceProviderSummaryWithETag(t *testing.T) {
 
 				expectedETag = etag.New(bs)
 				obj := database.Object{
-					Metadata: database.Metadata{
-						ID:   tt.summaryID.String(),
-						ETag: expectedETag,
-					},
+					ID:   tt.summaryID.String(),
+					ETag: expectedETag,
 					Data: converted,
 				}
 				client.EXPECT().Get(gomock.Any(), tt.summaryID.String()).Return(&obj, nil)

--- a/pkg/ucp/datamodel/genericresource.go
+++ b/pkg/ucp/datamodel/genericresource.go
@@ -75,13 +75,9 @@ type GenericResourceProperties struct {
 // GenericResourceFromID creates a new GenericResource from the given original resource ID and tracking ID.
 func GenericResourceFromID(originalID resources.ID, trackingID resources.ID) *GenericResource {
 	return &GenericResource{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   trackingID.String(),
-				Type: trackingID.Type(),
-				Name: trackingID.Name(),
-			},
-		},
+		ID:   trackingID.String(),
+		Type: trackingID.Type(),
+		Name: trackingID.Name(),
 		Properties: GenericResourceProperties{
 			ID:   originalID.String(),
 			Name: originalID.Name(),

--- a/pkg/ucp/frontend/aws/module.go
+++ b/pkg/ucp/frontend/aws/module.go
@@ -34,8 +34,8 @@ const (
 
 // NewModule creates a new AWS module.
 func NewModule(options *ucp.Options) *Module {
-	m := Module{options: options}
-	m.router = chi.NewRouter()
+	m := Module{options: options,
+		router: chi.NewRouter()}
 	m.router.NotFound(validator.APINotFoundHandler())
 	m.router.MethodNotAllowed(validator.APIMethodNotAllowedHandler())
 

--- a/pkg/ucp/frontend/controller/credentials/aws/deleteawscredential_test.go
+++ b/pkg/ucp/frontend/controller/credentials/aws/deleteawscredential_test.go
@@ -136,9 +136,7 @@ func setupCredentialMocks(mockDatabaseClient database.MockClient) {
 	mockDatabaseClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, id string, options ...database.GetOptions) (*database.Object, error) {
 			return &database.Object{
-				Metadata: database.Metadata{
-					ID: datamodelCredential.TrackedResource.ID,
-				},
+				ID:   datamodelCredential.TrackedResource.ID,
 				Data: &datamodelCredential,
 			}, nil
 		}).Times(1)

--- a/pkg/ucp/frontend/controller/credentials/azure/deleteazurecredential_test.go
+++ b/pkg/ucp/frontend/controller/credentials/azure/deleteazurecredential_test.go
@@ -139,9 +139,7 @@ func setupCredentialMocks(mockDatabaseClient database.MockClient) {
 	mockDatabaseClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, id string, options ...database.GetOptions) (*database.Object, error) {
 			return &database.Object{
-				Metadata: database.Metadata{
-					ID: datamodelCredential.TrackedResource.ID,
-				},
+				ID:   datamodelCredential.TrackedResource.ID,
 				Data: &datamodelCredential,
 			}, nil
 		}).Times(1)

--- a/pkg/ucp/frontend/controller/planes/listplanes_test.go
+++ b/pkg/ucp/frontend/controller/planes/listplanes_test.go
@@ -46,14 +46,10 @@ func Test_ListPlanes(t *testing.T) {
 	testPlaneType := datamodel.AWSPlaneResourceType
 
 	planeData := datamodel.AWSPlane{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       testPlaneId,
-				Name:     testPlaneName,
-				Type:     testPlaneType,
-				Location: "global",
-			},
-		},
+		ID:         testPlaneId,
+		Name:       testPlaneName,
+		Type:       testPlaneType,
+		Location:   "global",
 		Properties: datamodel.AWSPlaneProperties{},
 	}
 

--- a/pkg/ucp/frontend/controller/planes/listplanesbytype_test.go
+++ b/pkg/ucp/frontend/controller/planes/listplanesbytype_test.go
@@ -58,14 +58,10 @@ func Test_ListPlanesByType(t *testing.T) {
 	testPlaneType := datamodel.RadiusPlaneResourceType
 
 	planeData := datamodel.RadiusPlane{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       testPlaneId,
-				Name:     testPlaneName,
-				Type:     testPlaneType,
-				Location: "global",
-			},
-		},
+		ID:       testPlaneId,
+		Name:     testPlaneName,
+		Type:     testPlaneType,
+		Location: "global",
 		Properties: datamodel.RadiusPlaneProperties{
 			ResourceProviders: map[string]string{
 				"Applications.Core": "https://applications-rp",

--- a/pkg/ucp/frontend/controller/radius/proxy.go
+++ b/pkg/ucp/frontend/controller/radius/proxy.go
@@ -313,7 +313,7 @@ retry:
 		}
 
 		logger.V(ucplog.LevelDebug).Info("enqueuing tracked resource update")
-		err = p.DatabaseClient().Save(ctx, &database.Object{Metadata: database.Metadata{ID: trackingID.String()}, Data: entry}, database.WithETag(etag))
+		err = p.DatabaseClient().Save(ctx, &database.Object{ID: trackingID.String(), Data: entry}, database.WithETag(etag))
 		if errors.Is(err, &database.ErrConcurrency{}) {
 			// This means we hit a concurrency error saving the tracked resource entry. This means that the resource
 			// was updated in the background. We should retry.

--- a/pkg/ucp/frontend/controller/radius/proxy_test.go
+++ b/pkg/ucp/frontend/controller/radius/proxy_test.go
@@ -81,30 +81,18 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	resourceGroup := &datamodel.ResourceGroup{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID: id.RootScope(),
-			},
-		},
+		ID: id.RootScope(),
 	}
 
 	resourceTypeResource := &datamodel.ResourceType{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				Name: "testResources",
-				ID:   resourceTypeID.String(),
-			},
-		},
+		Name:       "testResources",
+		ID:         resourceTypeID.String(),
 		Properties: datamodel.ResourceTypeProperties{},
 	}
 
 	locationResource := &datamodel.Location{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				Name: "global",
-				ID:   locationID.String(),
-			},
-		},
+		Name: "global",
+		ID:   locationID.String(),
 		Properties: datamodel.LocationProperties{
 			Address: new("https://localhost:1234"),
 			ResourceTypes: map[string]datamodel.LocationResourceTypeConfiguration{
@@ -314,11 +302,7 @@ func Test_Run(t *testing.T) {
 		// Tracking entry created
 		existingEntry := &database.Object{
 			Data: &datamodel.GenericResource{
-				BaseResource: v1.BaseResource{
-					InternalMetadata: v1.InternalMetadata{
-						AsyncProvisioningState: v1.ProvisioningStateAccepted,
-					},
-				},
+				AsyncProvisioningState: v1.ProvisioningStateAccepted,
 			},
 		}
 		databaseClient.EXPECT().

--- a/pkg/ucp/frontend/controller/resourcegroups/listresourcegroups_test.go
+++ b/pkg/ucp/frontend/controller/resourcegroups/listresourcegroups_test.go
@@ -53,14 +53,10 @@ func Test_ListResourceGroups(t *testing.T) {
 	testResourceGroupName := "test-rg"
 
 	rg := datamodel.ResourceGroup{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       testResourceGroupID,
-				Name:     testResourceGroupName,
-				Type:     ResourceGroupType,
-				Location: v1.LocationGlobal,
-			},
-		},
+		ID:       testResourceGroupID,
+		Name:     testResourceGroupName,
+		Type:     ResourceGroupType,
+		Location: v1.LocationGlobal,
 	}
 
 	mockDatabaseClient.EXPECT().Query(gomock.Any(), query).DoAndReturn(func(ctx context.Context, query database.Query, options ...database.QueryOptions) (*database.ObjectQueryResult, error) {

--- a/pkg/ucp/frontend/controller/resourcegroups/listresources_test.go
+++ b/pkg/ucp/frontend/controller/resourcegroups/listresources_test.go
@@ -40,13 +40,9 @@ func Test_ListResources(t *testing.T) {
 		Name: new("test-app"),
 	}
 	entryDatamodel := datamodel.GenericResource{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   "ignored",
-				Type: "ignored",
-				Name: "ignored",
-			},
-		},
+		ID:   "ignored",
+		Type: "ignored",
+		Name: "ignored",
 		Properties: datamodel.GenericResourceProperties{
 			ID:   *entryResource.ID,
 			Type: *entryResource.Type,

--- a/pkg/ucp/frontend/controller/resourcegroups/util_test.go
+++ b/pkg/ucp/frontend/controller/resourcegroups/util_test.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"testing"
 
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/components/database"
 	"github.com/radius-project/radius/pkg/ucp/datamodel"
 	"github.com/radius-project/radius/pkg/ucp/resources"
@@ -50,11 +49,7 @@ func Test_ValidateDownstream(t *testing.T) {
 	downstream := "http://localhost:7443"
 
 	plane := &datamodel.RadiusPlane{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID: id.PlaneScope(),
-			},
-		},
+		ID: id.PlaneScope(),
 		Properties: datamodel.RadiusPlaneProperties{
 			ResourceProviders: map[string]string{
 				"System.TestRP": downstream,
@@ -63,22 +58,14 @@ func Test_ValidateDownstream(t *testing.T) {
 	}
 
 	resourceTypeResource := &datamodel.ResourceType{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				Name: "testResources",
-				ID:   resourceTypeID.String(),
-			},
-		},
+		Name:       "testResources",
+		ID:         resourceTypeID.String(),
 		Properties: datamodel.ResourceTypeProperties{},
 	}
 
 	locationResource := &datamodel.Location{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				Name: location,
-				ID:   locationID.String(),
-			},
-		},
+		Name: location,
+		ID:   locationID.String(),
 		Properties: datamodel.LocationProperties{
 			Address: new("http://localhost:7443"),
 			ResourceTypes: map[string]datamodel.LocationResourceTypeConfiguration{
@@ -98,11 +85,7 @@ func Test_ValidateDownstream(t *testing.T) {
 
 	t.Run("success (resource group)", func(t *testing.T) {
 		resourceGroup := &datamodel.ResourceGroup{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: id.RootScope(),
-				},
-			},
+			ID: id.RootScope(),
 		}
 
 		databaseClient := setup(t)
@@ -244,11 +227,7 @@ func Test_ValidateDownstream(t *testing.T) {
 
 	t.Run("resource type error", func(t *testing.T) {
 		resourceGroup := &datamodel.ResourceGroup{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: id.RootScope(),
-				},
-			},
+			ID: id.RootScope(),
 		}
 
 		expected := fmt.Errorf("failed to fetch resource type %q: %w", "System.TestRP/testResources", errors.New("test error"))
@@ -266,11 +245,7 @@ func Test_ValidateDownstream(t *testing.T) {
 
 	t.Run("resource type not registered", func(t *testing.T) {
 		resourceGroup := &datamodel.ResourceGroup{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: id.RootScope(),
-				},
-			},
+			ID: id.RootScope(),
 		}
 
 		databaseClient := setup(t)
@@ -286,11 +261,7 @@ func Test_ValidateDownstream(t *testing.T) {
 
 	t.Run("location error", func(t *testing.T) {
 		resourceGroup := &datamodel.ResourceGroup{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: id.RootScope(),
-				},
-			},
+			ID: id.RootScope(),
 		}
 
 		expected := fmt.Errorf("failed to fetch location %q: %w", locationResource.ID, errors.New("test error"))
@@ -309,20 +280,12 @@ func Test_ValidateDownstream(t *testing.T) {
 
 	t.Run("resource type not found in location", func(t *testing.T) {
 		resourceGroup := &datamodel.ResourceGroup{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: id.RootScope(),
-				},
-			},
+			ID: id.RootScope(),
 		}
 
 		locationResource := &datamodel.Location{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: location,
-					ID:   locationResource.ID,
-				},
-			},
+			Name: location,
+			ID:   locationResource.ID,
 			Properties: datamodel.LocationProperties{
 				Address: new("http://localhost:7443"),
 				ResourceTypes: map[string]datamodel.LocationResourceTypeConfiguration{
@@ -349,20 +312,12 @@ func Test_ValidateDownstream(t *testing.T) {
 
 	t.Run("api-version not found in location", func(t *testing.T) {
 		resourceGroup := &datamodel.ResourceGroup{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: id.RootScope(),
-				},
-			},
+			ID: id.RootScope(),
 		}
 
 		locationResource := &datamodel.Location{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: location,
-					ID:   locationResource.ID,
-				},
-			},
+			Name: location,
+			ID:   locationResource.ID,
 			Properties: datamodel.LocationProperties{
 				Address: new("http://localhost:7443"),
 				ResourceTypes: map[string]datamodel.LocationResourceTypeConfiguration{
@@ -389,20 +344,12 @@ func Test_ValidateDownstream(t *testing.T) {
 
 	t.Run("location invalid URL", func(t *testing.T) {
 		resourceGroup := &datamodel.ResourceGroup{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID: id.RootScope(),
-				},
-			},
+			ID: id.RootScope(),
 		}
 
 		locationResource := &datamodel.Location{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					Name: location,
-					ID:   locationResource.ID,
-				},
-			},
+			Name: location,
+			ID:   locationResource.ID,
 			Properties: datamodel.LocationProperties{
 				Address: new("\ninvalid"),
 				ResourceTypes: map[string]datamodel.LocationResourceTypeConfiguration{

--- a/pkg/ucp/frontend/controller/resourceproviders/geticon.go
+++ b/pkg/ucp/frontend/controller/resourceproviders/geticon.go
@@ -68,8 +68,7 @@ func (r *GetIcon) Run(ctx context.Context, w http.ResponseWriter, req *http.Requ
 
 	result, err := r.DatabaseClient().Get(ctx, id.String())
 	if err != nil {
-		var notFound *database.ErrNotFound
-		if errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*database.ErrNotFound](err); ok {
 			return armrpc_rest.NewNotFoundResponse(id), nil
 		}
 		return nil, err

--- a/pkg/ucp/initializer/service.go
+++ b/pkg/ucp/initializer/service.go
@@ -191,17 +191,11 @@ func registerResourceProviderDirect(ctx context.Context, dbClient database.Clien
 
 	// 1. Save ResourceProvider
 	rpModel := &datamodel.ResourceProvider{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       rpID,
-				Name:     rp.Namespace,
-				Type:     datamodel.ResourceProviderResourceType,
-				Location: locationName,
-			},
-			InternalMetadata: v1.InternalMetadata{
-				AsyncProvisioningState: v1.ProvisioningStateSucceeded,
-			},
-		},
+		ID:                     rpID,
+		Name:                   rp.Namespace,
+		Type:                   datamodel.ResourceProviderResourceType,
+		Location:               locationName,
+		AsyncProvisioningState: v1.ProvisioningStateSucceeded,
 	}
 
 	if err := saveResource(ctx, dbClient, rpID, rpModel); err != nil {
@@ -228,16 +222,10 @@ func registerResourceProviderDirect(ctx context.Context, dbClient database.Clien
 		}
 
 		typeModel := &datamodel.ResourceType{
-			BaseResource: v1.BaseResource{
-				TrackedResource: v1.TrackedResource{
-					ID:   typeID,
-					Name: typeName,
-					Type: datamodel.ResourceTypeResourceType,
-				},
-				InternalMetadata: v1.InternalMetadata{
-					AsyncProvisioningState: v1.ProvisioningStateSucceeded,
-				},
-			},
+			ID:                     typeID,
+			Name:                   typeName,
+			Type:                   datamodel.ResourceTypeResourceType,
+			AsyncProvisioningState: v1.ProvisioningStateSucceeded,
 			Properties: datamodel.ResourceTypeProperties{
 				Capabilities:      resourceType.Capabilities,
 				DefaultAPIVersion: resourceType.DefaultAPIVersion,
@@ -258,16 +246,10 @@ func registerResourceProviderDirect(ctx context.Context, dbClient database.Clien
 
 			schema, _ := apiVersion.Schema.(map[string]any)
 			avModel := &datamodel.APIVersion{
-				BaseResource: v1.BaseResource{
-					TrackedResource: v1.TrackedResource{
-						ID:   avID,
-						Name: apiVersionName,
-						Type: datamodel.APIVersionResourceType,
-					},
-					InternalMetadata: v1.InternalMetadata{
-						AsyncProvisioningState: v1.ProvisioningStateSucceeded,
-					},
-				},
+				ID:                     avID,
+				Name:                   apiVersionName,
+				Type:                   datamodel.APIVersionResourceType,
+				AsyncProvisioningState: v1.ProvisioningStateSucceeded,
 				Properties: datamodel.APIVersionProperties{
 					Schema: schema,
 				},
@@ -306,16 +288,10 @@ func registerResourceProviderDirect(ctx context.Context, dbClient database.Clien
 	}
 
 	locationModel := &datamodel.Location{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   locationID,
-				Name: locationName,
-				Type: datamodel.LocationResourceType,
-			},
-			InternalMetadata: v1.InternalMetadata{
-				AsyncProvisioningState: v1.ProvisioningStateSucceeded,
-			},
-		},
+		ID:                     locationID,
+		Name:                   locationName,
+		Type:                   datamodel.LocationResourceType,
+		AsyncProvisioningState: v1.ProvisioningStateSucceeded,
 		Properties: datamodel.LocationProperties{
 			ResourceTypes: locationResourceTypes,
 		},
@@ -331,13 +307,9 @@ func registerResourceProviderDirect(ctx context.Context, dbClient database.Clien
 	// 4. Save ResourceProviderSummary
 	summaryID := rootScope + "/providers/System.Resources/resourceProviderSummaries/" + rp.Namespace
 	summaryModel := &datamodel.ResourceProviderSummary{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   summaryID,
-				Name: rp.Namespace,
-				Type: datamodel.ResourceProviderSummaryResourceType,
-			},
-		},
+		ID:   summaryID,
+		Name: rp.Namespace,
+		Type: datamodel.ResourceProviderSummaryResourceType,
 		Properties: datamodel.ResourceProviderSummaryProperties{
 			Locations: map[string]datamodel.ResourceProviderSummaryPropertiesLocation{
 				locationName: {},
@@ -355,7 +327,7 @@ func registerResourceProviderDirect(ctx context.Context, dbClient database.Clien
 
 func saveResource(ctx context.Context, dbClient database.Client, id string, data any) error {
 	return dbClient.Save(ctx, &database.Object{
-		Metadata: database.Metadata{ID: id},
-		Data:     data,
+		ID:   id,
+		Data: data,
 	})
 }

--- a/pkg/ucp/initializer/service_test.go
+++ b/pkg/ucp/initializer/service_test.go
@@ -464,13 +464,9 @@ func Test_saveResource(t *testing.T) {
 
 	dbClient := inmemory.NewClient()
 	data := &datamodel.ResourceProvider{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   "/planes/radius/local/providers/System.Resources/resourceProviders/Test",
-				Name: "Test",
-				Type: datamodel.ResourceProviderResourceType,
-			},
-		},
+		ID:   "/planes/radius/local/providers/System.Resources/resourceProviders/Test",
+		Name: "Test",
+		Type: datamodel.ResourceProviderResourceType,
 	}
 
 	err := saveResource(t.Context(), dbClient, data.ID, data)

--- a/pkg/ucp/integrationtests/testrp/converter.go
+++ b/pkg/ucp/integrationtests/testrp/converter.go
@@ -61,19 +61,13 @@ func (src *TestResource) ConvertTo() (v1.DataModelInterface, error) {
 	// Note: SystemData conversion isn't required since this property comes ARM and datastore.
 
 	converted := &TestResourceDatamodel{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:       to.String(src.ID),
-				Name:     to.String(src.Name),
-				Type:     to.String(src.Type),
-				Location: to.String(src.Location),
-				Tags:     to.StringMap(src.Tags),
-			},
-			InternalMetadata: v1.InternalMetadata{
-				CreatedAPIVersion: Version,
-				UpdatedAPIVersion: Version,
-			},
-		},
+		ID:                to.String(src.ID),
+		Name:              to.String(src.Name),
+		Type:              to.String(src.Type),
+		Location:          to.String(src.Location),
+		Tags:              to.StringMap(src.Tags),
+		CreatedAPIVersion: Version,
+		UpdatedAPIVersion: Version,
 		Properties: TestResourceDatamodelProperties{
 			Message: src.Properties.Message,
 		},

--- a/pkg/ucp/options.go
+++ b/pkg/ucp/options.go
@@ -71,11 +71,10 @@ func NewOptions(ctx context.Context, config *Config) (*Options, error) {
 		Config: config,
 
 		Modules: nil, // Default to nil, which implies the default set of modules.
-	}
 
-	options.DatabaseProvider = databaseprovider.FromOptions(config.Database)
-	options.QueueProvider = queueprovider.New(config.Queue)
-	options.SecretProvider = secretprovider.NewSecretProvider(config.Secrets)
+		DatabaseProvider: databaseprovider.FromOptions(config.Database),
+		QueueProvider:    queueprovider.New(config.Queue),
+		SecretProvider:   secretprovider.NewSecretProvider(config.Secrets)}
 
 	databaseClient, err := options.DatabaseProvider.GetClient(ctx)
 	if err != nil {

--- a/pkg/ucp/proxy/types.go
+++ b/pkg/ucp/proxy/types.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"slices"
 )
 
 // DirectorFunc is a function that modifies the request before it is sent to the downstream server.
@@ -120,8 +121,8 @@ func rewrite(target *url.URL, directors []DirectorFunc) func(*httputil.ProxyRequ
 
 func responder(directors []ResponderFunc) ResponderFunc {
 	return func(r *http.Response) error {
-		for i := len(directors) - 1; i >= 0; i-- {
-			err := directors[i](r)
+		for _, director := range slices.Backward(directors) {
+			err := director(r)
 			if err != nil {
 				return err
 			}

--- a/pkg/ucp/trackedresource/update.go
+++ b/pkg/ucp/trackedresource/update.go
@@ -235,9 +235,7 @@ func (u *Updater) run(ctx context.Context, id resources.ID, destination *url.URL
 	}
 
 	obj = &database.Object{
-		Metadata: database.Metadata{
-			ID: trackingID.String(),
-		},
+		ID:   trackingID.String(),
 		Data: entry,
 	}
 	logger.V(ucplog.LevelDebug).Info("updating tracked resource entry")

--- a/pkg/ucp/trackedresource/update_test.go
+++ b/pkg/ucp/trackedresource/update_test.go
@@ -293,7 +293,7 @@ func Test_run(t *testing.T) {
 			Times(1)
 		databaseClient.EXPECT().
 			Get(gomock.Any(), LegacyIDFor(testID).String()).
-			Return(&database.Object{Metadata: database.Metadata{ETag: etag}, Data: dm}, nil).
+			Return(&database.Object{ETag: etag, Data: dm}, nil).
 			Times(1)
 
 		// Mock a successful (terminal) response from the downstream API.
@@ -332,7 +332,7 @@ func Test_run(t *testing.T) {
 
 		databaseClient.EXPECT().
 			Get(gomock.Any(), IDFor(testID).String()).
-			Return(&database.Object{Metadata: database.Metadata{ETag: etag}, Data: dm}, nil).
+			Return(&database.Object{ETag: etag, Data: dm}, nil).
 			Times(1)
 
 		// Mock a successful (terminal) response from the downstream API.
@@ -364,7 +364,7 @@ func Test_run(t *testing.T) {
 
 		databaseClient.EXPECT().
 			Get(gomock.Any(), IDFor(testID).String()).
-			Return(&database.Object{Metadata: database.Metadata{ETag: etag}, Data: dm}, nil).
+			Return(&database.Object{ETag: etag, Data: dm}, nil).
 			Times(1)
 
 		// Mock a successful (terminal) response from the downstream API.

--- a/pkg/upgrade/preflight/kubernetes_check_test.go
+++ b/pkg/upgrade/preflight/kubernetes_check_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -50,7 +49,7 @@ func TestKubernetesConnectivityCheck_Run(t *testing.T) {
 		// Setup: namespace exists, deployments can be listed
 		clientset := fake.NewClientset(
 			&corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{Name: RadiusSystemNamespace},
+				Name: RadiusSystemNamespace,
 			},
 		)
 
@@ -78,7 +77,7 @@ func TestKubernetesConnectivityCheck_Run(t *testing.T) {
 		// Setup: namespace exists but can't list deployments
 		clientset := fake.NewClientset(
 			&corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{Name: RadiusSystemNamespace},
+				Name: RadiusSystemNamespace,
 			},
 		)
 

--- a/pkg/upgrade/preflight/resource_check_test.go
+++ b/pkg/upgrade/preflight/resource_check_test.go
@@ -25,7 +25,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -181,7 +180,7 @@ func TestKubernetesResourceCheck_NoClientset(t *testing.T) {
 
 func createNode(name, cpu, memory string) *corev1.Node {
 	return &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Name: name,
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{
 				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
@@ -201,11 +200,9 @@ func createNode(name, cpu, memory string) *corev1.Node {
 
 func createRadiusDeployment(name, cpu, memory string, replicas int32) *appsv1.Deployment {
 	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "radius-system",
-			Labels:    map[string]string{"app.kubernetes.io/part-of": "radius"},
-		},
+		Name:      name,
+		Namespace: "radius-system",
+		Labels:    map[string]string{"app.kubernetes.io/part-of": "radius"},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Template: corev1.PodTemplateSpec{

--- a/test/functional-portable/corerp/cloud/resources/radiuscore_azure_mysql_portallink_test.go
+++ b/test/functional-portable/corerp/cloud/resources/radiuscore_azure_mysql_portallink_test.go
@@ -95,7 +95,7 @@ func Test_RadiusCore_AzureMySql_PortalLink(t *testing.T) {
 			// auto-creates it). Pre-create it so the environment resource can bind.
 			Executor: step.NewFuncExecutor(func(ctx context.Context, t *testing.T, opts test.TestOptions) {
 				_, err := opts.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{Name: appNamespace},
+					Name: appNamespace,
 				}, metav1.CreateOptions{})
 				if err != nil && !strings.Contains(err.Error(), "already exists") {
 					require.NoError(t, err)

--- a/test/functional-portable/database/noncloud/database_install_test.go
+++ b/test/functional-portable/database/noncloud/database_install_test.go
@@ -50,6 +50,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -399,11 +400,8 @@ func requireNoPermissionDeniedInLogs(ctx context.Context, t *testing.T, k8s kube
 func containersToScan(pod corev1.Pod) []string {
 	matched := []string{}
 	for _, container := range pod.Spec.Containers {
-		for _, wanted := range controlPlaneComponents {
-			if container.Name == wanted {
-				matched = append(matched, container.Name)
-				break
-			}
+		if slices.Contains(controlPlaneComponents, container.Name) {
+			matched = append(matched, container.Name)
 		}
 	}
 	return matched
@@ -431,7 +429,7 @@ func readContainerLogs(ctx context.Context, k8s kubernetes.Interface, podName st
 // findLine returns the first line containing marker, so failures report the offending log line
 // instead of an entire container log.
 func findLine(logs string, marker string) (string, bool) {
-	for _, line := range strings.Split(logs, "\n") {
+	for line := range strings.SplitSeq(logs, "\n") {
 		if strings.Contains(line, marker) {
 			return strings.TrimSpace(line), true
 		}

--- a/test/functional-portable/dynamicrp/noncloud/resources/directmodule_test.go
+++ b/test/functional-portable/dynamicrp/noncloud/resources/directmodule_test.go
@@ -64,9 +64,7 @@ func Test_DirectModule_Terraform(t *testing.T) {
 			// Create the Kubernetes namespace the recipe deploys into.
 			Executor: step.NewFuncExecutor(func(ctx context.Context, t *testing.T, options test.TestOptions) {
 				_, err := options.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: appNamespace,
-					},
+					Name: appNamespace,
 				}, metav1.CreateOptions{})
 				if err != nil && !apierrors.IsAlreadyExists(err) {
 					require.NoError(t, err)
@@ -193,9 +191,7 @@ func Test_DirectModule_Bicep(t *testing.T) {
 			// Create the Kubernetes namespace the recipe deploys into.
 			Executor: step.NewFuncExecutor(func(ctx context.Context, t *testing.T, options test.TestOptions) {
 				_, err := options.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: appNamespace,
-					},
+					Name: appNamespace,
 				}, metav1.CreateOptions{})
 				if err != nil && !apierrors.IsAlreadyExists(err) {
 					require.NoError(t, err)

--- a/test/functional-portable/dynamicrp/noncloud/resources/recipepacks_test.go
+++ b/test/functional-portable/dynamicrp/noncloud/resources/recipepacks_test.go
@@ -49,9 +49,7 @@ func runRecipePacksDeploymentTest(t *testing.T, template, appName, appNamespace,
 			// The first step in this test is to create the Kubernetes namespace.
 			Executor: step.NewFuncExecutor(func(ctx context.Context, t *testing.T, options test.TestOptions) {
 				_, err := options.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: appNamespace,
-					},
+					Name: appNamespace,
 				}, metav1.CreateOptions{})
 				if err != nil && !strings.Contains(err.Error(), "already exists") {
 					require.NoError(t, err)

--- a/test/functional-portable/dynamicrp/noncloud/resources/terraformsettings_bicepsettings_test.go
+++ b/test/functional-portable/dynamicrp/noncloud/resources/terraformsettings_bicepsettings_test.go
@@ -44,9 +44,7 @@ func Test_TerraformSettings_Redis(t *testing.T) {
 			// Create the Kubernetes namespace (Radius.Core requires pre-existing namespaces).
 			Executor: step.NewFuncExecutor(func(ctx context.Context, t *testing.T, options test.TestOptions) {
 				_, err := options.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: appNamespace,
-					},
+					Name: appNamespace,
 				}, metav1.CreateOptions{})
 				if err != nil && !strings.Contains(err.Error(), "already exists") {
 					require.NoError(t, err)
@@ -105,9 +103,7 @@ func Test_BicepSettings_CRUD(t *testing.T) {
 			// Create the Kubernetes namespace.
 			Executor: step.NewFuncExecutor(func(ctx context.Context, t *testing.T, options test.TestOptions) {
 				_, err := options.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: appNamespace,
-					},
+					Name: appNamespace,
 				}, metav1.CreateOptions{})
 				if err != nil && !strings.Contains(err.Error(), "already exists") {
 					require.NoError(t, err)
@@ -170,9 +166,7 @@ func Test_TerraformSettings_SecuritySecret_Credentials(t *testing.T) {
 			// Create the consumer environment's Kubernetes namespace (Radius.Core requires pre-existing namespaces).
 			Executor: step.NewFuncExecutor(func(ctx context.Context, t *testing.T, options test.TestOptions) {
 				_, err := options.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: appNamespace,
-					},
+					Name: appNamespace,
 				}, metav1.CreateOptions{})
 				if err != nil && !strings.Contains(err.Error(), "already exists") {
 					require.NoError(t, err)
@@ -252,9 +246,7 @@ func Test_TerraformSettings_BicepSettings_Combined(t *testing.T) {
 			// Create the Kubernetes namespace (Radius.Core requires pre-existing namespaces).
 			Executor: step.NewFuncExecutor(func(ctx context.Context, t *testing.T, options test.TestOptions) {
 				_, err := options.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: appNamespace,
-					},
+					Name: appNamespace,
 				}, metav1.CreateOptions{})
 				if err != nil && !strings.Contains(err.Error(), "already exists") {
 					require.NoError(t, err)

--- a/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
+++ b/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
@@ -69,7 +69,7 @@ func Test_DeploymentTemplate_Env(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the namespace, if it already exists we can ignore the error.
-	_, err = opts.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, metav1.CreateOptions{})
+	_, err = opts.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{Name: namespace}, metav1.CreateOptions{})
 	require.NoError(t, controller_runtime.IgnoreAlreadyExists(err))
 
 	deploymentTemplate := makeDeploymentTemplate(types.NamespacedName{Name: name, Namespace: namespace}, string(template), providerConfig, parametersMap)
@@ -121,7 +121,7 @@ func Test_DeploymentTemplate_Env(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+			ns := &corev1.Namespace{Name: namespace}
 			err = opts.Client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
 			return apierrors.IsNotFound(err)
 		}, time.Minute*10, time.Second*10, "waiting for environment namespace to be deleted")
@@ -150,7 +150,7 @@ func Test_DeploymentTemplate_Module(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the namespace, if it already exists we can ignore the error.
-	_, err = opts.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, metav1.CreateOptions{})
+	_, err = opts.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{Name: namespace}, metav1.CreateOptions{})
 	require.NoError(t, controller_runtime.IgnoreAlreadyExists(err))
 
 	deploymentTemplate := makeDeploymentTemplate(types.NamespacedName{Name: name, Namespace: namespace}, string(template), providerConfig, parametersMap)
@@ -227,7 +227,7 @@ func Test_DeploymentTemplate_Recipe(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the namespace, if it already exists we can ignore the error.
-	_, err = opts.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, metav1.CreateOptions{})
+	_, err = opts.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{Name: namespace}, metav1.CreateOptions{})
 	require.NoError(t, controller_runtime.IgnoreAlreadyExists(err))
 
 	deploymentTemplate := makeDeploymentTemplate(types.NamespacedName{Name: name, Namespace: namespace}, string(template), providerConfig, parametersMap)
@@ -284,10 +284,8 @@ func Test_DeploymentTemplate_Recipe(t *testing.T) {
 // makeDeploymentTemplate returns a DeploymentTemplate object with the given name, template, providerConfig, and parameters.
 func makeDeploymentTemplate(name types.NamespacedName, template, providerConfig string, parameters map[string]string) *radappiov1alpha3.DeploymentTemplate {
 	deploymentTemplate := &radappiov1alpha3.DeploymentTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.Name,
-			Namespace: name.Namespace,
-		},
+		Name:      name.Name,
+		Namespace: name.Namespace,
 		Spec: radappiov1alpha3.DeploymentTemplateSpec{
 			Template:       template,
 			Parameters:     parameters,
@@ -409,7 +407,7 @@ func deleteNamespace(ctx context.Context, t *testing.T, namespace string, opts r
 	}
 
 	require.Eventually(t, func() bool {
-		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		ns := &corev1.Namespace{Name: namespace}
 		err = opts.Client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
 		return apierrors.IsNotFound(err)
 	}, time.Minute*10, time.Second*10, "waiting for environment namespace to be deleted")
@@ -421,7 +419,7 @@ func deleteNamespace(ctx context.Context, t *testing.T, namespace string, opts r
 // before the K8s namespace delete in functional tests.
 func deleteDeploymentTemplateAndWait(ctx context.Context, t *testing.T, nn types.NamespacedName, opts rp.RPTestOptions) {
 	dt := &radappiov1alpha3.DeploymentTemplate{
-		ObjectMeta: metav1.ObjectMeta{Name: nn.Name, Namespace: nn.Namespace},
+		Name: nn.Name, Namespace: nn.Namespace,
 	}
 	err := opts.Client.Delete(ctx, dt)
 	if controller_runtime.IgnoreNotFound(err) != nil {

--- a/test/functional-portable/kubernetes/noncloud/flux_test.go
+++ b/test/functional-portable/kubernetes/noncloud/flux_test.go
@@ -203,11 +203,9 @@ func testFluxIntegration(t *testing.T, testName string, steps []GitOpsTestStep, 
 
 	// Create the secret for the Flux GitRepository.
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      gitRepoName,
-			Namespace: fluxSystemNamespace,
-		},
-		Type: corev1.SecretTypeBasicAuth,
+		Name:      gitRepoName,
+		Namespace: fluxSystemNamespace,
+		Type:      corev1.SecretTypeBasicAuth,
 		Data: map[string][]byte{
 			"username": []byte(gitUsername),
 			"password": []byte(gitPassword),
@@ -222,10 +220,8 @@ func testFluxIntegration(t *testing.T, testName string, steps []GitOpsTestStep, 
 
 	// Create the Flux GitRepository object.
 	fluxGitRepository := &sourcev1.GitRepository{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      gitRepoName,
-			Namespace: fluxSystemNamespace,
-		},
+		Name:      gitRepoName,
+		Namespace: fluxSystemNamespace,
 		Spec: sourcev1.GitRepositorySpec{
 			URL: fmt.Sprintf(gitServerInternalRepoURLFormat, gitRepoName),
 			SecretRef: &meta.LocalObjectReference{

--- a/test/functional-portable/kubernetes/noncloud/kubernetes_test.go
+++ b/test/functional-portable/kubernetes/noncloud/kubernetes_test.go
@@ -56,7 +56,7 @@ func Test_TutorialApplication_KubernetesManifests(t *testing.T) {
 	applicationName := namespace
 
 	// Create the namespace, if it already exists we can ignore the error.
-	_, err := opts.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, metav1.CreateOptions{})
+	_, err := opts.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{Name: namespace}, metav1.CreateOptions{})
 	require.NoError(t, controller_runtime.IgnoreAlreadyExists(err))
 
 	cli := radcli.NewCLI(t, "")
@@ -160,15 +160,13 @@ func Test_TutorialApplication_KubernetesManifests(t *testing.T) {
 
 func makeDeployment(name types.NamespacedName, environmentName string, applicationName string) *appsv1.Deployment {
 	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.Name,
-			Namespace: name.Namespace,
-			Annotations: map[string]string{
-				"radapp.io/enabled":          "true",
-				"radapp.io/connection-redis": "db",
-				"radapp.io/environment":      environmentName,
-				"radapp.io/application":      applicationName,
-			},
+		Name:      name.Name,
+		Namespace: name.Namespace,
+		Annotations: map[string]string{
+			"radapp.io/enabled":          "true",
+			"radapp.io/connection-redis": "db",
+			"radapp.io/environment":      environmentName,
+			"radapp.io/application":      applicationName,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
@@ -198,13 +196,11 @@ func makeDeployment(name types.NamespacedName, environmentName string, applicati
 
 func makeRecipe(name types.NamespacedName, environmentName string, applicationName string) *radappiov1alpha3.Recipe {
 	return &radappiov1alpha3.Recipe{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.Name,
-			Namespace: name.Namespace,
-			Annotations: map[string]string{
-				"radapp.io/enabled":          "true",
-				"radapp.io/connection-redis": "db",
-			},
+		Name:      name.Name,
+		Namespace: name.Namespace,
+		Annotations: map[string]string{
+			"radapp.io/enabled":          "true",
+			"radapp.io/connection-redis": "db",
 		},
 		Spec: radappiov1alpha3.RecipeSpec{
 			Type:        "Applications.Datastores/redisCaches",

--- a/test/ucp/kubeenv/testenv.go
+++ b/test/ucp/kubeenv/testenv.go
@@ -25,7 +25,6 @@ import (
 
 	ucpv1alpha1 "github.com/radius-project/radius/pkg/components/database/apiserverstore/api/ucp.dev/v1alpha1"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -91,9 +90,7 @@ func getKubeAssetsDir() (string, error) {
 // created.
 func EnsureNamespace(ctx context.Context, client runtimeclient.Client, namespace string) error {
 	nsObject := v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
-		},
+		Name: namespace,
 	}
 	return client.Create(ctx, &nsObject, &runtimeclient.CreateOptions{})
 }

--- a/test/ucp/storetest/shared.go
+++ b/test/ucp/storetest/shared.go
@@ -145,9 +145,7 @@ func parseOrPanic(id string) resources.ID {
 
 func createObject(id resources.ID, data any) database.Object {
 	return database.Object{
-		Metadata: database.Metadata{
-			ID: id.String(),
-		},
+		ID:   id.String(),
 		Data: data,
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Radius! Please fill out each section below so
reviewers have the context they need. Sections marked optional can be removed
if they do not apply.
-->

## Summary

Apply the structural simplifications emitted by Go 1.27 `go fix` across the Go source and test files. The changes flatten promoted struct literals and use `strings.SplitSeq` for sequence iteration where applicable.

## Reason for change

Keep the Go code aligned with the latest Go 1.27 simplification guidance and improve readability without changing intended behavior.

## How to test

- `go version` reports `go1.27.0 windows/amd64`.
- `go test ./pkg/...` was run. Most packages passed, but three existing environment-sensitive tests failed on this Windows workstation: a Windows temp-path assertion, a fixture commit requiring unavailable signing configuration, and a Windows path validation case.

## File change summary

<!-- Summarize the change made in each file that was modified. -->

| File | Summary of change |
| ---- | ----------------- |
| 254 Go source and test files | Apply Go 1.27 `go fix` structural literal and string iteration simplifications. |