### PR TITLE
Fix Validate Bicep Code by repointing every bicepconfig.json at the built extensions

### DIFF
--- a/.github/workflows/validate-bicep.yaml
+++ b/.github/workflows/validate-bicep.yaml
@@ -104,20 +104,34 @@ jobs:
         # Pinned version + checksums live in build/tools.yaml (JQ_VERSION).
         run: make install-jq
 
-      - name: Modify bicepconfig.json
+      - name: Modify bicepconfig.json files
+        # Repoint every bicepconfig.json in the repo at the extensions built above so
+        # the .bicep sources are validated against the types generated in this PR
+        # instead of the published ones. Only entries that already exist are rewritten,
+        # so unrelated extensions (for example aws) and configs that declare no
+        # extensions at all are left untouched. This covers every config, including
+        # ones outside test/ such as .radius/bicepconfig.json; build/validate-bicep.sh
+        # compiles with --no-restore, so a config left pointing at a remote artifact
+        # fails with BCP190.
         run: |
-          # Update bicepconfig.json with paths for extensions
-          jq \
-            --arg rad "$GITHUB_WORKSPACE/tmp-radius-bicep-extension/radius.tgz" \
-            --arg test "$GITHUB_WORKSPACE/tmp-testresources-bicep-extension/testresources.tgz" \
-            '.extensions.radius = $rad | .extensions.testresources = $test' \
-            bicepconfig.json > tmp.json && mv tmp.json bicepconfig.json
+          set -euo pipefail
 
-           # Copy to the dynamicrp resources test directory so the .bicep files there can find it
-           cp -f bicepconfig.json ./test/functional-portable/dynamicrp/noncloud/resources/bicepconfig.json
+          while IFS= read -r config; do
+            jq \
+              --arg rad "$GITHUB_WORKSPACE/tmp-radius-bicep-extension/radius.tgz" \
+              --arg test "$GITHUB_WORKSPACE/tmp-testresources-bicep-extension/testresources.tgz" \
+              'if has("extensions") then
+                 .extensions |= (
+                   (if has("radius") then .radius = $rad else . end)
+                   | (if has("testresources") then .testresources = $test else . end)
+                 )
+               else . end' \
+              "$config" > "$config.tmp"
+            mv "$config.tmp" "$config"
 
-      - name: Print updated bicepconfig.json
-        run: cat bicepconfig.json
+            echo "== $config"
+            cat "$config"
+          done < <(find . -type f -name bicepconfig.json -not -path '*/node_modules/*')
 
       - name: Verify Bicep files
         run: ./build/validate-bicep.sh

--- a/build/validate-bicep.sh
+++ b/build/validate-bicep.sh
@@ -50,6 +50,11 @@ WARNINGS=()
 for F in $FILES
 do
     echo "validating $F"
+    # Reset the results from the previous iteration. Files without an extension are
+    # not built below, and without this reset they would inherit the previous file's
+    # stderr and exit code and be reported as spurious failures or warnings.
+    STDERR=""
+    EXITCODE=0
     # We need to run bicep and fail in one of two cases:
     # - non-zero exit code
     # - non-empty stderr


### PR DESCRIPTION
## Summary

The **Validate Bicep Code** check is failing on every PR against `main`. This repoints *every* `bicepconfig.json` in the repo at the Bicep extensions built during the workflow, instead of two hardcoded paths, which unblocks `.radius/app.bicep`.

## Reason for change

Example failure ([run 33446837552](https://github.com/radius-project/radius/actions/runs/33446837552/job/99667770265)):

```text
Failed: ./.radius/app.bicep
/home/runner/work/radius/radius/.radius/app.bicep(1,11) : Error BCP190:
  The artifact with reference "br:biceptypes.azurecr.io/radius:latest" has not been restored.
```

`.radius/app.bicep` and `.radius/bicepconfig.json` (the Radius application model used by the graph tooling) were added in #12476. That config points the `radius` extension at the published remote artifact `br:biceptypes.azurecr.io/radius:latest`.

`validate-bicep.yaml` builds the Radius extension from the types generated in the PR into a local `.tgz`, then rewrote only two `bicepconfig.json` files to point at it — the root one via `jq`, and the dynamicrp test one via `cp -f`. `.radius/bicepconfig.json` was never rewritten, and `build/validate-bicep.sh` compiles with `--no-restore` (it restores once up front using the first file it finds under the root config's scope), so that remote reference is never restored and the build fails with `BCP190`.

Restoring the remote artifact instead is not the right fix: the point of the check is to validate `.bicep` sources against the types generated in the PR, not against whatever is currently published.

The loop is generic, so any `bicepconfig.json` added later — inside or outside `test/` — is handled automatically. Only extension entries that already exist are rewritten, so `aws` and configs that declare no extensions at all (`test/infra/azure/bicepconfig.json`) are untouched. This also removes the `cp -f` that clobbered the dynamicrp config wholesale.

Second, smaller fix: `build/validate-bicep.sh` only runs `bicep build` for files containing `extension`, but did not reset `STDERR` / `EXITCODE` between iterations. A file without an extension therefore inherited the previous file's result and could be reported as a spurious failure or warning immediately after a genuinely failing file.

## How to test

CI on this PR exercises the change end to end — **Validate Bicep Code** should pass.

Reproduced locally with the repo's pinned Bicep (0.42.1):

```bash
bicep publish-extension ./hack/bicep-types-radius/generated/index.json --target /tmp/vb/radius.tgz --force
# apply the same jq rewrite to every bicepconfig.json
bicep build ./pkg/cli/cmd/bicep/generatekubernetesmanifest/testdata/deploymenttemplate/deploymenttemplate.bicep --stdout >/dev/null
bicep build --no-restore ./.radius/app.bicep --stdout >/dev/null   # exit 0, no errors or warnings
```

Confirmed the rewrite produces the expected result for all four configs, and that every `.bicep` file using `extension testresources` lives under `test/functional-portable/dynamicrp/noncloud/resources/testdata`, whose config already declares `testresources` — so dropping the "add `testresources` to the root config" behavior is safe.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `.github/workflows/validate-bicep.yaml` | Replace the hardcoded `jq` + `cp -f` rewrite (and the separate print step) with a loop over every `bicepconfig.json` that repoints existing `radius` / `testresources` entries at the locally built extensions and prints each result |
| `build/validate-bicep.sh` | Reset `STDERR` and `EXITCODE` at the top of the validation loop so files without an `extension` line don't inherit the previous file's result |
