### PR TITLE
refactor(go): apply Go 1.27 go fix simplifications - part 2

### DIFF
--- a/pkg/corerp/renderers/kubernetesmetadata/render_test.go
+++ b/pkg/corerp/renderers/kubernetesmetadata/render_test.go
@@ -36,11 +36,10 @@ func (r *noop) Render(ctx context.Context, dm apiv1.DataModelInterface, options 
 		Namespace:  "test-namespace",
 		Kind:       "Deployment",
 		APIVersion: "apps/v1",
-	}
 
-	// Populate Meta labels with existing values
-	deployment.Annotations = map[string]string{"prior.MetaAnnotation1": "prior.MetaAnnotationVal1", "prior.MetaAnnotation2": "prior.MetaAnnotationVal2"}
-	deployment.Labels = map[string]string{"prior.MetaLabel1": "prior.MetaLabelVal1", "prior.MetaLabel2": "prior.MetaLabelVal2"}
+		// Populate Meta labels with existing values
+		Annotations: map[string]string{"prior.MetaAnnotation1": "prior.MetaAnnotationVal1", "prior.MetaAnnotation2": "prior.MetaAnnotationVal2"},
+		Labels:      map[string]string{"prior.MetaLabel1": "prior.MetaLabelVal1", "prior.MetaLabel2": "prior.MetaLabelVal2"}}
 
 	resources := []rpv1.OutputResource{rpv1.NewKubernetesOutputResource(rpv1.LocalIDDeployment, &deployment, deployment.ObjectMeta)}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Radius! Please fill out each section below so
reviewers have the context they need. Sections marked optional can be removed
if they do not apply.
-->

## Summary

<!-- Provide a concise description of what this PR does. -->

Apply the Go 1.27 `go fix` composite-literal simplification to the Kubernetes metadata renderer test.

## Reason for change

<!--
Explain why this change is needed. If it addresses a GitHub issue, link it
below so it is automatically closed when this PR merges (optional).
-->

Keep the test code aligned with Go 1.27's automated simplifications without changing behavior.

## How to test

<!-- Describe the steps a reviewer can take to verify these changes. -->

Validation was not run as part of PR creation.

## File change summary

<!-- Summarize the change made in each file that was modified. -->

| File | Summary of change |
| ---- | ----------------- |
| `pkg/corerp/renderers/kubernetesmetadata/render_test.go` | Initialize annotations and labels directly in the deployment composite literal. |