### PR TITLE
Align missing namespace test with stock ARM errors

### DIFF
--- a/test/functional-portable/dynamicrp/noncloud/resources/recipepacks_test.go
+++ b/test/functional-portable/dynamicrp/noncloud/resources/recipepacks_test.go
@@ -283,8 +283,13 @@ func Test_RecipePacks_MissingNamespace_Failure(t *testing.T) {
 	cli := radcli.NewCLI(t, options.ConfigFilePath)
 
 	validate := step.ValidateSingleDetail("DeploymentFailed", step.DeploymentErrorDetail{
-		Code:            "BadRequest",
-		MessageContains: "Namespace 'recipepacks-ns' does not exist in the Kubernetes cluster. Please create it before proceeding.",
+		Code: "ResourceDeploymentFailure",
+		Details: []step.DeploymentErrorDetail{
+			{
+				Code:            "BadRequest",
+				MessageContains: "Namespace 'recipepacks-ns' does not exist in the Kubernetes cluster. Please create it before proceeding.",
+			},
+		},
 	})
 
 	test := rp.NewRPTest(t, appName, []rp.TestStep{


### PR DESCRIPTION
## 📊 Application Graph Diff

Comparing `main` → `willdavsmith-stock-error-assertion`

✅ No application graph changes detected. The application model is identical between `main` and `willdavsmith-stock-error-assertion`.
```mermaid
graph TD
    classDef added fill:#dafbe1,stroke:#1a7f37,stroke-width:2px,color:#1a7f37
    classDef removed fill:#ffebe9,stroke:#cf222e,stroke-width:2px,color:#cf222e
    classDef modified fill:#fff8c5,stroke:#bf8700,stroke-width:2px,color:#9a6700
    classDef unchanged fill:#f6f8fa,stroke:#d1d9e0,stroke-width:1px,color:#656d76
    repo_radius_state_container["repo-radius-state-container\ncontainers"]:::unchanged
```

## Summary

Update the modern UDT recipe pack missing-namespace functional test to expect the standard stock ARM deployment error hierarchy: `DeploymentFailed` → `ResourceDeploymentFailure` → `BadRequest`.

This preserves the existing namespace-missing message assertion and aligns the test with the stock `Azure.Deployments.Engine` semantics introduced by azure-octo/deployment-engine#637. It does not change Deployment Engine behavior or deprecated `Applications.*` assertions.

## Validation

- `gofmt -w test/functional-portable/dynamicrp/noncloud/resources/recipepacks_test.go`
- `go test ./test/functional-portable/dynamicrp/noncloud/resources -run '^$'`