### PR TITLE
Fix gateway timeout validation assertion

### DIFF
--- a/test/functional-portable/corerp/noncloud/resources/gateway_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/gateway_test.go
@@ -297,7 +297,7 @@ func Test_Gateway_Timeout_Invalid_Duration(t *testing.T) {
 			Details: []step.DeploymentErrorDetail{
 				{
 					Code:            "InvalidProperties",
-					MessageContains: "properties.routes.timeoutPolicy.request in body should match",
+					MessageContains: "properties.routes.0.timeoutPolicy.request in body should match",
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

Updates the gateway invalid-duration functional test to expect the route array index in the validation error path.

## Reason for change

[PR #12897](https://github.com/radius-project/radius/pull/12897) upgraded `github.com/go-openapi/validate` to v0.26.3. That version began including array positions in validation error paths. Because this invalid value is in the first route, its path now includes `.0`: `$.properties.routes.0.timeoutPolicy.request`.

The deployment still returns the intended invalid-duration error. The test failed only because it searched for the old path without `.0`, so it could not find the updated error message.

Fixes https://github.com/radius-project/radius/issues/12905

## How to test

Run `Test_Gateway_Timeout_Invalid_Duration` from `./test/functional-portable/corerp/noncloud/resources/...` against a local Radius installation. Confirm the deployment returns `DeploymentFailed` with nested `HttpRequestPayloadAPISpecValidationFailed` and `InvalidProperties` details and that the test passes.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `test/functional-portable/corerp/noncloud/resources/gateway_test.go` | Includes route index `0` in the expected validation error path. |