### PR TITLE
Support windowless background CLI execution on Windows

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -105,3 +105,38 @@ jobs:
           test_group_name: Unit Tests
           artifact_name: unit_test_results
           result_directory: dist/unit_test/
+
+  windows-cli-tests:
+    name: Windows CLI Tests (${{ matrix.arch }})
+    needs: [changes]
+    if: needs.changes.outputs.only_changed != 'true'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: windows-2025
+          - arch: arm64
+            runner: windows-11-arm
+    steps:
+      - name: Checkout Radius repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+          cache: false
+
+      - name: Run Windows CLI process tests
+        env:
+          CGO_ENABLED: 0
+        run: go test ./pkg/process ./pkg/cli/style ./test/windowless -count=1 -timeout=2m

--- a/docs/architecture/rad-cli.md
+++ b/docs/architecture/rad-cli.md
@@ -90,7 +90,7 @@ own packages.
 
 ### Windows background automation
 
-Windows automation callers launch `rad.exe`; `rad.exe` does not launch or require Node.js. A Node.js caller should use `detached: false`, `windowsHide: true`, and piped stdout and stderr. The caller's `windowsHide` option suppresses the initial `rad.exe` console because Radius cannot change its own process creation flags after startup.
+Windows automation callers launch `rad.exe`. A Node.js caller should use `detached: false`, `windowsHide: true`, and piped stdout and stderr. The caller's `windowsHide` option suppresses the initial `rad.exe` console because Radius cannot change its own process creation flags after startup.
 
 When `rad.exe` has no attached console, [pkg/process](../../pkg/process/) automatically applies `SysProcAttr.HideWindow` and `CREATE_NO_WINDOW` to Radius-owned child processes such as Bicep, kubectl, Git, and the direct Azure CLI wrapper. It does not set `DETACHED_PROCESS` or `CREATE_BREAKAWAY_FROM_JOB`, so `rad.exe` and its descendants remain in the automation caller's Windows Job Object for process-tree cancellation. Standard input, output, error, exit codes, and context cancellation retain their existing behavior.
 

--- a/docs/architecture/rad-cli.md
+++ b/docs/architecture/rad-cli.md
@@ -90,11 +90,11 @@ own packages.
 
 ### Windows background automation
 
-Windows automation callers launch `rad.exe`; `rad.exe` does not launch or require Node.js. A Node.js caller should use `detached: false`, `windowsHide: true`, and piped stdout and stderr, and set `RADIUS_CLI_NO_WINDOW=true` in the child environment. The caller's `windowsHide` option suppresses the initial `rad.exe` console because Radius cannot change its own process creation flags after startup.
+Windows automation callers launch `rad.exe`; `rad.exe` does not launch or require Node.js. A Node.js caller should use `detached: false`, `windowsHide: true`, and piped stdout and stderr. The caller's `windowsHide` option suppresses the initial `rad.exe` console because Radius cannot change its own process creation flags after startup.
 
-When `RADIUS_CLI_NO_WINDOW=true`, [pkg/process](../../pkg/process/) applies `SysProcAttr.HideWindow` and `CREATE_NO_WINDOW` to Radius-owned child processes such as Bicep, kubectl, Git, and the direct Azure CLI wrapper. It does not set `DETACHED_PROCESS` or `CREATE_BREAKAWAY_FROM_JOB`, so `rad.exe` and its descendants remain in the automation caller's Windows Job Object for process-tree cancellation. Standard input, output, error, exit codes, and context cancellation retain their existing behavior.
+When `rad.exe` has no attached console, [pkg/process](../../pkg/process/) automatically applies `SysProcAttr.HideWindow` and `CREATE_NO_WINDOW` to Radius-owned child processes such as Bicep, kubectl, Git, and the direct Azure CLI wrapper. It does not set `DETACHED_PROCESS` or `CREATE_BREAKAWAY_FROM_JOB`, so `rad.exe` and its descendants remain in the automation caller's Windows Job Object for process-tree cancellation. Standard input, output, error, exit codes, and context cancellation retain their existing behavior.
 
-The environment variable is opt-in. Without it, interactive CLI behavior and child terminal access are unchanged. Azure Identity credentials create their own Azure CLI process and do not use `pkg/process`; automation that must guarantee windowless descendants should use a non-CLI authentication method such as `ServicePrincipal`, `ManagedIdentity`, or `UCPCredential`.
+When `rad.exe` has an attached console, child terminal access and interactive CLI behavior are unchanged. Azure Identity credentials create their own Azure CLI process and do not use `pkg/process`; automation that must guarantee windowless descendants should use a non-CLI authentication method such as `ServicePrincipal`, `ManagedIdentity`, or `UCPCredential`.
 
 ## Invariants And Constraints
 

--- a/docs/architecture/rad-cli.md
+++ b/docs/architecture/rad-cli.md
@@ -39,8 +39,10 @@ place for backend business rules that belong in UCP or a resource provider.
 | `pkg/cli/config` | CLI config loading and persistence |
 | `pkg/cli/connections` | workspace connection resolution |
 | `pkg/cli/output` | formatting and output |
+| `pkg/cli/style` | lazy terminal-aware styling |
 | `pkg/cli/helm` | installation and upgrade helpers |
 | `pkg/cli/kubernetes` | cluster-facing helpers |
+| `pkg/process` | external process construction and platform policy |
 | `pkg/sdk` | Radius API clients used by commands |
 
 ## How It Works
@@ -85,6 +87,14 @@ common `NewCommand(factory)` plus `Runner.Validate` and `Runner.Run` pattern.
 That keeps command-specific behavior in `pkg/cli/cmd/...` while shared config,
 workspace resolution, connection creation, and operation helpers stay in their
 own packages.
+
+### Windows background automation
+
+Windows automation callers launch `rad.exe`; `rad.exe` does not launch or require Node.js. A Node.js caller should use `detached: false`, `windowsHide: true`, and piped stdout and stderr, and set `RADIUS_CLI_NO_WINDOW=true` in the child environment. The caller's `windowsHide` option suppresses the initial `rad.exe` console because Radius cannot change its own process creation flags after startup.
+
+When `RADIUS_CLI_NO_WINDOW=true`, [pkg/process](../../pkg/process/) applies `SysProcAttr.HideWindow` and `CREATE_NO_WINDOW` to Radius-owned child processes such as Bicep, kubectl, Git, and the direct Azure CLI wrapper. It does not set `DETACHED_PROCESS` or `CREATE_BREAKAWAY_FROM_JOB`, so `rad.exe` and its descendants remain in the automation caller's Windows Job Object for process-tree cancellation. Standard input, output, error, exit codes, and context cancellation retain their existing behavior.
+
+The environment variable is opt-in. Without it, interactive CLI behavior and child terminal access are unchanged. Azure Identity credentials create their own Azure CLI process and do not use `pkg/process`; automation that must guarantee windowless descendants should use a non-CLI authentication method such as `ServicePrincipal`, `ManagedIdentity`, or `UCPCredential`.
 
 ## Invariants And Constraints
 

--- a/docs/contributing/contributing-code/contributing-code-cli/README.md
+++ b/docs/contributing/contributing-code/contributing-code-cli/README.md
@@ -50,6 +50,16 @@ Override the destination with `RAD_LOCATION`. The path must end in `rad` and sho
 RAD_LOCATION=/my/custom/location/rad sudo make install
 ```
 
+### Test Windows background execution
+
+Run the focused Windows process tests on a native Windows host:
+
+```powershell
+go test ./pkg/process ./pkg/cli/style ./test/windowless -count=1 -timeout=2m
+```
+
+The process unit tests verify the Windows no-window creation flags. The integration test builds `rad.exe`, launches it non-detached with piped output inside a kill-on-close Windows Job Object, and verifies `rad version --cli --output json`, a windowless Bicep child, and process-tree cancellation. CI runs these tests on Windows amd64 and arm64.
+
 ### Debug rad in VS Code
 
 The repo's [.vscode/launch.json](../../../../.vscode/launch.json) defines the **"Debug rad CLI (prompt for args)"** configuration, which launches [cmd/rad/main.go](../../../../cmd/rad/main.go) and prompts you for the command-line arguments to run.
@@ -86,6 +96,7 @@ if errors.Is(err, NotFoundError{}) {
 - `go run ./cmd/rad/main.go version` prints version information that includes your local changes.
 - After `sudo make install`, running `rad version` from any directory resolves to your freshly installed build.
 - A breakpoint set in `cmd/rad/` is hit when you run **"Debug rad CLI (prompt for args)"**.
+- On Windows, the focused process tests pass on the native architecture.
 
 ## Troubleshooting
 

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/aws/smithy-go v1.27.8
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260615092313-b57e5e6d29bb
+	github.com/charmbracelet/x/term v0.2.2
 	github.com/distribution/reference v0.6.0
 	github.com/fatih/color v1.19.0
 	github.com/fluxcd/pkg/apis/meta v1.31.0
@@ -98,6 +99,7 @@ require (
 	golang.org/x/crypto v0.55.0
 	golang.org/x/exp v0.0.0-20260611194520-c48552f49976
 	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/text v0.41.0
 	helm.sh/helm/v4 v4.2.4
 	k8s.io/api v0.36.4
@@ -147,7 +149,6 @@ require (
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260811164956-006e29f97886 // indirect
 	github.com/charmbracelet/x/exp/golden v0.0.0-20251109135125-8916d276318f // indirect
-	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
@@ -294,7 +295,6 @@ require (
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect

--- a/pkg/azure/azcli/azcli.go
+++ b/pkg/azure/azcli/azcli.go
@@ -19,8 +19,9 @@ package azcli
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"runtime"
+
+	"github.com/radius-project/radius/pkg/process"
 )
 
 // RunCLICommand runs the Azure CLI command based on the OS type and returns an error if the command fails.
@@ -38,7 +39,7 @@ func RunCLICommand(args ...string) error {
 
 	executableArgs = append(executableArgs, args...)
 
-	c := exec.Command(executableName, executableArgs...)
+	c := process.Command(executableName, executableArgs...)
 	c.Stderr = os.Stderr
 	c.Stdout = os.Stdout
 	err := c.Run()

--- a/pkg/cli/bicep/build.go
+++ b/pkg/cli/bicep/build.go
@@ -21,12 +21,12 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 	"sync"
 
 	"github.com/radius-project/radius/pkg/cli/bicep/tools"
+	"github.com/radius-project/radius/pkg/process"
 )
 
 // Official regex for semver
@@ -47,7 +47,7 @@ func runBicepRaw(args ...string) ([]byte, error) {
 
 	// runs 'bicep'
 	fullCmd := binPath + " " + strings.Join(args, " ")
-	c := exec.Command(binPath, args...)
+	c := process.Command(binPath, args...)
 
 	stdout, err := c.StdoutPipe()
 	if err != nil {

--- a/pkg/cli/cmd/bicep/publishextension/publish.go
+++ b/pkg/cli/cmd/bicep/publishextension/publish.go
@@ -19,7 +19,6 @@ package publishextension
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/radius-project/radius/bicep-tools/generator"
@@ -29,6 +28,7 @@ import (
 	"github.com/radius-project/radius/pkg/cli/framework"
 	"github.com/radius-project/radius/pkg/cli/manifest"
 	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/process"
 	"github.com/spf13/cobra"
 )
 
@@ -152,7 +152,7 @@ func publishExtension(ctx context.Context, inputDirectoryPath string, target str
 		args = append(args, "--force")
 	}
 
-	cmd := exec.CommandContext(ctx, bicepFilePath, args...)
+	cmd := process.CommandContext(ctx, bicepFilePath, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/pkg/cli/cmd/radinit/common/display.go
+++ b/pkg/cli/cmd/radinit/common/display.go
@@ -27,11 +27,11 @@ import (
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/radius-project/radius/pkg/cli/aws"
 	"github.com/radius-project/radius/pkg/cli/azure"
 	"github.com/radius-project/radius/pkg/cli/prompt"
+	"github.com/radius-project/radius/pkg/cli/style"
 )
 
 // Display constants used to render the summary and progress views shown by
@@ -68,7 +68,7 @@ var (
 		FPS:    time.Second / 4,
 	}
 
-	foregroundBrightStyle = lipgloss.NewStyle().Foreground(compat.AdaptiveColor{Light: lipgloss.Color("#111111"), Dark: lipgloss.Color("#EEEEEE")}).Bold(true)
+	foregroundBrightStyle = lipgloss.NewStyle().Foreground(style.AdaptiveColor{Light: lipgloss.Color("#111111"), Dark: lipgloss.Color("#EEEEEE")}).Bold(true)
 )
 
 // DisplayOptions is the data model rendered by the summary and progress views.

--- a/pkg/cli/pgbackup/pgbackup.go
+++ b/pkg/cli/pgbackup/pgbackup.go
@@ -28,10 +28,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/radius-project/radius/pkg/process"
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
 )
 
@@ -113,7 +113,7 @@ func Backup(ctx context.Context, kubeContext, namespace, stateDir string) error 
 	for _, db := range Databases {
 		logger.Info("Backing up database", "database", db, "stateDir", stateDir)
 
-		cmd := exec.CommandContext(ctx, "kubectl",
+		cmd := process.CommandContext(ctx, "kubectl",
 			"--context", kubeContext,
 			"-n", namespace,
 			"exec", podName, "--",
@@ -168,7 +168,7 @@ func Restore(ctx context.Context, kubeContext, namespace, stateDir string) error
 			return fmt.Errorf("failed to read backup file %q: %w", sqlPath, err)
 		}
 
-		cmd := exec.CommandContext(ctx, "kubectl",
+		cmd := process.CommandContext(ctx, "kubectl",
 			"--context", kubeContext,
 			"-n", namespace,
 			"exec", "-i", podName, "--",
@@ -196,7 +196,7 @@ func WaitForReady(ctx context.Context, kubeContext, namespace string) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 	logger.Info("Waiting for PostgreSQL pod to be ready")
 
-	cmd := exec.CommandContext(ctx, "kubectl",
+	cmd := process.CommandContext(ctx, "kubectl",
 		"--context", kubeContext,
 		"-n", namespace,
 		"wait",
@@ -219,7 +219,7 @@ func WaitForReady(ctx context.Context, kubeContext, namespace string) error {
 
 // getPodName resolves the name of the PostgreSQL pod via its label selector.
 func getPodName(ctx context.Context, kubeContext, namespace string) (string, error) {
-	cmd := exec.CommandContext(ctx, "kubectl",
+	cmd := process.CommandContext(ctx, "kubectl",
 		"--context", kubeContext,
 		"-n", namespace,
 		"get", "pods",

--- a/pkg/cli/prompt/list/list.go
+++ b/pkg/cli/prompt/list/list.go
@@ -23,15 +23,15 @@ import (
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/radius-project/radius/pkg/cli/style"
 )
 
 var (
 	titleStyle        = lipgloss.NewStyle().PaddingLeft(2)
 	itemStyle         = lipgloss.NewStyle().PaddingLeft(4)
 	selectedItemStyle = lipgloss.NewStyle().PaddingLeft(2).Foreground(lipgloss.Color("170"))
-	helpStyle         = lipgloss.NewStyle().Foreground(compat.AdaptiveColor{Light: lipgloss.Color("#555555"), Dark: lipgloss.Color("#AAAAAA")})
+	helpStyle         = lipgloss.NewStyle().Foreground(style.AdaptiveColor{Light: lipgloss.Color("#555555"), Dark: lipgloss.Color("#AAAAAA")})
 )
 
 type item string

--- a/pkg/cli/prompt/text/text.go
+++ b/pkg/cli/prompt/text/text.go
@@ -22,8 +22,8 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/radius-project/radius/pkg/cli/style"
 )
 
 var (
@@ -82,7 +82,7 @@ func NewTextModel(prompt string, options TextModelOptions) Model {
 
 	return Model{
 		Style:     lipgloss.NewStyle(), // No border or padding by default
-		ErrStyle:  lipgloss.NewStyle().Width(80).Foreground(compat.AdaptiveColor{Light: lipgloss.Color("#666666"), Dark: lipgloss.Color("#999999")}),
+		ErrStyle:  lipgloss.NewStyle().Width(80).Foreground(style.AdaptiveColor{Light: lipgloss.Color("#666666"), Dark: lipgloss.Color("#999999")}),
 		options:   options,
 		prompt:    prompt,
 		textInput: ti,

--- a/pkg/cli/style/color.go
+++ b/pkg/cli/style/color.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package style provides shared CLI styling that is safe for non-interactive processes.
+package style
+
+import (
+	"image/color"
+	"os"
+	"strings"
+	"sync"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/term"
+	"github.com/radius-project/radius/pkg/process"
+)
+
+var (
+	backgroundDetection  sync.Once
+	hasDarkBackground    bool
+	detectDarkBackground = func() bool {
+		if !term.IsTerminal(os.Stdin.Fd()) || !term.IsTerminal(os.Stdout.Fd()) {
+			return true
+		}
+		return lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+	}
+)
+
+// AdaptiveColor selects a color for the terminal background when the color is rendered.
+type AdaptiveColor struct {
+	Light color.Color
+	Dark  color.Color
+}
+
+// RGBA returns the color selected for the current terminal background.
+func (c AdaptiveColor) RGBA() (uint32, uint32, uint32, uint32) {
+	backgroundDetection.Do(func() {
+		if strings.EqualFold(os.Getenv(process.NoWindowEnvVar), "true") {
+			hasDarkBackground = true
+			return
+		}
+		hasDarkBackground = detectDarkBackground()
+	})
+
+	if hasDarkBackground {
+		return c.Dark.RGBA()
+	}
+	return c.Light.RGBA()
+}

--- a/pkg/cli/style/color.go
+++ b/pkg/cli/style/color.go
@@ -20,21 +20,19 @@ package style
 import (
 	"image/color"
 	"os"
-	"strings"
 	"sync"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/term"
-	"github.com/radius-project/radius/pkg/process"
 )
 
 var (
-	backgroundDetection  sync.Once
-	hasDarkBackground    bool
+	backgroundDetection sync.Once
+	hasDarkBackground   bool
+	hasTerminal         = func() bool {
+		return term.IsTerminal(os.Stdin.Fd()) && term.IsTerminal(os.Stdout.Fd())
+	}
 	detectDarkBackground = func() bool {
-		if !term.IsTerminal(os.Stdin.Fd()) || !term.IsTerminal(os.Stdout.Fd()) {
-			return true
-		}
 		return lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
 	}
 )
@@ -48,7 +46,7 @@ type AdaptiveColor struct {
 // RGBA returns the color selected for the current terminal background.
 func (c AdaptiveColor) RGBA() (uint32, uint32, uint32, uint32) {
 	backgroundDetection.Do(func() {
-		if strings.EqualFold(os.Getenv(process.NoWindowEnvVar), "true") {
+		if !hasTerminal() {
 			hasDarkBackground = true
 			return
 		}

--- a/pkg/cli/style/color_test.go
+++ b/pkg/cli/style/color_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package style
+
+import (
+	"image/color"
+	"sync"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/radius-project/radius/pkg/process"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdaptiveColor_NoWindowUsesDarkColorWithoutTerminalQuery(t *testing.T) {
+	t.Setenv(process.NoWindowEnvVar, "true")
+	resetBackgroundDetection(t, func() bool {
+		t.Fatal("terminal background must not be queried in no-window mode")
+		return false
+	})
+
+	color := AdaptiveColor{
+		Light: lipgloss.Color("#111111"),
+		Dark:  lipgloss.Color("#EEEEEE"),
+	}
+
+	require.Equal(t, rgba(lipgloss.Color("#EEEEEE")), rgba(color))
+}
+
+func TestAdaptiveColor_UsesDetectedBackground(t *testing.T) {
+	t.Setenv(process.NoWindowEnvVar, "")
+	resetBackgroundDetection(t, func() bool {
+		return false
+	})
+
+	color := AdaptiveColor{
+		Light: lipgloss.Color("#111111"),
+		Dark:  lipgloss.Color("#EEEEEE"),
+	}
+
+	require.Equal(t, rgba(lipgloss.Color("#111111")), rgba(color))
+}
+
+func rgba(value color.Color) [4]uint32 {
+	red, green, blue, alpha := value.RGBA()
+	return [4]uint32{red, green, blue, alpha}
+}
+
+func resetBackgroundDetection(t *testing.T, detect func() bool) {
+	t.Helper()
+	originalDetect := detectDarkBackground
+	backgroundDetection = sync.Once{}
+	hasDarkBackground = false
+	detectDarkBackground = detect
+	t.Cleanup(func() {
+		backgroundDetection = sync.Once{}
+		hasDarkBackground = false
+		detectDarkBackground = originalDetect
+	})
+}

--- a/pkg/cli/style/color_test.go
+++ b/pkg/cli/style/color_test.go
@@ -52,6 +52,19 @@ func TestAdaptiveColor_UsesDetectedBackground(t *testing.T) {
 	require.Equal(t, rgba(lipgloss.Color("#111111")), rgba(color))
 }
 
+func TestAdaptiveColor_DarkTerminalUsesDarkColor(t *testing.T) {
+	resetBackgroundDetection(t, true, func() bool {
+		return true
+	})
+
+	color := AdaptiveColor{
+		Light: lipgloss.Color("#111111"),
+		Dark:  lipgloss.Color("#EEEEEE"),
+	}
+
+	require.Equal(t, rgba(lipgloss.Color("#EEEEEE")), rgba(color))
+}
+
 func rgba(value color.Color) [4]uint32 {
 	red, green, blue, alpha := value.RGBA()
 	return [4]uint32{red, green, blue, alpha}

--- a/pkg/cli/style/color_test.go
+++ b/pkg/cli/style/color_test.go
@@ -22,14 +22,12 @@ import (
 	"testing"
 
 	"charm.land/lipgloss/v2"
-	"github.com/radius-project/radius/pkg/process"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAdaptiveColor_NoWindowUsesDarkColorWithoutTerminalQuery(t *testing.T) {
-	t.Setenv(process.NoWindowEnvVar, "true")
-	resetBackgroundDetection(t, func() bool {
-		t.Fatal("terminal background must not be queried in no-window mode")
+func TestAdaptiveColor_NoTerminalUsesDarkColorWithoutTerminalQuery(t *testing.T) {
+	resetBackgroundDetection(t, false, func() bool {
+		t.Fatal("terminal background must not be queried without a terminal")
 		return false
 	})
 
@@ -42,8 +40,7 @@ func TestAdaptiveColor_NoWindowUsesDarkColorWithoutTerminalQuery(t *testing.T) {
 }
 
 func TestAdaptiveColor_UsesDetectedBackground(t *testing.T) {
-	t.Setenv(process.NoWindowEnvVar, "")
-	resetBackgroundDetection(t, func() bool {
+	resetBackgroundDetection(t, true, func() bool {
 		return false
 	})
 
@@ -60,15 +57,20 @@ func rgba(value color.Color) [4]uint32 {
 	return [4]uint32{red, green, blue, alpha}
 }
 
-func resetBackgroundDetection(t *testing.T, detect func() bool) {
+func resetBackgroundDetection(t *testing.T, terminal bool, detect func() bool) {
 	t.Helper()
+	originalHasTerminal := hasTerminal
 	originalDetect := detectDarkBackground
 	backgroundDetection = sync.Once{}
 	hasDarkBackground = false
+	hasTerminal = func() bool {
+		return terminal
+	}
 	detectDarkBackground = detect
 	t.Cleanup(func() {
 		backgroundDetection = sync.Once{}
 		hasDarkBackground = false
+		hasTerminal = originalHasTerminal
 		detectDarkBackground = originalDetect
 	})
 }

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package process constructs external commands using Radius process policies.
+package process
+
+import (
+	"context"
+	"os/exec"
+)
+
+// NoWindowEnvVar enables windowless Radius child processes on Windows.
+const NoWindowEnvVar = "RADIUS_CLI_NO_WINDOW"
+
+// Command returns the Cmd to execute the named program with the given arguments.
+func Command(name string, args ...string) *exec.Cmd {
+	return configure(exec.Command(name, args...))
+}
+
+// CommandContext returns the Cmd to execute the named program with the given arguments.
+// The provided context controls the command lifetime.
+func CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return configure(exec.CommandContext(ctx, name, args...))
+}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -22,9 +22,6 @@ import (
 	"os/exec"
 )
 
-// NoWindowEnvVar enables windowless Radius child processes on Windows.
-const NoWindowEnvVar = "RADIUS_CLI_NO_WINDOW"
-
 // Command returns the Cmd to execute the named program with the given arguments.
 func Command(name string, args ...string) *exec.Cmd {
 	return configure(exec.Command(name, args...))

--- a/pkg/process/process_other.go
+++ b/pkg/process/process_other.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import "os/exec"
+
+func configure(cmd *exec.Cmd) *exec.Cmd {
+	return cmd
+}

--- a/pkg/process/process_other_test.go
+++ b/pkg/process/process_other_test.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommand_NoWindowIsWindowsOnly(t *testing.T) {
+	t.Setenv(NoWindowEnvVar, "true")
+
+	cmd := Command("test-command")
+
+	require.Nil(t, cmd.SysProcAttr)
+}

--- a/pkg/process/process_other_test.go
+++ b/pkg/process/process_other_test.go
@@ -24,9 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCommand_NoWindowIsWindowsOnly(t *testing.T) {
-	t.Setenv(NoWindowEnvVar, "true")
-
+func TestCommand_UnchangedOnNonWindows(t *testing.T) {
 	cmd := Command("test-command")
 
 	require.Nil(t, cmd.SysProcAttr)

--- a/pkg/process/process_windows.go
+++ b/pkg/process/process_windows.go
@@ -26,6 +26,9 @@ import (
 )
 
 var hasConsole = func() bool {
+	// GetConsoleWindow returns zero for Windows Terminal and other pseudoconsole hosts even when
+	// the process has an attached console. GetConsoleCP succeeds for both classic consoles and
+	// pseudoconsole hosts, so it preserves interactive child behavior in either environment.
 	_, err := windows.GetConsoleCP()
 	return err == nil
 }

--- a/pkg/process/process_windows.go
+++ b/pkg/process/process_windows.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func configure(cmd *exec.Cmd) *exec.Cmd {
+	if !strings.EqualFold(os.Getenv(NoWindowEnvVar), "true") {
+		return cmd
+	}
+
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NO_WINDOW
+	return cmd
+}

--- a/pkg/process/process_windows.go
+++ b/pkg/process/process_windows.go
@@ -19,16 +19,19 @@ limitations under the License.
 package process
 
 import (
-	"os"
 	"os/exec"
-	"strings"
 	"syscall"
 
 	"golang.org/x/sys/windows"
 )
 
+var hasConsole = func() bool {
+	_, err := windows.GetConsoleCP()
+	return err == nil
+}
+
 func configure(cmd *exec.Cmd) *exec.Cmd {
-	if !strings.EqualFold(os.Getenv(NoWindowEnvVar), "true") {
+	if hasConsole() {
 		return cmd
 	}
 

--- a/pkg/process/process_windows_test.go
+++ b/pkg/process/process_windows_test.go
@@ -28,16 +28,16 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func TestCommand_NoWindowDisabled(t *testing.T) {
-	t.Setenv(NoWindowEnvVar, "")
+func TestCommand_ConsoleAttached(t *testing.T) {
+	setHasConsole(t, true)
 
 	cmd := Command("test-command")
 
 	require.Nil(t, cmd.SysProcAttr)
 }
 
-func TestCommand_NoWindowEnabled(t *testing.T) {
-	t.Setenv(NoWindowEnvVar, "TRUE")
+func TestCommand_NoConsole(t *testing.T) {
+	setHasConsole(t, false)
 
 	cmd := Command("test-command")
 
@@ -45,8 +45,8 @@ func TestCommand_NoWindowEnabled(t *testing.T) {
 	require.Equal(t, uint32(windows.CREATE_NO_WINDOW), cmd.SysProcAttr.CreationFlags)
 }
 
-func TestCommandContext_NoWindowEnabled(t *testing.T) {
-	t.Setenv(NoWindowEnvVar, "true")
+func TestCommandContext_NoConsole(t *testing.T) {
+	setHasConsole(t, false)
 
 	cmd := CommandContext(context.Background(), "test-command")
 
@@ -55,7 +55,7 @@ func TestCommandContext_NoWindowEnabled(t *testing.T) {
 }
 
 func TestConfigure_PreservesCreationFlags(t *testing.T) {
-	t.Setenv(NoWindowEnvVar, "true")
+	setHasConsole(t, false)
 	cmd := exec.Command("test-command")
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP,
@@ -65,4 +65,15 @@ func TestConfigure_PreservesCreationFlags(t *testing.T) {
 
 	require.True(t, cmd.SysProcAttr.HideWindow)
 	require.Equal(t, uint32(windows.CREATE_NEW_PROCESS_GROUP|windows.CREATE_NO_WINDOW), cmd.SysProcAttr.CreationFlags)
+}
+
+func setHasConsole(t *testing.T, attached bool) {
+	t.Helper()
+	original := hasConsole
+	hasConsole = func() bool {
+		return attached
+	}
+	t.Cleanup(func() {
+		hasConsole = original
+	})
 }

--- a/pkg/process/process_windows_test.go
+++ b/pkg/process/process_windows_test.go
@@ -1,0 +1,68 @@
+//go:build windows
+
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestCommand_NoWindowDisabled(t *testing.T) {
+	t.Setenv(NoWindowEnvVar, "")
+
+	cmd := Command("test-command")
+
+	require.Nil(t, cmd.SysProcAttr)
+}
+
+func TestCommand_NoWindowEnabled(t *testing.T) {
+	t.Setenv(NoWindowEnvVar, "TRUE")
+
+	cmd := Command("test-command")
+
+	require.True(t, cmd.SysProcAttr.HideWindow)
+	require.Equal(t, uint32(windows.CREATE_NO_WINDOW), cmd.SysProcAttr.CreationFlags)
+}
+
+func TestCommandContext_NoWindowEnabled(t *testing.T) {
+	t.Setenv(NoWindowEnvVar, "true")
+
+	cmd := CommandContext(context.Background(), "test-command")
+
+	require.True(t, cmd.SysProcAttr.HideWindow)
+	require.Equal(t, uint32(windows.CREATE_NO_WINDOW), cmd.SysProcAttr.CreationFlags)
+}
+
+func TestConfigure_PreservesCreationFlags(t *testing.T) {
+	t.Setenv(NoWindowEnvVar, "true")
+	cmd := exec.Command("test-command")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP,
+	}
+
+	configure(cmd)
+
+	require.True(t, cmd.SysProcAttr.HideWindow)
+	require.Equal(t, uint32(windows.CREATE_NEW_PROCESS_GROUP|windows.CREATE_NO_WINDOW), cmd.SysProcAttr.CreationFlags)
+}

--- a/pkg/statearchive/git/git.go
+++ b/pkg/statearchive/git/git.go
@@ -41,6 +41,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/radius-project/radius/pkg/process"
 	"github.com/radius-project/radius/pkg/statearchive"
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
 )
@@ -229,7 +230,7 @@ func gitIdentityConfigured(ctx context.Context, dir string) bool {
 // gitConfigValue returns the trimmed value of a git config key for the repository at dir, or an
 // empty string if the key is unset or git fails.
 func gitConfigValue(ctx context.Context, dir, key string) string {
-	cmd := exec.CommandContext(ctx, "git", "config", "--get", key)
+	cmd := process.CommandContext(ctx, "git", "config", "--get", key)
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
@@ -240,7 +241,7 @@ func gitConfigValue(ctx context.Context, dir, key string) string {
 
 // hasRemote reports whether a remote named origin is configured.
 func hasRemote(ctx context.Context, root string) bool {
-	cmd := exec.CommandContext(ctx, "git", "remote", "get-url", remoteName)
+	cmd := process.CommandContext(ctx, "git", "remote", "get-url", remoteName)
 	cmd.Dir = root
 	return cmd.Run() == nil
 }
@@ -252,7 +253,7 @@ func hasRemote(ctx context.Context, root string) bool {
 // proceeds to fetch and fails loudly, rather than treating an unreachable remote as "branch absent"
 // and silently creating an empty branch that would restore the wrong (empty) state.
 func remoteHasBranch(ctx context.Context, root, branch string) bool {
-	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--exit-code", "--heads", remoteName, branch)
+	cmd := process.CommandContext(ctx, "git", "ls-remote", "--exit-code", "--heads", remoteName, branch)
 	cmd.Dir = root
 	err := cmd.Run()
 	if err == nil {
@@ -267,7 +268,7 @@ func remoteHasBranch(ctx context.Context, root, branch string) bool {
 
 // branchExists reports whether branch exists locally in the repository at root.
 func branchExists(ctx context.Context, root, branch string) bool {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", "refs/heads/"+branch)
+	cmd := process.CommandContext(ctx, "git", "rev-parse", "--verify", "refs/heads/"+branch)
 	cmd.Dir = root
 	return cmd.Run() == nil
 }
@@ -277,7 +278,7 @@ func branchExists(ctx context.Context, root, branch string) bool {
 // constant across all git repositories.
 func createOrphanBranch(ctx context.Context, root, branch string) error {
 	args := append(identityArgs(ctx, root), "commit-tree", emptyTreeSHA, "-m", "radius: init state branch")
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := process.CommandContext(ctx, "git", args...)
 	cmd.Dir = root
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -292,7 +293,7 @@ func createOrphanBranch(ctx context.Context, root, branch string) error {
 
 // repoRoot returns the absolute path to the root of the current git repository.
 func repoRoot(ctx context.Context) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
+	cmd := process.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
@@ -303,7 +304,7 @@ func repoRoot(ctx context.Context) (string, error) {
 
 // gitExecIn runs a git command with its working directory set to dir.
 func gitExecIn(ctx context.Context, dir string, args ...string) error {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := process.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/test/windowless/windowless_windows_test.go
+++ b/test/windowless/windowless_windows_test.go
@@ -30,12 +30,12 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 	"unsafe"
 
 	"github.com/radius-project/radius/pkg/cli/bicep"
+	"github.com/radius-project/radius/pkg/process"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
 )
@@ -57,6 +57,7 @@ const (
 
 var (
 	getConsoleWindow = windows.NewLazySystemDLL("kernel32.dll").NewProc("GetConsoleWindow")
+	freeConsole      = windows.NewLazySystemDLL("kernel32.dll").NewProc("FreeConsole")
 	radBinaryPath    string
 )
 
@@ -181,6 +182,11 @@ func newAutomationParentCommand(ctx context.Context, statusPath string, bicepMod
 }
 
 func runAutomationParent() int {
+	if result, _, err := freeConsole.Call(); result == 0 {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
 	job, err := createKillOnCloseJob()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -194,15 +200,11 @@ func runAutomationParent() int {
 	// Keep the only job handle open for the helper lifetime. Its automatic close when the helper
 	// exits is what terminates rad and every descendant during the cancellation test.
 
-	cmd := exec.Command(os.Getenv(testRadBinaryEnv), "version", "--cli", "--output", "json")
+	cmd := process.Command(os.Getenv(testRadBinaryEnv), "version", "--cli", "--output", "json")
 	cmd.Env = append(os.Environ(),
 		testHelperEnv+"="+testHelperBicep,
 		bicep.BicepEnvVar+"="+os.Args[0],
 	)
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		HideWindow:    true,
-		CreationFlags: windows.CREATE_NO_WINDOW,
-	}
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/test/windowless/windowless_windows_test.go
+++ b/test/windowless/windowless_windows_test.go
@@ -51,6 +51,7 @@ const (
 	testProcessTimeout     = 20 * time.Second
 	testJobExitCode        = 125
 	testBicepVersion       = "0.42.1"
+	testBicepStderr        = "Bicep diagnostic from test"
 	testStatusPollInterval = 25 * time.Millisecond
 )
 
@@ -105,6 +106,7 @@ func TestRadVersion_NonDetachedWindowlessProcessCompletesInsideJob(t *testing.T)
 	}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result), stdout.String())
 	require.Equal(t, testBicepVersion, result.Bicep)
+	require.Contains(t, stderr.String(), testBicepStderr)
 
 	status := readBicepStatus(t, statusPath)
 	require.Equal(t, "false", status["console"], "Bicep must not have an attached console")
@@ -284,6 +286,7 @@ func runFakeBicep() int {
 		}
 	}
 
+	fmt.Fprintln(os.Stderr, testBicepStderr)
 	fmt.Printf("Bicep CLI version %s (test)\n", testBicepVersion)
 	return 0
 }

--- a/test/windowless/windowless_windows_test.go
+++ b/test/windowless/windowless_windows_test.go
@@ -1,0 +1,322 @@
+//go:build windows
+
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package windowless
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/radius-project/radius/pkg/cli/bicep"
+	"github.com/radius-project/radius/pkg/process"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	testHelperEnv          = "RADIUS_TEST_HELPER"
+	testHelperParent       = "automation-parent"
+	testHelperBicep        = "bicep"
+	testRadBinaryEnv       = "RADIUS_TEST_RAD_BINARY"
+	testBicepModeEnv       = "RADIUS_TEST_BICEP_MODE"
+	testBicepStatusEnv     = "RADIUS_TEST_BICEP_STATUS"
+	testBicepModeHang      = "hang"
+	testProcessTimeout     = 20 * time.Second
+	testJobExitCode        = 125
+	testBicepVersion       = "0.42.1"
+	testStatusPollInterval = 25 * time.Millisecond
+)
+
+var (
+	getConsoleWindow = windows.NewLazySystemDLL("kernel32.dll").NewProc("GetConsoleWindow")
+	radBinaryPath    string
+)
+
+func TestMain(m *testing.M) {
+	switch os.Getenv(testHelperEnv) {
+	case testHelperParent:
+		os.Exit(runAutomationParent()) //nolint:forbidigo // Test helper subprocess must return the rad exit code.
+	case testHelperBicep:
+		os.Exit(runFakeBicep()) //nolint:forbidigo // Test helper subprocess must behave as the Bicep executable.
+	}
+
+	tempDir, err := os.MkdirTemp("", "radius-windowless-test-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1) //nolint:forbidigo // TestMain cannot continue without a temporary build directory.
+	}
+	radBinaryPath = filepath.Join(tempDir, "rad.exe")
+	if err := buildRad(radBinaryPath); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		_ = os.RemoveAll(tempDir)
+		os.Exit(1) //nolint:forbidigo // TestMain must report a failed integration-test build.
+	}
+
+	code := m.Run()
+	_ = os.RemoveAll(tempDir)
+	os.Exit(code) //nolint:forbidigo // TestMain must return the test suite exit code.
+}
+
+func TestRadVersion_NonDetachedWindowlessProcessCompletesInsideJob(t *testing.T) {
+	statusPath := filepath.Join(t.TempDir(), "bicep-status.txt")
+	ctx, cancel := context.WithTimeout(context.Background(), testProcessTimeout)
+	defer cancel()
+
+	cmd := newAutomationParentCommand(ctx, statusPath, "")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		status, _ := os.ReadFile(statusPath)
+		require.NoErrorf(t, err, "stderr: %s\nBicep status: %s\ncontext: %v", stderr.String(), status, ctx.Err())
+	}
+
+	var result struct {
+		Bicep string `json:"bicep"`
+	}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result), stdout.String())
+	require.Equal(t, testBicepVersion, result.Bicep)
+
+	status := readBicepStatus(t, statusPath)
+	require.Equal(t, "false", status["console"], "Bicep must not have an attached console")
+}
+
+func TestRadVersion_CancellationTerminatesJobProcessTree(t *testing.T) {
+	statusPath := filepath.Join(t.TempDir(), "bicep-status.txt")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := newAutomationParentCommand(ctx, statusPath, testBicepModeHang)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	require.NoError(t, cmd.Start())
+
+	status := waitForBicepStatus(t, statusPath, testProcessTimeout)
+	pid, err := strconv.ParseUint(status["pid"], 10, 32)
+	require.NoError(t, err)
+	require.Equal(t, "false", status["console"], "Bicep must not have an attached console")
+
+	processHandle, err := windows.OpenProcess(windows.SYNCHRONIZE|windows.PROCESS_TERMINATE, false, uint32(pid))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = windows.TerminateProcess(processHandle, testJobExitCode)
+		_ = windows.CloseHandle(processHandle)
+	})
+
+	cancel()
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-waitDone:
+		require.Error(t, err)
+	case <-time.After(testProcessTimeout):
+		t.Fatal("automation parent did not exit after cancellation")
+	}
+
+	waitResult, err := windows.WaitForSingleObject(processHandle, uint32(testProcessTimeout.Milliseconds()))
+	require.NoError(t, err)
+	require.Equal(t, uint32(windows.WAIT_OBJECT_0), waitResult, "Bicep outlived the canceled automation parent")
+}
+
+func buildRad(outputPath string) error {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return fmt.Errorf("failed to locate repository root")
+	}
+	repositoryRoot := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+
+	cmd := exec.Command("go", "build", "-o", outputPath, "./cmd/rad")
+	cmd.Dir = repositoryRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to build rad: %w: %s", err, output)
+	}
+	return nil
+}
+
+func newAutomationParentCommand(ctx context.Context, statusPath string, bicepMode string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, os.Args[0])
+	cmd.Env = append(os.Environ(),
+		testHelperEnv+"="+testHelperParent,
+		testRadBinaryEnv+"="+radBinaryPath,
+		testBicepModeEnv+"="+bicepMode,
+		testBicepStatusEnv+"="+statusPath,
+	)
+	return cmd
+}
+
+func runAutomationParent() int {
+	job, err := createKillOnCloseJob()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if err := windows.AssignProcessToJobObject(job, windows.CurrentProcess()); err != nil {
+		_ = windows.CloseHandle(job)
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	// Keep the only job handle open for the helper lifetime. Its automatic close when the helper
+	// exits is what terminates rad and every descendant during the cancellation test.
+
+	cmd := exec.Command(os.Getenv(testRadBinaryEnv), "version", "--cli", "--output", "json")
+	cmd.Env = append(os.Environ(),
+		testHelperEnv+"="+testHelperBicep,
+		bicep.BicepEnvVar+"="+os.Args[0],
+		process.NoWindowEnvVar+"=true",
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: windows.CREATE_NO_WINDOW,
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	stdoutDone := copyPipe(stdout, os.Stdout)
+	stderrDone := copyPipe(stderr, os.Stderr)
+	stdoutResult := <-stdoutDone
+	stderrResult := <-stderrDone
+	waitErr := cmd.Wait()
+
+	if stdoutResult.err != nil || stderrResult.err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read rad output: %v %v\n", stdoutResult.err, stderrResult.err)
+		return 1
+	}
+	if waitErr != nil {
+		fmt.Fprintln(os.Stderr, waitErr)
+		return 1
+	}
+	return 0
+}
+
+func createKillOnCloseJob() (windows.Handle, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{}
+	info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	_, err = windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	)
+	if err != nil {
+		_ = windows.CloseHandle(job)
+		return 0, err
+	}
+	return job, nil
+}
+
+type pipeResult struct {
+	content []byte
+	err     error
+}
+
+func copyPipe(reader io.Reader, writer io.Writer) <-chan pipeResult {
+	done := make(chan pipeResult, 1)
+	go func() {
+		var content bytes.Buffer
+		_, err := io.Copy(io.MultiWriter(&content, writer), reader)
+		done <- pipeResult{content: content.Bytes(), err: err}
+	}()
+	return done
+}
+
+func runFakeBicep() int {
+	consoleWindow, _, _ := getConsoleWindow.Call()
+	status := fmt.Sprintf("pid=%d\nconsole=%t\n", os.Getpid(), consoleWindow != 0)
+	if err := os.WriteFile(os.Getenv(testBicepStatusEnv), []byte(status), 0o600); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	if os.Getenv(testBicepModeEnv) == testBicepModeHang {
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+
+	fmt.Printf("Bicep CLI version %s (test)\n", testBicepVersion)
+	return 0
+}
+
+func readBicepStatus(t *testing.T, path string) map[string]string {
+	t.Helper()
+	return waitForBicepStatus(t, path, time.Second)
+}
+
+func waitForBicepStatus(t *testing.T, path string, timeout time.Duration) map[string]string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		content, err := os.ReadFile(path)
+		if err == nil {
+			status := map[string]string{}
+			for line := range strings.SplitSeq(strings.TrimSpace(string(content)), "\n") {
+				key, value, ok := strings.Cut(line, "=")
+				if ok {
+					status[key] = value
+				}
+			}
+			if status["pid"] != "" && status["console"] != "" {
+				return status
+			}
+		}
+		if !os.IsNotExist(err) {
+			require.NoError(t, err)
+		}
+		time.Sleep(testStatusPollInterval)
+	}
+	t.Fatalf("Bicep did not write status within %s", timeout)
+	return nil
+}

--- a/test/windowless/windowless_windows_test.go
+++ b/test/windowless/windowless_windows_test.go
@@ -36,7 +36,6 @@ import (
 	"unsafe"
 
 	"github.com/radius-project/radius/pkg/cli/bicep"
-	"github.com/radius-project/radius/pkg/process"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
 )
@@ -197,7 +196,6 @@ func runAutomationParent() int {
 	cmd.Env = append(os.Environ(),
 		testHelperEnv+"="+testHelperBicep,
 		bicep.BicepEnvVar+"="+os.Args[0],
-		process.NoWindowEnvVar+"=true",
 	)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		HideWindow:    true,


### PR DESCRIPTION
## Summary

- Automatically apply `HideWindow` and `CREATE_NO_WINDOW` to Radius-owned Windows child processes when `rad.exe` has no attached console, without detaching them from the caller's Job Object.
- Replace eager terminal background detection with lazy, terminal-only detection so redirected `rad.exe` invocations reach command execution without hanging.
- Add native Windows amd64 and arm64 coverage for non-detached execution, piped output, child window suppression, and process-tree cancellation.

## Reason for change

Automated Windows callers need to capture `rad.exe` output and cancel its complete process tree without visible console windows. The previous detached workaround prevented `CREATE_NO_WINDOW` from taking effect, while eager terminal background detection could block before `main` when standard streams were redirected.

Fixes #12883

## How to use
Windows automation callers launch `rad.exe`. A Node.js caller should use `detached: false`, `windowsHide: true`, and piped stdout and stderr. The caller's `windowsHide` option suppresses the initial `rad.exe` console because Radius cannot change its own process creation flags after startup.

When `rad.exe` has no attached console, [pkg/process](../../pkg/process/) automatically applies `SysProcAttr.HideWindow` and `CREATE_NO_WINDOW` to Radius-owned child processes such as Bicep, kubectl, Git, and the direct Azure CLI wrapper. It does not set `DETACHED_PROCESS` or `CREATE_BREAKAWAY_FROM_JOB`, so `rad.exe` and its descendants remain in the automation caller's Windows Job Object for process-tree cancellation. Standard input, output, error, exit codes, and context cancellation retain their existing behavior.

When `rad.exe` has an attached console, child terminal access and interactive CLI behavior are unchanged. Azure Identity credentials create their own Azure CLI process and do not use `pkg/process`; automation that must guarantee windowless descendants should use a non-CLI authentication method such as `ServicePrincipal`, `ManagedIdentity`, or `UCPCredential`.

## How to test

```powershell
go test ./pkg/process ./pkg/cli/style ./test/windowless -count=1 -timeout=2m
go test ./pkg/cli/bicep -run '^TestVersion_ClosesCallerStderrPipePromptly$' -count=1 -timeout=30s
go test ./pkg/azure/azcli ./pkg/cli/cmd/bicep/publishextension ./pkg/cli/cmd/radinit/common ./pkg/cli/pgbackup ./pkg/cli/prompt/... ./pkg/statearchive/git ./cmd/rad/cmd -count=1 -timeout=3m
```

To run a local build from Windows (ARM or AMD64), run this from the root of the repo:

```powershell
go build -o "dist\windows_$(go env GOARCH)\release\rad.exe" ./cmd/rad
```

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `.github/workflows/unit-tests.yaml` | Run focused Windows CLI process tests on native amd64 and arm64 runners. |
| `docs/architecture/rad-cli.md` | Document automatic windowless child behavior and the Azure Identity limitation. |
| `docs/contributing/contributing-code/contributing-code-cli/README.md` | Document native Windows process test commands and coverage. |
| `go.mod` | Promote terminal and Windows syscall modules to direct dependencies. |
| `pkg/azure/azcli/azcli.go` | Construct the direct Azure CLI child through the shared process policy. |
| `pkg/cli/bicep/build.go` | Construct Bicep through the shared process policy while retaining private stderr piping. |
| `pkg/cli/cmd/bicep/publishextension/publish.go` | Construct Bicep publishing through the shared process policy. |
| `pkg/cli/cmd/radinit/common/display.go` | Replace eager compatibility color detection with Radius lazy styling. |
| `pkg/cli/pgbackup/pgbackup.go` | Construct kubectl children through the shared process policy. |
| `pkg/cli/prompt/list/list.go` | Use lazy adaptive colors for list prompts. |
| `pkg/cli/prompt/text/text.go` | Use lazy adaptive colors for text prompt errors. |
| `pkg/cli/style/color.go` | Add adaptive color detection that avoids terminal queries when no terminal is attached. |
| `pkg/cli/style/color_test.go` | Cover terminal-free and interactive adaptive color selection. |
| `pkg/process/process.go` | Add centralized command constructors. |
| `pkg/process/process_other.go` | Preserve default command behavior on non-Windows platforms. |
| `pkg/process/process_other_test.go` | Cover non-Windows no-op behavior. |
| `pkg/process/process_windows.go` | Detect console attachment and automatically configure windowless children when needed. |
| `pkg/process/process_windows_test.go` | Cover console detection, windowless flags, contexts, and existing flag preservation. |
| `pkg/statearchive/git/git.go` | Construct Git children through the shared process policy. |
| `test/windowless/windowless_windows_test.go` | Build the real `rad.exe` and test Job Object execution, output, automatic window suppression, and cancellation. |