### PR TITLE
Fix controller image build with Debian 13

### DIFF
--- a/deploy/images/controller/Dockerfile
+++ b/deploy/images/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Use a specific Debian slim image to enable running Bicep CLI
-FROM debian:bullseye-20250317-slim
+FROM debian:13.6-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132
 
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary

- replace the unsupported Debian 11 Bullseye controller base with Debian 13.6 Trixie slim
- pin the multi-platform OCI image index digest for reproducible AMD64, ARM64, and ARMv7 builds
- restore controller image builds that fail when Bullseye security repository metadata expires

## Testing

- `make docker-build-controller DOCKER_REGISTRY=radius-local DOCKER_TAG_VERSION=controller-debian13`
- `make docker-multi-arch-build-controller DOCKER_REGISTRY=radius-local DOCKER_TAG_VERSION=controller-debian13`

Closes #12921