### PR TITLE
ci: bundle noncloud functional test inputs

### DIFF
--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -190,27 +190,23 @@ jobs:
           DOCKER_REGISTRY: ${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}
           DOCKER_TAG_VERSION: ${{ steps.gen-id.outputs.REL_VERSION }}
 
-      # Keep JavaScript actions sequential. Parallel action startup rewrites the shared
-      # GITHUB_EVENT_PATH and can expose a partially written payload to another action.
-      - name: Upload rad CLI binary
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: radius_test_cli
-          path: ./dist/linux_amd64/release/rad
-          if-no-files-found: error
+      - name: Check functional test inputs
+        # A combined upload's if-no-files-found only fails when all inputs are missing.
+        run: |
+          ls ./dist/linux_amd64/release/rad \
+            ./dist/images/*.tar \
+            ./hack/bicep-types-radius/generated/index.json
 
-      - name: Upload container image artifacts
+      - name: Upload functional test inputs
+        # Multiple paths use the workspace as their common root, preserving the
+        # directory layout while avoiding three artifact lookups per matrix leg.
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: radius_test_images
-          path: ./dist/images
-          if-no-files-found: error
-
-      - name: Upload Radius Bicep types artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: radius_test_bicep_types
-          path: ./hack/bicep-types-radius/generated
+          name: radius_test_inputs
+          path: |
+            ./dist/linux_amd64/release/rad
+            ./dist/images
+            ./hack/bicep-types-radius/generated
           if-no-files-found: error
 
   tests:
@@ -290,26 +286,13 @@ jobs:
       # The rad CLI, container images and Bicep types are built once in the
       # "build" job and shared with every matrix leg. Downloading them here avoids
       # recompiling the source and reinstalling the Node/yq toolchain in each leg.
-      # They land in the same paths a local build would produce, so the remaining
-      # steps are unchanged. Keep these JavaScript actions sequential for the same
-      # shared GITHUB_EVENT_PATH constraint as the upload steps above.
-      - name: Download rad CLI binary
+      # One run-scoped artifact restores the original paths on every fresh runner,
+      # including when only failed matrix jobs are re-run.
+      - name: Download functional test inputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: radius_test_cli
-          path: ./dist/linux_amd64/release
-
-      - name: Download container image artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: radius_test_images
-          path: ./dist/images
-
-      - name: Download Radius Bicep types artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: radius_test_bicep_types
-          path: ./hack/bicep-types-radius/generated
+          name: radius_test_inputs
+          path: .
 
       - name: Create a secure local registry
         id: create-local-registry


### PR DESCRIPTION
## Summary

Bundle the CLI binary, container image tarballs, and generated Radius Bicep types into one `radius_test_inputs` artifact. Each of the 13 noncloud functional-test matrix legs downloads it once, reducing input-artifact download invocations from 39 to 13 without reducing test parallelism.

## Reason for change

Concurrent artifact lookups have triggered GitHub secondary rate limits before functional tests begin. Consolidating the inputs reduces artifact-service calls while preserving repository-relative paths, per-runner local registry publishing, and failed-job reruns on fresh runners.

Check each required input before upload so combining artifacts does not hide a missing output behind `if-no-files-found: error`.

Fixes #12930

## How to test

- Run `actionlint -shellcheck= .github/workflows/functional-test-noncloud.yaml` and `git diff --check` (passed locally).
- Local fixture checks passed for artifact name/path matching, workspace-relative restoration including nested Bicep types, all 13 matrix legs, and failure when the CLI, image tarballs, or types index is missing.
- Full `actionlint` reports the same 11 pre-existing ShellCheck diagnostics as the baseline; no new diagnostics were introduced.
- In GitHub Actions, confirm the build uploads one input artifact and each matrix leg restores the CLI at `dist/linux_amd64/release/rad`, images under `dist/images`, and types under `hack/bicep-types-radius/generated`. Confirm local registry publishing succeeds and rerun a failed leg without rerunning the build. Hosted execution and rate-limit behavior have not yet been verified.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `.github/workflows/functional-test-noncloud.yaml` | Check required build outputs, replace three input uploads with one multi-path artifact, and restore it with a single workspace-root download per matrix leg. |