### PR TITLE
refactor(uuid): use built-in package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,6 @@ require (
 	github.com/gofrs/flock v0.13.0
 	github.com/google/gnostic-models v0.7.1
 	github.com/google/go-cmp v0.7.0
-	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-getter/v2 v2.2.3
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/go-version v1.9.0
@@ -200,6 +199,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/pkg/armrpc/api/v1/armrequestcontext.go
+++ b/pkg/armrpc/api/v1/armrequestcontext.go
@@ -26,7 +26,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
 )

--- a/pkg/armrpc/asyncoperation/controller/request.go
+++ b/pkg/armrpc/asyncoperation/controller/request.go
@@ -19,7 +19,7 @@ package controller
 import (
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/ucp/resources"

--- a/pkg/armrpc/asyncoperation/controller/request_test.go
+++ b/pkg/armrpc/asyncoperation/controller/request_test.go
@@ -22,7 +22,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/armrpc/rpctest"
 	"github.com/radius-project/radius/pkg/ucp/resources"

--- a/pkg/armrpc/asyncoperation/statusmanager/mock_statusmanager.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/mock_statusmanager.go
@@ -14,7 +14,7 @@ import (
 	reflect "reflect"
 	time "time"
 
-	uuid "github.com/google/uuid"
+	uuid 	"uuid"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	resources "github.com/radius-project/radius/pkg/ucp/resources"
 	gomock "go.uber.org/mock/gomock"

--- a/pkg/armrpc/asyncoperation/statusmanager/mock_statusmanager.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/mock_statusmanager.go
@@ -13,8 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 	time "time"
+	uuid "uuid"
 
-	uuid 	"uuid"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	resources "github.com/radius-project/radius/pkg/ucp/resources"
 	gomock "go.uber.org/mock/gomock"

--- a/pkg/armrpc/asyncoperation/statusmanager/statusmanager.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/statusmanager.go
@@ -31,7 +31,7 @@ import (
 	"github.com/radius-project/radius/pkg/components/trace"
 	"github.com/radius-project/radius/pkg/ucp/resources"
 
-	"github.com/google/uuid"
+	"uuid"
 )
 
 // statusManager includes the necessary functions to manage asynchronous operations.

--- a/pkg/armrpc/asyncoperation/statusmanager/statusmanager_test.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/statusmanager_test.go
@@ -22,7 +22,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/armrpc/rpctest"
 	"github.com/radius-project/radius/pkg/components/database"
@@ -59,7 +60,7 @@ func setup(tb testing.TB) (asyncOperationsManagerTest, *gomock.Controller) {
 
 var reqCtx = &v1.ARMRequestContext{
 	ResourceID:     resources.MustParse("/planes/radius/local/resourceGroups/radius-test-rg/providers/Applications.Core/container/container0"),
-	OperationID:    uuid.Must(uuid.NewRandom()),
+	OperationID:    uuid.New(),
 	HomeTenantID:   "home-tenant-id",
 	ClientObjectID: "client-object-id",
 	OperationType:  rpctest.MustParseOperationType("APPLICATIONS.CORE/ENVIRONMENTS|PUT"),

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -36,7 +36,8 @@ import (
 	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"golang.org/x/sync/semaphore"
 )
 

--- a/pkg/armrpc/asyncoperation/worker/worker_runoperation_test.go
+++ b/pkg/armrpc/asyncoperation/worker/worker_runoperation_test.go
@@ -25,7 +25,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	ctrl "github.com/radius-project/radius/pkg/armrpc/asyncoperation/controller"
 	manager "github.com/radius-project/radius/pkg/armrpc/asyncoperation/statusmanager"
@@ -47,7 +48,7 @@ const (
 var (
 	testResourceType    = "Applications.Core/environments"
 	testOperationStatus = &manager.Status{
-		ID:               uuid.NewString(),
+		ID:               uuid.New().String(),
 		Name:             "operation-status",
 		Status:           v1.ProvisioningStateUpdating,
 		StartTime:        time.Now().UTC(),
@@ -127,8 +128,8 @@ func genTestMessage(opID uuid.UUID, opTimeout time.Duration) *queue.Message {
 		OperationID:   opID,
 		OperationType: "APPLICATIONS.CORE/ENVIRONMENTS|PUT",
 		ResourceID: fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/%s",
-			uuid.NewString()),
-		CorrelationID:    uuid.NewString(),
+			uuid.New().String()),
+		CorrelationID:    uuid.New().String(),
 		OperationTimeout: &opTimeout,
 	})
 

--- a/pkg/armrpc/asyncoperation/worker/worker_test.go
+++ b/pkg/armrpc/asyncoperation/worker/worker_test.go
@@ -27,7 +27,8 @@ import (
 	"github.com/radius-project/radius/pkg/components/database"
 	"github.com/radius-project/radius/pkg/ucp/resources"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )

--- a/pkg/armrpc/frontend/controller/util_test.go
+++ b/pkg/armrpc/frontend/controller/util_test.go
@@ -25,8 +25,9 @@ import (
 	"strings"
 	"testing"
 
+	"uuid"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/google/uuid"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/armrpc/frontend/defaultoperation/listresources_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/listresources_test.go
@@ -29,7 +29,8 @@ import (
 	"github.com/radius-project/radius/pkg/armrpc/rpctest"
 	"github.com/radius-project/radius/pkg/components/database"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )

--- a/pkg/armrpc/rest/results.go
+++ b/pkg/armrpc/rest/results.go
@@ -25,8 +25,9 @@ import (
 	"net/url"
 	"time"
 
+	"uuid"
+
 	"github.com/go-playground/validator/v10"
-	"github.com/google/uuid"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/logging"
 

--- a/pkg/armrpc/rest/results_test.go
+++ b/pkg/armrpc/rest/results_test.go
@@ -26,7 +26,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/stretchr/testify/require"
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"

--- a/pkg/azure/roleassignment/roleassignment.go
+++ b/pkg/azure/roleassignment/roleassignment.go
@@ -24,8 +24,9 @@ import (
 	"strings"
 	"time"
 
+	"uuid"
+
 	armauthorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
-	"github.com/google/uuid"
 	"github.com/radius-project/radius/pkg/to"
 
 	"github.com/radius-project/radius/pkg/azure/armauth"

--- a/pkg/cli/clivalidation.go
+++ b/pkg/cli/clivalidation.go
@@ -23,7 +23,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/radius-project/radius/pkg/cli/clierrors"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
 	"github.com/radius-project/radius/pkg/cli/output"

--- a/pkg/cli/deployment/deploy.go
+++ b/pkg/cli/deployment/deploy.go
@@ -24,8 +24,9 @@ import (
 	"sync"
 	"time"
 
+	"uuid"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments"
-	"github.com/google/uuid"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/cli/clients"
 	sdkclients "github.com/radius-project/radius/pkg/sdk/clients"

--- a/pkg/components/queue/inmemory/queue.go
+++ b/pkg/components/queue/inmemory/queue.go
@@ -21,7 +21,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/radius-project/radius/pkg/components/queue"
 )
 
@@ -71,7 +72,7 @@ func (q *InmemQueue) Enqueue(msg *queue.Message) {
 	q.vMu.Lock()
 	defer q.vMu.Unlock()
 
-	msg.Metadata.ID = uuid.NewString()
+	msg.Metadata.ID = uuid.New().String()
 	msg.Metadata.DequeueCount = 0
 	msg.Metadata.EnqueueAt = time.Now().UTC()
 	msg.Metadata.ExpireAt = time.Now().UTC().Add(messageExpireDuration)

--- a/pkg/controller/reconciler/deploymenttemplate_reconciler.go
+++ b/pkg/controller/reconciler/deploymenttemplate_reconciler.go
@@ -29,9 +29,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"uuid"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments"
 	"github.com/go-logr/logr"
-	"github.com/google/uuid"
 	"github.com/radius-project/radius/pkg/cli/clients"
 	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
 	"github.com/radius-project/radius/pkg/hashutil"

--- a/pkg/controller/reconciler/mock_radius_client_test.go
+++ b/pkg/controller/reconciler/mock_radius_client_test.go
@@ -22,9 +22,10 @@ import (
 	"strings"
 	"sync"
 
+	"uuid"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	azcoreruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/google/uuid"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
 	corerpv20231001preview "github.com/radius-project/radius/pkg/corerp/api/v20231001preview"

--- a/pkg/corerp/backend/controller/createorupdateresource_test.go
+++ b/pkg/corerp/backend/controller/createorupdateresource_test.go
@@ -22,7 +22,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -66,7 +67,7 @@ func TestCreateOrUpdateResourceRun_20231001Preview(t *testing.T) {
 			"container-put-success",
 			container.ResourceType,
 			"APPLICATIONS.CORE/CONTAINERS|PUT",
-			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/containers/%s", uuid.NewString()),
+			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/containers/%s", uuid.New().String()),
 			nil,
 			false,
 			nil,
@@ -78,7 +79,7 @@ func TestCreateOrUpdateResourceRun_20231001Preview(t *testing.T) {
 			"container-put-not-found",
 			container.ResourceType,
 			"APPLICATIONS.CORE/CONTAINERS|PUT",
-			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/containers/%s", uuid.NewString()),
+			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/containers/%s", uuid.New().String()),
 			&database.ErrNotFound{},
 			false,
 			nil,
@@ -90,7 +91,7 @@ func TestCreateOrUpdateResourceRun_20231001Preview(t *testing.T) {
 			"container-put-get-err",
 			container.ResourceType,
 			"APPLICATIONS.CORE/CONTAINERS|PUT",
-			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/containers/%s", uuid.NewString()),
+			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/containers/%s", uuid.New().String()),
 			errors.New("error getting object"),
 			false,
 			nil,
@@ -102,7 +103,7 @@ func TestCreateOrUpdateResourceRun_20231001Preview(t *testing.T) {
 			"gateway-put-success",
 			gateway.ResourceType,
 			"APPLICATIONS.CORE/GATEWAYS|PUT",
-			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/gateways/%s", uuid.NewString()),
+			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/gateways/%s", uuid.New().String()),
 			nil,
 			false,
 			nil,
@@ -114,7 +115,7 @@ func TestCreateOrUpdateResourceRun_20231001Preview(t *testing.T) {
 			"gateway-put-not-found",
 			gateway.ResourceType,
 			"APPLICATIONS.CORE/GATEWAYS|PUT",
-			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/gateways/%s", uuid.NewString()),
+			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/gateways/%s", uuid.New().String()),
 			&database.ErrNotFound{},
 			false,
 			nil,
@@ -145,7 +146,7 @@ func TestCreateOrUpdateResourceRun_20231001Preview(t *testing.T) {
 				OperationID:      uuid.New(),
 				OperationType:    tt.opType,
 				ResourceID:       tt.rId,
-				CorrelationID:    uuid.NewString(),
+				CorrelationID:    uuid.New().String(),
 				OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
 			}
 
@@ -239,7 +240,7 @@ func TestCreateOrUpdateResourceRun_20231001Preview(t *testing.T) {
 			"container-patch-success",
 			container.ResourceType,
 			"APPLICATIONS.CORE/CONTAINERS|PATCH",
-			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/containers/%s", uuid.NewString()),
+			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/containers/%s", uuid.New().String()),
 			nil,
 			false,
 			nil,
@@ -251,7 +252,7 @@ func TestCreateOrUpdateResourceRun_20231001Preview(t *testing.T) {
 			"container-patch-not-found",
 			container.ResourceType,
 			"APPLICATIONS.CORE/CONTAINERS|PATCH",
-			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/containers/%s", uuid.NewString()),
+			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/containers/%s", uuid.New().String()),
 			&database.ErrNotFound{},
 			false,
 			nil,
@@ -263,7 +264,7 @@ func TestCreateOrUpdateResourceRun_20231001Preview(t *testing.T) {
 			"container-patch-get-err",
 			container.ResourceType,
 			"APPLICATIONS.CORE/CONTAINERS|PATCH",
-			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/containers/%s", uuid.NewString()),
+			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/containers/%s", uuid.New().String()),
 			errors.New("error getting object"),
 			false,
 			nil,
@@ -275,7 +276,7 @@ func TestCreateOrUpdateResourceRun_20231001Preview(t *testing.T) {
 			"gateway-patch-success",
 			gateway.ResourceType,
 			"APPLICATIONS.CORE/GATEWAYS|PATCH",
-			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/gateways/%s", uuid.NewString()),
+			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/gateways/%s", uuid.New().String()),
 			nil,
 			false,
 			nil,
@@ -287,7 +288,7 @@ func TestCreateOrUpdateResourceRun_20231001Preview(t *testing.T) {
 			"gateway-patch-not-found",
 			gateway.ResourceType,
 			"APPLICATIONS.CORE/GATEWAYS|PATCH",
-			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/gateways/%s", uuid.NewString()),
+			fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/gateways/%s", uuid.New().String()),
 			&database.ErrNotFound{},
 			false,
 			nil,
@@ -318,7 +319,7 @@ func TestCreateOrUpdateResourceRun_20231001Preview(t *testing.T) {
 				OperationID:      uuid.New(),
 				OperationType:    tt.opType,
 				ResourceID:       tt.rId,
-				CorrelationID:    uuid.NewString(),
+				CorrelationID:    uuid.New().String(),
 				OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
 			}
 

--- a/pkg/corerp/backend/controller/deleteresource_test.go
+++ b/pkg/corerp/backend/controller/deleteresource_test.go
@@ -21,7 +21,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	ctrl "github.com/radius-project/radius/pkg/armrpc/asyncoperation/controller"
 	"github.com/radius-project/radius/pkg/components/database"
 	deployment "github.com/radius-project/radius/pkg/corerp/backend/deployment"
@@ -41,8 +42,8 @@ func TestDeleteResourceRun_20231001Preview(t *testing.T) {
 			OperationID:   uuid.New(),
 			OperationType: "APPLICATIONS.CORE/CONTAINERS|DELETE",
 			ResourceID: fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/containers/%s",
-				uuid.NewString()),
-			CorrelationID:    uuid.NewString(),
+				uuid.New().String()),
+			CorrelationID:    uuid.New().String(),
 			OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
 		}
 

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
@@ -36,7 +36,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -39,7 +39,8 @@ import (
 	resources_kubernetes "github.com/radius-project/radius/pkg/ucp/resources/kubernetes"
 	"github.com/radius-project/radius/test/testutil"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/dynamicrp/integrationtest/dynamic/operations_test.go
+++ b/pkg/dynamicrp/integrationtest/dynamic/operations_test.go
@@ -21,7 +21,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/armrpc/asyncoperation/statusmanager"
 	"github.com/radius-project/radius/pkg/components/database"

--- a/pkg/dynamicrp/testhost/host.go
+++ b/pkg/dynamicrp/testhost/host.go
@@ -23,7 +23,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/armrpc/hostoptions"
 	"github.com/radius-project/radius/pkg/components/database/databaseprovider"

--- a/pkg/portableresources/backend/controller/createorupdateresource_test.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource_test.go
@@ -25,10 +25,11 @@ import (
 	"net/http"
 	"testing"
 
+	"uuid"
+
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 	"github.com/go-viper/mapstructure/v2"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
@@ -381,7 +382,7 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 				OperationID:      uuid.New(),
 				OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT", // Operation does not affect the behavior of the controller.
 				ResourceID:       TestResourceID,
-				CorrelationID:    uuid.NewString(),
+				CorrelationID:    uuid.New().String(),
 				OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
 			}
 
@@ -648,7 +649,7 @@ func TestCreateOrUpdateResource_Run_RecipeErrorSurfacedWhenStatusSaveFails(t *te
 		OperationID:      uuid.New(),
 		OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT",
 		ResourceID:       TestResourceID,
-		CorrelationID:    uuid.NewString(),
+		CorrelationID:    uuid.New().String(),
 		OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
 	})
 
@@ -793,7 +794,7 @@ func TestCreateOrUpdateResource_Run_SensitiveRedaction(t *testing.T) {
 		OperationID:      uuid.New(),
 		OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT",
 		ResourceID:       TestResourceID,
-		CorrelationID:    uuid.NewString(),
+		CorrelationID:    uuid.New().String(),
 		OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
 	})
 	require.NoError(t, err)
@@ -867,7 +868,7 @@ func TestCreateOrUpdateResource_Run_SensitiveMissingKey(t *testing.T) {
 		OperationID:      uuid.New(),
 		OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT",
 		ResourceID:       TestResourceID,
-		CorrelationID:    uuid.NewString(),
+		CorrelationID:    uuid.New().String(),
 		OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
 	})
 	require.Error(t, err)
@@ -975,7 +976,7 @@ func TestCreateOrUpdateResource_Run_SensitiveNilKubeClient(t *testing.T) {
 		OperationID:      uuid.New(),
 		OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT",
 		ResourceID:       TestResourceID,
-		CorrelationID:    uuid.NewString(),
+		CorrelationID:    uuid.New().String(),
 		OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
 	})
 	require.Error(t, err)
@@ -1088,7 +1089,7 @@ func TestCreateOrUpdateResource_Run_SensitiveRedactionSaveFails(t *testing.T) {
 		OperationID:      uuid.New(),
 		OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT",
 		ResourceID:       TestResourceID,
-		CorrelationID:    uuid.NewString(),
+		CorrelationID:    uuid.New().String(),
 		OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
 	})
 	require.Error(t, err)
@@ -1251,7 +1252,7 @@ func TestCreateOrUpdateResource_Run_SensitiveMultipleFields(t *testing.T) {
 		OperationID:      uuid.New(),
 		OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT",
 		ResourceID:       TestResourceID,
-		CorrelationID:    uuid.NewString(),
+		CorrelationID:    uuid.New().String(),
 		OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
 	})
 	require.NoError(t, err)

--- a/pkg/portableresources/backend/controller/deleteresource_test.go
+++ b/pkg/portableresources/backend/controller/deleteresource_test.go
@@ -21,7 +21,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	ctrl "github.com/radius-project/radius/pkg/armrpc/asyncoperation/controller"
 	"github.com/radius-project/radius/pkg/components/database"
@@ -53,7 +54,7 @@ func TestDeleteResourceRun_20231001Preview(t *testing.T) {
 			OperationID:      uuid.New(),
 			OperationType:    "APPLICATIONS.DATASTORES/MONGODATABASES|DELETE",
 			ResourceID:       resourceID,
-			CorrelationID:    uuid.NewString(),
+			CorrelationID:    uuid.New().String(),
 			OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
 		}
 

--- a/pkg/recipes/driver/terraform/terraform.go
+++ b/pkg/recipes/driver/terraform/terraform.go
@@ -26,7 +26,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/components/kubernetesclient/kubernetesclientprovider"
 	"github.com/radius-project/radius/pkg/components/secret/secretprovider"
@@ -278,13 +279,13 @@ func (d *terraformDriver) createExecutionDirectory(ctx context.Context, recipe r
 	// but we can also trace them to the resource we were working on through operationID. UUID is added to the path to prevent overwrite across retries for same ARM request.
 	dirID := ""
 	armCtx := v1.ARMRequestContextFromContext(ctx)
-	if armCtx.OperationID != uuid.Nil {
-		dirID = armCtx.OperationID.String() + "-" + uuid.NewString()
+	if armCtx.OperationID != uuid.Nil() {
+		dirID = armCtx.OperationID.String() + "-" + uuid.New().String()
 	} else {
 		// If the operationID is nil, we generate a new UUID for unique directory name combined with resource id so that we can trace it to the resource.
 		// Ideally operationID should not be nil.
 		logger.Info("Empty operation ID provided in the request context, using uuid to generate a unique directory name")
-		dirID = util.NormalizeStringToLower(recipe.ResourceID) + "-" + uuid.NewString()
+		dirID = util.NormalizeStringToLower(recipe.ResourceID) + "-" + uuid.New().String()
 	}
 	requestDirPath := filepath.Join(d.options.Path, dirID)
 

--- a/pkg/recipes/driver/terraform/terraform_test.go
+++ b/pkg/recipes/driver/terraform/terraform_test.go
@@ -23,7 +23,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	tfjson "github.com/hashicorp/terraform-json"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/corerp/datamodel"

--- a/pkg/recipes/terraform/config/config_test.go
+++ b/pkg/recipes/terraform/config/config_test.go
@@ -24,7 +24,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 

--- a/pkg/recipes/terraform/config/providers/aws.go
+++ b/pkg/recipes/terraform/config/providers/aws.go
@@ -21,7 +21,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	ucp_datamodel "github.com/radius-project/radius/pkg/ucp/datamodel"
 
 	"github.com/radius-project/radius/pkg/azure/tokencredentials"

--- a/pkg/rp/util/authclient/awsirsa.go
+++ b/pkg/rp/util/authclient/awsirsa.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 	"strings"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/google/uuid"
 	ucp_aws "github.com/radius-project/radius/pkg/ucp/aws"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"

--- a/pkg/sdk/clients/mock_resourcedeploymentsclient.go
+++ b/pkg/sdk/clients/mock_resourcedeploymentsclient.go
@@ -21,9 +21,10 @@ import (
 	"net/http"
 	"sync"
 
+	"uuid"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments"
-	"github.com/google/uuid"
 )
 
 // This file contains mocks for the ResourceDeploymentsClient interface.

--- a/pkg/ucp/aws/ucpcredentialprovider.go
+++ b/pkg/ucp/aws/ucpcredentialprovider.go
@@ -22,11 +22,12 @@ import (
 	"fmt"
 	"time"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/google/uuid"
 
 	sdk_cred "github.com/radius-project/radius/pkg/ucp/credentials"
 	"github.com/radius-project/radius/pkg/ucp/ucplog"

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource.go
@@ -21,11 +21,12 @@ import (
 	"maps"
 	http "net/http"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
-	"github.com/google/uuid"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	armrpc_controller "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
 	armrpc_rest "github.com/radius-project/radius/pkg/armrpc/rest"

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
@@ -23,11 +23,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
-	"github.com/google/uuid"
 	armrpc_controller "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
 	"github.com/radius-project/radius/pkg/armrpc/rpctest"
 	ucp_aws "github.com/radius-project/radius/pkg/ucp/aws"
@@ -36,7 +37,7 @@ import (
 )
 
 func Test_CreateAWSResource(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -114,7 +115,7 @@ func Test_CreateAWSResource(t *testing.T) {
 }
 
 func Test_CreateAWSResourceInvalidRegion(t *testing.T) {
-	testResource := CreateKinesisStreamTestResourceWithInvalidRegion(uuid.NewString())
+	testResource := CreateKinesisStreamTestResourceWithInvalidRegion(uuid.New().String())
 	testOptions := setupTest(t)
 
 	requestBody := map[string]any{
@@ -170,7 +171,7 @@ func Test_CreateAWSResourceInvalidRegion(t *testing.T) {
 }
 
 func Test_UpdateAWSResource(t *testing.T) {
-	testResource := CreateMemoryDBClusterTestResource(uuid.NewString())
+	testResource := CreateMemoryDBClusterTestResource(uuid.New().String())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
@@ -265,7 +266,7 @@ func Test_UpdateAWSResource(t *testing.T) {
 }
 
 func Test_UpdateNoChangesDoesNotCallUpdate(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
@@ -23,11 +23,12 @@ import (
 	"maps"
 	http "net/http"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
-	"github.com/google/uuid"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	armrpc_controller "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
 	armrpc_rest "github.com/radius-project/radius/pkg/armrpc/rest"

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
@@ -23,11 +23,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
-	"github.com/google/uuid"
 	armrpc_controller "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
 	"github.com/radius-project/radius/pkg/armrpc/rpctest"
 	ucp_aws "github.com/radius-project/radius/pkg/ucp/aws"
@@ -38,7 +39,7 @@ import (
 
 func Test_CreateAWSResourceWithPost(t *testing.T) {
 	testOptions := setupTest(t)
-	testResource := CreateMemoryDBClusterTestResource(uuid.NewString())
+	testResource := CreateMemoryDBClusterTestResource(uuid.New().String())
 
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudformation.DescribeTypeOutput{
@@ -114,7 +115,7 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 }
 
 func Test_UpdateAWSResourceWithPost(t *testing.T) {
-	testResource := CreateMemoryDBClusterTestResource(uuid.NewString())
+	testResource := CreateMemoryDBClusterTestResource(uuid.New().String())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
@@ -212,7 +213,7 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 }
 
 func Test_UpdateAWSResourceWithPost_NoChangesNoops(t *testing.T) {
-	testResource := CreateMemoryDBClusterTestResource(uuid.NewString())
+	testResource := CreateMemoryDBClusterTestResource(uuid.New().String())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
@@ -301,7 +302,7 @@ func Test_UpdateAWSResourceWithPost_NoChangesNoops(t *testing.T) {
 }
 
 func Test_CreateAWSResourceWithPost_NoPrimaryIdentifierAvailable(t *testing.T) {
-	testResource := CreateRedshiftEndpointAuthorizationTestResource(uuid.NewString())
+	testResource := CreateRedshiftEndpointAuthorizationTestResource(uuid.New().String())
 	clusterIdentifierValue := "abc"
 	accountValue := "xyz"
 	multiIdentifierResourceID := clusterIdentifierValue + "|" + accountValue
@@ -376,7 +377,7 @@ func Test_CreateAWSResourceWithPost_NoPrimaryIdentifierAvailable(t *testing.T) {
 }
 
 func Test_CreateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
-	testResource := CreateRedshiftEndpointAuthorizationTestResource(uuid.NewString())
+	testResource := CreateRedshiftEndpointAuthorizationTestResource(uuid.New().String())
 	clusterIdentifierValue := "abc"
 	accountValue := "xyz"
 	multiIdentifierResourceID := clusterIdentifierValue + "|" + accountValue
@@ -458,7 +459,7 @@ func Test_CreateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 }
 
 func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
-	testResource := CreateRedshiftEndpointAuthorizationTestResource(uuid.NewString())
+	testResource := CreateRedshiftEndpointAuthorizationTestResource(uuid.New().String())
 	clusterIdentifierValue := "abc"
 	accountValue := "xyz"
 	multiIdentifierResourceID := clusterIdentifierValue + "|" + accountValue

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresource.go
@@ -19,9 +19,10 @@ import (
 	"context"
 	http "net/http"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
-	"github.com/google/uuid"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	armrpc_controller "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
 	armrpc_rest "github.com/radius-project/radius/pkg/armrpc/rest"

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresource_test.go
@@ -21,10 +21,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
-	"github.com/google/uuid"
 	armrpc_controller "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
 	"github.com/radius-project/radius/pkg/armrpc/rpctest"
 	ucp_aws "github.com/radius-project/radius/pkg/ucp/aws"
@@ -33,7 +34,7 @@ import (
 )
 
 func Test_DeleteAWSResource(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().DeleteResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudcontrol.DeleteResourceOutput{
@@ -71,7 +72,7 @@ func Test_DeleteAWSResource(t *testing.T) {
 }
 
 func Test_DeleteAWSResource_ResourceDoesNotExist(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().DeleteResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost.go
@@ -27,11 +27,12 @@ import (
 	"github.com/radius-project/radius/pkg/ucp/datamodel"
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
-	"github.com/google/uuid"
 )
 
 var _ armrpc_controller.Controller = (*DeleteAWSResourceWithPost)(nil)

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost_test.go
@@ -23,11 +23,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
-	"github.com/google/uuid"
 	ucp_aws "github.com/radius-project/radius/pkg/ucp/aws"
 	"go.uber.org/mock/gomock"
 
@@ -37,7 +38,7 @@ import (
 )
 
 func Test_DeleteAWSResourceWithPost(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
@@ -91,7 +92,7 @@ func Test_DeleteAWSResourceWithPost(t *testing.T) {
 }
 
 func Test_DeleteAWSResourceWithPost_ResourceDoesNotExist(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
@@ -154,7 +155,7 @@ func Test_DeleteAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	requestBodyBytes, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	testResource := CreateRedshiftEndpointAuthorizationTestResource(uuid.NewString())
+	testResource := CreateRedshiftEndpointAuthorizationTestResource(uuid.New().String())
 	request, err := http.NewRequest(http.MethodPost, testResource.CollectionPath+"/:delete", bytes.NewBuffer(requestBodyBytes))
 	require.NoError(t, err)
 

--- a/pkg/ucp/frontend/controller/awsproxy/getawsoperationresults_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsoperationresults_test.go
@@ -20,10 +20,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
-	"github.com/google/uuid"
 	"go.uber.org/mock/gomock"
 
 	armrpc_controller "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
@@ -34,7 +35,7 @@ import (
 )
 
 func Test_GetAWSOperationResults_TerminalStatus(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResourceRequestStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -65,7 +66,7 @@ func Test_GetAWSOperationResults_TerminalStatus(t *testing.T) {
 }
 
 func Test_GetAWSOperationResults_NonTerminalStatus(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResourceRequestStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/pkg/ucp/frontend/controller/awsproxy/getawsoperationstatuses_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsoperationstatuses_test.go
@@ -20,10 +20,11 @@ import (
 	"testing"
 	"time"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
-	"github.com/google/uuid"
 	"go.uber.org/mock/gomock"
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
@@ -35,7 +36,7 @@ import (
 )
 
 func Test_GetAWSOperationStatuses(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	eventTime := time.Now()
 	testOptions := setupTest(t)
@@ -71,7 +72,7 @@ func Test_GetAWSOperationStatuses(t *testing.T) {
 }
 
 func Test_GetAWSOperationStatuses_Failed(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	eventTime := time.Now()
 	errorCode := types.HandlerErrorCodeInternalFailure
@@ -116,7 +117,7 @@ func Test_GetAWSOperationStatuses_Failed(t *testing.T) {
 }
 
 func Test_GetAWSOperationStatuses_Delete_NotFound(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	eventTime := time.Now()
 	testOptions := setupTest(t)

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresource_test.go
@@ -21,12 +21,13 @@ import (
 	"net/http"
 	"testing"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
-	"github.com/google/uuid"
 	"go.uber.org/mock/gomock"
 
 	armrpc_v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
@@ -39,7 +40,7 @@ import (
 )
 
 func Test_GetAWSResource(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	getResponseBody := map[string]any{
 		"RetentionPeriodHours": 178,
@@ -85,7 +86,7 @@ func Test_GetAWSResource(t *testing.T) {
 }
 
 func Test_GetAWSResource_NotFound(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -115,7 +116,7 @@ func Test_GetAWSResource_NotFound(t *testing.T) {
 }
 
 func Test_GetAWSResource_UnknownError(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("something bad happened"))
@@ -139,7 +140,7 @@ func Test_GetAWSResource_UnknownError(t *testing.T) {
 }
 
 func Test_GetAWSResource_SmithyError(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, &smithy.OperationError{

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost_test.go
@@ -25,13 +25,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
-	"github.com/google/uuid"
 	"go.uber.org/mock/gomock"
 
 	armrpc_v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
@@ -45,7 +46,7 @@ import (
 )
 
 func Test_GetAWSResourceWithPost(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
@@ -108,7 +109,7 @@ func Test_GetAWSResourceWithPost(t *testing.T) {
 }
 
 func Test_GetAWSResourceWithPost_NotFound(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
@@ -150,7 +151,7 @@ func Test_GetAWSResourceWithPost_NotFound(t *testing.T) {
 }
 
 func Test_GetAWSResourceWithPost_UnknownError(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
@@ -189,7 +190,7 @@ func Test_GetAWSResourceWithPost_UnknownError(t *testing.T) {
 }
 
 func Test_GetAWSResourceWithPost_SmithyError(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
@@ -241,7 +242,7 @@ func Test_GetAWSResourceWithPost_SmithyError(t *testing.T) {
 }
 
 func Test_GetAWSResourceWithPost_MultiIdentifier(t *testing.T) {
-	testResource := CreateRedshiftEndpointAuthorizationTestResource(uuid.NewString())
+	testResource := CreateRedshiftEndpointAuthorizationTestResource(uuid.New().String())
 	clusterIdentifierValue := "abc"
 	accountValue := "xyz"
 	requestBody := map[string]any{
@@ -326,7 +327,7 @@ func Test_GetAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 }
 
 func Test_GetAWSResourceWithPost_RetryableError(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
@@ -396,7 +397,7 @@ func Test_GetAWSResourceWithPost_RetryableError(t *testing.T) {
 }
 
 func Test_GetAWSResourceWithPost_NonRetryableError(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),

--- a/pkg/ucp/frontend/controller/awsproxy/listawsresources_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/listawsresources_test.go
@@ -21,12 +21,13 @@ import (
 	"net/http"
 	"testing"
 
+	"uuid"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
-	"github.com/google/uuid"
 	"go.uber.org/mock/gomock"
 
 	armrpc_v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
@@ -39,8 +40,8 @@ import (
 
 func Test_ListAWSResources(t *testing.T) {
 
-	firstTestResource := CreateKinesisStreamTestResource(uuid.NewString())
-	secondTestResource := CreateKinesisStreamTestResource(uuid.NewString())
+	firstTestResource := CreateKinesisStreamTestResource(uuid.New().String())
+	secondTestResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	firstTestResourceResponseBody := map[string]any{
 		"RetentionPeriodHours": 178,
@@ -112,7 +113,7 @@ func Test_ListAWSResources(t *testing.T) {
 }
 
 func Test_ListAWSResourcesEmpty(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any(), gomock.Any()).Return(&cloudcontrol.ListResourcesOutput{}, nil)
@@ -139,7 +140,7 @@ func Test_ListAWSResourcesEmpty(t *testing.T) {
 }
 
 func Test_ListAWSResource_UnknownError(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("something bad happened"))
@@ -163,7 +164,7 @@ func Test_ListAWSResource_UnknownError(t *testing.T) {
 }
 
 func Test_ListAWSResource_SmithyError(t *testing.T) {
-	testResource := CreateKinesisStreamTestResource(uuid.NewString())
+	testResource := CreateKinesisStreamTestResource(uuid.New().String())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, &smithy.OperationError{

--- a/pkg/ucp/frontend/controller/resourcegroups/listresources_test.go
+++ b/pkg/ucp/frontend/controller/resourcegroups/listresources_test.go
@@ -19,7 +19,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 

--- a/pkg/ucp/integrationtests/handler_test.go
+++ b/pkg/ucp/integrationtests/handler_test.go
@@ -20,7 +20,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/ucp"
 	"github.com/radius-project/radius/pkg/ucp/testhost"

--- a/test/functional-portable/cli/noncloud/env_deploy_test.go
+++ b/test/functional-portable/cli/noncloud/env_deploy_test.go
@@ -23,7 +23,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/radius-project/radius/test/radcli"
 	"github.com/radius-project/radius/test/rp"
 	"github.com/stretchr/testify/require"

--- a/test/functional-portable/corerp/cloud/mechanics/aws_mechanics_test.go
+++ b/test/functional-portable/corerp/cloud/mechanics/aws_mechanics_test.go
@@ -19,7 +19,8 @@ package mechanics_test
 import (
 	"testing"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/radius-project/radius/test/rp"
 	"github.com/radius-project/radius/test/step"
 	"github.com/radius-project/radius/test/testutil"

--- a/test/functional-portable/corerp/cloud/resources/aws_logs_loggroup_test.go
+++ b/test/functional-portable/corerp/cloud/resources/aws_logs_loggroup_test.go
@@ -19,7 +19,8 @@ package resource_test
 import (
 	"testing"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/radius-project/radius/test/rp"
 	"github.com/radius-project/radius/test/step"
 	"github.com/radius-project/radius/test/testutil"

--- a/test/functional-portable/corerp/cloud/resources/aws_multi_identifier_resource_test.go
+++ b/test/functional-portable/corerp/cloud/resources/aws_multi_identifier_resource_test.go
@@ -21,7 +21,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/radius-project/radius/test/rp"
 	"github.com/radius-project/radius/test/step"
 	"github.com/radius-project/radius/test/validation"

--- a/test/functional-portable/corerp/cloud/resources/extender_test.go
+++ b/test/functional-portable/corerp/cloud/resources/extender_test.go
@@ -22,7 +22,8 @@ import (
 
 	"os"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	"github.com/radius-project/radius/test/rp"
 	"github.com/radius-project/radius/test/step"
 	"github.com/radius-project/radius/test/testutil"

--- a/test/functional-portable/ucp/cloud/aws_test.go
+++ b/test/functional-portable/ucp/cloud/aws_test.go
@@ -28,10 +28,11 @@ import (
 	"testing"
 	"time"
 
+	"uuid"
+
 	awsgo "github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
-	"github.com/google/uuid"
 	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	"github.com/radius-project/radius/pkg/ucp/aws"
 	"github.com/radius-project/radius/pkg/ucp/frontend/controller/awsproxy"
@@ -205,7 +206,7 @@ func waitForSuccess(t *testing.T, ctx context.Context, awsClient aws.AWSCloudCon
 
 func generateLogGroupName(t *testing.T) string {
 	t.Helper()
-	return "ucpfunctionaltest-" + uuid.NewString()
+	return "ucpfunctionaltest-" + uuid.New().String()
 }
 
 func requireResponseStatus(t *testing.T, response *http.Response, expectedStatus int) {

--- a/test/functional-portable/ucp/noncloud/tracked_resource_test.go
+++ b/test/functional-portable/ucp/noncloud/tracked_resource_test.go
@@ -23,8 +23,9 @@ import (
 	"testing"
 	"time"
 
+	"uuid"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/google/uuid"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
 	corerp "github.com/radius-project/radius/pkg/corerp/api/v20231001preview"

--- a/test/testutil/testutil.go
+++ b/test/testutil/testutil.go
@@ -29,7 +29,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
+
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
## Summary

- Replace direct `github.com/google/uuid` usage with Go 1.27's standard `uuid` package.
- Adapt UUID helper calls to the standard API and retain the external module only as a transitive dependency.

## Validation

- `git diff --check`
- `go test ./pkg/...` *(blocked by an unrelated Windows path assertion in `pkg/cli/bicep` and timeouts in CLI command packages)*
