### PR TITLE
chore(deps): upgrade applications-rp base image to Alpine 3.24.1

### DIFF
--- a/deploy/images/applications-rp/Dockerfile
+++ b/deploy/images/applications-rp/Dockerfile
@@ -1,6 +1,6 @@
 # Use Alpine image to enable Git installation for Terraform module downloads.
 # Switch to distroless when Terraform execution is moved to a separate container.
-FROM alpine:3.21.3
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary

Bumps the `applications-rp` base image from `alpine:3.21.3` to `alpine:3.24.1`, pinned to the immutable multi-platform digest `sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b`.

## Reason for change

`alpine:3.21` reaches end of support on 2026-11-01 (per [releases.json](https://alpinelinux.org/releases.json)); `alpine:3.24` is supported through 2028-06-01. Adding the digest makes the base immutable, so a build resolves to the same bytes regardless of when it runs.

Worth flagging for review: Alpine 3.24 ships **apk-tools 3.x** (3.0.6 in the image, 3.0.8 in the repos) where 3.21.3 shipped apk-tools 2.14.6. apk 3 replaced the standalone `--no-cache` flag with a boolean `--cache[=BOOL]` global option, and `--no-option` is the documented alias for `--option=no` — so the existing `apk --no-cache add` line keeps working unchanged. I ran it to confirm rather than relying on the docs (below).

Fixes #12923

## How to test

The digest is what Docker Hub currently serves for the `3.24.1` tag, and it resolves to an OCI image index covering all three published container targets:

```
$ docker buildx imagetools inspect \
    alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
...
  linux/amd64     sha256:79ff19e9084a...
  linux/arm64/v8  sha256:e7a1a92a5bfe...
  linux/arm/v7    sha256:48bf253520b1...
```

Build the image and exercise the Git toolchain that Terraform module downloads depend on:

```
docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 \
  -f deploy/images/applications-rp/Dockerfile .

docker run --rm --entrypoint sh <image> -c \
  'git --version && su rpuser -c "git ls-remote https://github.com/radius-project/radius.git HEAD"'
```

`git ls-remote` over HTTPS as `rpuser` exercises `git`, `ca-certificates`, and the non-root user in one step, which is what a `git::https://` Terraform module source needs.

I ran the `RUN` layer against the pinned base on **linux/amd64** and **linux/arm64**; both report `/etc/alpine-release` `3.24.1`, install `git 2.54.0` and `ca-certificates 20260611-r0`, create `rpuser` as uid/gid 65532, and complete `git ls-remote` against this repo as `rpuser`. I could not execute the **linux/arm/v7** variant locally (no 32-bit ARM emulation available), so for that target I confirmed the image is present in the index above and that `main/armv7` for Alpine v3.24 carries the identical `git 2.54.0-r0` and `ca-certificates 20260611-r0` packages. CI's ARMv7 build leg is the real check there.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `deploy/images/applications-rp/Dockerfile` | `FROM alpine:3.21.3` → `FROM alpine:3.24.1@sha256:28bd5fe8...43f8b` |

## Not included: dependency automation

The issue also asks for automation to keep the tag and digest current. `.github/dependabot.yml` has no `docker` ecosystem entry, and its header says it is synced from `radius-project/.github` and must not be edited here — so that belongs in that repository rather than this PR. Happy to open an issue there if that is the preferred route.

Scoped to `applications-rp` only; #12926 (dynamic-rp) and #12928 (bicep) track the sibling images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
